### PR TITLE
Add events filtering by type and subject type

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -7,7 +7,7 @@ class Admin::EventsController < ApplicationController
     page = (params[:page] || 1).to_i
     offset = (page - 1) * PER_PAGE
 
-    @filter_query = optional_filter_query
+    @filter = optional_filter
     @events = paginated_events(offset)
     @total_count = events_count
     @current_page = page
@@ -49,10 +49,10 @@ class Admin::EventsController < ApplicationController
   end
 
   def apply_filters(scope)
-    optional_filter_query.blank? ? scope : scope.where(**optional_filter_query)
+    optional_filter.blank? ? scope : scope.where(**optional_filter)
   end
 
-  def optional_filter_query
-    @optional_filter_query ||= params.fetch(:filter_query, {}).permit(:type, :subject_type, :level)
+  def optional_filter
+    @optional_filter ||= params.fetch(:filter, {}).permit(:type, :subject_type, :level)
   end
 end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -7,7 +7,7 @@ class Admin::EventsController < ApplicationController
     page = (params[:page] || 1).to_i
     offset = (page - 1) * PER_PAGE
 
-    @filter_query = filter_query
+    @filter_query = optional_filter_query
     @events = paginated_events(offset)
     @total_count = events_count
     @current_page = page
@@ -49,19 +49,10 @@ class Admin::EventsController < ApplicationController
   end
 
   def apply_filters(scope)
-    filter_query.blank? ? scope : scope.where(**filter_query)
+    optional_filter_query.blank? ? scope : scope.where(**optional_filter_query)
   end
 
-  def filter_query
-    @filter_query ||= begin
-      query = params[:filter_query]
-      return {} unless query.present?
-
-      begin
-        JSON.parse(query).slice("type", "subject_type", "level")
-      rescue JSON::ParserError
-        {}
-      end
-    end
+  def optional_filter_query
+    @optional_filter_query ||= params.fetch(:filter_query, {}).permit(:type, :subject_type, :level)
   end
 end

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -23,7 +23,7 @@
         <% @events.each do |event| %>
           <tr>
             <td>
-              <%= link_to admin_events_path(filter_query: { type: event.type }.to_json),
+              <%= link_to admin_events_path(filter_query: { type: event.type }),
                           class: "text-decoration-none",
                           title: "Filter by type: #{event.type}" do %>
                 <code><%= event.type %></code>
@@ -42,7 +42,7 @@
             </td>
             <td>
               <% if event.subject %>
-                <%= link_to admin_events_path(filter_query: { subject_type: event.subject_type }.to_json),
+                <%= link_to admin_events_path(filter_query: { subject_type: event.subject_type }),
                             class: "text-decoration-none text-muted",
                             title: "Filter by subject type: #{event.subject_type}" do %>
                   <%= event.subject_type %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -68,7 +68,7 @@
       <ul class="pagination justify-content-center">
         <% if @current_page > 1 %>
           <li class="page-item">
-            <%= link_to "Previous", admin_events_path(page: @current_page - 1, filter_query: params[:filter_query]), class: "page-link" %>
+            <%= link_to "Previous", admin_events_path(page: @current_page - 1, filter_query: @filter_query), class: "page-link" %>
           </li>
         <% else %>
           <li class="page-item disabled">
@@ -87,14 +87,14 @@
             </li>
           <% else %>
             <li class="page-item">
-              <%= link_to page, admin_events_path(page: page, filter_query: params[:filter_query]), class: "page-link" %>
+              <%= link_to page, admin_events_path(page: page, filter_query: @filter_query), class: "page-link" %>
             </li>
           <% end %>
         <% end %>
 
         <% if @current_page < @total_pages %>
           <li class="page-item">
-            <%= link_to "Next", admin_events_path(page: @current_page + 1, filter_query: params[:filter_query]), class: "page-link" %>
+            <%= link_to "Next", admin_events_path(page: @current_page + 1, filter_query: @filter_query), class: "page-link" %>
           </li>
         <% else %>
           <li class="page-item disabled">

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Events" %>
 
 <%= page_header "Events" do %>
-  <% if @filter_query.present? %>
+  <% if @filter.present? %>
     <%= link_to "Reset Filter", admin_events_path, class: "btn btn-outline-secondary btn-sm" %>
   <% end %>
 <% end %>
