### PR TITLE
Update gems and quiet Honeybadger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 09e09519ec50f5f2bde847d9c533d413383ee610
+  revision: 7aeda6a9c4782e527ec7e73a0aad5ec84092c910
   branch: main
   specs:
     actioncable (8.2.0.alpha)
@@ -145,7 +145,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
-    factory_bot (6.5.6)
+    factory_bot (6.6.0)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
@@ -170,7 +170,7 @@ GEM
     globalid (1.3.0)
       activesupport (>= 6.1)
     hashdiff (1.2.1)
-    honeybadger (6.5.6)
+    honeybadger (6.6.0)
       logger
       ostruct
     httparty (0.24.2)
@@ -235,7 +235,7 @@ GEM
       stimulus-rails
       turbo-rails
     msgpack (1.8.0)
-    multi_xml (0.9.0)
+    multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)
     net-http (0.9.1)
@@ -358,7 +358,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.34.3)
+    rubocop-rails (2.35.0)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -3,5 +3,8 @@ Honeybadger.configure do |config|
   config.env = Rails.env
   config.root = Rails.root.to_s
   config.development_environments = %w[test development]
+  # Honeybadger checks ActiveRecord too early when loading this plugin.
+  # TODO: Remove after honeybadger-ruby#812 lands and ships: https://github.com/honeybadger-io/honeybadger-ruby/pull/812
+  config.solid_queue.insights.enabled = false
   config.exceptions.ignore += [SignalException]
 end


### PR DESCRIPTION
Changes:

- Remove Honeybadger warning caused by premature ActiveRecord load.
- Update gems.