### PR TITLE
Set up SimpleCov and CodeCov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,9 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: dreikanter/f2

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 
 /node_modules
 bun.lockb
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,10 @@ group :development, :test do
   gem "factory_bot_rails"
 end
 
+group :test do
+  gem "simplecov", require: false
+end
+
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
+    docile (1.4.1)
     dotenv (3.1.8)
     drb (2.2.3)
     ed25519 (1.4.0)
@@ -300,6 +301,12 @@ GEM
       rbs (>= 3, < 5)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     solargraph (0.56.2)
       backport (~> 1.2)
       benchmark (~> 0.4)
@@ -406,6 +413,7 @@ DEPENDENCIES
   rails (~> 8.0.2)
   rubocop-rails-omakase
   ruby-lsp
+  simplecov
   solargraph
   solid_cable
   solid_cache

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,8 @@
 ENV["RAILS_ENV"] ||= "test"
+
+require "simplecov"
+SimpleCov.start "rails"
+
 require_relative "../config/environment"
 require "rails/test_help"
 


### PR DESCRIPTION
Changes:

- Enable SimpleCov.
- Upload coverage reports to CodeCov.