### PR TITLE
Settings page layout improvements and password tracking

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,5 +1,6 @@
 class SettingsController < ApplicationController
   def show
     @user = Current.user
+    @access_tokens = Current.user.access_tokens
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
   before_create :set_password_updated_at
+  before_update :update_password_timestamp, if: :will_save_change_to_password_digest?
 
   generates_token_for :password_reset, expires_in: 15.minutes do
     password_salt&.last(10)
@@ -27,6 +28,10 @@ class User < ApplicationRecord
   private
 
   def set_password_updated_at
+    self.password_updated_at = Time.current
+  end
+
+  def update_password_timestamp
     self.password_updated_at = Time.current
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   validates :email_address, presence: true, uniqueness: true
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
+  before_create :set_password_updated_at
+
   generates_token_for :password_reset, expires_in: 15.minutes do
     password_salt&.last(10)
   end
@@ -20,5 +22,11 @@ class User < ApplicationRecord
 
   def permission?(permission_name)
     permissions.exists?(name: permission_name)
+  end
+
+  private
+
+  def set_password_updated_at
+    self.password_updated_at = Time.current
   end
 end

--- a/app/views/settings/access_tokens/index.html.erb
+++ b/app/views/settings/access_tokens/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="mb-0">Access Tokens</h1>
   <div class="d-flex align-items-center">
     <%= link_to "Create New Token", new_settings_access_token_path, class: "btn btn-primary me-3" %>
-    <%= link_to "← Back to Settings", settings_path, class: "btn btn-outline-secondary" %>
+    <%= link_to "Back to Settings", settings_path, class: "btn btn-outline-secondary" %>
   </div>
 </div>
 

--- a/app/views/settings/access_tokens/index.html.erb
+++ b/app/views/settings/access_tokens/index.html.erb
@@ -1,6 +1,9 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h1>Access Tokens</h1>
-  <%= link_to "Create New Token", new_settings_access_token_path, class: "btn btn-primary" %>
+  <h1 class="mb-0">Access Tokens</h1>
+  <div class="d-flex align-items-center">
+    <%= link_to "Create New Token", new_settings_access_token_path, class: "btn btn-primary me-3" %>
+    <%= link_to "← Back to Settings", settings_path, class: "btn btn-outline-secondary" %>
+  </div>
 </div>
 
 <% if @access_tokens.inactive.exists? %>

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -7,26 +7,19 @@
 
 <div class="row">
   <div class="col-6">
-    <div class="card">
-      <div class="card-header">
-        <h4 class="card-title mb-0">Update Email</h4>
+    <%= form_with model: @user, url: settings_email_update_path, method: :patch, local: true do |form| %>
+      <div class="mb-3">
+        <p>Current email: <strong class="mx-2"><%= @user.email_address %></strong></p>
       </div>
-      <div class="card-body">
-        <%= form_with model: @user, url: settings_email_update_path, method: :patch, local: true do |form| %>
-          <div class="mb-3">
-            <p>Current email: <strong class="mx-2"><%= @user.email_address %></strong></p>
-          </div>
 
-          <div class="mb-3">
-            <%= form.label :email_address, "New email:", class: "form-label" %>
-            <%= form.email_field :email_address, value: "", class: "form-control", placeholder: "Enter new email address" %>
-          </div>
-
-          <div>
-            <%= form.submit "Update Email", class: "btn btn-primary" %>
-          </div>
-        <% end %>
+      <div class="mb-3">
+        <%= form.label :email_address, "New email:", class: "form-label" %>
+        <%= form.email_field :email_address, value: "", class: "form-control", placeholder: "Enter new email address" %>
       </div>
-    </div>
+
+      <div class="mt-4">
+        <%= form.submit "Update Email", class: "btn btn-primary" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -18,7 +18,8 @@
       </div>
 
       <div class="mt-4">
-        <%= form.submit "Update Email", class: "btn btn-primary" %>
+        <%= form.submit "Update Email", class: "btn btn-primary me-2" %>
+        <%= link_to "Cancel", settings_path, class: "btn btn-outline-secondary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/settings/password_updates/edit.html.erb
+++ b/app/views/settings/password_updates/edit.html.erb
@@ -24,7 +24,8 @@
       </div>
 
       <div class="mt-4">
-        <%= form.submit "Change Password", class: "btn btn-primary" %>
+        <%= form.submit "Change Password", class: "btn btn-primary me-2" %>
+        <%= link_to "Cancel", settings_path, class: "btn btn-outline-secondary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/settings/password_updates/edit.html.erb
+++ b/app/views/settings/password_updates/edit.html.erb
@@ -7,32 +7,25 @@
 
 <div class="row">
   <div class="col-6">
-    <div class="card">
-      <div class="card-header">
-        <h4 class="card-title mb-0">Update Password</h4>
+    <%= form_with model: @user, url: settings_password_update_path, method: :patch, local: true do |form| %>
+      <div class="mb-3">
+        <%= form.label :current_password, "Current password:", class: "form-label" %>
+        <%= form.password_field :current_password, class: "form-control", required: true %>
       </div>
