### PR TITLE
Replace callbacks with service and rename controllers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,28 +45,6 @@ This repository contains the **Feeder** Rails 8 application for scheduling and r
 * **Never** stage unrelated edits together (formatting, renames, feature code in one commit).
 * If mid-flow you discover a second concern, **stop** and create a new TODO line; do not keep coding in the same commit.
 * Prefer many small PRs built from atomic commits; they’re easier to review, revert, and bisect.
-  
-## Development Practices
-- Check and fix RuboCop violations after each change to the code (use command: `bin/rubocop -f github`)
-- Use FactoryBot to create test data
-- Prefer lazy test data initialization over eager initialization in setup block
-
-```ruby
-# Bad:
-setup do
-  @user = create(:user)
-  @feed = create(:feed, user: @user)
-end
-
-# Good:
-def user
-  @user ||= create(:user)
-end
-
-def feed
-  @feed ||= create(:feed, user: user)
-end
-```
 
 ## Code style
 
@@ -85,17 +63,11 @@ Controllers:
 
 - Eliminate blank action methods.
 
-Testing:
-
-- Use factory_bot for test data.
-
 ## Development Guidelines
 
 - Ruby version is defined in `.ruby-version`.
 - Follow standard Rails conventions.
 - Use two-space indentation.
-- Keep tests and code together.
-- Add or update tests for any code change.
 
 ## PR description
 
@@ -113,7 +85,27 @@ When listing the changes, start from the most important. Generalize. Skip boring
 
 ## Testing
 
+- Keep tests and code together.
+- Add or update tests for any code change.
 - Verify database migrations work both ways (up/down).
-- Run these commands before committing:
-  - `bin/rubocop -f github` – ensures Ruby style follows the Omakase RuboCop rules.
-  - `bin/rails test` – runs the full test suite.
+- Run test before committing: `bin/rails test`.
+- Use FactoryBot to create test data.
+- Check and fix RuboCop violations after each change to the code (use command: `bin/rubocop -f github`).
+- Prefer lazy test data initialization over eager initialization in setup block
+
+```ruby
+# Bad:
+setup do
+  @user = create(:user)
+  @feed = create(:feed, user: @user)
+end
+
+# Good:
+def user
+  @user ||= create(:user)
+end
+
+def feed
+  @feed ||= create(:feed, user: user)
+end
+```

--- a/app/controllers/access_token_validations_controller.rb
+++ b/app/controllers/access_token_validations_controller.rb
@@ -1,4 +1,4 @@
-class StatusesController < ApplicationController
+class AccessTokenValidationsController < ApplicationController
   include ActionView::RecordIdentifier
 
   def create

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,5 +1,4 @@
 class AccessTokensController < ApplicationController
-
   def index
     @access_tokens = ordered_access_tokens
   end

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,5 +1,4 @@
 class AccessTokensController < ApplicationController
-  before_action :require_authentication
 
   def index
     @access_tokens = ordered_access_tokens

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,3 +1,2 @@
 class DashboardsController < ApplicationController
-  before_action :require_authentication
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,4 @@
 class EventsController < ApplicationController
-  before_action :require_authentication
 
   PER_PAGE = 25
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,4 @@
 class EventsController < ApplicationController
-
   PER_PAGE = 25
 
   def index

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,5 +1,4 @@
 class FeedsController < ApplicationController
-  before_action :require_authentication
 
   def index
     @feeds = user_feeds.order(:name)

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,5 +1,4 @@
 class FeedsController < ApplicationController
-
   def index
     @feeds = user_feeds.order(:name)
   end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,6 +1,5 @@
 class PasswordsController < ApplicationController
   allow_unauthenticated_access
-  before_action :set_user_by_token, only: %i[edit update]
 
   def create
     if user = User.find_by(email_address: params[:email_address])
@@ -10,7 +9,13 @@ class PasswordsController < ApplicationController
     redirect_to new_session_path, notice: "Password reset instructions sent (if user with that email address exists)."
   end
 
+  def edit
+    @user = find_user_by_token
+  end
+
   def update
+    @user = find_user_by_token
+
     if @user.update(params.permit(:password, :password_confirmation))
       redirect_to new_session_path, notice: "Password has been reset."
     else
