### PR TITLE
Update navigation bar and profile page

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,9 +2,6 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h1>Events</h1>
-  <div class="text-muted">
-    <%= pluralize(@total_count, 'event') %> total
-  </div>
 </div>
 
 <% if @events.any? %>
@@ -100,7 +97,6 @@
 
       <div class="text-center text-muted">
         Showing <%= @events.size %> of <%= @total_count %> events
-        (Page <%= @current_page %> of <%= @total_pages %>)
       </div>
     </nav>
   <% end %>

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -13,7 +13,6 @@
               <th>Name</th>
               <th>Status</th>
               <th>Target Group</th>
-              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -37,16 +36,6 @@
                     <%= feed.target_group %>
                   <% else %>
                     <em class="text-muted">None</em>
-                  <% end %>
-                </td>
-                <td>
-                  <% if feed.feed_profile.present? %>
-                    <%= button_to "Preview", feed_previews_path,
-                        params: { url: feed.url, feed_profile_name: feed.feed_profile.name },
-                        method: :post,
-                        class: "btn btn-sm btn-outline-secondary",
-                        title: "Generate feed preview",
-                        data: { turbo: false } %>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,9 +60,6 @@
                   <i class="bi bi-gear"></i>
                 <% end %>
               </li>
-              <li class="nav-item">
-                <%= link_to "Sign Out", session_path, data: { turbo_method: :delete }, class: "nav-link" %>
-              </li>
             </ul>
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,7 +56,6 @@
                 </a>
                 <ul class="dropdown-menu dropdown-menu-end">
                   <li><%= link_to "Settings", profile_path, class: "dropdown-item" %></li>
-                  <li><%= link_to "Tokens", access_tokens_path, class: "dropdown-item" %></li>
                   <% if policy(Event).index? %>
                     <li><hr class="dropdown-divider"></li>
                     <li><%= link_to "Events", events_path, class: "dropdown-item" %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
             <ul class="navbar-nav">
               <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                  <%= Current.user.email_address %>
+                  <i class="bi bi-gear"></i>
                 </a>
                 <ul class="dropdown-menu dropdown-menu-end">
                   <li><%= link_to "Settings", profile_path, class: "dropdown-item" %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,11 @@
               <li class="nav-item">
                 <%= link_to "Feeds", feeds_path, class: "nav-link #{'active' if current_page?(feeds_path) || controller_name == 'feeds'}" %>
               </li>
+              <% if policy(Event).index? %>
+                <li class="nav-item">
+                  <%= link_to "Events", events_path, class: "nav-link #{'active' if current_page?(events_path) || controller_name == 'events'}" %>
+                </li>
+              <% end %>
             </ul>
 
             <%# Dropdown menu %>
@@ -56,10 +61,6 @@
                 </a>
                 <ul class="dropdown-menu dropdown-menu-end">
                   <li><%= link_to "Settings", profile_path, class: "dropdown-item" %></li>
-                  <% if policy(Event).index? %>
-                    <li><hr class="dropdown-divider"></li>
-                    <li><%= link_to "Events", events_path, class: "dropdown-item" %></li>
-                  <% end %>
                   <li><hr class="dropdown-divider"></li>
                   <li>
                     <%= link_to "Sign Out", session_path, data: { turbo_method: :delete }, class: "dropdown-item" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,17 +55,13 @@
 
             <%# Dropdown menu %>
             <ul class="navbar-nav">
-              <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <li class="nav-item">
+                <%= link_to profile_path, class: "nav-link" do %>
                   <i class="bi bi-gear"></i>
-                </a>
-                <ul class="dropdown-menu dropdown-menu-end">
-                  <li><%= link_to "Settings", profile_path, class: "dropdown-item" %></li>
-                  <li><hr class="dropdown-divider"></li>
-                  <li>
-                    <%= link_to "Sign Out", session_path, data: { turbo_method: :delete }, class: "dropdown-item" %>
-                  </li>
-                </ul>
+                <% end %>
+              </li>
+              <li class="nav-item">
+                <%= link_to "Sign Out", session_path, data: { turbo_method: :delete }, class: "nav-link" %>
               </li>
             </ul>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,7 @@
                   <%= Current.user.email_address %>
                 </a>
                 <ul class="dropdown-menu dropdown-menu-end">
-                  <li><%= link_to "Profile", profile_path, class: "dropdown-item" %></li>
+                  <li><%= link_to "Settings", profile_path, class: "dropdown-item" %></li>
                   <li><%= link_to "Tokens", access_tokens_path, class: "dropdown-item" %></li>
                   <% if policy(Event).index? %>
                     <li><hr class="dropdown-divider"></li>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title, "Profile" %>
+<% content_for :title, "Settings" %>
 
-<h1>Profile</h1>
+<h1>Settings</h1>
 
 <div class="row">
   <div class="col-6">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h1>Settings</h1>
-  <%= link_to "Sign Out", session_path, data: { turbo_method: :delete }, class: "btn btn-outline-danger" %>
+  <%= link_to "Sign Out", session_path, data: { turbo_method: :delete }, class: "btn btn-outline-secondary" %>
 </div>
 
 <div class="row">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,6 +1,9 @@
 <% content_for :title, "Settings" %>
 
-<h1>Settings</h1>
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1>Settings</h1>
+  <%= link_to "Sign Out", session_path, data: { turbo_method: :delete }, class: "btn btn-outline-danger" %>
+</div>
 
 <div class="row">
   <div class="col-6">


### PR DESCRIPTION
Changes:

- Rename Profile page to Settings.
- Replaces email dropdown with gear icon link to Settings.
- Move Events moved to main navbar (admin access).
- Move Sign Out to the Settings page.