### PR TITLE
Add smolvm CI workflow with GitHub Actions cache

### DIFF
--- a/.github/smolvm/Smolfile.toml
+++ b/.github/smolvm/Smolfile.toml
@@ -1,0 +1,5 @@
+image = "ruby:3.4.1"
+net = true
+
+[dev]
+volumes = ["WORKSPACE_PATH:/workspace"]

--- a/.github/workflows/test-smolvm.yml
+++ b/.github/workflows/test-smolvm.yml
@@ -38,18 +38,55 @@ jobs:
           curl -sSL https://smolmachines.com/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Diagnose smolvm environment
+        run: |
+          {
+            echo "## smolvm diagnostics"
+            echo ""
+            echo "**which smolvm:** $(which smolvm 2>&1)"
+            echo ""
+            echo "**smolvm wrapper:**"
+            echo '```'
+            head -5 ~/.smolvm/smolvm 2>&1 || echo "not a text file"
+            echo '```'
+            echo ""
+            echo "**installed files:**"
+            echo '```'
+            ls -la ~/.smolvm/ 2>&1
+            echo '```'
+            echo ""
+            echo "**smolvm lib:**"
+            echo '```'
+            ls -la ~/.smolvm/lib/ 2>&1 || echo "no lib dir"
+            echo '```'
+            echo ""
+            echo "**ldd:**"
+            echo '```'
+            ldd ~/.smolvm/smolvm-bin 2>&1 || ldd ~/.smolvm/smolvm 2>&1 || echo "ldd failed"
+            echo '```'
+            echo ""
+            echo "**KVM:**"
+            echo '```'
+            ls -la /dev/kvm 2>&1 || echo "KVM not found"
+            echo '```'
+            echo ""
+            echo "**smolvm --version:**"
+            echo '```'
+            smolvm --version 2>&1 || echo "smolvm --version failed with exit $?"
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
       - name: Start smolvm server
         run: |
-          mkdir -p "${XDG_RUNTIME_DIR:-/tmp/smolvm-run}"
-          export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/smolvm-run}"
-          smolvm serve &
-          echo "SMOLVM_PID=$!" >> $GITHUB_ENV
+          XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+          mkdir -p "${XDG_RUNTIME_DIR}"
           echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" >> $GITHUB_ENV
-          sleep 2
+          smolvm serve &
+          sleep 3
 
       - name: Smoke test smolvm
         run: |
-          smolvm machine run --image alpine -- echo "smolvm works"
+          smolvm machine run --net --image alpine -- sh -c "echo smolvm-ok"
 
       - name: Cache smolvm machine state
         id: smolvm-cache

--- a/.github/workflows/test-smolvm.yml
+++ b/.github/workflows/test-smolvm.yml
@@ -32,18 +32,23 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+          ls -la /dev/kvm
 
       - name: Install smolvm
         run: |
           curl -sSL https://smolmachines.com/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Verify smolvm installation
+        run: |
+          smolvm --version
+          smolvm machine --help
+
       - name: Cache smolvm machine state
         id: smolvm-cache
         uses: actions/cache@v4
         with:
           path: |
-            ~/.smolvm
             ~/.cache/smolvm
             ~/.local/share/smolvm
           key: smolvm-${{ runner.os }}-ruby-3.4.1-${{ hashFiles('Gemfile.lock') }}
@@ -53,12 +58,16 @@ jobs:
       - name: Create machine and install gems (cache miss)
         if: steps.smolvm-cache.outputs.cache-hit != 'true'
         run: |
-          sed "s|WORKSPACE_PATH|${GITHUB_WORKSPACE}|g" \
-            .github/smolvm/Smolfile.toml > /tmp/Smolfile
-          smolvm machine create ci-test -s /tmp/Smolfile
+          set -x
+          smolvm machine create ci-test \
+            --image ruby:3.4.1 \
+            --net \
+            --volume "${GITHUB_WORKSPACE}:/workspace"
           smolvm machine start --name ci-test
-          smolvm machine exec --name ci-test -- bash -c "apt-get update -qq && apt-get install -y --no-install-recommends libpq-dev pkg-config libyaml-dev build-essential"
-          smolvm machine exec --name ci-test -- bash -c "cd /workspace && bundle install"
+          smolvm machine exec --name ci-test -- \
+            bash -c "apt-get update -qq && apt-get install -y --no-install-recommends libpq-dev pkg-config libyaml-dev build-essential"
+          smolvm machine exec --name ci-test -- \
+            bash -c "cd /workspace && bundle install"
           smolvm machine stop --name ci-test
 
       - name: Start machine