@@ -19,9 +24,10 @@ class PasswordsController < ApplicationController
   end
 
   private
-    def set_user_by_token
-      @user = User.find_by_password_reset_token!(params[:token])
-    rescue ActiveSupport::MessageVerifier::InvalidSignature
-      redirect_to new_password_path, alert: "Password reset link is invalid or has expired."
-    end
+
+  def find_user_by_token
+    User.find_by_password_reset_token!(params[:token])
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    redirect_to new_password_path, alert: "Password reset link is invalid or has expired."
+  end
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,5 +1,6 @@
 class PasswordsController < ApplicationController
   allow_unauthenticated_access
+  before_action :find_user_by_token, only: [:edit, :update]
 
   def create
     if user = User.find_by(email_address: params[:email_address])
@@ -9,13 +10,7 @@ class PasswordsController < ApplicationController
     redirect_to new_session_path, notice: "Password reset instructions sent (if user with that email address exists)."
   end
 
-  def edit
-    @user = find_user_by_token
-  end
-
   def update
-    @user = find_user_by_token
-
     if @user.update(params.permit(:password, :password_confirmation))
       redirect_to new_session_path, notice: "Password has been reset."
     else
@@ -26,7 +21,7 @@ class PasswordsController < ApplicationController
   private
 
   def find_user_by_token
-    User.find_by_password_reset_token!(params[:token])
+    @user = User.find_by_password_reset_token!(params[:token])
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     redirect_to new_password_path, alert: "Password reset link is invalid or has expired."
   end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,8 +1,6 @@
 class StatusesController < ApplicationController
   include ActionView::RecordIdentifier
 
-  before_action :require_authentication
-
   def create
     @access_token = access_tokens.find(params[:access_token_id])
     @access_token.validate_token_async

--- a/app/javascript/controllers/polling_controller.js
+++ b/app/javascript/controllers/polling_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
         return;
       }
       