-      <div class="card-body">
-        <%= form_with model: @user, url: settings_password_update_path, method: :patch, local: true do |form| %>
-          <div class="mb-3">
-            <%= form.label :current_password, "Current password:", class: "form-label" %>
-            <%= form.password_field :current_password, class: "form-control", required: true %>
-          </div>
 
-          <div class="mb-3">
-            <%= form.label :password, "New password:", class: "form-label" %>
-            <%= form.password_field :password, class: "form-control", required: true %>
-          </div>
-
-          <div class="mb-3">
-            <%= form.label :password_confirmation, "Confirm new password:", class: "form-label" %>
-            <%= form.password_field :password_confirmation, class: "form-control", required: true %>
-          </div>
-
-          <div>
-            <%= form.submit "Change Password", class: "btn btn-primary" %>
-          </div>
-        <% end %>
+      <div class="mb-3">
+        <%= form.label :password, "New password:", class: "form-label" %>
+        <%= form.password_field :password, class: "form-control", required: true %>
       </div>
-    </div>
+
+      <div class="mb-3">
+        <%= form.label :password_confirmation, "Confirm new password:", class: "form-label" %>
+        <%= form.password_field :password_confirmation, class: "form-control", required: true %>
+      </div>
+
+      <div class="mt-4">
+        <%= form.submit "Change Password", class: "btn btn-primary" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -8,18 +8,14 @@
 <div class="row">
   <div class="col-12">
     <div class="list-group">
-      <div class="list-group-item d-flex justify-content-between align-items-center">
-        <div>
-          <strong>Email:</strong> <%= @user.email_address %>
-        </div>
-        <%= link_to "Change...", edit_settings_email_update_path, class: "btn btn-sm btn-outline-primary" %>
+      <div class="list-group-item">
+        <strong>Email:</strong> <%= @user.email_address %>
+        <%= link_to "Change", edit_settings_email_update_path, class: "text-decoration-none ms-2" %>
       </div>
 
-      <div class="list-group-item d-flex justify-content-between align-items-center">
-        <div>
-          <strong>Password:</strong> last updated <%= time_ago_in_words(@user.password_updated_at || @user.created_at) %> ago
-        </div>
-        <%= link_to "Change...", edit_settings_password_update_path, class: "btn btn-sm btn-outline-primary" %>
+      <div class="list-group-item">
+        <strong>Password:</strong> last updated <%= time_ago_in_words(@user.password_updated_at || @user.created_at) %> ago
+        <%= link_to "Change", edit_settings_password_update_path, class: "text-decoration-none ms-2" %>
       </div>
 
       <% if @user.permissions.any? %>
@@ -35,16 +31,15 @@
         </div>
       <% end %>
 
-      <div class="list-group-item d-flex justify-content-between align-items-center">
-        <div>
-          <strong>Tokens:</strong>
-          <% if @access_tokens.any? %>
-            <%= pluralize(@access_tokens.active.count, 'active') %><% if @access_tokens.inactive.any? %>, <%= pluralize(@access_tokens.inactive.count, 'inactive') %><% end %>
-          <% else %>
-            none configured
-          <% end %>
-        </div>
-        <%= link_to (@access_tokens.any? ? "Manage..." : "Add a token..."), (@access_tokens.any? ? settings_access_tokens_path : new_settings_access_token_path), class: "btn btn-sm btn-outline-primary" %>
+      <div class="list-group-item">
+        <strong>Tokens:</strong>
+        <% if @access_tokens.any? %>
+          <%= pluralize(@access_tokens.active.count, 'active') %><% if @access_tokens.inactive.any? %>, <%= pluralize(@access_tokens.inactive.count, 'inactive') %><% end %>
+          <%= link_to "Manage", settings_access_tokens_path, class: "text-decoration-none ms-2" %>
+        <% else %>
+          none configured
+          <%= link_to "Add a token", new_settings_access_token_path, class: "text-decoration-none ms-2" %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -20,14 +20,8 @@
 
       <% if @user.permissions.any? %>
         <div class="list-group-item">
-          <div class="mb-2">
-            <strong>Permissions:</strong>
-          </div>
-          <ul class="mb-0">
-            <% @user.permissions.each do |permission| %>
-              <li><%= permission.name.humanize %></li>
-            <% end %>
-          </ul>
+          <strong>Permissions:</strong>
+          <%= @user.permissions.map { |permission| permission.name.humanize }.join(", ") %>
         </div>
       <% end %>
 

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -6,48 +6,45 @@
 </div>
 
 <div class="row">