--- a/.github/workflows/test-smolvm.yml
+++ b/.github/workflows/test-smolvm.yml
@@ -32,17 +32,11 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-          ls -la /dev/kvm
 
       - name: Install smolvm
         run: |
           curl -sSL https://smolmachines.com/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Verify smolvm installation
-        run: |
-          smolvm --version
-          smolvm machine --help
 
       - name: Cache smolvm machine state
         id: smolvm-cache
@@ -58,7 +52,6 @@ jobs:
       - name: Create machine and install gems (cache miss)
         if: steps.smolvm-cache.outputs.cache-hit != 'true'
         run: |
-          set -x
           smolvm machine create ci-test \
             --image ruby:3.4.1 \
             --net \

--- a/.github/workflows/test-smolvm.yml
+++ b/.github/workflows/test-smolvm.yml
@@ -37,6 +37,9 @@ jobs:
           sudo modprobe kvm-amd 2>/dev/null || true
           ls -la /dev/kvm
 
+      - name: Install dependencies
+        run: sudo apt-get install -y e2fsprogs
+
       - name: Install smolvm
         run: |
           curl -sSL https://smolmachines.com/install.sh | bash
@@ -47,9 +50,19 @@ jobs:
           export XDG_RUNTIME_DIR=/tmp/smolvm-run
           mkdir -p "$XDG_RUNTIME_DIR"
           echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> $GITHUB_ENV
-          smolvm serve &
-          for i in $(seq 15); do
-            [ -S "$XDG_RUNTIME_DIR/smolvm.sock" ] && echo "Server ready" && break
+          smolvm serve > /tmp/smolvm-serve.log 2>&1 &
+          echo "smolvm serve PID: $!"
+          for i in $(seq 20); do
+            if [ -S "$XDG_RUNTIME_DIR/smolvm.sock" ]; then
+              echo "Server ready after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 20 ]; then
+              echo "::error::smolvm server did not start within 20s"
+              echo "--- serve log ---"
+              cat /tmp/smolvm-serve.log
+              exit 1
+            fi
             sleep 1
           done
 
@@ -61,6 +74,8 @@ jobs:
           cat /tmp/smolvm-smoke.txt
           if [ $EXIT -ne 0 ]; then
             echo "::error::smolvm smoke test failed (exit $EXIT): $(head -5 /tmp/smolvm-smoke.txt | tr '\n' ' ')"
+            echo "--- smolvm serve log ---"
+            cat /tmp/smolvm-serve.log || true
             exit $EXIT
           fi
 

--- a/.github/workflows/test-smolvm.yml
+++ b/.github/workflows/test-smolvm.yml
@@ -3,7 +3,7 @@ name: CI (smolvm)
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, "claude/**"]
 
 jobs:
   test:

--- a/.github/workflows/test-smolvm.yml
+++ b/.github/workflows/test-smolvm.yml
@@ -38,6 +38,19 @@ jobs:
           curl -sSL https://smolmachines.com/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Start smolvm server
+        run: |
+          mkdir -p "${XDG_RUNTIME_DIR:-/tmp/smolvm-run}"
+          export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/smolvm-run}"
+          smolvm serve &
+          echo "SMOLVM_PID=$!" >> $GITHUB_ENV
+          echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" >> $GITHUB_ENV
+          sleep 2
+
+      - name: Smoke test smolvm
+        run: |
+          smolvm machine run --image alpine -- echo "smolvm works"
+
       - name: Cache smolvm machine state
         id: smolvm-cache
         uses: actions/cache@v4