@@ -23,7 +23,7 @@
         <% @events.each do |event| %>
           <tr>
             <td>
-              <%= link_to admin_events_path(filter_query: { type: event.type }),
+              <%= link_to admin_events_path(filter: { type: event.type }),
                           class: "text-decoration-none",
                           title: "Filter by type: #{event.type}" do %>
                 <code><%= event.type %></code>
@@ -42,7 +42,7 @@
             </td>
             <td>
               <% if event.subject %>
-                <%= link_to admin_events_path(filter_query: { subject_type: event.subject_type }),
+                <%= link_to admin_events_path(filter: { subject_type: event.subject_type }),
                             class: "text-decoration-none text-muted",
                             title: "Filter by subject type: #{event.subject_type}" do %>
                   <%= event.subject_type %>
@@ -68,7 +68,7 @@
       <ul class="pagination justify-content-center">
         <% if @current_page > 1 %>
           <li class="page-item">
-            <%= link_to "Previous", admin_events_path(page: @current_page - 1, filter_query: @filter_query), class: "page-link" %>
+            <%= link_to "Previous", admin_events_path(page: @current_page - 1, filter: @filter), class: "page-link" %>
           </li>
         <% else %>
           <li class="page-item disabled">
@@ -87,14 +87,14 @@
             </li>
           <% else %>
             <li class="page-item">
-              <%= link_to page, admin_events_path(page: page, filter_query: @filter_query), class: "page-link" %>
+              <%= link_to page, admin_events_path(page: page, filter: @filter), class: "page-link" %>
             </li>
           <% end %>
         <% end %>
 
         <% if @current_page < @total_pages %>
           <li class="page-item">
-            <%= link_to "Next", admin_events_path(page: @current_page + 1, filter_query: @filter_query), class: "page-link" %>
+            <%= link_to "Next", admin_events_path(page: @current_page + 1, filter: @filter), class: "page-link" %>
           </li>
         <% else %>
           <li class="page-item disabled">

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,6 +1,10 @@
 <% content_for :title, "Events" %>
 
-<%= page_header "Events" %>
+<%= page_header "Events" do %>
+  <% if @filter_query.present? %>
+    <%= link_to "Reset Filter", admin_events_path, class: "btn btn-outline-secondary btn-sm" %>
+  <% end %>
+<% end %>
 
 <% if @events.any? %>
   <div class="table-responsive">
@@ -19,7 +23,9 @@
         <% @events.each do |event| %>
           <tr>
             <td>
-              <%= link_to admin_event_path(event), class: "text-decoration-none" do %>
+              <%= link_to admin_events_path(filter_query: { type: event.type }.to_json),
+                          class: "text-decoration-none",
+                          title: "Filter by type: #{event.type}" do %>
                 <code><%= event.type %></code>
               <% end %>
             </td>
@@ -36,7 +42,11 @@
             </td>
             <td>
               <% if event.subject %>
-                <span class="text-muted"><%= event.subject_type %></span>
+                <%= link_to admin_events_path(filter_query: { subject_type: event.subject_type }.to_json),
+                            class: "text-decoration-none text-muted",
+                            title: "Filter by subject type: #{event.subject_type}" do %>
+                  <%= event.subject_type %>
+                <% end %>
                 <span class="text-primary">#<%= event.subject_id %></span>
               <% else %>
                 <em class="text-muted">None</em>
@@ -58,7 +68,7 @@
       <ul class="pagination justify-content-center">
         <% if @current_page > 1 %>
           <li class="page-item">
-            <%= link_to "Previous", admin_events_path(page: @current_page - 1), class: "page-link" %>
+            <%= link_to "Previous", admin_events_path(page: @current_page - 1, filter_query: params[:filter_query]), class: "page-link" %>
           </li>
         <% else %>
           <li class="page-item disabled">
@@ -77,14 +87,14 @@
             </li>
           <% else %>
             <li class="page-item">
-              <%= link_to page, admin_events_path(page: page), class: "page-link" %>
+              <%= link_to page, admin_events_path(page: page, filter_query: params[:filter_query]), class: "page-link" %>
             </li>
           <% end %>
         <% end %>
 
         <% if @current_page < @total_pages %>
           <li class="page-item">
