### PR TITLE
Add Feed and FeedSchedule models with scheduling functionality

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(bin/rails:*)",
-      "Bash(bin/rubocop:*)"
+      "Bash(bin/rubocop:*)",
+      "WebFetch(domain:docs.anthropic.com)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# F2 Project Memory
+
+## Tech Stack
+- Rails 8.0.2 with PostgreSQL
+- Authentication: bcrypt, sessions, password reset
+- Frontend: Turbo, Stimulus, Bootstrap CSS
+- Deployment: Kamal
+
+## Current State
+- Basic authentication system complete
+- User/Session models with secure passwords
+- Dashboard as root route
+- Branch: feature/feeds-configuration
+- Modified: Gemfile, Gemfile.lock
+
+## Key Files
+- `app/models/user.rb` - User model with authentication
+- `app/controllers/concerns/authentication.rb` - Auth logic
+- `config/routes.rb` - Simple routing setup

--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,5 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
 end
+
+gem "fugit", "~> 1.11"

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ group :development, :test do
   gem "rubocop-rails-omakase", require: false
 
   gem "solargraph"
+
+  # Test data factories [https://github.com/thoughtbot/factory_bot]
+  gem "factory_bot_rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,11 @@ GEM
     erubi (1.13.1)
     et-orbi (1.3.0)
       tzinfo
+    factory_bot (6.5.5)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.0)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -391,6 +396,7 @@ DEPENDENCIES
   brakeman
   cssbundling-rails
   debug
+  factory_bot_rails
   fugit (~> 1.11)
   importmap-rails
   kamal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,6 +391,7 @@ DEPENDENCIES
   brakeman
   cssbundling-rails
   debug
+  fugit (~> 1.11)
   importmap-rails
   kamal
   pg (~> 1.1)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -1,0 +1,17 @@
+class Feed < ApplicationRecord
+  has_one :feed_schedule, dependent: :destroy
+
+  enum state: { enabled: 0, paused: 1, disabled: 2 }
+
+  validates :name, presence: true
+  validates :url, presence: true
+  validates :cron_expression, presence: true
+  validates :loader, presence: true
+  validates :processor, presence: true
+  validates :normalizer, presence: true
+
+  scope :due, -> {
+    left_joins(:feed_schedule)
+      .where('feed_schedules.next_run_at <= ? OR feed_schedules.id IS NULL', Time.current)
+  }
+end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -1,7 +1,7 @@
 class Feed < ApplicationRecord
   has_one :feed_schedule, dependent: :destroy
 
-  enum state: { enabled: 0, paused: 1, disabled: 2 }
+  enum :state, { enabled: 0, paused: 1, disabled: 2 }
 
   validates :name, presence: true
   validates :url, presence: true
@@ -12,6 +12,6 @@ class Feed < ApplicationRecord
 
   scope :due, -> {
     left_joins(:feed_schedule)
-      .where('feed_schedules.next_run_at <= ? OR feed_schedules.id IS NULL', Time.current)
+      .where("feed_schedules.next_run_at <= ? OR feed_schedules.id IS NULL", Time.current)
   }
 end

--- a/app/models/feed_schedule.rb
+++ b/app/models/feed_schedule.rb
@@ -2,6 +2,6 @@ class FeedSchedule < ApplicationRecord
   belongs_to :feed
 
   def calculate_next_run_at
-    Fugit.parse(feed.cron_expression).next_at.to_t
+    Fugit.parse(feed.cron_expression).next_time.to_t
   end
 end

--- a/app/models/feed_schedule.rb
+++ b/app/models/feed_schedule.rb
@@ -1,0 +1,7 @@
+class FeedSchedule < ApplicationRecord
+  belongs_to :feed
+
+  def calculate_next_run_at
+    Fugit.parse(feed.cron_expression).next_at.to_t
+  end
+end

--- a/db/migrate/20250817115100_create_feeds.rb
+++ b/db/migrate/20250817115100_create_feeds.rb
@@ -1,0 +1,17 @@
+class CreateFeeds < ActiveRecord::Migration[8.0]
+  def change
+    create_table :feeds do |t|
+      t.string :name, null: false
+      t.string :url, null: false
+      t.string :cron_expression, null: false
+      t.string :loader, null: false
+      t.string :processor, null: false
+      t.string :normalizer, null: false
+      t.datetime :import_after
+      t.integer :state, null: false, default: 0
+      t.string :description, null: false, default: ""
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250817115108_create_feed_schedules.rb
+++ b/db/migrate/20250817115108_create_feed_schedules.rb
@@ -1,0 +1,11 @@
+class CreateFeedSchedules < ActiveRecord::Migration[8.0]
+  def change
+    create_table :feed_schedules do |t|
+      t.references :feed, null: false, foreign_key: true
+      t.datetime :next_run_at
+      t.datetime :last_run_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_16_125704) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_17_115108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "feed_schedules", force: :cascade do |t|
+    t.bigint "feed_id", null: false
+    t.datetime "next_run_at"
+    t.datetime "last_run_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feed_id"], name: "index_feed_schedules_on_feed_id"
+  end
+
+  create_table "feeds", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "url", null: false
+    t.string "cron_expression", null: false
+    t.string "loader", null: false
+    t.string "processor", null: false
+    t.string "normalizer", null: false
+    t.datetime "import_after"
+    t.integer "state", default: 0, null: false
+    t.string "description", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "sessions", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -31,5 +54,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_16_125704) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "feed_schedules", "feeds"
   add_foreign_key "sessions", "users"
 end

