### PR TITLE
Integrate posts publication

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,11 +25,6 @@ class User < ApplicationRecord
     permissions.exists?(name: permission_name)
   end
 
-  # TBD: Use policies
-  def admin?
-    permission?("admin")
-  end
-
   private
 
   def set_password_updated_at

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -105,20 +105,8 @@ class FeedRefreshWorkflow
     current_time = Time.current
 
     posts_data = posts_to_persist.map do |post|
-      {
-        feed_id: post.feed_id,
-        feed_entry_id: post.feed_entry_id,
-        uid: post.uid,
-        content: post.content,
-        source_url: post.source_url,
-        published_at: post.published_at,
-        attachment_urls: post.attachment_urls || [],
-        comments: post.comments || [],
-        validation_errors: post.validation_errors || [],
-        status: post.status,
-        created_at: current_time,
-        updated_at: current_time
-      }
+      post.slice(:feed_id, :feed_entry_id, :uid, :content, :source_url, :published_at, :attachment_urls, :comments, :validation_errors, :status)
+          .merge(created_at: current_time, updated_at: current_time)
     end
 
     Post.insert_all(posts_data) if posts_data.any?

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -100,18 +100,17 @@ class FeedRefreshWorkflow
   end
 
   def persist_posts(posts)
-    posts_to_persist = posts.select { |post| post.enqueued? || post.rejected? }
-    return posts if posts_to_persist.empty?
+    return posts if posts.empty?
     current_time = Time.current
 
-    posts_data = posts_to_persist.map do |post|
+    posts_data = posts.map do |post|
       post.slice(:feed_id, :feed_entry_id, :uid, :content, :source_url, :published_at, :attachment_urls, :comments, :validation_errors, :status)
           .merge(created_at: current_time, updated_at: current_time)
     end
 
     Post.insert_all(posts_data) if posts_data.any?
 