-            <%= link_to "Next", admin_events_path(page: @current_page + 1), class: "page-link" %>
+            <%= link_to "Next", admin_events_path(page: @current_page + 1, filter_query: params[:filter_query]), class: "page-link" %>
           </li>
         <% else %>
           <li class="page-item disabled">

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -84,7 +84,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     event2 = create(:event, type: "TypeB", message: "Event B")
     event3 = create(:event, type: "TypeA", message: "Another A")
 
-    get admin_events_path, params: { filter_query: { type: "TypeA" }.to_json }
+    get admin_events_path, params: { filter_query: { type: "TypeA" } }
 
     assert_response :success
     assert_select "tbody tr", count: 2 # Should show 2 TypeA events
@@ -101,7 +101,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     event2 = create(:event, type: "Event2", subject: feed)
     event3 = create(:event, type: "Event3", subject: test_user)
 
-    get admin_events_path, params: { filter_query: { subject_type: "User" }.to_json }
+    get admin_events_path, params: { filter_query: { subject_type: "User" } }
 
     assert_response :success
     assert_select "tbody tr", count: 2 # Should show 2 User events
@@ -113,7 +113,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     login_as(admin_user)
     create(:event, type: "TestEvent")
 
-    get admin_events_path, params: { filter_query: { type: "TestEvent" }.to_json }
+    get admin_events_path, params: { filter_query: { type: "TestEvent" } }
 
     assert_response :success
     assert_select "a", text: "Reset Filter"
@@ -133,7 +133,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     login_as(admin_user)
     create(:event, type: "TestEvent")
 
-    get admin_events_path, params: { filter_query: "invalid json" }
+    get admin_events_path, params: { filter_query: { invalid_field: "value" } }
 
     assert_response :success
     assert_select "tbody tr", count: 1 # Should show all events
@@ -147,7 +147,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
       create(:event, type: "FilteredType", message: "Event #{i}")
     end
 
-    get admin_events_path, params: { filter_query: { type: "FilteredType" }.to_json }
+    get admin_events_path, params: { filter_query: { type: "FilteredType" } }
 
     assert_response :success
     assert_select ".pagination a[href*='filter_query']", minimum: 1

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -84,7 +84,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     event2 = create(:event, type: "TypeB", message: "Event B")
     event3 = create(:event, type: "TypeA", message: "Another A")
 
-    get admin_events_path, params: { filter_query: { type: "TypeA" } }
+    get admin_events_path, params: { filter: { type: "TypeA" } }
 
     assert_response :success
     assert_select "tbody tr", count: 2 # Should show 2 TypeA events
@@ -101,7 +101,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     event2 = create(:event, type: "Event2", subject: feed)
     event3 = create(:event, type: "Event3", subject: test_user)
 
-    get admin_events_path, params: { filter_query: { subject_type: "User" } }
+    get admin_events_path, params: { filter: { subject_type: "User" } }
 
     assert_response :success
     assert_select "tbody tr", count: 2 # Should show 2 User events
@@ -113,7 +113,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     login_as(admin_user)
     create(:event, type: "TestEvent")
 
-    get admin_events_path, params: { filter_query: { type: "TestEvent" } }
+    get admin_events_path, params: { filter: { type: "TestEvent" } }
 
     assert_response :success
     assert_select "a", text: "Reset Filter"
@@ -129,11 +129,11 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Reset Filter", count: 0
   end
 
-  test "should handle invalid filter_query parameter gracefully" do
+  test "should handle invalid filter parameter gracefully" do
     login_as(admin_user)
     create(:event, type: "TestEvent")
 
-    get admin_events_path, params: { filter_query: { invalid_field: "value" } }
+    get admin_events_path, params: { filter: { invalid_field: "value" } }
 
     assert_response :success
     assert_select "tbody tr", count: 1 # Should show all events
@@ -147,10 +147,10 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
       create(:event, type: "FilteredType", message: "Event #{i}")
     end
 
-    get admin_events_path, params: { filter_query: { type: "FilteredType" } }
+    get admin_events_path, params: { filter: { type: "FilteredType" } }
 
     assert_response :success
-    assert_select ".pagination a[href*='filter_query']", minimum: 1
+    assert_select ".pagination a[href*='filter']", minimum: 1
   end
 
   private


### PR DESCRIPTION
## Summary
- Add clickable filtering for event type and subject type in admin events table
- Display "Reset Filter" button when filters are active
- Preserve filter parameters during pagination
- Include comprehensive test coverage for all filtering scenarios