### PR TITLE
Fix Kamal secrets bash expansion

### DIFF
--- a/.kamal/secrets-common
+++ b/.kamal/secrets-common
@@ -2,4 +2,4 @@
 # Values are pulled from the local environment or files. Do not put raw secrets here.
 
 # GitHub Container Registry token used to pull/push the image from GHCR.
-KAMAL_REGISTRY_PASSWORD=${GHCR_TOKEN:?GHCR_TOKEN is required}
+KAMAL_REGISTRY_PASSWORD=$(printenv GHCR_TOKEN | grep . || { echo "GHCR_TOKEN is required and must be non-empty" >&2; exit 1; })

--- a/.kamal/secrets.production
+++ b/.kamal/secrets.production
@@ -2,7 +2,7 @@
 # Values are pulled from the local environment or files. Do not put raw secrets here.
 
 # PostgreSQL password for the production database accessory.
-POSTGRES_PASSWORD=${POSTGRES_PASSWORD_PRODUCTION:?POSTGRES_PASSWORD_PRODUCTION is required}
+POSTGRES_PASSWORD=$(printenv POSTGRES_PASSWORD_PRODUCTION | grep . || { echo "POSTGRES_PASSWORD_PRODUCTION is required and must be non-empty" >&2; exit 1; })
 
 # Rails credentials key for config/credentials/production.yml.enc.
 RAILS_MASTER_KEY=$(cat config/credentials/production.key)

--- a/.kamal/secrets.staging
+++ b/.kamal/secrets.staging
@@ -2,7 +2,7 @@
 # Values are pulled from the local environment or files. Do not put raw secrets here.
 
 # PostgreSQL password for the staging database accessory.
-POSTGRES_PASSWORD=${POSTGRES_PASSWORD_STAGING:?POSTGRES_PASSWORD_STAGING is required}
+POSTGRES_PASSWORD=$(printenv POSTGRES_PASSWORD_STAGING | grep . || { echo "POSTGRES_PASSWORD_STAGING is required and must be non-empty" >&2; exit 1; })
 
 # Rails credentials key for config/credentials/staging.yml.enc.
 RAILS_MASTER_KEY=$(cat config/credentials/staging.key)


### PR DESCRIPTION
Changes:

- Replace the `${VAR:?msg}` syntax in `.kamal/secrets-common`, `.kamal/secrets.staging`, and `.kamal/secrets.production` with a `$(printenv VAR | grep . || ...)` form that survives dotenv's variable substitution.

PR #357 used bash's `${VAR:?error}` syntax to fail loudly on unset secrets, but Kamal parses `.kamal/secrets*` with Dotenv (3.1.x), whose variable-substitution regex captures only `[A-Z0-9_]+` as the name and leaves `:?msg}` appended as literal text. The result: `docker login` to ghcr.io was sent `<token>:?GHCR_TOKEN is required}` instead of the token, and the same corruption applied to `POSTGRES_PASSWORD`. The new form contains no `$VAR` references for dotenv to mangle, and still fails loudly (stderr) on unset or empty input.