### PR TITLE
Publishing integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,5 @@ gem "mini_mime", "~> 1.1"
 gem "pundit", "~> 2.5"
 
 gem "with_advisory_lock", "~> 7.0.1"
+
+gem "amazing_print", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       railties
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    amazing_print (1.8.1)
     ast (2.4.3)
     backport (1.2.0)
     base64 (0.3.0)
@@ -462,6 +463,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  amazing_print (~> 1.8)
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,13 +1,10 @@
 class AccessToken < ApplicationRecord
-  MAX_TOKENS_PER_USER = 20
-
   belongs_to :user
   has_many :feeds
 
   validates :name, presence: true, uniqueness: { scope: :user_id }
   validates :token, presence: true, on: :create
   validates :host, presence: true, format: { with: /\Ahttps?:\/\/[^\s]+\z/, message: "must be a valid HTTP(S) URL" }
-  validate :user_tokens_limit
 
   enum :status, { pending: 0, validating: 1, active: 2, inactive: 3 }
 
@@ -48,13 +45,6 @@ class AccessToken < ApplicationRecord
   end
 
   private
-
-  def user_tokens_limit
-    return unless user&.persisted?
-    return unless user.access_tokens.where.not(id: id).count >= MAX_TOKENS_PER_USER
-
-    errors.add(:user, "cannot have more than #{MAX_TOKENS_PER_USER} access tokens")
-  end
 
   def disable_associated_feeds
     feeds.update_all(state: :disabled, access_token_id: nil)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -8,6 +8,7 @@ class Feed < ApplicationRecord
   belongs_to :access_token, optional: true
   belongs_to :feed_profile, optional: true
   has_one :feed_schedule, dependent: :destroy
+  has_many :events, as: :subject, dependent: :destroy
 
   delegate :loader, :processor, :normalizer, :loader_class, :processor_class, :normalizer_class, to: :feed_profile, allow_nil: true
   has_many :feed_entries, dependent: :destroy

--- a/app/services/normalizer.rb
+++ b/app/services/normalizer.rb
@@ -1,3 +1,3 @@
 module Normalizer
-  AVAILABLE_OPTIONS = %w[rss].freeze
+  AVAILABLE_OPTIONS = %w[rss xkcd].freeze
 end

--- a/app/services/normalizer/rss_normalizer.rb
+++ b/app/services/normalizer/rss_normalizer.rb
@@ -18,13 +18,33 @@ module Normalizer
     def validate_post(post)
       errors = []
 
-      errors << "blank_content" if post.content.blank?
-      errors << "invalid_source_url" if post.source_url.blank? || !valid_url?(post.source_url)
-      errors << "future_date" if post.published_at > Time.current
-      errors << "content_too_long" if post.content.length > Post::MAX_CONTENT_LENGTH
-      errors << "comment_too_long" if post.comments.any? { |c| c.length > Post::MAX_COMMENT_LENGTH }
+      errors << "blank_content" if content_blank?(post)
+      errors << "invalid_source_url" if source_url_invalid?(post)
+      errors << "future_date" if published_in_future?(post)
+      errors << "content_too_long" if content_too_long?(post)
+      errors << "comment_too_long" if comment_too_long?(post)
 
       errors
+    end
+
+    def content_blank?(post)
+      post.content.blank?
+    end
+
+    def source_url_invalid?(post)
+      post.source_url.blank? || !valid_url?(post.source_url)
+    end
+
+    def published_in_future?(post)
+      post.published_at > Time.current
+    end
+
+    def content_too_long?(post)
+      post.content.length > Post::MAX_CONTENT_LENGTH
+    end
+
+    def comment_too_long?(post)
+      post.comments.any? { |c| c.length > Post::MAX_COMMENT_LENGTH }
     end
 
     def extract_source_url(raw_data)

--- a/app/services/normalizer/xkcd_normalizer.rb
+++ b/app/services/normalizer/xkcd_normalizer.rb
@@ -27,5 +27,19 @@ module Normalizer
         super(raw_data)
       end
     end
+
+    # Override to extract image URLs from summary field for XKCD comics
+    # @param raw_data [Hash] RSS feed item data
+    # @return [Array<String>] array of image URLs
+    def extract_attachment_urls(raw_data)
+      enclosures = raw_data.dig("enclosures") || []
+      image_urls = enclosures.filter_map { |e| e["url"] if e["type"]&.start_with?("image/") }
+
+      # Extract images from summary field (where XKCD stores comic images)
+      summary_images = extract_images_from_content(raw_data.dig("summary") || "")
+      content_images = extract_images_from_content(raw_data.dig("content") || "")
+
+      (image_urls + summary_images + content_images).uniq
+    end
   end
 end

