### PR TITLE
Show deployed version stats

### DIFF
--- a/app/controllers/admin/system_stats_controller.rb
+++ b/app/controllers/admin/system_stats_controller.rb
@@ -1,8 +1,27 @@
 class Admin::SystemStatsController < ApplicationController
   def show
     authorize :admin, :show?
+    @release_info = release_info
     @disk_usage = Rails.cache.fetch("admin/system_stats/v3", expires_in: 5.minutes) do
       DiskUsageService.new.call
     end
+  end
+
+  private
+
+  def release_info
+    revision = ENV.fetch("APP_REVISION", nil)
+
+    {
+      revision: revision,
+      revision_short: ENV.fetch("APP_REVISION_SHORT", nil).presence || revision&.first(7),
+      deployed_at: deployed_at
+    }
+  end
+
+  def deployed_at
+    Time.zone.parse(ENV.fetch("APP_DEPLOYED_AT", nil))
+  rescue ArgumentError, TypeError
+    nil
   end
 end

--- a/app/views/admin/system_stats/show.html.erb
+++ b/app/views/admin/system_stats/show.html.erb
@@ -9,6 +9,36 @@
   other_used_percentage = @disk_usage[:other_used_percentage]
   free_percentage = @disk_usage[:free_percentage]
 
+  revision_value = if @release_info[:revision_short].present?
+    tag.code(@release_info[:revision_short], title: @release_info[:revision])
+  else
+    "—"
+  end
+
+  deployed_at_value = if @release_info[:deployed_at]
+    tag.code(long_time_tag(@release_info[:deployed_at]))
+  else
+    "—"
+  end
+
+  release_info_list = ListGroupComponent.new.tap do |list|
+    list.with_item(ListGroupComponent::StatItemComponent.new(
+      label: "Revision",
+      value: revision_value,
+      key: "release.revision"
+    ))
+    list.with_item(ListGroupComponent::StatItemComponent.new(
+      label: "Deployed at",
+      value: deployed_at_value,
+      key: "release.deployed_at"
+    ))
+    list.with_item(ListGroupComponent::StatItemComponent.new(
+      label: "Environment",
+      value: tag.code(Rails.env),
+      key: "release.environment"
+    ))
+  end
+
   # TBD: Extract component
   table_usage_list = ListGroupComponent.new.tap do |list|
     @disk_usage[:table_usage].each do |row|
@@ -36,6 +66,11 @@
       <%= link_to "Back to Admin", admin_path, class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
     <% end %>
   <% end %>
+
+  <section class="space-y-4">
+    <h2 class="ff-h2">Deployed Version</h2>
+    <%= render(release_info_list) %>
+  </section>
 
   <section class="space-y-4">
     <h2 class="ff-h2">Disk Usage</h2>

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -19,6 +19,10 @@ registry:
 
 # Environment variables shared by all destinations.
 env:
+  clear:
+    APP_REVISION: <%= `git rev-parse HEAD`.strip %>
+    APP_REVISION_SHORT: <%= `git rev-parse --short HEAD`.strip %>
+    APP_DEPLOYED_AT: <%= `date -u +%Y-%m-%dT%H:%M:%SZ`.strip %>
   secret:
     - RAILS_MASTER_KEY
     - POSTGRES_PASSWORD

--- a/test/controllers/admin/system_stats_controller_test.rb
+++ b/test/controllers/admin/system_stats_controller_test.rb
@@ -36,9 +36,40 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should show deployed version details" do
+    with_release_env(
+      "APP_REVISION" => "0123456789abcdef",
+      "APP_REVISION_SHORT" => "0123456",
+      "APP_DEPLOYED_AT" => "2026-05-09T12:34:56Z"
+    ) do
+      login_as(admin_user)
+
+      get admin_system_stats_path
+    end
+
+    assert_response :success
+    assert_select "[data-key='release.revision.value'] code", text: "0123456"
+    assert_select "[data-key='release.deployed_at.value'] code", text: /9 May 2026, 12:34/
+    assert_select "[data-key='release.environment.value'] code", text: Rails.env
+  end
+
   private
 
   def login_as(user)
     post session_path, params: { email_address: user.email_address, password: "password123" }
+  end
+
+  def with_release_env(values)
+    previous_values = values.keys.index_with { |key| ENV.fetch(key, nil) }
+    values.each { |key, value| ENV[key] = value }
+    yield
+  ensure
+    previous_values.each do |key, value|
+      if value.nil?
+        ENV.delete(key)
+      else
+        ENV[key] = value
+      end
+    end
   end
 end


### PR DESCRIPTION
Changes:

- Pass deployed revision and timestamp through Kamal env vars
- Show deployed version details at the top of System Stats
- Add controller coverage for release details