### PR TITLE
Add required environment variable validation to Kamal secrets

### DIFF
--- a/.kamal/secrets-common
+++ b/.kamal/secrets-common
@@ -2,4 +2,4 @@
 # Values are pulled from the local environment or files. Do not put raw secrets here.
 
 # GitHub Container Registry token used to pull/push the image from GHCR.
-KAMAL_REGISTRY_PASSWORD=$GHCR_TOKEN
+KAMAL_REGISTRY_PASSWORD=${GHCR_TOKEN:?GHCR_TOKEN is required}

--- a/.kamal/secrets.production
+++ b/.kamal/secrets.production
@@ -2,7 +2,7 @@
 # Values are pulled from the local environment or files. Do not put raw secrets here.
 
 # PostgreSQL password for the production database accessory.
-POSTGRES_PASSWORD=$POSTGRES_PASSWORD_PRODUCTION
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD_PRODUCTION:?POSTGRES_PASSWORD_PRODUCTION is required}
 
 # Rails credentials key for config/credentials/production.yml.enc.
 RAILS_MASTER_KEY=$(cat config/credentials/production.key)

--- a/.kamal/secrets.staging
+++ b/.kamal/secrets.staging
@@ -2,7 +2,7 @@
 # Values are pulled from the local environment or files. Do not put raw secrets here.
 
 # PostgreSQL password for the staging database accessory.
-POSTGRES_PASSWORD=$POSTGRES_PASSWORD_STAGING
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD_STAGING:?POSTGRES_PASSWORD_STAGING is required}
 
 # Rails credentials key for config/credentials/staging.yml.enc.
 RAILS_MASTER_KEY=$(cat config/credentials/staging.key)


### PR DESCRIPTION
Changes:

- Add bash parameter expansion with required validation to `KAMAL_REGISTRY_PASSWORD` in `.kamal/secrets-common` to ensure `GHCR_TOKEN` is set
- Add bash parameter expansion with required validation to `POSTGRES_PASSWORD` in `.kamal/secrets.production` to ensure `POSTGRES_PASSWORD_PRODUCTION` is set
- Add bash parameter expansion with required validation to `POSTGRES_PASSWORD` in `.kamal/secrets.staging` to ensure `POSTGRES_PASSWORD_STAGING` is set

These changes use bash's `${VAR:?error message}` syntax to fail fast with a clear error message if required environment variables are not defined, preventing silent failures during deployment.

References:

- https://app.honeybadger.io/projects/134930/faults/130348712