-  <div class="col-6">
-    <div class="card mb-4">
-      <div class="card-header">
-        <h4 class="card-title mb-0">Email Address</h4>
-      </div>
-      <div class="card-body">
-        <p>Current email: <strong><%= @user.email_address %></strong></p>
-        <%= link_to "Change Email Address", edit_settings_email_update_path, class: "btn btn-primary" %>
-      </div>
-    </div>
-    <% if @user.permissions.any? %>
-      <div class="card mb-4">
-        <div class="card-header">
-          <h4 class="card-title mb-0">Permissions</h4>
+  <div class="col-12">
+    <div class="list-group">
+      <div class="list-group-item d-flex justify-content-between align-items-center">
+        <div>
+          <strong>Email:</strong> <%= @user.email_address %>
         </div>
-        <div class="card-body">
-          <ul class="col-sm-8 mb-0">
+        <%= link_to "Change...", edit_settings_email_update_path, class: "btn btn-sm btn-outline-primary" %>
+      </div>
+
+      <div class="list-group-item d-flex justify-content-between align-items-center">
+        <div>
+          <strong>Password:</strong> last updated <%= time_ago_in_words(@user.password_updated_at || @user.created_at) %> ago
+        </div>
+        <%= link_to "Change...", edit_settings_password_update_path, class: "btn btn-sm btn-outline-primary" %>
+      </div>
+
+      <% if @user.permissions.any? %>
+        <div class="list-group-item">
+          <div class="mb-2">
+            <strong>Permissions:</strong>
+          </div>
+          <ul class="mb-0">
             <% @user.permissions.each do |permission| %>
               <li><%= permission.name.humanize %></li>
             <% end %>
           </ul>
         </div>
-      </div>
-    <% end %>
-  </div>
-  <div class="col-6">
-    <div class="card mb-4">
-      <div class="card-header">
-        <h4 class="card-title mb-0">Password</h4>
-      </div>
-      <div class="card-body">
-        <p>Secure your account with a strong password.</p>
-        <%= link_to "Change Password", edit_settings_password_update_path, class: "btn btn-primary" %>
-      </div>
-    </div>
-    <div class="card mb-4">
-      <div class="card-header">
-        <h4 class="card-title mb-0">Access Tokens</h4>
-      </div>
-      <div class="card-body">
-        <p>Manage API access tokens for external integrations.</p>
-        <%= link_to "Manage Access Tokens", settings_access_tokens_path, class: "btn btn-primary" %>
+      <% end %>
+
+      <div class="list-group-item d-flex justify-content-between align-items-center">
+        <div>
+          <strong>Tokens:</strong>
+          <% if @access_tokens.any? %>
+            <%= pluralize(@access_tokens.active.count, 'active') %><% if @access_tokens.inactive.any? %>, <%= pluralize(@access_tokens.inactive.count, 'inactive') %><% end %>
+          <% else %>
+            none configured
+          <% end %>
+        </div>
+        <%= link_to (@access_tokens.any? ? "Manage..." : "Add a token..."), (@access_tokens.any? ? settings_access_tokens_path : new_settings_access_token_path), class: "btn btn-sm btn-outline-primary" %>
       </div>
     </div>
   </div>

--- a/db/migrate/20250925081920_add_password_updated_at_to_users.rb
+++ b/db/migrate/20250925081920_add_password_updated_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordUpdatedAtToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :password_updated_at, :timestamp
+  end
+end

--- a/db/migrate/20250925082833_change_password_updated_at_null_constraint.rb
+++ b/db/migrate/20250925082833_change_password_updated_at_null_constraint.rb
@@ -1,0 +1,5 @@
+class ChangePasswordUpdatedAtNullConstraint < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :users, :password_updated_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_09_23_114505) do
+ActiveRecord::Schema[8.1].define(version: 2025_09_25_081920) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -273,6 +273,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_09_23_114505) do
     t.datetime "created_at", null: false
     t.string "email_address", null: false
     t.string "password_digest", null: false
+    t.datetime "password_updated_at", precision: nil
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_09_25_081920) do
+ActiveRecord::Schema[8.1].define(version: 2025_09_25_082833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -273,7 +273,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_09_25_081920) do
     t.datetime "created_at", null: false
     t.string "email_address", null: false
     t.string "password_digest", null: false
-    t.datetime "password_updated_at", precision: nil
+    t.datetime "password_updated_at", precision: nil, null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,9 @@ if Rails.env.development?
     user.password = "password"
     user.password_confirmation = "password"
   end
+
+  # Update existing users to have password_updated_at
+  User.where(password_updated_at: nil).update_all(password_updated_at: Time.current)
   puts "✅ Development user created: test@example.com / password"
 
   # Add admin permission to the first user

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,9 @@
 one:
   email_address: one@example.com
   password_digest: <%= password_digest %>
+  password_updated_at: <%= 1.week.ago %>
 
 two:
   email_address: two@example.com
   password_digest: <%= password_digest %>
+  password_updated_at: <%= 2.days.ago %>


### PR DESCRIPTION
Changes:

- Add `password_updated_at` column to track password changes with automatic timestamping.
- Redesign Settings page with clean list-based layout showing all account information at a glance.
- Display password last updated timestamp with fallback to account creation date.
- Show access token counts.
- Update seed script to populate `password_updated_at`.
- Add database constraint to make `password_updated_at` non-nullable.