### PR TITLE
Add FreeFeed API client

### DIFF
--- a/app/jobs/token_validation_job.rb
+++ b/app/jobs/token_validation_job.rb
@@ -5,13 +5,10 @@ class TokenValidationJob < ApplicationJob
     return unless access_token.token_value.present?
 
     begin
-      response = validate_freefeed_token(access_token.token_value)
-
-      if response[:success] && response[:username]
-        access_token.update!(status: :active, owner: response[:username])
-      else
-        access_token.inactive!
-      end
+      user_info = freefeed_client(access_token.token_value).whoami
+      access_token.update!(status: :active, owner: user_info[:username])
+    rescue FreefeedClient::UnauthorizedError
+      access_token.inactive!
     rescue => e
       access_token.inactive!
     end
@@ -19,51 +16,8 @@ class TokenValidationJob < ApplicationJob
 
   private
 
-  def validate_freefeed_token(token)
-    response = make_api_request(token)
-    parse_api_response(response)
-  rescue JSON::ParserError
-    { success: false, error: "Invalid JSON response" }
-  rescue HttpClient::TooManyRedirectsError => e
-    { success: false, error: "Too many redirects" }
-  rescue HttpClient::Error => e
-    { success: false, error: e.message }
-  rescue => e
-    { success: false, error: e.message }
-  end
-
-  def make_api_request(token)
-    http_client.get(
-      "#{freefeed_host}/v4/users/whoami",
-      headers: {
-        "Authorization" => "Bearer #{token}",
-        "Accept" => "application/json",
-        "User-Agent" => "FreeFeed-Token-Validator"
-      }
-    )
-  end
-
-  def parse_api_response(response)
-    if response.success?
-      parse_success_response(response.body)
-    else
-      { success: false, error: "HTTP #{response.status}: #{response.body}" }
-    end
-  end
-
-  def parse_success_response(body)
-    data = JSON.parse(body)
-    username = data.dig("users", "username")
-
-    if username
-      { success: true, username: username }
-    else
-      { success: false, error: "Invalid response format" }
-    end
-  end
-
-  def http_client
-    @http_client ||= HttpClient::FaradayAdapter.new
+  def freefeed_client(token)
+    FreefeedClient.new(host: freefeed_host, token: token)
   end
 
   def freefeed_host

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -1,0 +1,103 @@
+# FreeFeed API Client
+#
+# Minimal client for FreeFeed API focused on specific application needs.
+# Provides high-level methods for token validation and group management.
+class FreefeedClient
+  class Error < StandardError; end
+  class UnauthorizedError < Error; end
+  class NotFoundError < Error; end
+
+  DEFAULT_OPTIONS = {
+    timeout: 30,
+    follow_redirects: true,
+    max_redirects: 5
+  }.freeze
+
+  attr_reader :host, :http_client
+
+  def initialize(host:, token:, http_client: nil, options: {})
+    @host = host.chomp("/")
+    @token = token
+    @http_client = http_client || HttpClient::FaradayAdapter.new(DEFAULT_OPTIONS.merge(options))
+  end
+
+  # Validate token and get current user info
+  # Used for access token validation
+  def whoami
+    response = get("/v4/users/whoami")
+    parse_whoami_response(response.body)
+  rescue HttpClient::Error => e
+    raise Error, "Failed to validate token: #{e.message}"
+  end
+
+  # Get list of groups that current user can post to
+  # Returns simplified array of group objects
+  def managed_groups
+    response = get("/v4/managedGroups")
+    parse_managed_groups_response(response.body)
+  rescue HttpClient::Error => e
+    raise Error, "Failed to fetch managed groups: #{e.message}"
+  end
+
+  private
+
+  def get(path, options: {})
+    url = "#{@host}#{path}"
+    headers = {
+      "Authorization" => "Bearer #{@token}",
+      "Accept" => "application/json",
+      "User-Agent" => "FreeFeed-Rails-Client"
+    }
+
+    response = @http_client.get(url, headers: headers, options: options)
+
+    case response.status
+    when 200
+      response
+    when 401, 403
+      raise UnauthorizedError, "Invalid or expired token"
+    when 404
+      raise NotFoundError, "Resource not found"
+    else
+      raise Error, "HTTP #{response.status}: #{response.body}"
+    end
+  end
+
+  def parse_whoami_response(body)
+    data = JSON.parse(body)
+    user = data.dig("users")
+
+    unless user && user["username"]
+      raise Error, "Invalid whoami response format"
+    end
+
+    {
+      id: user["id"],
+      username: user["username"],
+      screen_name: user["screenName"],
+      email: user["email"]
+    }
+  rescue JSON::ParserError => e
+    raise Error, "Invalid JSON response: #{e.message}"
+  end
+
+  def parse_managed_groups_response(body)
+    groups = JSON.parse(body)
+
+    unless groups.is_a?(Array)
+      raise Error, "Invalid managed groups response format"
+    end
+
+    groups.map do |group|
+      {
+        id: group["id"],
+        username: group["username"],
+        screen_name: group["screenName"],
+        is_private: group["isPrivate"] == "1",
+        is_restricted: group["isRestricted"] == "1"
+      }
+    end
+  rescue JSON::ParserError => e
+    raise Error, "Invalid JSON response: #{e.message}"
+  end
+end

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -1,3 +1,8 @@
+# HTTP Client abstraction layer
+#
+# Provides a standardized interface over HTTP libraries (currently Faraday).
+# This abstraction allows swapping HTTP implementations (Faraday -> Net::HTTP, HTTParty, etc.)
+# without changing application code, and ensures consistent error handling across the app.
 module HttpClient
   class Response
     attr_reader :status, :body, :headers

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -59,6 +59,13 @@ class TokenValidationJobTest < ActiveJob::TestCase
   test "marks token as inactive when JSON parsing fails" do
     # Mock response with invalid JSON
     stub_request(:get, "https://freefeed.test/v4/users/whoami")