--- a/app/services/normalizer/xkcd_normalizer.rb
+++ b/app/services/normalizer/xkcd_normalizer.rb
@@ -1,41 +1,26 @@
 module Normalizer
-  # XKCD-specific normalizer for RSS feeds
-  # Extracts content from image title attributes which contain comic descriptions
   class XkcdNormalizer < RssNormalizer
     private
 
-    # Override to extract content from image title attributes for XKCD comics
-    # @param raw_data [Hash] RSS feed item data
-    # @return [String] extracted content
     def extract_content(raw_data)
-      # Try to get content from summary/content fields first
       html_content = raw_data.dig("summary") || raw_data.dig("content") || raw_data.dig("description") || ""
 
       return "" if html_content.blank?
 
-      # Parse HTML to extract image title attributes
       doc = Nokogiri::HTML::DocumentFragment.parse(html_content)
-
-      # Look for img tags with title attributes (XKCD comic descriptions)
       img_titles = doc.css("img").map { |img| img["title"] }.compact.reject(&:blank?)
 
       if img_titles.any?
-        # Use the first image title as content (XKCD comics typically have one main image)
         img_titles.first.strip
       else
-        # Fallback to regular text extraction if no image titles found
         super(raw_data)
       end
     end
 
-    # Override to extract image URLs from summary field for XKCD comics
-    # @param raw_data [Hash] RSS feed item data
-    # @return [Array<String>] array of image URLs
     def extract_attachment_urls(raw_data)
       enclosures = raw_data.dig("enclosures") || []
       image_urls = enclosures.filter_map { |e| e["url"] if e["type"]&.start_with?("image/") }
 
-      # Extract images from summary field (where XKCD stores comic images)
       summary_images = extract_images_from_content(raw_data.dig("summary") || "")
       content_images = extract_images_from_content(raw_data.dig("content") || "")
 

--- a/app/services/normalizer/xkcd_normalizer.rb
+++ b/app/services/normalizer/xkcd_normalizer.rb
@@ -26,5 +26,19 @@ module Normalizer
 
       (image_urls + summary_images + content_images).uniq
     end
+
+    def validate_post(post)
+      errors = super(post)
+      errors << "no_content_or_images" if missing_content_and_images?(post)
+      errors
+    end
+
+    def content_blank?(post)
+      false
+    end
+
+    def missing_content_and_images?(post)
+      post.content.blank? && post.attachment_urls.empty?
+    end
   end
 end

--- a/app/services/normalizer/xkcd_normalizer.rb
+++ b/app/services/normalizer/xkcd_normalizer.rb
@@ -1,0 +1,31 @@
+module Normalizer
+  # XKCD-specific normalizer for RSS feeds
+  # Extracts content from image title attributes which contain comic descriptions
+  class XkcdNormalizer < RssNormalizer
+    private
+
+    # Override to extract content from image title attributes for XKCD comics
+    # @param raw_data [Hash] RSS feed item data
+    # @return [String] extracted content
+    def extract_content(raw_data)
+      # Try to get content from summary/content fields first
+      html_content = raw_data.dig("summary") || raw_data.dig("content") || raw_data.dig("description") || ""
+
+      return "" if html_content.blank?
+
+      # Parse HTML to extract image title attributes
+      doc = Nokogiri::HTML::DocumentFragment.parse(html_content)
+
+      # Look for img tags with title attributes (XKCD comic descriptions)
+      img_titles = doc.css("img").map { |img| img["title"] }.compact.reject(&:blank?)
+
+      if img_titles.any?
+        # Use the first image title as content (XKCD comics typically have one main image)
+        img_titles.first.strip
+      else
+        # Fallback to regular text extraction if no image titles found
+        super(raw_data)
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
   
   normalizers:
     rss: "RSS"
+    xkcd: "XKCD"
 
   feed_profiles:
     rss: "RSS Feed Profile"

--- a/script/refresh_job_example.rb
+++ b/script/refresh_job_example.rb
@@ -7,39 +7,59 @@ unless token_value
   exit 1
 end
 
+# Find or create user
 user = User.first || FactoryBot.create(:user)
 