--- a/test/factories/feed_schedules.rb
+++ b/test/factories/feed_schedules.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :feed_schedule do
+    association :feed
+    next_run_at { 1.hour.from_now }
+    last_run_at { nil }
+
+    trait :past_due do
+      next_run_at { 1.hour.ago }
+    end
+
+    trait :future do
+      next_run_at { 1.hour.from_now }
+    end
+
+    trait :with_last_run do
+      last_run_at { 2.hours.ago }
+    end
+  end
+end

--- a/test/factories/feeds.rb
+++ b/test/factories/feeds.rb
@@ -1,0 +1,35 @@
+FactoryBot.define do
+  factory :feed do
+    name { "Sample Feed" }
+    url { "https://example.com/feed.xml" }
+    cron_expression { "0 */6 * * *" }
+    loader { "http" }
+    processor { "rss" }
+    normalizer { "rss" }
+    state { :enabled }
+    description { "" }
+    import_after { nil }
+
+    trait :with_schedule do
+      after(:create) do |feed|
+        create(:feed_schedule, feed: feed)
+      end
+    end
+
+    trait :paused do
+      state { :paused }
+    end
+
+    trait :disabled do
+      state { :disabled }
+    end
+
+    trait :with_description do
+      description { "A sample RSS feed for testing" }
+    end
+
+    trait :with_import_threshold do
+      import_after { 1.week.ago }
+    end
+  end
+end

--- a/test/models/feed_schedule_test.rb
+++ b/test/models/feed_schedule_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class FeedScheduleTest < ActiveSupport::TestCase
+  test "should be valid with feed association" do
+    schedule = build(:feed_schedule)
+    assert schedule.valid?
+  end
+
+  test "should require feed" do
+    schedule = build(:feed_schedule, feed: nil)
+    assert_not schedule.valid?
+    assert schedule.errors.of_kind?(:feed, :blank)
+  end
+
+  test "calculate_next_run_at should parse cron expression" do
+    feed = build(:feed, cron_expression: "0 */6 * * *")
+    schedule = build(:feed_schedule, feed: feed)
+
+    freeze_time do
+      next_run = schedule.calculate_next_run_at
+      assert next_run.is_a?(Time)
+      assert next_run > Time.current
+    end
+  end
+
+  test "calculate_next_run_at should handle daily cron" do
+    feed = build(:feed, cron_expression: "0 9 * * *")
+    schedule = build(:feed_schedule, feed: feed)
+
+    freeze_time do
+      next_run = schedule.calculate_next_run_at
+      assert next_run.is_a?(Time)
+    end
+  end
+
+  test "calculate_next_run_at should handle hourly cron" do
+    feed = build(:feed, cron_expression: "0 * * * *")
+    schedule = build(:feed_schedule, feed: feed)
+
+    freeze_time do
+      next_run = schedule.calculate_next_run_at
+      assert next_run.is_a?(Time)
+    end
+  end
+end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class FeedTest < ActiveSupport::TestCase
+  test "should be valid with all required attributes" do
+    feed = build(:feed)
+    assert feed.valid?
+  end
+
+  test "should require name" do
+    feed = build(:feed, name: nil)
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:name, :blank)
+  end
+
+  test "should require url" do
+    feed = build(:feed, url: nil)
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:url, :blank)
+  end
+
+  test "should require cron_expression" do
+    feed = build(:feed, cron_expression: nil)
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:cron_expression, :blank)
+  end
+
+  test "should require loader" do
+    feed = build(:feed, loader: nil)
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:loader, :blank)
+  end
+
+  test "should require processor" do
+    feed = build(:feed, processor: nil)
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:processor, :blank)
+  end
+
+  test "should require normalizer" do
+    feed = build(:feed, normalizer: nil)
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:normalizer, :blank)
+  end
+
+  test "should have enabled state by default" do
+    feed = build(:feed)
+    assert_equal "enabled", feed.state
+  end
+
+  test "should support state transitions" do
+    feed = create(:feed)
+
+    feed.paused!
+    assert feed.paused?
+
+    feed.disabled!
+    assert feed.disabled?
+
+    feed.enabled!
+    assert feed.enabled?
+  end
+
+  test "should have empty description by default" do
+    feed = build(:feed)
+    assert_equal "", feed.description
+  end
+
+  test "should destroy associated feed_schedule when destroyed" do
+    feed = create(:feed, :with_schedule)
+
+    assert_difference("FeedSchedule.count", -1) do
+      feed.destroy!
+    end
+  end
+
+  test "due scope should include feeds without schedule" do
+    freeze_time do
+      feed = create(:feed)
+
+      assert_includes Feed.due, feed
+    end
+  end
+
+  test "due scope should include feeds with past next_run_at" do
+    freeze_time do
+      feed = create(:feed)
+      create(:feed_schedule, feed: feed, next_run_at: 1.hour.ago)
+
+      assert_includes Feed.due, feed
+    end
+  end
+
+  test "due scope should exclude feeds with future next_run_at" do
+    freeze_time do
+      feed = create(:feed)
+      create(:feed_schedule, feed: feed, next_run_at: 1.hour.from_now)
+
+      assert_not_includes Feed.due, feed
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require "rails/test_help"
 
 module ActiveSupport
   class TestCase
+    include FactoryBot::Syntax::Methods
+
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
 


### PR DESCRIPTION
Changes:

- Add `Feed` and `FeedSchedule` models with cron-based scheduling configuration.
- Add FactoryBot.
- Add `CLAUDE.md`.