--- a/.github/workflows/test-smolvm.yml
+++ b/.github/workflows/test-smolvm.yml
@@ -1,0 +1,80 @@
+name: CI (smolvm)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install smolvm
+        run: |
+          curl -sSL https://smolmachines.com/install.sh | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Cache smolvm machine state
+        id: smolvm-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.smolvm
+            ~/.cache/smolvm
+            ~/.local/share/smolvm
+          key: smolvm-${{ runner.os }}-ruby-3.4.1-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            smolvm-${{ runner.os }}-ruby-3.4.1-
+
+      - name: Create machine and install gems (cache miss)
+        if: steps.smolvm-cache.outputs.cache-hit != 'true'
+        run: |
+          sed "s|WORKSPACE_PATH|${GITHUB_WORKSPACE}|g" \
+            .github/smolvm/Smolfile.toml > /tmp/Smolfile
+          smolvm machine create ci-test -s /tmp/Smolfile
+          smolvm machine start --name ci-test
+          smolvm machine exec --name ci-test -- bash -c "apt-get update -qq && apt-get install -y --no-install-recommends libpq-dev pkg-config libyaml-dev build-essential"
+          smolvm machine exec --name ci-test -- bash -c "cd /workspace && bundle install"
+          smolvm machine stop --name ci-test
+
+      - name: Start machine
+        run: smolvm machine start --name ci-test
+
+      - name: Get PostgreSQL host IP
+        run: |
+          echo "POSTGRES_HOST=$(ip route show default | awk '{print $3}')" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: |
+          smolvm machine exec --name ci-test -- bash -c "
+            cd /workspace &&
+            RAILS_ENV=test DATABASE_URL=postgres://postgres:postgres@${POSTGRES_HOST}:5432 bin/rails db:test:prepare test
+          "
+
+      - name: Stop machine
+        if: always()
+        run: smolvm machine stop --name ci-test

--- a/.github/workflows/test-smolvm.yml
+++ b/.github/workflows/test-smolvm.yml
@@ -32,61 +32,37 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+          sudo modprobe kvm 2>/dev/null || true
+          sudo modprobe kvm-intel 2>/dev/null || true
+          sudo modprobe kvm-amd 2>/dev/null || true
+          ls -la /dev/kvm
 
       - name: Install smolvm
         run: |
           curl -sSL https://smolmachines.com/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Diagnose smolvm environment
-        run: |
-          {
-            echo "## smolvm diagnostics"
-            echo ""
-            echo "**which smolvm:** $(which smolvm 2>&1)"
-            echo ""
-            echo "**smolvm wrapper:**"
-            echo '```'
-            head -5 ~/.smolvm/smolvm 2>&1 || echo "not a text file"
-            echo '```'
-            echo ""
-            echo "**installed files:**"
-            echo '```'
-            ls -la ~/.smolvm/ 2>&1
-            echo '```'
-            echo ""
-            echo "**smolvm lib:**"
-            echo '```'
-            ls -la ~/.smolvm/lib/ 2>&1 || echo "no lib dir"
-            echo '```'
-            echo ""
-            echo "**ldd:**"
-            echo '```'
-            ldd ~/.smolvm/smolvm-bin 2>&1 || ldd ~/.smolvm/smolvm 2>&1 || echo "ldd failed"
-            echo '```'
-            echo ""
-            echo "**KVM:**"
-            echo '```'
-            ls -la /dev/kvm 2>&1 || echo "KVM not found"
-            echo '```'
-            echo ""
-            echo "**smolvm --version:**"
-            echo '```'
-            smolvm --version 2>&1 || echo "smolvm --version failed with exit $?"
-            echo '```'
-          } >> $GITHUB_STEP_SUMMARY
-
       - name: Start smolvm server
         run: |
-          XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
-          mkdir -p "${XDG_RUNTIME_DIR}"
-          echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" >> $GITHUB_ENV
+          export XDG_RUNTIME_DIR=/tmp/smolvm-run
+          mkdir -p "$XDG_RUNTIME_DIR"
+          echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> $GITHUB_ENV
           smolvm serve &
-          sleep 3
+          for i in $(seq 15); do
+            [ -S "$XDG_RUNTIME_DIR/smolvm.sock" ] && echo "Server ready" && break
+            sleep 1
+          done
 
       - name: Smoke test smolvm
         run: |
-          smolvm machine run --net --image alpine -- sh -c "echo smolvm-ok"
+          smolvm machine run --net --image alpine -- sh -c "echo smolvm-ok" \
+            > /tmp/smolvm-smoke.txt 2>&1
+          EXIT=$?
+          cat /tmp/smolvm-smoke.txt
+          if [ $EXIT -ne 0 ]; then
+            echo "::error::smolvm smoke test failed (exit $EXIT): $(head -5 /tmp/smolvm-smoke.txt | tr '\n' ' ')"
+            exit $EXIT
+          fi
 
       - name: Cache smolvm machine state
         id: smolvm-cache


### PR DESCRIPTION
Runs the test suite inside a stateful smolvm machine. On cache miss, the
machine is provisioned with Ruby 3.4.1 + system deps + bundled gems and
then cached by Gemfile.lock hash. Subsequent runs restore the machine and
skip gem installation entirely.

PostgreSQL runs as a standard GitHub Actions service; the host gateway IP
is resolved at runtime so the VM can reach it.

https://claude.ai/code/session_01NuNgMKg5rzPCFXo1B4icC5