### PR TITLE
Add documentation for email emulation in development

### DIFF
--- a/docs/email-dev-emulation.md
+++ b/docs/email-dev-emulation.md
@@ -10,6 +10,4 @@ In development and test environments, the app does not send real emails. Outgoin
 
 ## Viewing captured emails
 
-- `GET /development/sent_emails` — list all captured messages.
-- `GET /development/sent_emails/:id` — view a single message.
-- `DELETE /development/sent_emails/purge` — clear the inbox.
+With the Rails server running, open `/development/sent_emails` in your browser to see the inbox of captured messages. Click any entry to read it. Use the "Purge All" button to clear the inbox when you want a clean slate.

--- a/docs/email-dev-emulation.md
+++ b/docs/email-dev-emulation.md
@@ -1,0 +1,15 @@
+# Email Emulation in Development
+
+In development and test environments, the app does not send real emails. Outgoing mail is captured to disk and viewable through a built-in inbox UI.
+
+## How it works
+
+- `config.action_mailer.delivery_method = :file` (see `config/environments/development.rb`) routes outgoing mail through `lib/file_delivery.rb`.
+- `config.email_storage_adapter = :file_system` persists captured messages via `EmailStorage::FileSystemStorage`.
+- Routes under `namespace :development` are mounted only when `Rails.env.development? || Rails.env.test?`.
+
+## Viewing captured emails
+
+- `GET /development/sent_emails` — list all captured messages.
+- `GET /development/sent_emails/:id` — view a single message.
+- `DELETE /development/sent_emails/purge` — clear the inbox.


### PR DESCRIPTION
Changes:

- Add `docs/email-dev-emulation.md` documenting the email emulation system used in development and test environments
- Document how outgoing emails are captured to disk via `lib/file_delivery.rb` and `EmailStorage::FileSystemStorage`
- Document the development-only routes for viewing and managing captured emails (`/development/sent_emails`)
