### PR TITLE
Refactor processor tests with snapshot matching

### DIFF
--- a/app/services/processor/rss_processor.rb
+++ b/app/services/processor/rss_processor.rb
@@ -11,7 +11,7 @@ module Processor
           uid: extract_uid(entry),
           published_at: entry.published,
           status: :pending,
-          raw_data: entry_to_hash(entry)
+          raw_data: sanitize_feedjira_entry(entry)
         )
       end
     end
@@ -22,7 +22,7 @@ module Processor
       entry.id || entry.url
     end
 
-    def entry_to_hash(entry)
+    def sanitize_feedjira_entry(entry)
       {
         id: entry.id,
         title: entry.title,

--- a/test/fixtures/files/feeds/rss/entries.json
+++ b/test/fixtures/files/feeds/rss/entries.json
@@ -1,0 +1,61 @@
+[
+  {
+    "uid": "https://example.com/first-article",
+    "status": "pending",
+    "published_at": "2024-09-12T09:00:00.000Z",
+    "raw_data": {
+      "id": "https://example.com/first-article",
+      "title": "First Article",
+      "url": "https://example.com/first-article",
+      "link": "https://example.com/first-article",
+      "summary": "This is the first article content with some HTML <b>tags</b>.",
+      "content": null,
+      "published": "2024-09-12T09:00:00Z",
+      "updated": null,
+      "author": "john@example.com (John Doe)",
+      "categories": [
+        "Technology"
+      ],
+      "enclosures": []
+    }
+  },
+  {
+    "uid": "https://example.com/second-article",
+    "status": "pending",
+    "published_at": "2024-09-11T15:30:00.000Z",
+    "raw_data": {
+      "id": "https://example.com/second-article",
+      "title": "Second Article",
+      "url": "https://example.com/second-article",
+      "link": "https://example.com/second-article",
+      "summary": "This is the second article with different content.",
+      "content": null,
+      "published": "2024-09-11T15:30:00Z",
+      "updated": null,
+      "author": "jane@example.com (Jane Smith)",
+      "categories": [
+        "News",
+        "Technology"
+      ],
+      "enclosures": []
+    }
+  },
+  {
+    "uid": "no-content-123",
+    "status": "pending",
+    "published_at": "2024-09-10T12:00:00.000Z",
+    "raw_data": {
+      "id": "no-content-123",
+      "title": "Article Without Content",
+      "url": "https://example.com/no-content",
+      "link": "https://example.com/no-content",
+      "summary": null,
+      "content": null,
+      "published": "2024-09-10T12:00:00Z",
+      "updated": null,
+      "author": null,
+      "categories": [],
+      "enclosures": []
+    }
+  }
+]

--- a/test/services/processor/base_test.rb
+++ b/test/services/processor/base_test.rb
@@ -1,15 +1,6 @@
 require "test_helper"
 
 class Processor::BaseTest < ActiveSupport::TestCase
-  test "should initialize without errors" do
-    feed = create(:feed)
-    data = "test data"
-
-    assert_nothing_raised do
-      Processor::Base.new(feed, data)
-    end
-  end
-
   test "should raise NotImplementedError for process method" do
     feed = create(:feed)
     processor = Processor::Base.new(feed, "test data")

--- a/test/services/processor/rss_processor_test.rb
+++ b/test/services/processor/rss_processor_test.rb
@@ -18,17 +18,7 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
     assert entries.all? { |entry| entry.is_a?(FeedEntry) }
     assert entries.all? { |entry| entry.feed == feed }
     assert entries.all? { |entry| entry.status == "pending" }
-  end
-
-  test "should extract uid from guid or url" do
-    processor = Processor::RssProcessor.new(feed, sample_rss_content)
-    entries = processor.process
-
-    # First entry should use URL as uid (guid matches url)
-    assert_equal "https://example.com/first-article", entries[0].uid
-
-    # Third entry should use the guid as uid
-    assert_equal "no-content-123", entries[2].uid
+    assert entries.all? { |entry| entry.valid? }
   end
 
   test "should store raw entry data as JSON" do
@@ -38,11 +28,7 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
     first_entry = entries.first
     raw_data = first_entry.raw_data
 
-    assert raw_data.is_a?(Hash)
-    assert_equal "First Article", raw_data["title"]
-    assert_equal "https://example.com/first-article", raw_data["url"]
-    assert_not_nil raw_data["published"]
-    assert_not_nil raw_data["author"]
+    assert_matches_snapshot(raw_data, snapshot: "feeds/rss/raw_data.json")
   end
 
   test "should raise error for invalid RSS" do
@@ -68,26 +54,6 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
     entries = processor.process
 
     assert_equal [], entries
-  end
-
-  test "integration: should work with HTTP loader output" do
-    loader_output = {
-      status: :success,
-      data: sample_rss_content,
-      content_type: "application/rss+xml"
-    }
-
-    processor = Processor::RssProcessor.new(feed, loader_output[:data])
-    entries = processor.process
-
-    assert_equal 3, entries.length
-
-    entries.each do |entry|
-      assert_equal feed, entry.feed
-    end
-
-    valid_entries = entries.select(&:valid?)
-    assert valid_entries.length >= 1
   end
 
   test "should handle entries without id or url" do

--- a/test/services/processor/rss_processor_test.rb
+++ b/test/services/processor/rss_processor_test.rb
@@ -11,7 +11,6 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
 
   test "should parse RSS feed and create FeedEntry objects" do
     processor = Processor::RssProcessor.new(feed, sample_rss_content)
-
     entries = processor.process
 
     assert_equal 3, entries.length
@@ -19,16 +18,12 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
     assert entries.all? { |entry| entry.feed == feed }
     assert entries.all? { |entry| entry.status == "pending" }
     assert entries.all? { |entry| entry.valid? }
-  end
 
-  test "should store raw entry data as JSON" do
-    processor = Processor::RssProcessor.new(feed, sample_rss_content)
-    entries = processor.process
+    entries_snapshot = entries.map do |entry|
+      entry.as_json(only: %i[uid status published_at raw_data])
+    end
 
-    first_entry = entries.first
-    raw_data = first_entry.raw_data
-
-    assert_matches_snapshot(raw_data, snapshot: "feeds/rss/raw_data.json")
+    assert_matches_snapshot(entries_snapshot, snapshot: "feeds/rss/entries.json")
   end
 
   test "should raise error for invalid RSS" do


### PR DESCRIPTION
Changes:

- Use snapshot tests for RSS processor.
- Remove redundant code from the tests.