### PR TITLE
Improve events presentation

### DIFF
--- a/app/models/feed_refresh_event.rb
+++ b/app/models/feed_refresh_event.rb
@@ -6,7 +6,7 @@ class FeedRefreshEvent
   # @return [Event] created event record
   def self.create_stats(feed:, stats: {})
     Event.create!(
-      type: "feed_refresh_stats",
+      type: "FeedRefreshStats",
       level: :info,
       subject: feed,
       user: feed.user,
@@ -23,7 +23,7 @@ class FeedRefreshEvent
   # @return [Event] created event record
   def self.create_error(feed:, error:, stage:, stats: {})
     Event.create!(
-      type: "feed_refresh_error",
+      type: "FeedRefreshError",
       level: :error,
       subject: feed,
       user: feed.user,

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -8,29 +8,34 @@
 
 <% if @events.any? %>
   <div class="table-responsive">
-    <table class="table table-hover table-bordered">
+    <table class="table table-hover table-bordered text-nowrap">
       <thead>
         <tr>
+          <th style="width: 1%;" class="text-center"><i class="bi bi-calendar-event"></i></th>
+          <th style="width: 1%;" class="text-center"><i class="bi bi-exclamation-circle"></i></th>
           <th>Type</th>
-          <th class="text-center">Lvl</th>
           <th>Message</th>
           <th>User</th>
           <th>Subject</th>
-          <th class="text-center"><i class="bi bi-calendar-event"></i></th>
         </tr>
       </thead>
       <tbody>
         <% @events.each do |event| %>
           <tr>
+            <td class="text-center" style="width: 1%;">
+              <%= link_to admin_event_path(event), class: "text-decoration-none text-muted", title: event.created_at.rfc3339 do %>
+                <%= short_time_ago(event.created_at) %>
+              <% end %>
+            </td>
+            <td class="text-center" style="width: 1%;">
+              <%= level_badge(event.level) %>
+            </td>
             <td>
               <%= link_to admin_events_path(filter: { type: event.type }),
                           class: "text-decoration-none",
                           title: "Filter by type: #{event.type}" do %>
                 <code><%= event.type %></code>
               <% end %>
-            </td>
-            <td class="text-center">
-              <%= level_badge(event.level) %>
             </td>
             <td>
               <div class="text-truncate" style="max-width: 300px;">
@@ -42,20 +47,21 @@
             </td>
             <td>
               <% if event.subject %>
-                <%= link_to admin_events_path(filter: { subject_type: event.subject_type }),
-                            class: "text-decoration-none text-muted",
-                            title: "Filter by subject type: #{event.subject_type}" do %>
-                  <%= event.subject_type %>
+                <% if event.subject_type == "Feed" %>
+                  <%= link_to event.subject_type, feed_path(event.subject), class: "text-decoration-none text-muted" %>
+                <% elsif event.subject_type == "Post" %>
+                  <%= link_to event.subject_type, post_path(event.subject), class: "text-decoration-none text-muted" %>
+                <% else %>
+                  <%= link_to admin_events_path(filter: { subject_type: event.subject_type }),
+                              class: "text-decoration-none text-muted",
+                              title: "Filter by subject type: #{event.subject_type}" do %>
+                    <%= event.subject_type %>
+                  <% end %>
                 <% end %>
-                <span class="text-primary">#<%= event.subject_id %></span>
+                <span class="text-muted">#<%= event.subject_id %></span>
               <% else %>
                 <em class="text-muted">None</em>
               <% end %>
-            </td>
-            <td class="text-center">
-              <span class="text-muted" title="<%= event.created_at.rfc3339 %>">
-                <%= short_time_ago(event.created_at) %>
-              </span>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -23,7 +23,7 @@
         <% @events.each do |event| %>
           <tr>
             <td class="text-center" style="width: 1%;">
-              <%= link_to admin_event_path(event), class: "text-decoration-none text-muted", title: event.created_at.rfc3339 do %>
+              <%= link_to admin_event_path(event), class: "text-muted", title: event.created_at.rfc3339 do %>
                 <%= short_time_ago(event.created_at) %>
               <% end %>
             </td>
@@ -48,12 +48,12 @@
             <td>
               <% if event.subject %>
                 <% if event.subject_type == "Feed" %>
-                  <%= link_to event.subject_type, feed_path(event.subject), class: "text-decoration-none text-muted" %>
+                  <%= link_to event.subject_type, feed_path(event.subject), class: "text-muted" %>
                 <% elsif event.subject_type == "Post" %>
-                  <%= link_to event.subject_type, post_path(event.subject), class: "text-decoration-none text-muted" %>
+                  <%= link_to event.subject_type, post_path(event.subject), class: "text-muted" %>
                 <% else %>
                   <%= link_to admin_events_path(filter: { subject_type: event.subject_type }),
-                              class: "text-decoration-none text-muted",
+                              class: "text-muted",
                               title: "Filter by subject type: #{event.subject_type}" do %>
                     <%= event.subject_type %>
                   <% end %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -1,111 +1,97 @@
 <% content_for :title, "Event ##{@event.id}" %>
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-  <h1>Event #<%= @event.id %></h1>
+<%= page_header "Event ##{@event.id}" do %>
   <div class="d-flex gap-2">
     <% if @previous_event %>
       <%= link_to "← Previous", admin_event_path(@previous_event), class: "btn btn-outline-secondary" %>
     <% else %>
       <span class="btn btn-outline-secondary disabled">← Previous</span>
     <% end %>
-    
+
     <% if @next_event %>
       <%= link_to "Next →", admin_event_path(@next_event), class: "btn btn-outline-secondary" %>
     <% else %>
       <span class="btn btn-outline-secondary disabled">Next →</span>
     <% end %>
-    
+
     <%= link_to "Back to Events", admin_events_path, class: "btn btn-outline-primary" %>
   </div>
-</div>
+<% end %>
 
-<div class="card mb-4">
-  <div class="card-header">
-    <h5 class="card-title mb-0">Event Details</h5>
+<% if @event.message.present? %>
+  <div class="alert alert-<%= @event.level == 'error' ? 'danger' : @event.level == 'warning' ? 'warning' : 'info' %> mb-4">
+    <%= simple_format(@event.message, class: "mb-0") %>
   </div>
-  <div class="card-body">
-    <dl class="row">
-      <dt class="col-lg-2 col-md-3">Type</dt>
-      <dd class="col-lg-4 col-md-9">
-        <code class="text-dark fs-6"><%= @event.type %></code>
-      </dd>
+<% end %>
 
-      <dt class="col-lg-2 col-md-3">Level</dt>
-      <dd class="col-lg-4 col-md-9 text-uppercase">
-        <%= level_badge_full(@event.level) %>
-      </dd>
+<div class="list-group">
+  <div class="list-group-item">
+    <strong>Type:</strong>
+    <code><%= @event.type %></code>
+  </div>
 
-      <dt class="col-lg-2 col-md-3">User</dt>
-      <dd class="col-lg-4 col-md-9">
-        <% if @event.user %>
-          <%= @event.user.email_address %>
-        <% else %>
-          <em class="text-muted">System</em>
-        <% end %>
-      </dd>
+  <div class="list-group-item">
+    <strong>Level:</strong>
+    <%= @event.level.capitalize %>
+  </div>
 
-      <dt class="col-lg-2 col-md-3">Subject</dt>
-      <dd class="col-lg-4 col-md-9">
-        <% if @event.subject %>
-          <span class="text-muted"><%= @event.subject_type %></span>
-          <span class="text-primary">#<%= @event.subject_id %></span>
-        <% else %>
-          <em class="text-muted">None</em>
-        <% end %>
-      </dd>
+  <div class="list-group-item">
+    <strong>User:</strong>
+    <% if @event.user %>
+      <%= @event.user.email_address %>
+    <% else %>
+      <em class="text-muted">System</em>
+    <% end %>
+  </div>
 
-      <dt class="col-lg-2 col-md-3">Created</dt>
-      <dd class="col-lg-4 col-md-9">
-        <%= @event.created_at.strftime("%B %d, %Y at %I:%M %p %Z") %>
-        <br>
-        <small class="text-muted">
-          <%= short_time_ago(@event.created_at) %>
-        </small>
-      </dd>
-
-      <dt class="col-lg-2 col-md-3">Updated</dt>
-      <dd class="col-lg-4 col-md-9">
-        <%= @event.updated_at.strftime("%B %d, %Y at %I:%M %p %Z") %>
-        <br>
-        <small class="text-muted">
-          <%= short_time_ago(@event.updated_at) %>
-        </small>
-      </dd>
-
-      <% if @event.expires_at %>
-        <dt class="col-lg-2 col-md-3">Expires</dt>
-        <dd class="col-lg-10 col-md-9">
-          <%= @event.expires_at.strftime("%B %d, %Y at %I:%M %p %Z") %>
-          <br>
-          <% if @event.expired? %>
-            <span class="badge bg-danger">Expired</span>
-          <% else %>
-            <small class="text-muted">
-              Expires in <%= short_time_ago(@event.expires_at) %>
-            </small>
-          <% end %>
-        </dd>
+  <div class="list-group-item">
+    <strong>Subject:</strong>
+    <% if @event.subject %>
+      <% if @event.subject_type == "Feed" %>
+        <%= link_to @event.subject_type, feed_path(@event.subject) %>
+      <% elsif @event.subject_type == "Post" %>
+        <%= link_to @event.subject_type, post_path(@event.subject) %>
+      <% else %>
+        <%= @event.subject_type %>
       <% end %>
-
-      <dt class="col-12">Message</dt>
-      <dd class="col-12">
-        <% if @event.message.present? %>
-          <%= simple_format(@event.message, class: "mb-0") %>
-        <% else %>
-          <em class="text-muted">No message</em>
-        <% end %>
-      </dd>
-    </dl>
+      <span class="text-muted">#<%= @event.subject_id %></span>
+    <% else %>
+      <em class="text-muted">None</em>
+    <% end %>
   </div>
+
+  <div class="list-group-item">
+    <strong>Created:</strong>
+    <%= long_time_tag(@event.created_at) %>
+    <span class="text-muted">(<%= short_time_ago(@event.created_at) %>)</span>
+  </div>
+
+  <div class="list-group-item">
+    <strong>Updated:</strong>
+    <%= long_time_tag(@event.updated_at) %>
+    <span class="text-muted">(<%= short_time_ago(@event.updated_at) %>)</span>
+  </div>
+
+  <% if @event.expires_at %>
+    <div class="list-group-item">
+      <strong>Expires:</strong>
+      <%= long_time_tag(@event.expires_at) %>
+      <% if @event.expired? %>
+        <span class="badge bg-danger">Expired</span>
+      <% else %>
+        <span class="text-muted">(in <%= short_time_ago(@event.expires_at) %>)</span>
+      <% end %>
+    </div>
+  <% end %>
 </div>
 
 <% if @event.metadata.present? && @event.metadata != {} %>
-  <div class="card">
-    <div class="card-header">
-      <h5 class="card-title mb-0">Metadata</h5>
-    </div>
-    <div class="card-body">
-      <pre class="event-metadata font-monospace small bg-light border rounded p-3 mb-0 overflow-auto"><code><%= JSON.pretty_generate(@event.metadata) %></code></pre>
+  <div class="mt-4">
+    <h3 class="mb-3">Metadata</h3>
+    <div class="list-group">
+      <div class="list-group-item">
+        <pre class="event-metadata font-monospace small bg-light border rounded p-3 mb-0 overflow-auto"><code><%= JSON.pretty_generate(@event.metadata) %></code></pre>
+      </div>
     </div>
   </div>
 <% end %>

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -47,7 +47,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "h1", "Event ##{event.id}"
-    assert_select "dd", "TestEvent"
+    assert_select "code", "TestEvent"
   end
 
   test "should paginate events" do

--- a/test/models/feed_refresh_event_test.rb
+++ b/test/models/feed_refresh_event_test.rb
@@ -21,7 +21,7 @@ class FeedRefreshEventTest < ActiveSupport::TestCase
 
     event = FeedRefreshEvent.create_stats(feed: feed, stats: stats)
 
-    assert_equal "feed_refresh_stats", event.type
+    assert_equal "FeedRefreshStats", event.type
     assert_equal "info", event.level
     assert_equal feed, event.subject
     assert_equal feed.user, event.user
@@ -41,7 +41,7 @@ class FeedRefreshEventTest < ActiveSupport::TestCase
   test "create_stats works with empty stats" do
     event = FeedRefreshEvent.create_stats(feed: feed)
 
-    assert_equal "feed_refresh_stats", event.type
+    assert_equal "FeedRefreshStats", event.type
     assert_equal({}, event.metadata["stats"])
   end
 
@@ -58,7 +58,7 @@ class FeedRefreshEventTest < ActiveSupport::TestCase
       stats: stats
     )
 
-    assert_equal "feed_refresh_error", event.type
+    assert_equal "FeedRefreshError", event.type
     assert_equal "error", event.level
     assert_equal feed, event.subject
     assert_equal feed.user, event.user

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -125,7 +125,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert workflow.stats[:total_duration] >= 0
 
     # Verify stats event was created
-    events = Event.where(subject: test_feed, type: "feed_refresh_stats")
+    events = Event.where(subject: test_feed, type: "FeedRefreshStats")
     assert_equal 1, events.count
     assert_equal 2, events.first.metadata["stats"]["new_posts"]
   end
@@ -201,7 +201,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal :load_feed_contents, workflow.stats[:failed_at_step]
 
     # Verify error event was created
-    events = Event.where(subject: test_feed, type: "feed_refresh_error")
+    events = Event.where(subject: test_feed, type: "FeedRefreshError")
     assert_equal 1, events.count
     error_event = events.first
     assert_equal "error", error_event.level
@@ -230,7 +230,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 0, Post.where(feed: test_feed).count
 
     # Verify error event was created
-    error_events = Event.where(subject: test_feed, type: "feed_refresh_error")
+    error_events = Event.where(subject: test_feed, type: "FeedRefreshError")
     assert_equal 1, error_events.count
 
     error_event = error_events.first
@@ -277,7 +277,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 1, FeedEntry.where(feed: test_feed).count
 
     # Verify error event was created
-    events = Event.where(subject: test_feed, type: "feed_refresh_error")
+    events = Event.where(subject: test_feed, type: "FeedRefreshError")
     assert_equal 1, events.count
     error_event = events.first
     assert_match(/Feed refresh failed at normalize_entries/, error_event.message)
@@ -316,7 +316,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       assert_equal :persist_entries, workflow.stats[:failed_at_step]
 
       # Verify error event was created
-      events = Event.where(subject: test_feed, type: "feed_refresh_error")
+      events = Event.where(subject: test_feed, type: "FeedRefreshError")
       assert_equal 1, events.count
       error_event = events.first
       assert_match(/Feed refresh failed at persist_entries/, error_event.message)
@@ -356,7 +356,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert workflow.stats[:new_posts] == 0 || workflow.stats[:new_posts].nil?
 
     # Should still create success event
-    events = Event.where(subject: test_feed, type: "feed_refresh_stats")
+    events = Event.where(subject: test_feed, type: "FeedRefreshStats")
     assert_equal 1, events.count
   end
 end


### PR DESCRIPTION
Changes:

- Timestamp first, Level second.
- Timestamp and Level columns width reduced.
- Word wrap disabled for the events table.
- Use an icon for the Level column header.
- Link Timestamps to event detail page.
- Link Feed/Post subjects and remove subject ID coloring.
- Use consistent formatting for the Event types.