+      .with(
+        headers: {
+          "Authorization" => /Bearer freefeed_token_/,
+          "Accept" => "application/json",
+          "User-Agent" => "FreeFeed-Rails-Client"
+        }
+      )
       .to_return(status: 200, body: "invalid json", headers: { "Content-Type" => "application/json" })
 
     assert access_token.pending?
@@ -74,6 +81,13 @@ class TokenValidationJobTest < ActiveJob::TestCase
     ENV["FREEFEED_HOST"] = "https://custom.freefeed.com"
 
     stub_request(:get, "https://custom.freefeed.com/v4/users/whoami")
+      .with(
+        headers: {
+          "Authorization" => /Bearer freefeed_token_/,
+          "Accept" => "application/json",
+          "User-Agent" => "FreeFeed-Rails-Client"
+        }
+      )
       .to_return(
         status: 200,
         body: { users: { username: "testuser" } }.to_json,
@@ -113,6 +127,13 @@ class TokenValidationJobTest < ActiveJob::TestCase
   test "marks token as inactive when response format is invalid" do
     # Mock response with missing username field
     stub_request(:get, "https://freefeed.test/v4/users/whoami")
+      .with(
+        headers: {
+          "Authorization" => /Bearer freefeed_token_/,
+          "Accept" => "application/json",
+          "User-Agent" => "FreeFeed-Rails-Client"
+        }
+      )
       .to_return(
         status: 200,
         body: { users: { screenName: "testuser", id: "test-id" } }.to_json,
@@ -186,7 +207,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
         headers: {
           "Authorization" => /Bearer freefeed_token_/,
           "Accept" => "application/json",
-          "User-Agent" => "FreeFeed-Token-Validator"
+          "User-Agent" => "FreeFeed-Rails-Client"
         }
       )
       .to_return(
@@ -208,7 +229,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
         headers: {
           "Authorization" => /Bearer freefeed_token_/,
           "Accept" => "application/json",
-          "User-Agent" => "FreeFeed-Token-Validator"
+          "User-Agent" => "FreeFeed-Rails-Client"
         }
       )
       .to_return(

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -1,0 +1,261 @@
+require "test_helper"
+
+class FreefeedClientTest < ActiveSupport::TestCase
+  def setup
+    @host = "https://freefeed.net"
+    @token = "test_token_123"
+    @client = FreefeedClient.new(host: @host, token: @token)
+  end
+
+  # Constructor tests
+  test "initializes with required parameters" do
+    client = FreefeedClient.new(host: @host, token: @token)
+    assert_equal "https://freefeed.net", client.host
+    assert_instance_of HttpClient::FaradayAdapter, client.http_client
+  end
+
+  test "initializes with custom http_client" do
+    custom_client = HttpClient::FaradayAdapter.new(timeout: 60)
+    client = FreefeedClient.new(host: @host, token: @token, http_client: custom_client)
+    assert_equal custom_client, client.http_client
+  end
+
+  test "strips trailing slash from host" do
+    client = FreefeedClient.new(host: "https://freefeed.net/", token: @token)
+    assert_equal "https://freefeed.net", client.host
+  end
+
+  # whoami method tests
+  test "whoami returns user data on success" do
+    response_body = {
+      "users" => {
+        "id" => "user123",
+        "username" => "testuser",
+        "screenName" => "Test User",
+        "email" => "test@example.com"
+      }
+    }.to_json
+
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .with(
+        headers: {
+          "Authorization" => "Bearer #{@token}",
+          "Accept" => "application/json",
+          "User-Agent" => "FreeFeed-Rails-Client"
+        }
+      )
+      .to_return(status: 200, body: response_body)
+
+    result = @client.whoami
+
+    assert_equal "user123", result[:id]
+    assert_equal "testuser", result[:username]
+    assert_equal "Test User", result[:screen_name]
+    assert_equal "test@example.com", result[:email]
+  end
+
+  test "whoami raises UnauthorizedError on 401" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 401, body: "Unauthorized")
+
+    assert_raises(FreefeedClient::UnauthorizedError) do
+      @client.whoami
+    end
+  end
+
+  test "whoami raises UnauthorizedError on 403" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 403, body: "Forbidden")
+
+    assert_raises(FreefeedClient::UnauthorizedError) do
+      @client.whoami
+    end
+  end
+
+  test "whoami raises NotFoundError on 404" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 404, body: "Not Found")
+
+    assert_raises(FreefeedClient::NotFoundError) do
+      @client.whoami
+    end
+  end
+
+  test "whoami raises Error on other HTTP errors" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.whoami
+    end
+    assert_includes error.message, "HTTP 500"
+  end
+
+  test "whoami raises Error on invalid JSON" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 200, body: "invalid json")
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.whoami
+    end
+    assert_includes error.message, "Invalid JSON response"
+  end
+
+  test "whoami raises Error on invalid response format" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 200, body: '{"invalid": "format"}')
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.whoami
+    end
+    assert_includes error.message, "Invalid whoami response format"
+  end
+
+  test "whoami raises Error on HTTP client errors" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_raise(HttpClient::TimeoutError.new("Connection timeout"))
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.whoami
+    end
+    assert_includes error.message, "Failed to validate token"
+    assert_includes error.message, "Connection timeout"
+  end
+
+  # managed_groups method tests
+  test "managed_groups returns groups data on success" do
+    response_body = [
+      {
+        "id" => "group1",
+        "username" => "testgroup",
+        "screenName" => "Test Group",
+        "isPrivate" => "0",
+        "isRestricted" => "1"
+      },
+      {
+        "id" => "group2",
+        "username" => "privategroup",
+        "screenName" => "Private Group",
+        "isPrivate" => "1",
+        "isRestricted" => "0"
+      }
+    ].to_json
+
+    stub_request(:get, "#{@host}/v4/managedGroups")
+      .with(
+        headers: {
+          "Authorization" => "Bearer #{@token}",
+          "Accept" => "application/json",
+          "User-Agent" => "FreeFeed-Rails-Client"
+        }
+      )
+      .to_return(status: 200, body: response_body)
+
+    result = @client.managed_groups
+
+    assert_equal 2, result.length
+
+    first_group = result[0]
+    assert_equal "group1", first_group[:id]
+    assert_equal "testgroup", first_group[:username]
+    assert_equal "Test Group", first_group[:screen_name]
+    assert_equal false, first_group[:is_private]
+    assert_equal true, first_group[:is_restricted]
+
+    second_group = result[1]
+    assert_equal "group2", second_group[:id]
+    assert_equal "privategroup", second_group[:username]
+    assert_equal "Private Group", second_group[:screen_name]
+    assert_equal true, second_group[:is_private]
+    assert_equal false, second_group[:is_restricted]
+  end
+
+  test "managed_groups raises UnauthorizedError on 401" do
+    stub_request(:get, "#{@host}/v4/managedGroups")
+      .to_return(status: 401, body: "Unauthorized")
+
+    assert_raises(FreefeedClient::UnauthorizedError) do
+      @client.managed_groups
+    end
+  end
+
+  test "managed_groups raises Error on invalid JSON" do
+    stub_request(:get, "#{@host}/v4/managedGroups")
+      .to_return(status: 200, body: "invalid json")
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.managed_groups
+    end
+    assert_includes error.message, "Invalid JSON response"
+  end
+
+  test "managed_groups raises Error on non-array response" do
+    stub_request(:get, "#{@host}/v4/managedGroups")
+      .to_return(status: 200, body: '{"invalid": "format"}')
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.managed_groups
+    end
+    assert_includes error.message, "Invalid managed groups response format"
+  end
+
+  test "managed_groups raises Error on HTTP client errors" do
+    stub_request(:get, "#{@host}/v4/managedGroups")
+      .to_raise(HttpClient::ConnectionError.new("Connection failed"))
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.managed_groups
+    end
+    assert_includes error.message, "Failed to fetch managed groups"
+    assert_includes error.message, "Connection failed"
+  end
+
+  # Edge cases
+  test "handles empty managed groups response" do
+    stub_request(:get, "#{@host}/v4/managedGroups")
+      .to_return(status: 200, body: "[]")
+
+    result = @client.managed_groups
+    assert_equal [], result
+  end
+
+  test "handles missing optional user fields in whoami" do
+    response_body = {
+      "users" => {
+        "id" => "user123",
+        "username" => "testuser"
+      }
+    }.to_json
+
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 200, body: response_body)
+
+    result = @client.whoami
+
+    assert_equal "user123", result[:id]
+    assert_equal "testuser", result[:username]
+    assert_nil result[:screen_name]
+    assert_nil result[:email]
+  end
+
+  test "handles missing optional group fields" do
+    response_body = [
+      {
+        "id" => "group1",
+        "username" => "testgroup"
+      }
+    ].to_json
+
+    stub_request(:get, "#{@host}/v4/managedGroups")
+      .to_return(status: 200, body: response_body)
+
+    result = @client.managed_groups
+
+    group = result[0]
+    assert_equal "group1", group[:id]
+    assert_equal "testgroup", group[:username]
+    assert_nil group[:screen_name]
+    assert_equal false, group[:is_private]  # Default when field is missing
+    assert_equal false, group[:is_restricted]  # Default when field is missing
+  end
+end


### PR DESCRIPTION
Changes:

- Add minimal `FreeFeedClient` for token validation and group management.
- Update `TokenValidationJob` to use new client instead of direct HTTP calls.
- Add comprehensive tests for `FreeFeedClient`.