### PR TITLE
Fix status page logic to distinguish onboarding from active users

### DIFF
--- a/app/components/feed_stats_component.rb
+++ b/app/components/feed_stats_component.rb
@@ -27,8 +27,8 @@ class FeedStatsComponent < ViewComponent::Base
       },
       {
         key: "most_recent_post",
-        label: "Most recent publication",
-        label_short: "Recent",
+        label: "Latest imported post",
+        label_short: "Latest",
         value: most_recent_post_value
       },
       {
@@ -86,7 +86,7 @@ class FeedStatsComponent < ViewComponent::Base
     if @feed.most_recent_post_date
       helpers.short_time_ago_tag(@feed.most_recent_post_date)
     else
-      content_tag(:span, "No posts imported", class: "text-slate-500")
+      content_tag(:span, "None", class: "text-slate-500")
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  helper_method :current_user
+
   private
 
   # Pundit uses this method to get the "user" for authorization checks

--- a/app/controllers/feed_details_controller.rb
+++ b/app/controllers/feed_details_controller.rb
@@ -76,7 +76,7 @@ class FeedDetailsController < ApplicationController
       return render(identification_error(error: "Feed identification is taking longer than expected. The feed URL may not be responding. Please try again."))
     end
 
-    render(identification_loading)
+    render(identification_loading_poll)
   end
 
   def handle_success_status
@@ -110,6 +110,15 @@ class FeedDetailsController < ApplicationController
         "feed-form",
         partial: "feeds/identification_loading",
         locals: { url: feed_url }
+      )
+    }
+  end
+
+  def identification_loading_poll
+    {
+      turbo_stream: turbo_stream.replace(
+        "feed-form",
+        partial: "feeds/identification_loading_poll"
       )
     }
   end