-    new_uids = posts_to_persist.map(&:uid)
+    new_uids = posts.map(&:uid)
     persisted_posts = feed.posts.where(uid: new_uids).order(:published_at)
 
     record_stats(

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -123,7 +123,6 @@ class FeedRefreshWorkflow
 
     Post.insert_all(posts_data) if posts_data.any?
 
-    # Return persisted post records to maintain order
     new_uids = posts_to_persist.map(&:uid)
     persisted_posts = feed.posts.where(uid: new_uids).order(:published_at)
 

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -8,6 +8,7 @@ class FeedRefreshWorkflow
   step :persist_entries
   step :normalize_entries
   step :persist_posts
+  step :publish_posts
   step :finalize_workflow
 
   attr_reader :feed, :stats
@@ -99,11 +100,11 @@ class FeedRefreshWorkflow
   end
 
   def persist_posts(posts)
-    enqueued_posts = posts.select(&:enqueued?)
-    return posts if enqueued_posts.empty?
+    posts_to_persist = posts.select { |post| post.enqueued? || post.rejected? }
+    return posts if posts_to_persist.empty?
     current_time = Time.current
 
-    posts_data = enqueued_posts.map do |post|
+    posts_data = posts_to_persist.map do |post|
       {
         feed_id: post.feed_id,
         feed_entry_id: post.feed_entry_id,
@@ -114,29 +115,70 @@ class FeedRefreshWorkflow
         attachment_urls: post.attachment_urls || [],
         comments: post.comments || [],
         validation_errors: post.validation_errors || [],
-        status: :published,
+        status: post.status,
         created_at: current_time,
         updated_at: current_time
       }
     end
 
     Post.insert_all(posts_data) if posts_data.any?
-    posts
+
+    # Return persisted post records to maintain order
+    new_uids = posts_to_persist.map(&:uid)
+    persisted_posts = feed.posts.where(uid: new_uids).order(:published_at)
+
+    record_stats(
+      new_posts: persisted_posts.where(status: :enqueued).count,
+      rejected_posts: persisted_posts.where(status: :rejected).count
+    )
+
+    persisted_posts
+  end
+
+  def publish_posts(persisted_posts)
+    enqueued_posts = persisted_posts.select(&:enqueued?).sort_by(&:published_at)
+    return persisted_posts if enqueued_posts.empty?
+
+    published_count = 0
+    failed_count = 0
+
+    enqueued_posts.each do |post|
+      begin
+        publisher = FreefeedPublisher.new(post)
+        freefeed_post_id = publisher.publish
+        post.update!(status: :published, freefeed_post_id: freefeed_post_id)
+        published_count += 1
+      rescue => e
+        post.update!(status: :failed)
+        failed_count += 1
+        Rails.logger.error "Failed to publish post #{post.id}: #{e.message}"
+      end
+    end
+
+    record_stats(
+      published_posts: published_count,
+      failed_posts: failed_count
+    )
+
+    persisted_posts
   end
 
   def finalize_workflow(posts)
-    enqueued_posts_count = posts.count(&:enqueued?)
+    published_posts_count = posts.count(&:published?)
+    failed_posts_count = posts.count(&:failed?)
     rejected_posts_count = posts.count(&:rejected?)
 
     record_stats(
-      new_posts: enqueued_posts_count,
-      rejected_posts: rejected_posts_count,
       completed_at: Time.current,
       total_duration: total_duration
     )
 
     FeedRefreshEvent.create_stats(feed: feed, stats: stats)
-    Rails.logger.info "Feed refresh completed for feed #{feed.id}, processed #{posts.count} posts"
+
+    Rails.logger.info "Feed refresh completed for feed #{feed.id}: " \
+                      "#{published_posts_count} published, " \
+                      "#{failed_posts_count} failed, " \
+                      "#{rejected_posts_count} rejected"
 
     posts
   end

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -1,7 +1,6 @@
-# FreeFeed Publisher
-#
 # Publishes posts to FreeFeed using the Post record data.
 # Handles attachment uploads, post creation, and comment creation.
+#
 class FreefeedPublisher
   class Error < StandardError; end
   class ValidationError < Error; end

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -37,6 +37,7 @@ class FreefeedPublisher
     raise ValidationError, "Post is required" unless post
     raise ValidationError, "Post feed is required" unless post.feed
     raise ValidationError, "Post feed access token is required" unless post.feed.access_token
+    raise ValidationError, "Post feed access token is inactive" unless post.feed.access_token.active?
     raise ValidationError, "Post feed target group is required" unless post.feed.target_group
     raise ValidationError, "Post content is required" unless post.content.present?
   end

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -136,6 +136,14 @@ class FreefeedClient
     handle_response(response)
   end
 
+  def auth_headers
+    {
+      "Authorization" => "Bearer #{@token}",
+      "Accept" => "application/json",
+      "User-Agent" => USER_AGENT
+    }
+  end
+
   def handle_response(response)
     case response.status
     when 200, 201
@@ -190,14 +198,6 @@ class FreefeedClient
     end
   rescue JSON::ParserError => e
     raise Error, "Invalid JSON response: #{e.message}"
-  end
-
-  def auth_headers
-    {
-      "Authorization" => "Bearer #{@token}",
-      "Accept" => "application/json",
-      "User-Agent" => USER_AGENT
-    }
   end
 
   def parse_attachment_response(body)

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -149,6 +149,11 @@ class FreefeedClient
     end
   end
 
+  # TBD: Consider simplifying response processing. Probably keep the keys
+  #   as is, just coerce some of the values when it makes sense. Also consider
+  #   unifying draft implementation of the response processing methods
+  #   since they are basically identical.
+
   def parse_whoami_response(body)
     data = JSON.parse(body)
     user = data.dig("users")

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -25,6 +25,11 @@ module HttpClient
   class TimeoutError < Error; end
   class TooManyRedirectsError < Error; end
 
+  # TBD: Parameterize the client adapter, so instead of
+  #   HttpClient::FaradayAdapter.new the consumer will call something like
+  #   HttpClient.build. There should be no direct reference to the
+  #   implementation, since it's irrelevant.
+
   class Base
     def get(url, headers: {}, options: {})
       raise NotImplementedError, "Subclasses must implement #get"

--- a/scripts/refresh_job_example.rb
+++ b/scripts/refresh_job_example.rb
@@ -1,6 +1,7 @@
 puts 'Testing FeedRefreshJob with staging data...'
 
 token_value = ENV['FREEFEED_STAGING_TOKEN']
+
 unless token_value
   puts 'Error: FREEFEED_STAGING_TOKEN environment variable is required'
   exit 1
@@ -78,6 +79,7 @@ begin
   end
 
   latest_event = feed.feed_refresh_events.order(:created_at).last
+
   if latest_event
     puts 'Workflow stats:'
     stats = latest_event.stats || {}
@@ -90,7 +92,6 @@ begin
     puts "  Failed posts: #{stats['failed_posts']}" if stats['failed_posts']
     puts "  Rejected posts: #{stats['rejected_posts']}" if stats['rejected_posts']
   end
-
 rescue => e
   puts 'Error: ' + e.message
   puts 'Class: ' + e.class.name

--- a/scripts/refresh_job_example.rb
+++ b/scripts/refresh_job_example.rb
@@ -1,0 +1,99 @@
+puts 'Testing FeedRefreshJob with staging data...'
+
+token_value = ENV['FREEFEED_STAGING_TOKEN']
+unless token_value
+  puts 'Error: FREEFEED_STAGING_TOKEN environment variable is required'
+  exit 1
+end
+
+user = User.first || FactoryBot.create(:user)
+
+access_token = AccessToken.build_with_token(
+  user: user,
+  name: 'Feed Refresh Test Token ' + Time.now.to_i.to_s,
+  token: token_value,
+  host: 'https://candy.freefeed.net',
+  status: :active
+)
+
+access_token.save!
+feed_profile = FeedProfile.first || FactoryBot.create(:feed_profile)
+
+feed = Feed.create!(
+  user: user,
+  access_token: access_token,
+  feed_profile: feed_profile,
+  name: 'Refresh Test Feed ' + Time.now.to_i.to_s,
+  url: 'https://xkcd.com/rss.xml',
+  target_group: 'xkcdtest',
+  state: :enabled,
+  cron_expression: '0 */6 * * *'
+)
+
+puts 'Created test feed:'
+puts '  User: ' + user.email_address
+puts '  Feed: ' + feed.name
+puts '  URL: ' + feed.url
+puts '  Target Group: ' + feed.target_group
+puts '  State: ' + feed.state
+
+begin
+  puts 'Starting feed refresh job...'
+
+  start_time = Time.current
+  FeedRefreshJob.perform_now(feed.id)
+  duration = Time.current - start_time
+
+  feed.reload
+  posts = feed.posts.order(:published_at)
+
+  puts 'SUCCESS! Feed refresh completed:'
+  puts '  Duration: ' + duration.round(2).to_s + ' seconds'
+  puts '  Total Posts: ' + posts.count.to_s
+  puts '  Published Posts: ' + posts.published.count.to_s
+  puts '  Failed Posts: ' + posts.failed.count.to_s
+  puts '  Rejected Posts: ' + posts.rejected.count.to_s
+
+  if posts.published.any?
+    puts 'Sample published posts:'
+    posts.published.limit(3).each_with_index do |post, i|
+      puts "  #{i + 1}. #{post.content[0..80]}#{'...' if post.content.length > 80}"
+      puts "     FreeFeed ID: #{post.freefeed_post_id}"
+      puts "     URL: #{access_token.host}/posts/#{post.freefeed_post_id}"
+    end
+  end
+
+  if posts.failed.any?
+    puts 'Failed posts:'
+    posts.failed.each do |post|
+      puts "  - #{post.content[0..50]}#{'...' if post.content.length > 50}"
+    end
+  end
+
+  if posts.rejected.any?
+    puts 'Rejected posts:'
+    posts.rejected.each do |post|
+      puts "  - #{post.content[0..50]}#{'...' if post.content.length > 50} (#{post.validation_errors.join(', ')})"
+    end
+  end
+
+  latest_event = feed.feed_refresh_events.order(:created_at).last
+  if latest_event
+    puts 'Workflow stats:'
+    stats = latest_event.stats || {}
+    puts "  Total duration: #{stats['total_duration']&.round(2)} seconds" if stats['total_duration']
+    puts "  Content size: #{stats['content_size']} bytes" if stats['content_size']
+    puts "  Total entries: #{stats['total_entries']}" if stats['total_entries']
+    puts "  New entries: #{stats['new_entries']}" if stats['new_entries']
+    puts "  New posts: #{stats['new_posts']}" if stats['new_posts']
+    puts "  Published posts: #{stats['published_posts']}" if stats['published_posts']
+    puts "  Failed posts: #{stats['failed_posts']}" if stats['failed_posts']
+    puts "  Rejected posts: #{stats['rejected_posts']}" if stats['rejected_posts']
+  end
+
+rescue => e
+  puts 'Error: ' + e.message
+  puts 'Class: ' + e.class.name
+  puts 'Backtrace:'
+  puts e.backtrace[0..5].join("\n")
+end

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -24,6 +24,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       :persist_entries,
       :normalize_entries,
       :persist_posts,
+      :publish_posts,
       :finalize_workflow
     ]
 

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -82,6 +82,17 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     assert_equal "Post content is required", error.message
   end
 
+  test "raises validation error for inactive access token" do
+    inactive_token = create(:access_token, user: user, status: :inactive)
+    feed_with_inactive_token = create(:feed, user: user, access_token: inactive_token, feed_profile: feed_profile, target_group: "testgroup")
+    post = create(:post, feed: feed_with_inactive_token, feed_entry: feed_entry, content: "Test content")
+
+    error = assert_raises(FreefeedPublisher::ValidationError) do
+      FreefeedPublisher.new(post)
+    end
+    assert_equal "Post feed access token is inactive", error.message
+  end
+
   test "publish creates post without attachments or comments" do
     post = post_with_content("Test post content")
 

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -90,6 +90,7 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     error = assert_raises(FreefeedPublisher::ValidationError) do
       FreefeedPublisher.new(post)
     end
+
     assert_equal "Post feed access token is inactive", error.message
   end
 


### PR DESCRIPTION
Changes:

- Integrated post publishing into the Feed Refresh Workflow as the final step.
- Updated post normalization to save posts with enqueued/rejected status instead of published.
- Handled publication state transitions - successful posts become published, failed posts become failed.