-      fetch(`/access_tokens/${this.accessTokenIdValue}/status`, {
+      fetch(`/access_tokens/${this.accessTokenIdValue}/validation`, {
         headers: { 
           "Accept": "text/vnd.turbo-stream.html",
           "X-Requested-With": "XMLHttpRequest"

--- a/app/jobs/token_validation_job.rb
+++ b/app/jobs/token_validation_job.rb
@@ -2,21 +2,6 @@ class TokenValidationJob < ApplicationJob
   queue_as :default
 
   def perform(access_token)
-    return unless access_token.token_value.present?
-
-    begin
-      user_info = freefeed_client(access_token).whoami
-      access_token.update!(status: :active, owner: user_info[:username])
-    rescue FreefeedClient::UnauthorizedError
-      access_token.inactive!
-    rescue => e
-      access_token.inactive!
-    end
-  end
-
-  private
-
-  def freefeed_client(access_token)
-    FreefeedClient.new(host: access_token.host, token: access_token.token_value)
+    AccessTokenValidationService.new(access_token).call
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -12,7 +12,6 @@ class AccessToken < ApplicationRecord
   enum :status, { pending: 0, validating: 1, active: 2, inactive: 3 }
 
   before_destroy :disable_associated_feeds
-  after_update :disable_feeds_on_inactivation, if: :saved_change_to_status?
 
   encrypts :encrypted_token
 
@@ -61,11 +60,5 @@ class AccessToken < ApplicationRecord
 
   def disable_associated_feeds
     feeds.update_all(state: :disabled, access_token_id: nil)
-  end
-
-  def disable_feeds_on_inactivation
-    return unless inactive? && status_previously_changed?(to: "inactive")
-
-    feeds.enabled.update_all(state: :disabled)
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -34,8 +34,6 @@ class AccessToken < ApplicationRecord
   end
 
   def validate_token_async
-    return unless valid?
-
     update!(status: :validating)
     TokenValidationJob.perform_later(self)
   end

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -9,7 +9,12 @@ class AccessTokenValidationService
     ActiveRecord::Base.transaction do
       begin
         user_info = freefeed_client.whoami
-        access_token.update!(status: :active, owner: user_info[:username])
+
+        access_token.update!(
+          status: :active,
+          owner: user_info[:username],
+          last_used_at: Time.current
+        )
       rescue
         disable_token_and_feeds
       end

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -1,0 +1,34 @@
+class AccessTokenValidationService
+  def initialize(access_token)
+    @access_token = access_token
+  end
+
+  def call
+    return unless @access_token.token_value.present?
+
+    ActiveRecord::Base.transaction do
+      begin
+        user_info = freefeed_client.whoami
+        @access_token.update!(status: :active, owner: user_info[:username])
+      rescue FreefeedClient::UnauthorizedError
+        update_token_and_disable_feeds(:inactive)
+      rescue => e
+        update_token_and_disable_feeds(:inactive)
+      end
+    end
+  end
+
+  private
+
+  def freefeed_client
+    FreefeedClient.new(host: @access_token.host, token: @access_token.token_value)
+  end
+
+  def update_token_and_disable_feeds(status)
+    @access_token.update!(status: status)
+
+    if status == :inactive
+      @access_token.feeds.enabled.update_all(state: :disabled)
+    end
+  end
+end

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -11,7 +11,7 @@ class AccessTokenValidationService
         user_info = freefeed_client.whoami
         access_token.update!(status: :active, owner: user_info[:username])
       rescue
-        update_token_and_disable_feeds
+        disable_token_and_feeds
       end
     end
   end
@@ -25,7 +25,7 @@ class AccessTokenValidationService
     )
   end
 
-  def update_token_and_disable_feeds
+  def disable_token_and_feeds
     access_token.update!(status: :inactive)
     access_token.feeds.enabled.update_all(state: :disabled)
   end

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -46,7 +46,7 @@
               <% end %>
             </td>
             <td class="text-end">
-              <%= link_to "Validate", access_token_status_path(access_token),
+              <%= link_to "Validate", access_token_validation_path(access_token),
                           class: "text-primary text-decoration-none me-3",
                           data: { turbo_method: :post } %>
               <%= link_to "Delete", access_token_path(access_token),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   mount MissionControl::Jobs::Engine, at: "/jobs"
 
   resources :access_tokens, only: [:index, :new, :create, :destroy] do
-    resource :validation, only: [:show, :create], controller: 'access_token_validations'
+    resource :validation, only: [:show, :create], controller: "access_token_validations"
   end
 
   resource :profile, only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   mount MissionControl::Jobs::Engine, at: "/jobs"
 
   resources :access_tokens, only: [:index, :new, :create, :destroy] do
-    resource :status, only: [:show, :create]
+    resource :validation, only: [:show, :create], controller: 'access_token_validations'
   end
 
   resource :profile, only: :show

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -7,6 +7,8 @@ class FreefeedClient
   class UnauthorizedError < Error; end
   class NotFoundError < Error; end
 
+  USER_AGENT = "FreeFeed-Rails-Client".freeze
+
   DEFAULT_OPTIONS = {
     timeout: 30,
     follow_redirects: true,
@@ -43,12 +45,6 @@ class FreefeedClient
 
   def get(path, options: {})
     url = "#{@host}#{path}"
-    headers = {
-      "Authorization" => "Bearer #{@token}",
-      "Accept" => "application/json",
-      "User-Agent" => "FreeFeed-Rails-Client"
-    }
-
     response = @http_client.get(url, headers: headers, options: options)
 
     case response.status
@@ -99,5 +95,13 @@ class FreefeedClient
     end
   rescue JSON::ParserError => e
     raise Error, "Invalid JSON response: #{e.message}"
+  end
+
+  def headers
+    {
+      "Authorization" => "Bearer #{@token}",
+      "Accept" => "application/json",
+      "User-Agent" => USER_AGENT
+    }
   end
 end

--- a/test/controllers/access_token_validations_controller_test.rb
+++ b/test/controllers/access_token_validations_controller_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class StatusesControllerTest < ActionDispatch::IntegrationTest
+class AccessTokenValidationsControllerTest < ActionDispatch::IntegrationTest
   def user
     @user ||= create(:user)
   end
@@ -10,7 +10,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "requires authentication" do
-    post access_token_status_path(access_token)
+    post access_token_validation_path(access_token)
     assert_redirected_to new_session_path
   end
 
@@ -18,7 +18,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as user
 
     assert_enqueued_with(job: TokenValidationJob, args: [access_token]) do
-      post access_token_status_path(access_token),
+      post access_token_validation_path(access_token),
            headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
@@ -28,7 +28,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
   test "responds with turbo stream" do
     sign_in_as user
 
-    post access_token_status_path(access_token),
+    post access_token_validation_path(access_token),
          headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
@@ -42,14 +42,14 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as user
 
-    post access_token_status_path(other_token)
+    post access_token_validation_path(other_token)
     assert_response :not_found
   end
 
   test "show responds with turbo stream" do
     sign_in_as user
 
-    get access_token_status_path(access_token),
+    get access_token_validation_path(access_token),
         headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
@@ -61,7 +61,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as user
 
     # Test pending state
-    get access_token_status_path(access_token),
+    get access_token_validation_path(access_token),
         headers: { "Accept" => "text/vnd.turbo-stream.html" }
     assert_response :success
     assert_includes response.body, "data-status=\"pending\""
@@ -69,7 +69,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     # Test validating state
     access_token.update!(status: :validating)
-    get access_token_status_path(access_token),
+    get access_token_validation_path(access_token),
         headers: { "Accept" => "text/vnd.turbo-stream.html" }
     assert_response :success
     assert_includes response.body, "data-status=\"validating\""
@@ -77,7 +77,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     # Test active state
     access_token.update!(status: :active, owner: "testuser")
-    get access_token_status_path(access_token),
+    get access_token_validation_path(access_token),
         headers: { "Accept" => "text/vnd.turbo-stream.html" }
     assert_response :success
     assert_includes response.body, "✅ Active"
@@ -85,7 +85,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     # Test inactive state
     access_token.update!(status: :inactive)
-    get access_token_status_path(access_token),
+    get access_token_validation_path(access_token),
         headers: { "Accept" => "text/vnd.turbo-stream.html" }
     assert_response :success
     assert_includes response.body, "Inactive"
@@ -97,7 +97,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as user
 
-    get access_token_status_path(other_token),
+    get access_token_validation_path(other_token),
         headers: { "Accept" => "text/vnd.turbo-stream.html" }
     assert_response :not_found
   end

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -45,17 +45,6 @@ class TokenValidationJobTest < ActiveJob::TestCase
     assert access_token.inactive?
   end
 
-  test "does nothing when token is not present" do
-    # Create token without token value, bypassing validation
-    token_without_value = AccessToken.new(name: "Test Token", user: user, status: :pending)
-    token_without_value.save!(validate: false)
-
-    TokenValidationJob.perform_now(token_without_value)
-
-    # Should remain pending since validation was skipped
-    assert token_without_value.reload.pending?
-  end
-
   test "marks token as inactive when JSON parsing fails" do
     # Mock response with invalid JSON
     stub_request(:get, "https://freefeed.test/v4/users/whoami")

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -134,17 +134,6 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert token.reload.validating?
   end
 
-  test "#validate_token_async does nothing when token is invalid" do
-    token = build(:access_token, name: nil) # Invalid token
-    assert_not token.valid?
-
-    assert_no_enqueued_jobs do
-      token.validate_token_async
-    end
-
-    assert token.pending?
-  end
-
   # Host validation tests
   test "validates presence of host" do
     token = build(:access_token, host: nil)

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -223,13 +223,14 @@ class AccessTokenTest < ActiveSupport::TestCase
     ActiveSupport::Notifications.unsubscribe("sql.active_record")
   end
 
-  test "should disable enabled feeds when token becomes inactive" do
+  test "should disable enabled feeds when token validation service marks token inactive" do
     access_token = create(:access_token, status: :active)
     enabled_feed = create(:feed, access_token: access_token, state: :enabled)
     another_disabled_feed = create(:feed, access_token: access_token, state: :disabled)
     disabled_feed = create(:feed, access_token: access_token, state: :disabled)
 
-    access_token.update!(status: :inactive)
+    service = AccessTokenValidationService.new(access_token)
+    service.send(:update_token_and_disable_feeds, :inactive)
 
     enabled_feed.reload
     another_disabled_feed.reload


### PR DESCRIPTION
Changes:

- Replace `after_update` callback with `AccessTokenValidationService` for transactional token validation.
- Rename `StatusesController` to `AccessTokenValidationsController` for clearer naming.
- Update routes from `/status` to `/validation` with proper controller mapping.