--- a/app/controllers/feed_details_controller.rb
+++ b/app/controllers/feed_details_controller.rb
@@ -96,7 +96,7 @@ class FeedDetailsController < ApplicationController
 
   def identification_error(error:)
     {
-      turbo_stream: turbo_stream.replace(
+      turbo_stream: turbo_stream.update(
         "feed-form",
         partial: "feeds/identification_error",
         locals: { url: feed_url, error: error }
@@ -107,7 +107,7 @@ class FeedDetailsController < ApplicationController
   def identification_loading
     {
       turbo_stream: turbo_stream.replace(
-        "feed-form",
+        "feed-form-wrapper",
         partial: "feeds/identification_loading",
         locals: { url: feed_url }
       )
@@ -116,7 +116,7 @@ class FeedDetailsController < ApplicationController
 
   def identification_loading_poll
     {
-      turbo_stream: turbo_stream.replace(
+      turbo_stream: turbo_stream.update(
         "feed-form",
         partial: "feeds/identification_loading_poll"
       )
@@ -125,7 +125,7 @@ class FeedDetailsController < ApplicationController
 
   def identification_success(feed)
     {
-      turbo_stream: turbo_stream.replace(
+      turbo_stream: turbo_stream.update(
         "feed-form",
         partial: "feeds/form_expanded",
         locals: { feed: feed }

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -57,6 +57,7 @@ class FeedsController < ApplicationController
     ActiveRecord::Base.transaction do
       @feed.save!
       @feed.reset_schedule! if @feed.enabled? && @feed.feed_schedule.nil?
+      Current.user.active! if Current.user.onboarding?
     end
 
     cleanup_feed_identification(@feed.url)

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,6 +1,4 @@
 class StatusesController < ApplicationController
-  helper_method :has_active_tokens?
-
   def show
     locals = {
       recent_events: recent_events,

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,8 +1,27 @@
 class StatusesController < ApplicationController
+  helper_method :has_active_tokens?
+
   def show
-    @user = Current.user
-    @has_active_tokens = @user.access_tokens.active.any?
-    @has_feeds = @user.total_feeds_count > 0
-    @recent_events = Event.where(user: @user).user_relevant.recent.limit(10)
+    locals = {
+      recent_events: recent_events,
+      has_active_tokens: has_active_tokens?,
+      no_feeds: no_feeds?
+    }
+
+    render locals: locals
+  end
+
+  private
+
+  def recent_events
+    Event.where(user: current_user).user_relevant.recent.limit(10)
+  end
+
+  def has_active_tokens?
+    current_user.access_tokens.active.any?
+  end
+
+  def no_feeds?
+    current_user.total_feeds_count.zero?
   end
 end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,6 +1,8 @@
 class StatusesController < ApplicationController
   def show
     @user = Current.user
+    @has_active_tokens = @user.access_tokens.active.any?
+    @has_feeds = @user.total_feeds_count > 0
     @recent_events = Event.where(user: @user).user_relevant.recent.limit(10)
   end
 end

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -1,23 +1,25 @@
 <%# locals: () %>
-<div id="feed-form">
-  <%= form_with url: feed_details_path, method: :post do |f| %>
-    <div class="space-y-6">
-      <div class="ff-form-group">
-        <%= f.label :url, "Feed URL", class: "ff-form-label" %>
-        <%= f.text_field :url,
-                         placeholder: "https://example.com/feed.xml",
-                         class: "ff-form-input",
-                         required: true,
-                         autofocus: true %>
-        <p class="ff-form-help">Enter the URL of the RSS feed or supported site you want to import.</p>
+<div id="feed-form-wrapper">
+  <div id="feed-form">
+    <%= form_with url: feed_details_path, method: :post do |f| %>
+      <div class="space-y-6">
+        <div class="ff-form-group">
+          <%= f.label :url, "Feed URL", class: "ff-form-label" %>
+          <%= f.text_field :url,
+                           placeholder: "https://example.com/feed.xml",
+                           class: "ff-form-input",
+                           required: true,
+                           autofocus: true %>
+          <p class="ff-form-help">Enter the URL of the RSS feed or supported site you want to import.</p>
+        </div>
       </div>
-    </div>
 
-    <div class="ff-card__footer">
-      <%= f.submit "Identify Feed Format",
-                   class: "ff-button",
-                   data: { turbo_submits_with: "Identifying..." } %>
-      <%= link_to "Cancel", feeds_path, class: "ff-button ff-button--secondary" %>
-    </div>
-  <% end %>
+      <div class="ff-card__footer">
+        <%= f.submit "Identify Feed Format",
+                     class: "ff-button",
+                     data: { turbo_submits_with: "Identifying..." } %>
+        <%= link_to "Cancel", feeds_path, class: "ff-button ff-button--secondary" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (edit_mode: false, feed: @feed) %>
 <% active_tokens = Current.user.access_tokens.active.order(:host) %>
 
-<div id="feed-form" data-identification-state="complete">
+<div data-identification-state="complete">
   <%= form_with model: feed,
                 url: (edit_mode ? feed_path(feed) : feeds_path),
                 method: (edit_mode ? :patch : :post),

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -13,17 +13,8 @@
                 } do |f| %>
     <div class="space-y-6">
       <% if edit_mode %>
-        <div class="rounded-md bg-blue-50 p-4 mb-6">
-          <div class="flex">
-            <div class="flex-shrink-0">
-              <%= icon("information-circle", css_class: "h-5 w-5 text-blue-400", aria_hidden: true) %>
-            </div>
-            <div class="ml-3">
-              <p class="text-sm text-blue-700">
-                Feed URL and Type cannot be changed after creation. To use a different URL, create a new feed.
-              </p>
-            </div>
-          </div>
+        <div class="ff-alert ff-alert--info">
+          <p>Feed URL and Type cannot be changed after creation. To use a different URL, create a new feed.</p>
         </div>
       <% end %>
 

--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -1,5 +1,4 @@
-<div data-identification-state="error"
-     class="rounded-lg border border-slate-200 bg-white px-6 py-8 shadow-sm space-y-6">
+<div data-identification-state="error" class="rounded-lg border border-slate-200 bg-white px-6 py-8 shadow-sm space-y-6">
   <div class="rounded-md bg-red-50 p-4">
     <div class="flex">
       <div class="flex-shrink-0">

--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -1,5 +1,4 @@
-<div id="feed-form"
-     data-identification-state="error"
+<div data-identification-state="error"
      class="rounded-lg border border-slate-200 bg-white px-6 py-8 shadow-sm space-y-6">
   <div class="rounded-md bg-red-50 p-4">
     <div class="flex">

--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -1,26 +1,28 @@
-<div data-identification-state="error" class="rounded-lg border border-slate-200 bg-white px-6 py-8 shadow-sm space-y-6">
-  <div class="rounded-md bg-red-50 p-4">
-    <div class="flex">
-      <div class="flex-shrink-0">
-        <%= icon("exclamation-triangle", css_class: "h-5 w-5 text-red-400", aria_hidden: true) %>
-      </div>
-      <div class="ml-3">
-        <h3 class="text-sm font-medium text-red-800">Feed identification failed</h3>
-        <div class="mt-2 text-sm text-red-700">
-          <p><%= error %></p>
+<div data-identification-state="error" class="ff-card">
+  <div class="ff-card__body">
+    <div class="rounded-md bg-red-50 p-4">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <%= icon("exclamation-triangle", css_class: "h-5 w-5 text-red-400", aria_hidden: true) %>
+        </div>
+        <div class="ml-3">
+          <h3 class="text-sm font-medium text-red-800">Feed identification failed</h3>
+          <div class="mt-2 text-sm text-red-700">
+            <p><%= error %></p>
+          </div>
         </div>
       </div>
     </div>
+
+    <%= form_with url: feed_details_path, method: :post do |f| %>
+      <div class="ff-form-group">
+        <%= f.label :url, "Feed URL", class: "ff-form-label" %>
+        <%= f.text_field :url, value: url, placeholder: "https://example.com/feed.xml", class: "ff-form-input" %>
+      </div>
+
+      <div>
+        <%= f.submit "Try Again", class: "ff-button ff-button--compact w-full sm:w-auto" %>
+      </div>
+    <% end %>
   </div>
-
-  <%= form_with url: feed_details_path, method: :post, class: "space-y-6" do |f| %>
-    <div class="ff-form-group">
-      <%= f.label :url, "Feed URL", class: "ff-form-label" %>
-      <%= f.text_field :url, value: url, placeholder: "https://example.com/feed.xml", class: "ff-form-input" %>
-    </div>
-
-    <div>
-      <%= f.submit "Try Again", class: "ff-button ff-button--compact w-full sm:w-auto" %>
-    </div>
-  <% end %>
 </div>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -1,20 +1,21 @@
-<%= render CardComponent.new(
-      id: "feed-form",
-      class: "flex items-center gap-3",
-      role: "status",
-      data: {
-        controller: "polling",
-        polling_endpoint_value: feed_details_path(url: url),
-        polling_interval_value: Feed::IDENTIFICATION_POLLING_INTERVAL_MS,
-        polling_max_polls_value: FeedDetailsController::IDENTIFICATION_TIMEOUT_SECONDS / 2,
-        polling_stop_condition_value: "[data-identification-state='complete'], [data-identification-state='error']"
-      }
-    ) do %>
-  <div class="flex-shrink-0">
-    <%= render SpinnerComponent.new %>
+<div id="feed-form-wrapper"
+     data-controller="polling"
+     data-polling-endpoint-value="<%= feed_details_path(url: url) %>"
+     data-polling-interval-value="<%= Feed::IDENTIFICATION_POLLING_INTERVAL_MS %>"
+     data-polling-max-polls-value="<%= FeedDetailsController::IDENTIFICATION_TIMEOUT_SECONDS / 2 %>"
+     data-polling-stop-condition-value="[data-identification-state='complete'], [data-identification-state='error']">
+  <div id="feed-form">
+    <%= render CardComponent.new(
+          class: "flex items-center gap-3",
+          role: "status"
+        ) do %>
+      <div class="flex-shrink-0">
+        <%= render SpinnerComponent.new %>
+      </div>
+      <div class="space-y-1">
+        <p class="ff-text ff-text--heavy">Checking this feed...</p>
+        <p class="ff-text">This usually takes a few seconds.</p>
+      </div>
+    <% end %>
   </div>
-  <div class="space-y-1">
-    <p class="ff-text ff-text--heavy">Checking this feed...</p>
-    <p class="ff-text">This usually takes a few seconds.</p>
-  </div>
-<% end %>
+</div>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -5,14 +5,18 @@
      data-polling-max-polls-value="<%= FeedDetailsController::IDENTIFICATION_TIMEOUT_SECONDS / 2 %>"
      data-polling-stop-condition-value="[data-identification-state='complete'], [data-identification-state='error']">
   <div id="feed-form">
-    <%= render CardComponent.new(class: "flex items-center gap-3", role: "status") do %>
-      <div class="flex-shrink-0">
-        <%= render SpinnerComponent.new %>
+    <div class="ff-card" role="status">
+      <div class="ff-card__body">
+        <div class="flex items-center gap-3">
+          <div class="flex-shrink-0">
+            <%= render SpinnerComponent.new %>
+          </div>
+          <div class="space-y-1">
+            <p class="ff-text ff-text--heavy">Checking this feed...</p>
+            <p class="ff-text">This usually takes a few seconds.</p>
+          </div>
+        </div>
       </div>
-      <div class="space-y-1">
-        <p class="ff-text ff-text--heavy">Checking this feed...</p>
-        <p class="ff-text">This usually takes a few seconds.</p>
-      </div>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -5,10 +5,7 @@
      data-polling-max-polls-value="<%= FeedDetailsController::IDENTIFICATION_TIMEOUT_SECONDS / 2 %>"
      data-polling-stop-condition-value="[data-identification-state='complete'], [data-identification-state='error']">
   <div id="feed-form">
-    <%= render CardComponent.new(
-          class: "flex items-center gap-3",
-          role: "status"
-        ) do %>
+    <%= render CardComponent.new(class: "flex items-center gap-3", role: "status") do %>
       <div class="flex-shrink-0">
         <%= render SpinnerComponent.new %>
       </div>

--- a/app/views/feeds/_identification_loading_poll.html.erb
+++ b/app/views/feeds/_identification_loading_poll.html.erb
@@ -1,0 +1,9 @@
+<div id="feed-form" class="rounded-lg border border-slate-200 px-4 py-3 shadow-sm flex items-center gap-3" role="status">
+  <div class="flex-shrink-0">
+    <%= render SpinnerComponent.new %>
+  </div>
+  <div class="space-y-1">
+    <p class="ff-text ff-text--heavy">Checking this feed...</p>
+    <p class="ff-text">This usually takes a few seconds.</p>
+  </div>
+</div>

--- a/app/views/feeds/_identification_loading_poll.html.erb
+++ b/app/views/feeds/_identification_loading_poll.html.erb
@@ -1,9 +1,13 @@
-<%= render CardComponent.new(class: "flex items-center gap-3", role: "status") do %>
-  <div class="flex-shrink-0">
-    <%= render SpinnerComponent.new %>
+<div class="ff-card" role="status">
+  <div class="ff-card__body">
+    <div class="flex items-center gap-3">
+      <div class="flex-shrink-0">
+        <%= render SpinnerComponent.new %>
+      </div>
+      <div class="space-y-1">
+        <p class="ff-text ff-text--heavy">Checking this feed...</p>
+        <p class="ff-text">This usually takes a few seconds.</p>
+      </div>
+    </div>
   </div>
-  <div class="space-y-1">
-    <p class="ff-text ff-text--heavy">Checking this feed...</p>
-    <p class="ff-text">This usually takes a few seconds.</p>
-  </div>
-<% end %>
+</div>

--- a/app/views/feeds/_identification_loading_poll.html.erb
+++ b/app/views/feeds/_identification_loading_poll.html.erb
@@ -1,4 +1,7 @@
-<div id="feed-form" class="rounded-lg border border-slate-200 px-4 py-3 shadow-sm flex items-center gap-3" role="status">
+<%= render CardComponent.new(
+      class: "flex items-center gap-3",
+      role: "status"
+    ) do %>
   <div class="flex-shrink-0">
     <%= render SpinnerComponent.new %>
   </div>
@@ -6,4 +9,4 @@
     <p class="ff-text ff-text--heavy">Checking this feed...</p>
     <p class="ff-text">This usually takes a few seconds.</p>
   </div>
-</div>
+<% end %>

--- a/app/views/feeds/_identification_loading_poll.html.erb
+++ b/app/views/feeds/_identification_loading_poll.html.erb
@@ -1,7 +1,4 @@
-<%= render CardComponent.new(
-      class: "flex items-center gap-3",
-      role: "status"
-    ) do %>
+<%= render CardComponent.new(class: "flex items-center gap-3", role: "status") do %>
   <div class="flex-shrink-0">
     <%= render SpinnerComponent.new %>
   </div>

--- a/app/views/feeds/edit.html.erb
+++ b/app/views/feeds/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Edit Feed") %>
 
-  <div class="max-w-3xl">
+  <div class="max-w-2xl">
     <%= render "form_expanded", feed: @feed, edit_mode: true %>
   </div>
 </div>

--- a/app/views/feeds/edit.html.erb
+++ b/app/views/feeds/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Edit Feed") %>
 
-  <div class="max-w-3xl mx-auto">
+  <div class="max-w-3xl">
     <%= render "form_expanded", feed: @feed, edit_mode: true %>
   </div>
 </div>

--- a/app/views/feeds/new.html.erb
+++ b/app/views/feeds/new.html.erb
@@ -3,7 +3,7 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "New Feed") %>
 
-  <div class="max-w-3xl">
+  <div class="max-w-2xl">
     <% if !active_access_tokens? %>
       <%= render "blocked_no_tokens" %>
     <% elsif @feed.url.present? %>

--- a/app/views/feeds/new.html.erb
+++ b/app/views/feeds/new.html.erb
@@ -3,7 +3,7 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "New Feed") %>
 
-  <div class="max-w-3xl mx-auto">
+  <div class="max-w-3xl">
     <% if !active_access_tokens? %>
       <%= render "blocked_no_tokens" %>
     <% elsif @feed.url.present? %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -1,21 +1,23 @@
+<%# locals: (recent_events:, has_active_tokens:, no_feeds:) %>
+
 <% content_for :title, "Status" %>
 
 <div class="space-y-8">
-  <% if @user.email_deactivated? %>
+  <% if current_user.email_deactivated? %>
     <div class="ff-alert ff-alert--warning space-y-2" role="alert">
       <p class="ff-text ff-text--heavy">Your email address is not receiving our emails.</p>
-      <% if @user.can_change_email? %>
+      <% if current_user.can_change_email? %>
         <p class="ff-text">
           <%= link_to "Update your email address", edit_settings_email_update_path, class: "ff-link" %>
           to continue receiving notifications.
         </p>
       <% else %>
-        <p class="ff-text">You can update your email address in <%= distance_of_time_in_words(@user.time_until_email_change_allowed) %>.</p>
+        <p class="ff-text">You can update your email address in <%= distance_of_time_in_words(current_user.time_until_email_change_allowed) %>.</p>
       <% end %>
     </div>
   <% end %>
 
-  <% if @user.onboarding? && !@has_active_tokens %>
+  <% if current_user.onboarding? && !has_active_tokens %>
     <%# State 1: Onboarding - No active tokens %>
     <section class="space-y-4">
       <h1 class="ff-h1">Welcome to Feeder</h1>
@@ -25,7 +27,7 @@
         <%= link_to "Add FreeFeed token", new_access_token_path, class: "ff-button" %>
       </div>
     </section>
-  <% elsif @user.onboarding? && @has_active_tokens && !@has_feeds %>
+  <% elsif current_user.onboarding? && has_active_tokens && no_feeds %>
     <%# State 2: Onboarding - Has token, no feeds %>
     <section class="space-y-4">
       <h1 class="ff-h1">Welcome to Feeder</h1>
@@ -38,7 +40,7 @@
     <%# State 3 & 4: Active user - Show normal dashboard %>
     <h1 class="ff-h1">Status</h1>
 
-    <% if @user.active? && !@has_active_tokens %>
+    <% if current_user.active? && !has_active_tokens %>
       <%# State 4: Active user with no active tokens - Show warning %>
       <div class="ff-alert ff-alert--warning space-y-2" role="alert">
         <p class="ff-text ff-text--heavy">You don't have any active FreeFeed tokens.</p>
@@ -49,12 +51,12 @@
       </div>
     <% end %>
 
-    <%= render UserStatsComponent.new(user: @user) %>
+    <%= render UserStatsComponent.new(user: current_user) %>
 
-    <% if @recent_events.any? %>
+    <% if recent_events.any? %>
       <section class="space-y-4">
         <h2 class="ff-h2">Recent Activity</h2>
-        <%= render RecentEventsComponent.new(events: @recent_events) %>
+        <%= render RecentEventsComponent.new(events: recent_events) %>
       </section>
     <% end %>
   <% end %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -8,8 +8,7 @@
       <p class="ff-text ff-text--heavy">Your email address is not receiving our emails.</p>
       <% if current_user.can_change_email? %>
         <p class="ff-text">
-          <%= link_to "Update your email address", edit_settings_email_update_path, class: "ff-link" %>
-          to continue receiving notifications.
+          <%= link_to "Update your email address", edit_settings_email_update_path, class: "ff-link" %> to continue receiving notifications.
         </p>
       <% else %>
         <p class="ff-text">You can update your email address in <%= distance_of_time_in_words(current_user.time_until_email_change_allowed) %>.</p>
@@ -18,7 +17,7 @@
   <% end %>
 
   <% if current_user.onboarding? && !has_active_tokens %>
-    <%# State 1: Onboarding - No active tokens %>
+    <%# Onboarding - No active tokens %>
     <section class="space-y-4">
       <h1 class="ff-h1">Welcome to Feeder</h1>
       <p class="ff-text">Feeder helps you automatically share content from your favorite sources to FreeFeed.</p>
@@ -28,7 +27,7 @@
       </div>
     </section>
   <% elsif current_user.onboarding? && has_active_tokens && no_feeds %>
-    <%# State 2: Onboarding - Has token, no feeds %>
+    <%# Onboarding - Has token, no feeds %>
     <section class="space-y-4">
       <h1 class="ff-h1">Welcome to Feeder</h1>
       <p class="ff-text">Great! You've added a FreeFeed access token. Now you can create your first feed.</p>
@@ -37,16 +36,15 @@
       </div>
     </section>
   <% else %>
-    <%# State 3 & 4: Active user - Show normal dashboard %>
+    <%# Active user %>
     <h1 class="ff-h1">Status</h1>
 
     <% if current_user.active? && !has_active_tokens %>
-      <%# State 4: Active user with no active tokens - Show warning %>
+      <%# Active user with no active tokens %>
       <div class="ff-alert ff-alert--warning space-y-2" role="alert">
         <p class="ff-text ff-text--heavy">You don't have any active FreeFeed tokens.</p>
         <p class="ff-text">
-          <%= link_to "Add a token", new_access_token_path, class: "ff-link" %>
-          to resume posting.
+          <%= link_to "Add a token", new_access_token_path, class: "ff-link" %> to resume posting.
         </p>
       </div>
     <% end %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -1,8 +1,5 @@
 <% content_for :title, "Status" %>
 
-<% suggest_to_add_tokens = @user.access_tokens.active.none? %>
-<% suggest_adding_feeds = @user.total_feeds_count.zero? %>
-
 <div class="space-y-8">
   <% if @user.email_deactivated? %>
     <div class="ff-alert ff-alert--warning space-y-2" role="alert">
@@ -18,7 +15,8 @@
     </div>
   <% end %>
 
-  <% if suggest_to_add_tokens %>
+  <% if @user.onboarding? && !@has_active_tokens %>
+    <%# State 1: Onboarding - No active tokens %>
     <section class="space-y-4">
       <h1 class="ff-h1">Welcome to Feeder</h1>
       <p class="ff-text">Feeder helps you automatically share content from your favorite sources to FreeFeed.</p>
@@ -27,7 +25,8 @@
         <%= link_to "Add FreeFeed token", new_access_token_path, class: "ff-button" %>
       </div>
     </section>
-  <% elsif suggest_adding_feeds %>
+  <% elsif @user.onboarding? && @has_active_tokens && !@has_feeds %>
+    <%# State 2: Onboarding - Has token, no feeds %>
     <section class="space-y-4">
       <h1 class="ff-h1">Welcome to Feeder</h1>
       <p class="ff-text">Great! You've added a FreeFeed access token. Now you can create your first feed.</p>
@@ -36,7 +35,20 @@
       </div>
     </section>
   <% else %>
+    <%# State 3 & 4: Active user - Show normal dashboard %>
     <h1 class="ff-h1">Status</h1>
+
+    <% if @user.active? && !@has_active_tokens %>
+      <%# State 4: Active user with no active tokens - Show warning %>
+      <div class="ff-alert ff-alert--warning space-y-2" role="alert">
+        <p class="ff-text ff-text--heavy">You don't have any active FreeFeed tokens.</p>
+        <p class="ff-text">
+          <%= link_to "Add a token", new_access_token_path, class: "ff-link" %>
+          to resume posting.
+        </p>
+      </div>
+    <% end %>
+
     <%= render UserStatsComponent.new(user: @user) %>
 
     <% if @recent_events.any? %>

--- a/docs/onboarding_test_manual.md
+++ b/docs/onboarding_test_manual.md
@@ -17,7 +17,7 @@ This manual provides test cases for validating the onboarding flow and status pa
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.access_tokens.update_all(status: :inactive); puts 'Setup complete: User is onboarding, all tokens inactive'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.access_tokens.update_all(status: :inactive); puts 'Setup complete: User is onboarding, all tokens inactive'"
 ```
 
 **Expected State:**
@@ -39,7 +39,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
 
 **Cleanup:**
 ```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); puts 'Cleanup complete'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; puts 'Cleanup complete'"
 ```
 
 ---
@@ -51,7 +51,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.feeds.destroy_all; u.access_tokens.each { |t| t.update!(status: :active) if t.status != 'active' }; puts 'Setup complete: User is onboarding, has active tokens, no feeds'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.each { |t| t.active! if t.status != 'active' }; puts 'Setup complete: User is onboarding, has active tokens, no feeds'"
 ```
 
 **Expected State:**
@@ -72,7 +72,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
 
 **Cleanup:**
 ```bash
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); puts 'User state reset'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; puts 'User state reset'"
 bin/rails db:seed
 ```
 
@@ -85,7 +85,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.feeds.destroy_all; u.access_tokens.first.update!(status: :active); puts 'Setup complete: User ready to complete onboarding'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!; puts 'Setup complete: User ready to complete onboarding'"
 ```
 
 **Expected State:**
@@ -127,7 +127,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.first.update!(status: :active) unless u.access_tokens.active.any?; puts 'Setup complete: Active user with active tokens and feeds'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active! unless u.access_tokens.active.any?; puts 'Setup complete: Active user with active tokens and feeds'"
 ```
 
 **Expected State:**
@@ -162,7 +162,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.update_all(status: :inactive); puts 'Setup complete: Active user with all tokens inactive'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.update_all(status: :inactive); puts 'Setup complete: Active user with all tokens inactive'"
 ```
 
 **Expected State:**
@@ -198,7 +198,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.access_
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.feeds.destroy_all; t = u.access_tokens.first; t.update!(status: :active); puts 'Setup complete: Onboarding user with one active token, no feeds'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; t = u.access_tokens.first; t.active!; puts 'Setup complete: Onboarding user with one active token, no feeds'"
 ```
 
 **Expected State:**
@@ -218,7 +218,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
 
 **Cleanup:**
 ```bash
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.first.update!(status: :active); puts 'User state reset'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active!; puts 'User state reset'"
 bin/rails db:seed
 ```
 
@@ -231,7 +231,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.first.update!(status: :active); puts 'Setup complete: Active user with feeds'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active!; puts 'Setup complete: Active user with feeds'"
 ```
 
 **Expected State:**
@@ -265,7 +265,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.feeds.destroy_all; u.access_tokens.first.update!(status: :active); puts 'Setup complete: Onboarding user ready to create first feed'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!; puts 'Setup complete: Onboarding user ready to create first feed'"
 ```
 
 **Expected State:**
@@ -289,7 +289,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
 
 **Cleanup:**
 ```bash
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); puts 'User state reset'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; puts 'User state reset'"
 bin/rails db:seed
 ```
 

--- a/docs/onboarding_test_manual.md
+++ b/docs/onboarding_test_manual.md
@@ -1,0 +1,341 @@
+# Onboarding Flow Testing Manual
+
+This manual provides test cases for validating the onboarding flow and status page states. Each test case includes setup scripts that can be run with Rails runner and detailed steps for browser agent testing.
+
+## Prerequisites
+
+- Development environment is set up
+- Database is seeded: `bin/rails db:seed`
+- Default user credentials: `test@example.com` / `password123`
+
+## Test Cases
+
+### Test Case 1: New User - Onboarding State 1 (No Active Tokens)
+
+**Objective:** Verify that a user in onboarding state without active tokens sees the token setup prompt.
+
+**Setup:**
+```ruby
+# Run in Rails console or as oneliner:
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.access_tokens.update_all(status: :inactive); puts 'Setup complete: User is onboarding, all tokens inactive'"
+```
+
+**Expected State:**
+- User state: `onboarding`
+- Active tokens: 0
+- Feeds: 0 or more (doesn't matter)
+
+**Test Steps:**
+1. Navigate to the login page
+2. Sign in with email `test@example.com` and password `password123`
+3. You should be redirected to the Status page
+4. Verify the page displays:
+   - Heading: "Welcome to Feeder"
+   - Text: "Feeder helps you automatically share content from your favorite sources to FreeFeed."
+   - Text: "To get started, add a FreeFeed access token so Feeder can post on your behalf."
+   - Button: "Add FreeFeed token"
+5. Click the "Add FreeFeed token" button
+6. Verify you are redirected to the token creation page
+
+**Cleanup:**
+```ruby
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); puts 'Cleanup complete'"
+```
+
+---
+
+### Test Case 2: New User - Onboarding State 2 (Has Token, No Feeds)
+
+**Objective:** Verify that a user in onboarding state with an active token but no feeds sees the feed creation prompt.
+
+**Setup:**
+```ruby
+# Run in Rails console or as oneliner:
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.feeds.destroy_all; u.access_tokens.each { |t| t.update!(status: :active) if t.status != 'active' }; puts 'Setup complete: User is onboarding, has active tokens, no feeds'"
+```
+
+**Expected State:**
+- User state: `onboarding`
+- Active tokens: 1 or more
+- Feeds: 0
+
+**Test Steps:**
+1. Navigate to the login page
+2. Sign in with email `test@example.com` and password `password123`
+3. You should be redirected to the Status page
+4. Verify the page displays:
+   - Heading: "Welcome to Feeder"
+   - Text: "Great! You've added a FreeFeed access token. Now you can create your first feed."
+   - Button: "Add feed"
+5. Click the "Add feed" button
+6. Verify you are redirected to the feed creation page
+
+**Cleanup:**
+```ruby
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); bin/rails db:seed; puts 'Cleanup complete'"
+```
+
+---
+
+### Test Case 3: Completing Onboarding - State Transition
+
+**Objective:** Verify that creating the first feed transitions the user from onboarding to active state.
+
+**Setup:**
+```ruby
+# Run in Rails console or as oneliner:
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.feeds.destroy_all; u.access_tokens.first.update!(status: :active); puts 'Setup complete: User ready to complete onboarding'"
+```
+
+**Expected State:**
+- User state: `onboarding`
+- Active tokens: 1 or more
+- Feeds: 0
+
+**Test Steps:**
+1. Sign in with email `test@example.com` and password `password123`
+2. You should see the "Welcome to Feeder" page with "Add feed" button
+3. Click "Add feed"
+4. Fill in the feed creation form:
+   - URL: `https://feeds.feedburner.com/GoogleOpenSourceBlog`
+   - Click "Identify Feed" (wait for it to load)
+   - Name: "Test Feed"
+   - Target Group: "test-group"
+   - Schedule: Select "Every hour"
+   - Check "Enable feed immediately"
+5. Click "Create Feed"
+6. Verify you are redirected to the feed details page
+7. Navigate back to the Status page (click "Status" in navigation)
+8. Verify the page NOW displays:
+   - Heading: "Status" (NOT "Welcome to Feeder")
+   - User statistics section
+   - No warning alerts
+
+**Cleanup:**
+```ruby
+bin/rails runner "Feed.find_by(name: 'Test Feed')&.destroy; bin/rails db:seed; puts 'Cleanup complete'"
+```
+
+---
+
+### Test Case 4: Active User - Normal Dashboard (State 3)
+
+**Objective:** Verify that an active user with active tokens and feeds sees the normal dashboard.
+
+**Setup:**
+```ruby
+# Run in Rails console or as oneliner:
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.first.update!(status: :active) unless u.access_tokens.active.any?; puts 'Setup complete: Active user with active tokens and feeds'"
+```
+
+**Expected State:**
+- User state: `active`
+- Active tokens: 1 or more
+- Feeds: 1 or more
+
+**Test Steps:**
+1. Sign in with email `test@example.com` and password `password123`
+2. You should be redirected to the Status page
+3. Verify the page displays:
+   - Heading: "Status"
+   - User statistics including:
+     - Total Feeds
+     - Total Imported Posts
+     - Total Published Posts
+     - Recent Activity section (if there are events)
+   - NO "Welcome to Feeder" message
+   - NO warning alerts about missing tokens
+
+**Cleanup:**
+```ruby
+# No cleanup needed - this is the default state
+```
+
+---
+
+### Test Case 5: Active User - Missing Active Tokens (State 4)
+
+**Objective:** Verify that an active user with no active tokens sees a warning but still displays the dashboard.
+
+**Setup:**
+```ruby
+# Run in Rails console or as oneliner:
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.update_all(status: :inactive); puts 'Setup complete: Active user with all tokens inactive'"
+```
+
+**Expected State:**
+- User state: `active`
+- Active tokens: 0
+- Feeds: 1 or more
+
+**Test Steps:**
+1. Sign in with email `test@example.com` and password `password123`
+2. You should be redirected to the Status page
+3. Verify the page displays:
+   - Heading: "Status"
+   - Warning alert (yellow/orange box) containing:
+     - Text: "You don't have any active FreeFeed tokens."
+     - Link: "Add a token" (links to new token page)
+   - User statistics section BELOW the warning
+   - Recent Activity section (if there are events)
+   - NO "Welcome to Feeder" message
+4. Click the "Add a token" link in the warning
+5. Verify you are redirected to the token creation page
+
+**Cleanup:**
+```ruby
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.access_tokens.first.update!(status: :active); puts 'Cleanup complete'"
+```
+
+---
+
+### Test Case 6: Token Deactivation During Onboarding
+
+**Objective:** Verify that if a user deactivates their only token during onboarding, they return to State 1.
+
+**Setup:**
+```ruby
+# Run in Rails console or as oneliner:
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.feeds.destroy_all; t = u.access_tokens.first; t.update!(status: :active); puts 'Setup complete: Onboarding user with one active token, no feeds'"
+```
+
+**Expected State:**
+- User state: `onboarding`
+- Active tokens: 1
+- Feeds: 0
+
+**Test Steps:**
+1. Sign in with email `test@example.com` and password `password123`
+2. You should see "Welcome to Feeder" with "Add feed" button (State 2)
+3. Navigate to "Access Tokens" page (from top navigation or settings)
+4. Find the active token and deactivate it (click "Deactivate" or similar)
+5. Navigate back to the Status page
+6. Verify the page NOW displays:
+   - State 1: "Welcome to Feeder" with "Add FreeFeed token" button
+   - The message about adding a token (NOT about creating a feed)
+
+**Cleanup:**
+```ruby
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.first.update!(status: :active); bin/rails db:seed; puts 'Cleanup complete'"
+```
+
+---
+
+### Test Case 7: Active User Deletes All Feeds
+
+**Objective:** Verify that an active user who deletes all feeds does NOT see "Welcome" message.
+
+**Setup:**
+```ruby
+# Run in Rails console or as oneliner:
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.first.update!(status: :active); puts 'Setup complete: Active user with feeds'"
+```
+
+**Expected State:**
+- User state: `active`
+- Active tokens: 1 or more
+- Feeds: 1 or more
+
+**Test Steps:**
+1. Sign in with email `test@example.com` and password `password123`
+2. Navigate to the Feeds page
+3. Delete all feeds one by one
+4. Navigate to the Status page
+5. Verify the page displays:
+   - Heading: "Status"
+   - User statistics showing "0 feeds"
+   - NO "Welcome to Feeder" message
+   - NO special onboarding prompts
+   - The page shows the normal dashboard with zero counts
+
+**Cleanup:**
+```ruby
+bin/rails runner "bin/rails db:seed; puts 'Cleanup complete'"
+```
+
+---
+
+### Test Case 8: First Feed Creation Fails - State Not Changed
+
+**Objective:** Verify that if feed creation fails during onboarding, the user remains in onboarding state.
+
+**Setup:**
+```ruby
+# Run in Rails console or as oneliner:
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :onboarding); u.feeds.destroy_all; u.access_tokens.first.update!(status: :active); puts 'Setup complete: Onboarding user ready to create first feed'"
+```
+
+**Expected State:**
+- User state: `onboarding`
+- Active tokens: 1 or more
+- Feeds: 0
+
+**Test Steps:**
+1. Sign in with email `test@example.com` and password `password123`
+2. You should see "Welcome to Feeder" with "Add feed" button
+3. Click "Add feed"
+4. Fill in the feed creation form with INVALID data:
+   - URL: Leave empty or enter invalid URL
+   - Click "Create Feed" (don't fill other required fields)
+5. Verify you see validation errors
+6. Navigate back to the Status page (click "Status" in navigation)
+7. Verify the page STILL displays:
+   - Heading: "Welcome to Feeder"
+   - The onboarding State 2 message (create your first feed)
+   - User is STILL in onboarding state
+
+**Cleanup:**
+```ruby
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); bin/rails db:seed; puts 'Cleanup complete'"
+```
+
+---
+
+### Test Case 9: Email Deactivation Warning Appears in All States
+
+**Objective:** Verify that email deactivation warning appears regardless of onboarding state.
+
+**Setup:**
+```ruby
+# Run in Rails console or as oneliner:
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(email_deactivated_at: Time.current, email_deactivation_reason: 'bounce'); puts 'Setup complete: User email deactivated'"
+```
+
+**Expected State:**
+- User email is deactivated
+- Any user state
+
+**Test Steps:**
+1. Sign in with email `test@example.com` and password `password123`
+2. Navigate to the Status page
+3. Verify that at the TOP of the page (before any other content):
+   - Yellow/orange warning alert appears
+   - Text: "Your email address is not receiving our emails."
+   - Link to update email address
+4. Verify the rest of the page displays normally (based on user's state)
+
+**Cleanup:**
+```ruby
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(email_deactivated_at: nil, email_deactivation_reason: nil); puts 'Cleanup complete'"
+```
+
+---
+
+## Quick Reset to Default State
+
+If tests leave the system in an inconsistent state, run:
+
+```bash
+bin/rails db:reset
+bin/rails db:seed
+```
+
+This will restore the default development user and sample data.
+
+## Notes for Browser Agents
+
+- Each test case is independent - run the setup, perform the test, then run cleanup
+- Setup scripts are provided as one-liners for easy copy-paste
+- Expected states are documented to help verify preconditions
+- All tests assume you're starting from a clean slate after running the setup script
+- After each test, run the cleanup script before moving to the next test

--- a/docs/onboarding_test_manual.md
+++ b/docs/onboarding_test_manual.md
@@ -17,7 +17,7 @@ This manual provides test cases for validating the onboarding flow and status pa
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.access_tokens.update_all(status: :inactive); puts 'Setup complete: User is onboarding, all tokens inactive'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.access_tokens.update_all(status: :inactive)"
 ```
 
 **Expected State:**
@@ -39,7 +39,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; puts 'Cleanup complete'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!"
 ```
 
 ---
@@ -51,7 +51,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.each { |t| t.active! if t.status != 'active' }; puts 'Setup complete: User is onboarding, has active tokens, no feeds'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.each { |t| t.active! if t.status != 'active' }"
 ```
 
 **Expected State:**
@@ -72,7 +72,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```bash
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; puts 'User state reset'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!"
 bin/rails db:seed
 ```
 
@@ -85,7 +85,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!; puts 'Setup complete: User ready to complete onboarding'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!"
 ```
 
 **Expected State:**
@@ -114,7 +114,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```bash
-bin/rails runner "Feed.find_by(name: 'Test Feed')&.destroy; puts 'Feed removed'"
+bin/rails runner "Feed.find_by(name: 'Test Feed')&.destroy"
 bin/rails db:seed
 ```
 
@@ -127,7 +127,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active! unless u.access_tokens.active.any?; puts 'Setup complete: Active user with active tokens and feeds'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active! unless u.access_tokens.active.any?"
 ```
 
 **Expected State:**
@@ -162,7 +162,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.update_all(status: :inactive); puts 'Setup complete: Active user with all tokens inactive'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.update_all(status: :inactive)"
 ```
 
 **Expected State:**
@@ -186,7 +186,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!
 
 **Cleanup:**
 ```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.access_tokens.first.update!(status: :active); puts 'Cleanup complete'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.access_tokens.first.active!"
 ```
 
 ---
@@ -198,7 +198,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.access_
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; t = u.access_tokens.first; t.active!; puts 'Setup complete: Onboarding user with one active token, no feeds'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!"
 ```
 
 **Expected State:**
@@ -218,7 +218,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```bash
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active!; puts 'User state reset'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active!"
 bin/rails db:seed
 ```
 
@@ -231,7 +231,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active!; puts 'Setup complete: Active user with feeds'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active!"
 ```
 
 **Expected State:**
@@ -265,7 +265,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!; puts 'Setup complete: Onboarding user ready to create first feed'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!"
 ```
 
 **Expected State:**
@@ -289,7 +289,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```bash
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; puts 'User state reset'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!"
 bin/rails db:seed
 ```
 
@@ -302,7 +302,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(email_deactivated_at: Time.current, email_deactivation_reason: 'bounce'); puts 'Setup complete: User email deactivated'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(email_deactivated_at: Time.current, email_deactivation_reason: 'bounce')"
 ```
 
 **Expected State:**
@@ -320,7 +320,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
 
 **Cleanup:**
 ```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(email_deactivated_at: nil, email_deactivation_reason: nil); puts 'Cleanup complete'"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(email_deactivated_at: nil, email_deactivation_reason: nil)"
 ```
 
 ---

--- a/docs/onboarding_test_manual.md
+++ b/docs/onboarding_test_manual.md
@@ -17,7 +17,7 @@ This manual provides test cases for validating the onboarding flow and status pa
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.access_tokens.update_all(status: :inactive)"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding\!; u.access_tokens.update_all(status: :inactive)"
 ```
 
 **Expected State:**
@@ -39,7 +39,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active\!"
 ```
 
 ---
@@ -51,7 +51,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.each { |t| t.active! if t.status != 'active' }"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding\!; u.feeds.destroy_all; u.access_tokens.each { |t| t.active\! if t.status != 'active' }"
 ```
 
 **Expected State:**
@@ -72,7 +72,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```bash
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active\!"
 bin/rails db:seed
 ```
 
@@ -85,7 +85,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding\!; u.feeds.destroy_all; u.access_tokens.first.active\!"
 ```
 
 **Expected State:**
@@ -114,7 +114,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```bash
-bin/rails runner "Feed.find_by(name: 'Test Feed')&.destroy"
+bin/rails runner "Feed.find_by(name: 'Test Feed')&.destroy\!"
 bin/rails db:seed
 ```
 
@@ -127,7 +127,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active! unless u.access_tokens.active.any?"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active\!; u.access_tokens.first.active\! unless u.access_tokens.active.any?"
 ```
 
 **Expected State:**
@@ -162,7 +162,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.update_all(status: :inactive)"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active\!; u.access_tokens.update_all(status: :inactive)"
 ```
 
 **Expected State:**
@@ -186,7 +186,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!
 
 **Cleanup:**
 ```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.access_tokens.first.active!"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.access_tokens.first.active\!"
 ```
 
 ---
@@ -198,7 +198,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.access_
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding\!; u.feeds.destroy_all; u.access_tokens.first.active\!"
 ```
 
 **Expected State:**
@@ -218,7 +218,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```bash
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active!"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active\!; u.access_tokens.first.active\!"
 bin/rails db:seed
 ```
 
@@ -231,7 +231,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!; u.access_tokens.first.active!"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active\!; u.access_tokens.first.active\!"
 ```
 
 **Expected State:**
@@ -265,7 +265,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding!; u.feeds.destroy_all; u.access_tokens.first.active!"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboarding\!; u.feeds.destroy_all; u.access_tokens.first.active\!"
 ```
 
 **Expected State:**
@@ -289,7 +289,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.onboard
 
 **Cleanup:**
 ```bash
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active!"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.active\!"
 bin/rails db:seed
 ```
 
@@ -302,7 +302,7 @@ bin/rails db:seed
 **Setup:**
 ```ruby
 # Run in Rails console or as oneliner:
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(email_deactivated_at: Time.current, email_deactivation_reason: 'bounce')"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update\!(email_deactivated_at: Time.current, email_deactivation_reason: 'bounce')"
 ```
 
 **Expected State:**
@@ -320,7 +320,7 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
 
 **Cleanup:**
 ```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(email_deactivated_at: nil, email_deactivation_reason: nil)"
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update\!(email_deactivated_at: nil, email_deactivation_reason: nil)"
 ```
 
 ---

--- a/docs/onboarding_test_manual.md
+++ b/docs/onboarding_test_manual.md
@@ -71,8 +71,9 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
 6. Verify you are redirected to the feed creation page
 
 **Cleanup:**
-```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); bin/rails db:seed; puts 'Cleanup complete'"
+```bash
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); puts 'User state reset'"
+bin/rails db:seed
 ```
 
 ---
@@ -112,8 +113,9 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
    - No warning alerts
 
 **Cleanup:**
-```ruby
-bin/rails runner "Feed.find_by(name: 'Test Feed')&.destroy; bin/rails db:seed; puts 'Cleanup complete'"
+```bash
+bin/rails runner "Feed.find_by(name: 'Test Feed')&.destroy; puts 'Feed removed'"
+bin/rails db:seed
 ```
 
 ---
@@ -215,8 +217,9 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
    - The message about adding a token (NOT about creating a feed)
 
 **Cleanup:**
-```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.first.update!(status: :active); bin/rails db:seed; puts 'Cleanup complete'"
+```bash
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); u.access_tokens.first.update!(status: :active); puts 'User state reset'"
+bin/rails db:seed
 ```
 
 ---
@@ -249,8 +252,8 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
    - The page shows the normal dashboard with zero counts
 
 **Cleanup:**
-```ruby
-bin/rails runner "bin/rails db:seed; puts 'Cleanup complete'"
+```bash
+bin/rails db:seed
 ```
 
 ---
@@ -285,8 +288,9 @@ bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!
    - User is STILL in onboarding state
 
 **Cleanup:**
-```ruby
-bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); bin/rails db:seed; puts 'Cleanup complete'"
+```bash
+bin/rails runner "u = User.find_by(email_address: 'test@example.com'); u.update!(state: :active); puts 'User state reset'"
+bin/rails db:seed
 ```
 
 ---

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -43,7 +43,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     mobile_layout = result.css(".md\\:hidden").first
     assert_not_nil mobile_layout
     assert_equal "Last refresh", result.css(".md\\:hidden [data-key=\"stats.last_refresh.label\"]").first.text
-    assert_equal "Most recent publication", result.css(".md\\:hidden [data-key=\"stats.most_recent_post.label\"]").first.text
+    assert_equal "Latest imported post", result.css(".md\\:hidden [data-key=\"stats.most_recent_post.label\"]").first.text
     assert_equal "Imported posts", result.css(".md\\:hidden [data-key=\"stats.imported_posts.label\"]").first.text
   end
 
@@ -53,7 +53,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     desktop_layout = result.css(".hidden.md\\:flex").first
     assert_not_nil desktop_layout
     assert_equal "Refreshed", result.css(".hidden.md\\:flex [data-key=\"stats.last_refresh.label\"]").first.text
-    assert_equal "Recent", result.css(".hidden.md\\:flex [data-key=\"stats.most_recent_post.label\"]").first.text
+    assert_equal "Latest", result.css(".hidden.md\\:flex [data-key=\"stats.most_recent_post.label\"]").first.text
     assert_equal "Imported", result.css(".hidden.md\\:flex [data-key=\"stats.imported_posts.label\"]").first.text
     assert_equal "Published", result.css(".hidden.md\\:flex [data-key=\"stats.published_posts.label\"]").first.text
   end
@@ -67,6 +67,6 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     assert_equal "Never", last_refresh_value
 
     most_recent_value = result.css('[data-key="stats.most_recent_post.value"]').first.text
-    assert_equal "No posts imported", most_recent_value
+    assert_equal "None", most_recent_value
   end
 end

--- a/test/controllers/feed_details_controller_test.rb
+++ b/test/controllers/feed_details_controller_test.rb
@@ -213,7 +213,7 @@ class FeedDetailsControllerTest < ActionDispatch::IntegrationTest
     get feed_details_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_includes response.body, 'action="replace"'
+    assert_includes response.body, 'action="update"'
     assert_includes response.body, 'target="feed-form"'
   end
 


### PR DESCRIPTION
Changes:

- Use `user.state` to distinguish onboarding flow from active users with deactivated tokens.
- Transition user from onboarding to active state on first feed creation.
- Show warning banner instead of Welcome message when active user has no active tokens.
- Add manual testing guide for onboarding scenarios.