-access_token = AccessToken.build_with_token(
+# Find or create access token
+access_token = AccessToken.find_by(name: 'test_refresh_token') || AccessToken.build_with_token(
   user: user,
-  name: 'Feed Refresh Test Token ' + Time.now.to_i.to_s,
+  name: 'test_refresh_token',
   token: token_value,
   host: 'https://candy.freefeed.net',
   status: :active
 )
 
-access_token.save!
-feed_profile = FeedProfile.first || FactoryBot.create(:feed_profile)
+unless access_token.persisted?
+  access_token.save!
+end
 
-feed = Feed.create!(
+# Find or create XKCD feed profile
+feed_profile = FeedProfile.find_by(name: 'test_xkcd') || FeedProfile.create!(
+  user: user,
+  name: 'test_xkcd',
+  loader: 'http',
+  processor: 'rss',
+  normalizer: 'xkcd'
+)
+
+# Clean up any existing test feeds
+Feed.where(target_group: 'xkcdtest').destroy_all
+
+# Find or create test feed
+feed = Feed.find_by(name: 'test_refresh_feed') || Feed.create!(
   user: user,
   access_token: access_token,
   feed_profile: feed_profile,
-  name: 'Refresh Test Feed ' + Time.now.to_i.to_s,
+  name: 'test_refresh_feed',
   url: 'https://xkcd.com/rss.xml',
   target_group: 'xkcdtest',
   state: :enabled,
   cron_expression: '0 */6 * * *'
 )
 
-puts 'Created test feed:'
+puts
+puts '---> Using test feed:'
 puts '  User: ' + user.email_address
 puts '  Feed: ' + feed.name
 puts '  URL: ' + feed.url
 puts '  Target Group: ' + feed.target_group
 puts '  State: ' + feed.state
+puts '  Feed Profile: ' + feed_profile.name
+puts '  Access Token: ' + access_token.name
 
 begin
-  puts 'Starting feed refresh job...'
+  puts
+  puts '---> Starting feed refresh job...'
 
   start_time = Time.current
   FeedRefreshJob.perform_now(feed.id)
@@ -48,7 +68,8 @@ begin
   feed.reload
   posts = feed.posts.order(:published_at)
 
-  puts 'SUCCESS! Feed refresh completed:'
+  puts
+  puts '---> SUCCESS! Feed refresh completed:'
   puts '  Duration: ' + duration.round(2).to_s + ' seconds'
   puts '  Total Posts: ' + posts.count.to_s
   puts '  Published Posts: ' + posts.published.count.to_s
@@ -56,45 +77,69 @@ begin
   puts '  Rejected Posts: ' + posts.rejected.count.to_s
 
   if posts.published.any?
-    puts 'Sample published posts:'
-    posts.published.limit(3).each_with_index do |post, i|
+    puts
+    puts '---> Published posts:'
+
+    posts.published.each_with_index do |post, i|
       puts "  #{i + 1}. #{post.content[0..80]}#{'...' if post.content.length > 80}"
-      puts "     FreeFeed ID: #{post.freefeed_post_id}"
       puts "     URL: #{access_token.host}/posts/#{post.freefeed_post_id}"
+      puts
     end
   end
 
   if posts.failed.any?
-    puts 'Failed posts:'
+    puts
+    puts '---> Failed posts:'
     posts.failed.each do |post|
       puts "  - #{post.content[0..50]}#{'...' if post.content.length > 50}"
     end
   end
 
   if posts.rejected.any?
-    puts 'Rejected posts:'
+    puts
+    puts '---> Rejected posts:'
     posts.rejected.each do |post|
       puts "  - #{post.content[0..50]}#{'...' if post.content.length > 50} (#{post.validation_errors.join(', ')})"
     end
   end
 
-  latest_event = feed.feed_refresh_events.order(:created_at).last
+  latest_event = feed.events.where(type: ["feed_refresh_stats", "feed_refresh_error"]).order(:created_at).last
 
   if latest_event
-    puts 'Workflow stats:'
-    stats = latest_event.stats || {}
-    puts "  Total duration: #{stats['total_duration']&.round(2)} seconds" if stats['total_duration']
-    puts "  Content size: #{stats['content_size']} bytes" if stats['content_size']
-    puts "  Total entries: #{stats['total_entries']}" if stats['total_entries']
-    puts "  New entries: #{stats['new_entries']}" if stats['new_entries']
-    puts "  New posts: #{stats['new_posts']}" if stats['new_posts']
-    puts "  Published posts: #{stats['published_posts']}" if stats['published_posts']
-    puts "  Failed posts: #{stats['failed_posts']}" if stats['failed_posts']
-    puts "  Rejected posts: #{stats['rejected_posts']}" if stats['rejected_posts']
+    puts
+    puts '---> Workflow stats:'
+    ap latest_event.metadata.fetch('stats')
   end
 rescue => e
+  puts
   puts 'Error: ' + e.message
   puts 'Class: ' + e.class.name
   puts 'Backtrace:'
   puts e.backtrace[0..5].join("\n")
+ensure
+  # Clean up test records
+  puts
+  puts '---> Cleaning up test records...'
+
+  # Delete test feed and its associated records
+  if defined?(feed) && feed&.persisted?
+    feed.destroy!
+    puts '  ✓ Deleted test feed'
+  end
+
+  # Delete test access token
+  test_token = AccessToken.find_by(name: 'test_refresh_token')
+  if test_token
+    test_token.destroy!
+    puts '  ✓ Deleted test access token'
+  end
+
+  # Delete test feed profile
+  test_profile = FeedProfile.find_by(name: 'test_xkcd')
+  if test_profile
+    test_profile.destroy!
+    puts '  ✓ Deleted test feed profile'
+  end
+
+  puts 'Cleanup complete!'
 end

--- a/test/helpers/component_options_helper_test.rb
+++ b/test/helpers/component_options_helper_test.rb
@@ -16,7 +16,7 @@ class ComponentOptionsHelperTest < ActionView::TestCase
   end
 
   test "normalizer_options returns normalizer options" do
-    expected = [["RSS", "rss"]]
+    expected = [["RSS", "rss"], ["XKCD", "xkcd"]]
     result = normalizer_options
 
     assert_equal expected, result

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -97,15 +97,6 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert_equal token_value, token.token
   end
 
-  test "validates user tokens limit" do
-    user = create(:user)
-    AccessToken::MAX_TOKENS_PER_USER.times { create(:access_token, user: user) }
-    new_token = build(:access_token, user: user)
-
-    assert_not new_token.valid?
-    assert_includes new_token.errors[:user], "cannot have more than #{AccessToken::MAX_TOKENS_PER_USER} access tokens"
-  end
-
   test "can update status to active with owner" do
     token = create(:access_token)
     assert token.pending?

--- a/test/services/normalizer/rss_normalizer_test.rb
+++ b/test/services/normalizer/rss_normalizer_test.rb
@@ -77,6 +77,7 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
       { "type" => "image/png", "url" => "https://example.com/image2.png" },
       { "type" => "audio/mp3", "url" => "https://example.com/audio.mp3" }
     ]
+
     feed_entry = feed_entry_with_raw_data("enclosures" => enclosures)
 
     normalizer = Normalizer::RssNormalizer.new(feed_entry)
@@ -138,6 +139,7 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
       "link" => "",
       "url" => ""
     )
