### PR TITLE
Refactor normalizer extractors

### DIFF
--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -29,10 +29,14 @@ module Normalizer
 
     attr_reader :feed_entry
 
+    def raw_data
+      feed_entry.raw_data
+    end
+
     # Builds Post from feed entry data
     # @return [Post] new post instance
     def build_post
-      post_attributes = extract_post_attributes(feed_entry.raw_data)
+      post_attributes = extract_post_attributes
 
       Post.new(
         feed: feed_entry.feed,
@@ -45,30 +49,29 @@ module Normalizer
     end
 
     # Extracts post attributes from raw data
-    # @param raw_data [Hash] the raw feed entry data
     # @return [Hash] post attributes (source_url, content, attachment_urls, comments)
-    def extract_post_attributes(raw_data)
+    def extract_post_attributes
       {
-        source_url: extract_source_url(raw_data),
-        content: extract_content(raw_data),
-        attachment_urls: extract_attachment_urls(raw_data),
-        comments: extract_comments(raw_data)
+        source_url: extract_source_url,
+        content: extract_content,
+        attachment_urls: extract_attachment_urls,
+        comments: extract_comments
       }
     end
 
-    def extract_source_url(raw_data)
+    def extract_source_url
       raise NotImplementedError, "Subclasses must implement #extract_source_url"
     end
 
-    def extract_content(raw_data)
+    def extract_content
       raise NotImplementedError, "Subclasses must implement #extract_content"
     end
 
-    def extract_attachment_urls(raw_data)
+    def extract_attachment_urls
       []
     end
 
-    def extract_comments(raw_data)
+    def extract_comments
       []
     end
 

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -52,11 +52,27 @@ module Normalizer
     # @return [Hash] post attributes (source_url, content, attachment_urls, comments)
     def extract_post_attributes
       {
-        source_url: extract_source_url,
-        content: extract_content,
-        attachment_urls: extract_attachment_urls,
-        comments: extract_comments
+        source_url: source_url,
+        content: content,
+        attachment_urls: attachment_urls,
+        comments: comments
       }
+    end
+
+    def source_url
+      @source_url ||= extract_source_url
+    end
+
+    def content
+      @content ||= extract_content
+    end
+
+    def attachment_urls
+      @attachment_urls ||= extract_attachment_urls
+    end
+
+    def comments
+      @comments ||= extract_comments
     end
 
     def extract_source_url

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -28,10 +28,7 @@ module Normalizer
     private
 
     attr_reader :feed_entry
-
-    def raw_data
-      feed_entry.raw_data
-    end
+    delegate :raw_data, to: :feed_entry
 
     # Builds Post from feed entry data
     # @return [Post] new post instance

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -60,34 +60,34 @@ module Normalizer
     end
 
     def source_url
-      @source_url ||= extract_source_url
+      @source_url ||= normalize_source_url
     end
 
     def content
-      @content ||= extract_content
+      @content ||= normalize_content
     end
 
     def attachment_urls
-      @attachment_urls ||= extract_attachment_urls
+      @attachment_urls ||= normalize_attachment_urls
     end
 
     def comments
-      @comments ||= extract_comments
+      @comments ||= normalize_comments
     end
 
-    def extract_source_url
-      raise NotImplementedError, "Subclasses must implement #extract_source_url"
+    def normalize_source_url
+      raise NotImplementedError, "Subclasses must implement #normalize_source_url"
     end
 
-    def extract_content
-      raise NotImplementedError, "Subclasses must implement #extract_content"
+    def normalize_content
+      raise NotImplementedError, "Subclasses must implement #normalize_content"
     end
 
-    def extract_attachment_urls
+    def normalize_attachment_urls
       []
     end
 
-    def extract_comments
+    def normalize_comments
       []
     end
 

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -33,16 +33,15 @@ module Normalizer
     # Builds Post from feed entry data
     # @return [Post] new post instance
     def build_post
-      post_attributes = extract_post_attributes
-
-      Post.new(
+      post_attributes = extract_post_attributes.merge(
         feed: feed_entry.feed,
         feed_entry: feed_entry,
         uid: feed_entry.uid,
         published_at: normalize_published_at(feed_entry.published_at),
-        status: :draft,
-        **post_attributes
+        status: :draft
       )
+
+      Post.new(**post_attributes)
     end
 
     # Extracts post attributes from raw data

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -20,7 +20,7 @@ module Normalizer
     def normalize
       post = build_post
       # TBD: Consider renaming this field
-      post.validation_errors = validate_post(post)
+      post.validation_errors = validate_content
       post.status = post.validation_errors.empty? ? :enqueued : :rejected
       post
     end
@@ -91,9 +91,9 @@ module Normalizer
       []
     end
 
-    def validate_post(post)
+    def validate_content
       errors = []
-      errors << "no_content_or_images" if missing_content_and_images?(post)
+      errors << "no_content_or_images" if missing_content_and_images?
       errors
     end
 
@@ -102,8 +102,8 @@ module Normalizer
       published_at
     end
 
-    def missing_content_and_images?(post)
-      post.content.blank? && post.attachment_urls.empty?
+    def missing_content_and_images?
+      content.blank? && attachment_urls.empty?
     end
   end
 end

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -33,15 +33,17 @@ module Normalizer
     # Builds Post from feed entry data
     # @return [Post] new post instance
     def build_post
-      post_attributes = extract_post_attributes.merge(
+      Post.new(**extract_post_attributes.merge(default_post_attributes))
+    end
+
+    def default_post_attributes
+      {
         feed: feed_entry.feed,
         feed_entry: feed_entry,
         uid: feed_entry.uid,
         published_at: normalize_published_at(feed_entry.published_at),
         status: :draft
-      )
-
-      Post.new(**post_attributes)
+      }
     end
 
     # Extracts post attributes from raw data

--- a/app/services/normalizer/rss_normalizer.rb
+++ b/app/services/normalizer/rss_normalizer.rb
@@ -3,16 +3,16 @@ module Normalizer
   class RssNormalizer < Base
     private
 
-    def extract_post_attributes(raw_data)
-      source_url = extract_source_url(raw_data)
-      text_content = extract_content(raw_data)
+    def extract_post_attributes
+      source_url = extract_source_url
+      text_content = extract_content
       content = post_content_with_url(text_content, source_url)
 
       {
         source_url: source_url,
         content: content,
-        attachment_urls: extract_attachment_urls(raw_data),
-        comments: extract_comments(raw_data)
+        attachment_urls: extract_attachment_urls,
+        comments: extract_comments
       }
     end
 
@@ -28,26 +28,26 @@ module Normalizer
       post.source_url.length > Post::MAX_URL_LENGTH
     end
 
-    def extract_source_url(raw_data)
+    def extract_source_url
       url = raw_data.dig("link") || raw_data.dig("url") || ""
       normalize_source_url(url)
     end
 
-    def extract_content(raw_data)
+    def extract_content
       content = raw_data.dig("summary") || raw_data.dig("content") || raw_data.dig("description") || raw_data.dig("title") || ""
       strip_html(content)
     end
 
-    def extract_attachment_urls(raw_data)
-      (image_urls(raw_data) + content_images(raw_data)).uniq
+    def extract_attachment_urls
+      (image_urls + content_images).uniq
     end
 
-    def image_urls(raw_data)
+    def image_urls
       enclosures = raw_data.dig("enclosures") || []
       enclosures.filter_map { |e| e["url"] if e["type"]&.start_with?("image/") }
     end
 
-    def content_images(raw_data)
+    def content_images
       extract_images(raw_data.dig("content") || "")
     end
 

--- a/app/services/normalizer/rss_normalizer.rb
+++ b/app/services/normalizer/rss_normalizer.rb
@@ -11,6 +11,10 @@ module Normalizer
       @text_content ||= extract_content
     end
 
+    def original_url
+      @original_url ||= raw_data.dig("link") || raw_data.dig("url") || ""
+    end
+
     def validate_content
       errors = super
       errors << "url_too_long" if url_too_long?
@@ -18,14 +22,15 @@ module Normalizer
     end
 
     def url_too_long?
-      return false if source_url.blank?
+      return false if original_url.blank?
 
-      source_url.length > Post::MAX_URL_LENGTH
+      original_url.length > Post::MAX_URL_LENGTH
     end
 
     def extract_source_url
-      url = raw_data.dig("link") || raw_data.dig("url") || ""
-      normalize_source_url(url)
+      return "" if url_too_long?
+
+      normalize_source_url(original_url)
     end
 
     def extract_content

--- a/app/services/normalizer/rss_normalizer.rb
+++ b/app/services/normalizer/rss_normalizer.rb
@@ -11,16 +11,16 @@ module Normalizer
       @text_content ||= extract_content
     end
 
-    def validate_post(post)
+    def validate_content
       errors = super
-      errors << "url_too_long" if url_too_long?(post)
+      errors << "url_too_long" if url_too_long?
       errors
     end
 
-    def url_too_long?(post)
-      return false if post.source_url.blank?
+    def url_too_long?
+      return false if source_url.blank?
 
-      post.source_url.length > Post::MAX_URL_LENGTH
+      source_url.length > Post::MAX_URL_LENGTH
     end
 
     def extract_source_url

--- a/app/services/normalizer/rss_normalizer.rb
+++ b/app/services/normalizer/rss_normalizer.rb
@@ -3,17 +3,12 @@ module Normalizer
   class RssNormalizer < Base
     private
 
-    def extract_post_attributes
-      source_url = extract_source_url
-      text_content = extract_content
-      content = post_content_with_url(text_content, source_url)
+    def content
+      @content ||= post_content_with_url(text_content, source_url)
+    end
 
-      {
-        source_url: source_url,
-        content: content,
-        attachment_urls: extract_attachment_urls,
-        comments: extract_comments
-      }
+    def text_content
+      @text_content ||= extract_content
     end
 
     def validate_post(post)

--- a/app/services/normalizer/rss_normalizer.rb
+++ b/app/services/normalizer/rss_normalizer.rb
@@ -8,7 +8,7 @@ module Normalizer
     end
 
     def text_content
-      @text_content ||= extract_content
+      @text_content ||= normalize_content
     end
 
     def original_url
@@ -27,18 +27,18 @@ module Normalizer
       original_url.length > Post::MAX_URL_LENGTH
     end
 
-    def extract_source_url
+    def normalize_source_url
       return "" if url_too_long?
 
-      normalize_source_url(original_url)
+      validate_url(original_url)
     end
 
-    def extract_content
+    def normalize_content
       content = raw_data.dig("summary") || raw_data.dig("content") || raw_data.dig("description") || raw_data.dig("title") || ""
       strip_html(content)
     end
 
-    def extract_attachment_urls
+    def normalize_attachment_urls
       (image_urls + content_images).uniq
     end
 
@@ -51,7 +51,7 @@ module Normalizer
       extract_images(raw_data.dig("content") || "")
     end
 
-    def normalize_source_url(url)
+    def validate_url(url)
       return "" if url.blank?
 
       URI.parse(url)

--- a/app/services/normalizer/xkcd_normalizer.rb
+++ b/app/services/normalizer/xkcd_normalizer.rb
@@ -2,12 +2,12 @@ module Normalizer
   class XkcdNormalizer < RssNormalizer
     private
 
-    def extract_content(raw_data)
+    def extract_content
       title = raw_data.dig("title") || ""
       title.strip
     end
 
-    def extract_comments(raw_data)
+    def extract_comments
       summary = raw_data.dig("summary") || ""
       return [] if summary.blank?
 
@@ -18,7 +18,7 @@ module Normalizer
       alt_text.present? ? [alt_text.strip] : []
     end
 
-    def extract_attachment_urls(raw_data)
+    def extract_attachment_urls
       summary = raw_data.dig("summary") || ""
       return [] if summary.blank?
 

--- a/app/services/normalizer/xkcd_normalizer.rb
+++ b/app/services/normalizer/xkcd_normalizer.rb
@@ -2,12 +2,12 @@ module Normalizer
   class XkcdNormalizer < RssNormalizer
     private
 
-    def extract_content
+    def normalize_content
       title = raw_data.dig("title") || ""
       title.strip
     end
 
-    def extract_comments
+    def normalize_comments
       summary = raw_data.dig("summary") || ""
       return [] if summary.blank?
 
@@ -18,7 +18,7 @@ module Normalizer
       alt_text.present? ? [alt_text.strip] : []
     end
 
-    def extract_attachment_urls
+    def normalize_attachment_urls
       summary = raw_data.dig("summary") || ""
       return [] if summary.blank?
 

--- a/test/services/normalizer/base_test.rb
+++ b/test/services/normalizer/base_test.rb
@@ -15,27 +15,27 @@ class Normalizer::BaseTest < ActiveSupport::TestCase
     end
   end
 
-  test "extract_source_url should raise NotImplementedError" do
+  test "normalize_source_url should raise NotImplementedError" do
     error = assert_raises(NotImplementedError) do
-      normalizer.send(:extract_source_url)
+      normalizer.send(:normalize_source_url)
     end
-    assert_equal "Subclasses must implement #extract_source_url", error.message
+    assert_equal "Subclasses must implement #normalize_source_url", error.message
   end
 
-  test "extract_content should raise NotImplementedError" do
+  test "normalize_content should raise NotImplementedError" do
     error = assert_raises(NotImplementedError) do
-      normalizer.send(:extract_content)
+      normalizer.send(:normalize_content)
     end
-    assert_equal "Subclasses must implement #extract_content", error.message
+    assert_equal "Subclasses must implement #normalize_content", error.message
   end
 
-  test "extract_attachment_urls should return empty array by default" do
-    result = normalizer.send(:extract_attachment_urls)
+  test "normalize_attachment_urls should return empty array by default" do
+    result = normalizer.send(:normalize_attachment_urls)
     assert_equal [], result
   end
 
-  test "extract_comments should return empty array by default" do
-    result = normalizer.send(:extract_comments)
+  test "normalize_comments should return empty array by default" do
+    result = normalizer.send(:normalize_comments)
     assert_equal [], result
   end
 end

--- a/test/services/normalizer/base_test.rb
+++ b/test/services/normalizer/base_test.rb
@@ -17,25 +17,25 @@ class Normalizer::BaseTest < ActiveSupport::TestCase
 
   test "extract_source_url should raise NotImplementedError" do
     error = assert_raises(NotImplementedError) do
-      normalizer.send(:extract_source_url, {})
+      normalizer.send(:extract_source_url)
     end
     assert_equal "Subclasses must implement #extract_source_url", error.message
   end
 
   test "extract_content should raise NotImplementedError" do
     error = assert_raises(NotImplementedError) do
-      normalizer.send(:extract_content, {})
+      normalizer.send(:extract_content)
     end
     assert_equal "Subclasses must implement #extract_content", error.message
   end
 
   test "extract_attachment_urls should return empty array by default" do
-    result = normalizer.send(:extract_attachment_urls, {})
+    result = normalizer.send(:extract_attachment_urls)
     assert_equal [], result
   end
 
   test "extract_comments should return empty array by default" do
-    result = normalizer.send(:extract_comments, {})
+    result = normalizer.send(:extract_comments)
     assert_equal [], result
   end
 end

--- a/test/services/normalizer/rss_normalizer_test.rb
+++ b/test/services/normalizer/rss_normalizer_test.rb
@@ -77,6 +77,7 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
     normalizer = Normalizer::RssNormalizer.new(entry)
     post = normalizer.normalize
 
+    assert_equal "", post.source_url
     assert_equal "Test content", post.content
     assert post.content.length <= Post::MAX_CONTENT_LENGTH
     assert_equal "rejected", post.status
@@ -96,6 +97,7 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
     normalizer = Normalizer::RssNormalizer.new(entry)
     post = normalizer.normalize
 
+    assert_equal "", post.source_url
     assert_equal "", post.content
     assert_equal "rejected", post.status
     assert_includes post.validation_errors, "url_too_long"


### PR DESCRIPTION
Changes:

- Normalizers should validate content, not `Post` object.
- Rename `extract_` methods to `normalize_` since they normalize content elements, not just extract.
- Do not save too long URLs to `Post` records. If the original content will be necessary for analysis., it is still available in the `FeedEntry` record.
- Memoize normalized values for validation.