+
     feed_entry.update(published_at: 1.hour.from_now)
 
     normalizer = Normalizer::RssNormalizer.new(feed_entry)

--- a/test/services/normalizer/xkcd_normalizer_test.rb
+++ b/test/services/normalizer/xkcd_normalizer_test.rb
@@ -1,0 +1,179 @@
+require "test_helper"
+
+class Normalizer::XkcdNormalizerTest < ActiveSupport::TestCase
+  def feed_entry_with_xkcd_data(raw_data = {})
+    default_data = {
+      "id" => "https://xkcd.com/3149/",
+      "url" => "https://xkcd.com/3149/",
+      "title" => "Measure Twice, Cut Once",
+      "summary" => '<img src="https://imgs.xkcd.com/comics/measure_twice_cut_once.png" title="&quot;Measure zero times, cut zero times.&quot; --carpenter who has achieved enlightenment and realized the wood is fine where it is" alt="&quot;Measure zero times, cut zero times.&quot; --carpenter who has achieved enlightenment and realized the wood is fine where it is" />',
+      "content" => "",
+      "enclosures" => []
+    }
+
+    create(:feed_entry, raw_data: default_data.merge(raw_data))
+  end
+
+  test "extracts content from image title attributes" do
+    feed_entry = feed_entry_with_xkcd_data
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    assert_equal '"Measure zero times, cut zero times." --carpenter who has achieved enlightenment and realized the wood is fine where it is', post.content
+    assert_equal "enqueued", post.status
+  end
+
+  test "extracts attachment URLs from summary field" do
+    feed_entry = feed_entry_with_xkcd_data
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    assert_includes post.attachment_urls, "https://imgs.xkcd.com/comics/measure_twice_cut_once.png"
+    assert_equal 1, post.attachment_urls.size
+  end
+
+  test "handles different XKCD comic" do
+    xkcd_data = {
+      "id" => "https://xkcd.com/3148/",
+      "url" => "https://xkcd.com/3148/",
+      "title" => "100% All Achievements",
+      "summary" => '<img src="https://imgs.xkcd.com/comics/100_all_achievements.png" title="I\'m trying to share my footage of the full run to prove it\'s not tool-assisted, but the uploader has problems with video lengths of more than a decade." alt="I\'m trying to share my footage of the full run to prove it\'s not tool-assisted, but the uploader has problems with video lengths of more than a decade." />'
+    }
+
+    feed_entry = feed_entry_with_xkcd_data(xkcd_data)
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    assert_equal "I'm trying to share my footage of the full run to prove it's not tool-assisted, but the uploader has problems with video lengths of more than a decade.", post.content
+    assert_includes post.attachment_urls, "https://imgs.xkcd.com/comics/100_all_achievements.png"
+  end
+
+  test "extracts images from both summary and content fields" do
+    mixed_data = {
+      "summary" => '<img src="https://imgs.xkcd.com/comics/summary_image.png" title="Summary image" />',
+      "content" => '<p>Content with <img src="https://imgs.xkcd.com/comics/content_image.png" /></p>'
+    }
+
+    feed_entry = feed_entry_with_xkcd_data(mixed_data)
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    assert_includes post.attachment_urls, "https://imgs.xkcd.com/comics/summary_image.png"
+    assert_includes post.attachment_urls, "https://imgs.xkcd.com/comics/content_image.png"
+    assert_equal 2, post.attachment_urls.size
+  end
+
+  test "falls back to regular RSS processing when no image titles found" do
+    fallback_data = {
+      "summary" => "<div>Some plain text content without images</div>",
+      "content" => "",
+      "title" => "Plain Text Entry"
+    }
+
+    feed_entry = feed_entry_with_xkcd_data(fallback_data)
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    assert_equal "Some plain text content without images", post.content
+    assert_equal [], post.attachment_urls
+  end
+
+  test "handles images without title attributes" do
+    no_title_data = {
+      "summary" => '<img src="https://imgs.xkcd.com/comics/no_title.png" alt="Image without title" />',
+      "content" => "",
+      "title" => "Fallback to title"
+    }
+
+    feed_entry = feed_entry_with_xkcd_data(no_title_data)
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    # When no image title found and summary only contains image, content becomes empty
+    assert_equal "", post.content
+    # But post should be accepted because it has an image attachment
+    assert_equal "enqueued", post.status
+    assert_equal [], post.validation_errors
+    # Should still extract the image as attachment
+    assert_includes post.attachment_urls, "https://imgs.xkcd.com/comics/no_title.png"
+  end
+
+  test "handles HTML entities in title attributes" do
+    entity_data = {
+      "summary" => '<img src="https://imgs.xkcd.com/comics/entities.png" title="&lt;script&gt;alert(\'xss\')&lt;/script&gt; &amp; entities" />'
+    }
+
+    feed_entry = feed_entry_with_xkcd_data(entity_data)
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    assert_equal "<script>alert('xss')</script> & entities", post.content
+  end
+
+  test "accepts posts with images but no content" do
+    image_only_data = {
+      "id" => "https://example.com/image-only",
+      "url" => "https://example.com/image-only",
+      "summary" => '<img src="https://imgs.xkcd.com/comics/image_only.png" />',
+      "content" => "",
+      "title" => ""
+    }
+
+    feed_entry = feed_entry_with_xkcd_data(image_only_data)
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    assert_equal "", post.content
+    assert_equal "enqueued", post.status
+    assert_equal [], post.validation_errors
+    assert_includes post.attachment_urls, "https://imgs.xkcd.com/comics/image_only.png"
+  end
+
+  test "accepts posts with text content but no images" do
+    text_only_data = {
+      "id" => "https://example.com/text-only",
+      "url" => "https://example.com/text-only",
+      "summary" => "<div>Some content</div>",
+      "content" => "",
+      "title" => ""
+    }
+
+    # Override to remove the default image
+    feed_entry = create(:feed_entry, raw_data: text_only_data)
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    assert_equal "Some content", post.content
+    assert_equal "enqueued", post.status
+    assert_equal [], post.validation_errors
+  end
+
+  test "rejects posts with completely blank content and no images" do
+    completely_blank_data = {
+      "id" => "https://example.com/blank",
+      "url" => "https://example.com/blank",
+      "summary" => "",
+      "content" => "",
+      "title" => ""
+    }
+
+    feed_entry = create(:feed_entry, raw_data: completely_blank_data)
+
+    normalizer = Normalizer::XkcdNormalizer.new(feed_entry)
+    post = normalizer.normalize
+
+    assert_equal "", post.content
+    assert_equal [], post.attachment_urls
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "no_content_or_images"
+  end
+end


### PR DESCRIPTION
Changes:

- Introduce an experimental normalizer.
- Make feed refresh example script work.
- Remove max tokens validation from the `Feed` model. It should belong to a policy and depend on a user permissions.