### PR TITLE
Remove unused CSS utility classes and inline styles

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -98,14 +98,6 @@
     @apply text-slate-500;
   }
 
-  .ff-nav-link {
-    @apply inline-flex items-center rounded-sm px-3 py-2 transition md:px-2 md:py-1;
-  }
-
-  .ff-nav-link--active {
-    @apply bg-slate-900 text-white md:bg-slate-100 md:text-slate-600 md:ring-2 md:ring-slate-600;
-  }
-
   .ff-h1 {
     @apply text-4xl font-semibold mb-0 text-slate-900;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -86,10 +86,6 @@
     @apply mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600;
   }
 
-  .ff-text {
-    @apply text-base text-slate-600;
-  }
-
   .ff-table-container {
     @apply overflow-x-auto rounded-lg border border-slate-200;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -98,10 +98,6 @@
     @apply text-slate-500;
   }
 
-  .ff-h1 {
-    @apply text-4xl font-semibold mb-0 text-slate-900;
-  }
-
   .ff-h2 {
     @apply text-2xl font-semibold mb-3 text-slate-900;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -106,14 +106,6 @@
     @apply bg-slate-900 text-white md:bg-slate-100 md:text-slate-600 md:ring-2 md:ring-slate-600;
   }
 
-  .ff-dropdown-panel {
-    @apply z-20 hidden w-60 rounded-lg border border-slate-200 bg-white shadow-sm;
-  }
-
-  .ff-dropdown-item {
-    @apply flex items-center justify-between gap-2 px-4 py-2 transition hover:bg-slate-50 focus:bg-slate-100 focus:outline-none;
-  }
-
   .ff-h1 {
     @apply text-4xl font-semibold mb-0 text-slate-900;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -102,10 +102,6 @@
     @apply rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white;
   }
 
-  .ff-nav-brand {
-    @apply inline-flex items-center text-lg font-semibold text-slate-900;
-  }
-
   .ff-nav-link {
     @apply inline-flex items-center rounded-sm px-3 py-2 transition md:px-2 md:py-1;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -174,14 +174,6 @@
     @apply inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide;
   }
 
-  .ff-icon-success {
-    @apply text-emerald-600;
-  }
-
-  .ff-icon-secondary {
-    @apply text-slate-400;
-  }
-
   /* aria-busy styling for loading states */
   [aria-busy="true"] {
     opacity: 0.8;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,30 +10,6 @@
 /* Reusable UI primitives, see [20251031_8549] */
 
 @layer components {
-  .ff-alert {
-    @apply rounded-lg border px-4 py-3 text-sky-800;
-  }
-
-  .ff-alert--info {
-    @apply border-sky-100 bg-sky-100;
-  }
-
-  .ff-alert--success {
-    @apply border-emerald-200 bg-emerald-100 text-emerald-800;
-  }
-
-  .ff-alert--error {
-    @apply border-red-200 bg-red-100 text-red-800;
-  }
-
-  .ff-alert--warning {
-    @apply border-amber-200 bg-amber-100 text-amber-800;
-  }
-
-  .ff-alert--secondary {
-    @apply border-sky-100 bg-slate-100;
-  }
-
   .ff-form-group {
     @apply space-y-2;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -7,25 +7,7 @@
   }
 }
 
-/* Reusable UI primitives, see [20251031_8549] */
-
 @layer components {
-  .ff-button {
-    @apply inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1;
-  }
-
-  .ff-button--secondary {
-    @apply inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1;
-  }
-
-  .ff-button--danger {
-    @apply inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1;
-  }
-
-  .ff-button--compact {
-    @apply px-4 py-2 text-base;
-  }
-
   /* aria-busy styling for loading states */
   [aria-busy="true"] {
     opacity: 0.8;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -126,10 +126,6 @@
     @apply text-2xl font-semibold mb-3 text-slate-900;
   }
 
-  .ff-h3 {
-    @apply text-xl font-semibold mb-2 text-slate-900;
-  }
-
   .ff-table-container {
     @apply overflow-x-auto rounded-lg border border-slate-200;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -170,10 +170,6 @@
     @apply px-4 py-2;
   }
 
-  .ff-event-level {
-    @apply inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide;
-  }
-
   /* aria-busy styling for loading states */
   [aria-busy="true"] {
     opacity: 0.8;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -62,10 +62,6 @@
     @apply text-slate-500;
   }
 
-  .ff-link {
-    @apply font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500;
-  }
-
   .ff-button {
     @apply inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -178,18 +178,6 @@
     @apply text-emerald-600;
   }
 
-  .ff-icon-danger {
-    @apply text-red-600;
-  }
-
-  .ff-icon-warning {
-    @apply text-amber-600;
-  }
-
-  .ff-icon-info {
-    @apply text-sky-600;
-  }
-
   .ff-icon-secondary {
     @apply text-slate-400;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -82,42 +82,6 @@
     @apply mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600;
   }
 
-  .ff-table-container {
-    @apply overflow-x-auto rounded-lg border border-slate-200;
-  }
-
-  .ff-table {
-    @apply w-full text-left text-sm text-slate-700;
-  }
-
-  .ff-table thead {
-    @apply border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600;
-  }
-
-  .ff-table th {
-    @apply px-6 py-3;
-  }
-
-  .ff-table tbody {
-    @apply divide-y divide-slate-200 bg-white;
-  }
-
-  .ff-table tr {
-    @apply hover:bg-slate-50;
-  }
-
-  .ff-table td {
-    @apply px-6 py-4 whitespace-nowrap;
-  }
-
-  .ff-table--dense th {
-    @apply px-4 py-2;
-  }
-
-  .ff-table--dense td {
-    @apply px-4 py-2;
-  }
-
   /* aria-busy styling for loading states */
   [aria-busy="true"] {
     opacity: 0.8;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -98,10 +98,6 @@
     @apply text-slate-500;
   }
 
-  .ff-h2 {
-    @apply text-2xl font-semibold mb-3 text-slate-900;
-  }
-
   .ff-table-container {
     @apply overflow-x-auto rounded-lg border border-slate-200;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -90,14 +90,6 @@
     @apply text-base text-slate-600;
   }
 
-  .ff-text--heavy {
-    @apply font-semibold text-slate-800;
-  }
-
-  .ff-text--muted {
-    @apply text-slate-500;
-  }
-
   .ff-table-container {
     @apply overflow-x-auto rounded-lg border border-slate-200;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -98,10 +98,6 @@
     @apply text-slate-500;
   }
 
-  .ff-focus-ring {
-    @apply rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white;
-  }
-
   .ff-nav-link {
     @apply inline-flex items-center rounded-sm px-3 py-2 transition md:px-2 md:py-1;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,22 +10,6 @@
 /* Reusable UI primitives, see [20251031_8549] */
 
 @layer components {
-  .ff-form-group {
-    @apply space-y-2;
-  }
-
-  .ff-form-label {
-    @apply block font-semibold text-slate-800;
-  }
-
-  .ff-form-input {
-    @apply w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2;
-  }
-
-  .ff-form-help {
-    @apply text-slate-500;
-  }
-
   .ff-button {
     @apply inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,18 +10,6 @@
 /* Reusable UI primitives, see [20251031_8549] */
 
 @layer components {
-  .ff-card {
-    @apply w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm;
-  }
-
-  .ff-card__title {
-    @apply text-4xl font-semibold mb-6 text-slate-900;
-  }
-
-  .ff-card__body {
-    @apply space-y-6;
-  }
-
   .ff-alert {
     @apply rounded-lg border px-4 py-3 text-sky-800;
   }
@@ -76,10 +64,6 @@
 
   .ff-button--compact {
     @apply px-4 py-2 text-base;
-  }
-
-  .ff-card__footer {
-    @apply mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600;
   }
 
   /* aria-busy styling for loading states */

--- a/app/components/confirmation_modal_component.html.erb
+++ b/app/components/confirmation_modal_component.html.erb
@@ -5,11 +5,11 @@
     <%= button_to @action,
                   @url,
                   method: @method,
-                  class: "ff-button ff-button--danger ff-button--compact",
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1",
                   data: { action: "modal#confirm" } %>
     <%= tag.button "Cancel",
                    type: "button",
-                   class: "ff-button ff-button--secondary ff-button--compact",
+                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
                    data: { action: "modal#close" } %>
   <% end %>
 <% end %>

--- a/app/components/edit_available_invites_modal_component.html.erb
+++ b/app/components/edit_available_invites_modal_component.html.erb
@@ -12,12 +12,12 @@
     <%= tag.button "Update",
                    type: "button",
                    form: "available-invites-form-#{@user.id}",
-                   class: "ff-button ff-button--compact",
+                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
                    data: { action: "click->modal#confirm" },
                    onclick: "this.form.requestSubmit()" %>
     <%= tag.button "Cancel",
                    type: "button",
-                   class: "ff-button ff-button--secondary ff-button--compact",
+                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
                    data: { action: "modal#close" } %>
   <% end %>
 <% end %>

--- a/app/components/edit_available_invites_modal_component.html.erb
+++ b/app/components/edit_available_invites_modal_component.html.erb
@@ -1,9 +1,9 @@
 <%= render ModalComponent.new(title: "Update Available Invites", modal_id: @modal_id) do |modal| %>
   <%= form_with(model: @user, url: admin_user_available_invites_path(@user), method: :patch, id: "available-invites-form-#{@user.id}", data: { turbo_frame: "_top" }) do |form| %>
-    <div class="ff-form-group">
-      <%= form.label :available_invites, "Available Invites", class: "ff-form-label" %>
+    <div class="space-y-2">
+      <%= form.label :available_invites, "Available Invites", class: "block font-semibold text-slate-800" %>
       <span id="available-invites-input-wrapper-<%= @user.id %>">
-        <%= form.number_field(:available_invites, min: 0, class: "ff-form-input", autofocus: true) %>
+        <%= form.number_field(:available_invites, min: 0, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", autofocus: true) %>
       </span>
     </div>
   <% end %>

--- a/app/components/empty_state_component.rb
+++ b/app/components/empty_state_component.rb
@@ -1,7 +1,7 @@
 class EmptyStateComponent < ViewComponent::Base
   def call
-    content_tag :div, class: "ff-card border-dashed border-slate-300 shadow-none", data: { key: "empty-state" } do
-      content_tag :div, class: "ff-card__body text-center py-12", data: { key: "empty-state.body" } do
+    content_tag :div, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-dashed sm:border-slate-300 sm:bg-white sm:p-6", data: { key: "empty-state" } do
+      content_tag :div, class: "space-y-6 text-center py-12", data: { key: "empty-state.body" } do
         content
       end
     end

--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -43,11 +43,11 @@ class EventDescriptionComponent < ViewComponent::Base
   def subject_link
     case event.subject
     when Feed
-      helpers.link_to(event.subject.name, helpers.feed_path(event.subject), class: "ff-link")
+      helpers.link_to(event.subject.name, helpers.feed_path(event.subject), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     when AccessToken
-      helpers.link_to(event.subject.name, helpers.access_tokens_path, class: "ff-link")
+      helpers.link_to(event.subject.name, helpers.access_tokens_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     when Post
-      helpers.link_to("Post", helpers.post_path(event.subject), class: "ff-link")
+      helpers.link_to("Post", helpers.post_path(event.subject), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     else
       ""
     end
@@ -70,7 +70,7 @@ class EventDescriptionComponent < ViewComponent::Base
     return "" if disabled_feed_ids.blank?
 
     links = disabled_feeds.map do |feed|
-      helpers.link_to(feed.name, helpers.feed_path(feed), class: "ff-link")
+      helpers.link_to(feed.name, helpers.feed_path(feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     end
 
     linked_feeds = helpers.safe_join(links, ", ")

--- a/app/components/event_details_component.rb
+++ b/app/components/event_details_component.rb
@@ -37,7 +37,7 @@ class EventDetailsComponent < ViewComponent::Base
     user_value = if @event.user_id.present?
       helpers.link_to("User ##{@event.user_id}",
                       helpers.admin_events_path(filter: { user_id: @event.user_id }),
-                      class: "ff-link",
+                      class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
                       data: { key: "admin.event.user" })
     else
       helpers.tag.em("System", class: "text-slate-500", data: { key: "admin.event.user" })
@@ -112,7 +112,7 @@ class EventDetailsComponent < ViewComponent::Base
 
     helpers.link_to(@event.subject_type,
                     helpers.admin_events_path(filter: filter_params),
-                    class: "ff-link",
+                    class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
                     data: { key: "admin.event.subject.type" })
   end
 

--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -33,6 +33,6 @@ class FeedsListComponent < ViewComponent::Base
     return "Target: #{target}" if target == "None" || !feed.access_token
 
     url = "#{feed.access_token.host}/#{feed.target_group}"
-    safe_join(["Target:", helpers.link_to(target, url, target: "_blank", rel: "noopener", class: "ff-link")], " ")
+    safe_join(["Target:", helpers.link_to(target, url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")], " ")
   end
 end

--- a/app/components/list_group_component/access_token_item_component.html.erb
+++ b/app/components/list_group_component/access_token_item_component.html.erb
@@ -6,7 +6,7 @@
     <div class="inline-flex items-center gap-2 text-base font-semibold text-slate-900">
       <%= link_to @access_token.name, access_token_path(@access_token), class: "transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
     </div>
-    <div class="ff-text flex flex-wrap items-center gap-x-2 gap-y-1 text-slate-500">
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-slate-500">
       <span><%= username_with_host %></span>
       <span class="text-slate-300" aria-hidden="true">&bull;</span>
       <span>Created: <%= created_ago %></span>

--- a/app/components/list_group_component/access_token_item_component.html.erb
+++ b/app/components/list_group_component/access_token_item_component.html.erb
@@ -4,7 +4,7 @@
   </span>
   <div class="flex flex-1 flex-col gap-1">
     <div class="inline-flex items-center gap-2 text-base font-semibold text-slate-900">
-      <%= link_to @access_token.name, access_token_path(@access_token), class: "transition hover:text-slate-700 ff-focus-ring" %>
+      <%= link_to @access_token.name, access_token_path(@access_token), class: "transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
     </div>
     <div class="ff-text flex flex-wrap items-center gap-x-2 gap-y-1 text-slate-500">
       <span><%= username_with_host %></span>

--- a/app/components/list_group_component/access_token_item_component.rb
+++ b/app/components/list_group_component/access_token_item_component.rb
@@ -14,13 +14,13 @@ class ListGroupComponent::AccessTokenItemComponent < ViewComponent::Base
   def status_icon
     case @access_token.status
     when "active"
-      icon("check-circle", css_class: "ff-icon-success", aria_label: "Active")
+      icon("check-circle", css_class: "text-emerald-600", aria_label: "Active")
     when "inactive"
-      icon("x-circle", css_class: "ff-icon-secondary", aria_label: "Inactive")
+      icon("x-circle", css_class: "text-slate-400", aria_label: "Inactive")
     when "pending", "validating"
-      icon("clock", css_class: "ff-icon-secondary", aria_label: @access_token.status.capitalize)
+      icon("clock", css_class: "text-slate-400", aria_label: @access_token.status.capitalize)
     else
-      icon("question-circle", css_class: "ff-icon-secondary", aria_label: "Unknown status")
+      icon("question-circle", css_class: "text-slate-400", aria_label: "Unknown status")
     end
   end
 

--- a/app/components/list_group_component/feed_item_component.rb
+++ b/app/components/list_group_component/feed_item_component.rb
@@ -3,7 +3,7 @@ class ListGroupComponent::FeedItemComponent < ViewComponent::Base
   ICON_CLASSES = "inline-flex shrink-0 text-slate-500"
   CONTENT_WRAPPER_CLASSES = "flex flex-1 flex-col gap-1"
   TITLE_CLASSES = "inline-flex items-center text-base font-semibold text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-  METADATA_CLASSES = "ff-text flex flex-wrap items-center gap-x-2 gap-y-1 text-slate-500"
+  METADATA_CLASSES = "flex flex-wrap items-center gap-x-2 gap-y-1 text-slate-500"
   BULLET_CLASSES = "text-slate-300"
 
   def initialize(icon:, title:, title_url:, metadata_segments: [], key: nil)

--- a/app/components/list_group_component/feed_item_component.rb
+++ b/app/components/list_group_component/feed_item_component.rb
@@ -2,7 +2,7 @@ class ListGroupComponent::FeedItemComponent < ViewComponent::Base
   DEFAULT_ITEM_CLASS = "flex items-baseline gap-3 p-4"
   ICON_CLASSES = "inline-flex shrink-0 text-slate-500"
   CONTENT_WRAPPER_CLASSES = "flex flex-1 flex-col gap-1"
-  TITLE_CLASSES = "inline-flex items-center text-base font-semibold text-slate-900 transition hover:text-slate-700 ff-focus-ring"
+  TITLE_CLASSES = "inline-flex items-center text-base font-semibold text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
   METADATA_CLASSES = "ff-text flex flex-wrap items-center gap-x-2 gap-y-1 text-slate-500"
   BULLET_CLASSES = "text-slate-300"
 

--- a/app/components/list_group_component/post_item_component.rb
+++ b/app/components/list_group_component/post_item_component.rb
@@ -3,7 +3,7 @@ class ListGroupComponent::PostItemComponent < ViewComponent::Base
   CONTENT_WRAPPER_CLASSES = "flex items-baseline gap-3 sm:flex-1"
   ICON_CLASSES = "inline-flex shrink-0 text-slate-500"
   INNER_WRAPPER_CLASSES = "flex flex-1 flex-col gap-1"
-  TITLE_CLASSES = "inline-flex items-start text-base font-semibold text-slate-900 transition hover:text-slate-700 ff-focus-ring"
+  TITLE_CLASSES = "inline-flex items-start text-base font-semibold text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
   METADATA_CLASSES = "ff-text flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-500"
   BULLET_CLASSES = "text-slate-300"
 

--- a/app/components/list_group_component/post_item_component.rb
+++ b/app/components/list_group_component/post_item_component.rb
@@ -4,7 +4,7 @@ class ListGroupComponent::PostItemComponent < ViewComponent::Base
   ICON_CLASSES = "inline-flex shrink-0 text-slate-500"
   INNER_WRAPPER_CLASSES = "flex flex-1 flex-col gap-1"
   TITLE_CLASSES = "inline-flex items-start text-base font-semibold text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-  METADATA_CLASSES = "ff-text flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-500"
+  METADATA_CLASSES = "flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-500"
   BULLET_CLASSES = "text-slate-300"
 
   def initialize(icon:, title:, title_url:, metadata_segments: [], key: nil)

--- a/app/components/page_header_component.html.erb
+++ b/app/components/page_header_component.html.erb
@@ -1,6 +1,6 @@
 <header class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
   <div class="flex flex-col gap-5">
-    <h1 class="ff-h1"><%= @title %></h1>
+    <h1 class="text-4xl font-semibold mb-0 text-slate-900"><%= @title %></h1>
     <% if context_paragraphs? %>
       <% context_paragraphs.each do |paragraph| %>
         <p class="ff-text"><%= paragraph %></p>

--- a/app/components/page_header_component.html.erb
+++ b/app/components/page_header_component.html.erb
@@ -3,7 +3,7 @@
     <h1 class="text-4xl font-semibold mb-0 text-slate-900"><%= @title %></h1>
     <% if context_paragraphs? %>
       <% context_paragraphs.each do |paragraph| %>
-        <p class="ff-text"><%= paragraph %></p>
+        <p class="text-slate-600"><%= paragraph %></p>
       <% end %>
     <% end %>
   </div>

--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -23,7 +23,7 @@ class PostDetailsComponent < ViewComponent::Base
   def add_feed_item(component)
     component.with_item(ListGroupComponent::StatItemComponent.new(
       label: "Feed",
-      value: helpers.link_to(@post.feed.name, @post.feed, class: "ff-link"),
+      value: helpers.link_to(@post.feed.name, @post.feed, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500"),
       key: "post.feed"
     ))
   end
@@ -41,7 +41,7 @@ class PostDetailsComponent < ViewComponent::Base
     attachments_html = safe_join(
       @post.attachment_urls.map do |url|
         filename = extract_filename(url)
-        helpers.link_to(url, target: "_blank", rel: "noopener", class: "ff-link inline-flex items-center") do
+        helpers.link_to(url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center") do
           safe_join([
             helpers.icon("file-earmark-image", aria_hidden: true),
             content_tag(:span, filename, class: "sr-only")
@@ -82,7 +82,7 @@ class PostDetailsComponent < ViewComponent::Base
 
   def add_source_url_item(component)
     value = if @post.source_url.present?
-      helpers.link_to(@post.source_url, @post.source_url, target: "_blank", rel: "noopener", class: "ff-link truncate block")
+      helpers.link_to(@post.source_url, @post.source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 truncate block")
     else
       content_tag(:span, "None", class: "text-slate-500")
     end

--- a/app/components/post_preview_component.html.erb
+++ b/app/components/post_preview_component.html.erb
@@ -3,7 +3,7 @@
     <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
       <h2 class="text-lg font-semibold text-slate-900"><%= title %></h2>
       <% if source_url %>
-        <%= link_to "View source", source_url, target: "_blank", rel: "noopener", class: "ff-link text-sm" %>
+        <%= link_to "View source", source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 text-sm" %>
       <% end %>
     </div>
     <% if metadata_segments.any? %>

--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -96,7 +96,7 @@ class PostPreviewComponent < ViewComponent::Base
   def attachment_list_item(attachment)
     helpers.content_tag(:li) do
       fragments = [
-        helpers.link_to(attachment[:url], attachment[:url], target: "_blank", rel: "noopener", class: "ff-link break-all")
+        helpers.link_to(attachment[:url], attachment[:url], target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 break-all")
       ]
       if attachment[:type]
         fragments << helpers.content_tag(:span, "(#{attachment[:type]})", class: "ml-2 text-xs text-slate-500")

--- a/app/components/posts_list_component.rb
+++ b/app/components/posts_list_component.rb
@@ -16,7 +16,7 @@ class PostsListComponent < ViewComponent::Base
   end
 
   def render_empty_state
-    content_tag(:p, @empty_text, class: "ff-text text-slate-500")
+    content_tag(:p, @empty_text, class: "text-slate-500")
   end
 
   def self.item_component(post:, helpers:, show_feed: false)

--- a/app/components/posts_list_component.rb
+++ b/app/components/posts_list_component.rb
@@ -47,7 +47,7 @@ class PostsListComponent < ViewComponent::Base
     return unless show_feed
     return unless post.feed.present?
 
-    helpers.link_to(post.feed.name, helpers.feed_path(post.feed), class: "ff-link")
+    helpers.link_to(post.feed.name, helpers.feed_path(post.feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
   end
 
   def self.published_segment(post:, helpers:)
@@ -79,7 +79,7 @@ class PostsListComponent < ViewComponent::Base
   def self.source_link_segment(post:, helpers:)
     return unless post.source_url.present?
 
-    helpers.link_to("Source post", post.source_url, target: "_blank", rel: "noopener", class: "ff-link")
+    helpers.link_to("Source post", post.source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
   end
 
   def self.freefeed_link_segment(post:, helpers:)
@@ -91,7 +91,7 @@ class PostsListComponent < ViewComponent::Base
     return unless feed.present? && access_token.present? && feed.target_group.present?
 
     freefeed_url = "#{access_token.host}/#{feed.target_group}/#{post.freefeed_post_id}"
-    helpers.link_to("FreeFeed post", freefeed_url, target: "_blank", rel: "noopener", class: "ff-link")
+    helpers.link_to("FreeFeed post", freefeed_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
   end
 
   def self.withdraw_link_segment(post:, helpers:, withdraw_allowed:)
@@ -101,7 +101,7 @@ class PostsListComponent < ViewComponent::Base
       "Withdraw",
       helpers.post_path(post),
       data: { turbo_method: :delete, turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here." },
-      class: helpers.class_names("ff-link", "text-red-600 hover:text-red-500")
+      class: "font-medium underline underline-offset-4 transition text-red-600 hover:text-red-500"
     )
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -7,8 +7,8 @@ module EventsHelper
   }.freeze
 
   LEVEL_ALERT_CLASSES = {
-    "error" => "ff-alert ff-alert--error",
-    "warning" => "ff-alert ff-alert--warning"
+    "error" => "rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800",
+    "warning" => "rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800"
   }.freeze
 
   def level_badge(level)
@@ -22,7 +22,7 @@ module EventsHelper
   end
 
   def event_alert_class(level)
-    LEVEL_ALERT_CLASSES.fetch(level.to_s, "ff-alert ff-alert--info")
+    LEVEL_ALERT_CLASSES.fetch(level.to_s, "rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800")
   end
 
   def mail_event_types

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -78,7 +78,7 @@ module PostHelper
 
       # Escape URL for safe embedding in href attribute and link text
       escaped_url = ERB::Util.html_escape(url)
-      result << %(<a href="#{escaped_url}" target="_blank" rel="noopener" class="ff-link">#{escaped_url}</a>)
+      result << %(<a href="#{escaped_url}" target="_blank" rel="noopener" class="font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500">#{escaped_url}</a>)
 
       last_end = match_end
     end
@@ -93,7 +93,7 @@ module PostHelper
     return unless show_feed
     return unless post.feed.present?
 
-    link_to(post.feed.name, feed_path(post.feed), class: "ff-link")
+    link_to(post.feed.name, feed_path(post.feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
   end
 
   def post_metadata_published_segment(post)
@@ -119,7 +119,7 @@ module PostHelper
   def post_metadata_source_link_segment(post)
     return unless post.source_url.present?
 
-    link_to("Source post", post.source_url, target: "_blank", rel: "noopener", class: "ff-link")
+    link_to("Source post", post.source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
   end
 
   def post_metadata_freefeed_link_segment(post)
@@ -131,7 +131,7 @@ module PostHelper
     return unless feed.present? && access_token.present? && feed.target_group.present?
 
     freefeed_url = "#{access_token.host}/#{feed.target_group}/#{post.freefeed_post_id}"
-    link_to("FreeFeed post", freefeed_url, target: "_blank", rel: "noopener", class: "ff-link")
+    link_to("FreeFeed post", freefeed_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
   end
 
   def post_metadata_withdraw_link_segment(post, withdraw_allowed)
@@ -141,7 +141,7 @@ module PostHelper
       "Withdraw",
       post_path(post),
       data: { turbo_method: :delete, turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here." },
-      class: class_names("ff-link", "text-red-600 hover:text-red-500")
+      class: "font-medium underline underline-offset-4 transition text-red-600 hover:text-red-500"
     )
   end
 end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -62,7 +62,7 @@
           <p><%= pluralize(groups.count, "groups") %> available for posting:</p>
           <ul class="list-disc list-inside">
             <% groups.sort_by { _1["username"] }.each do |group| %>
-              <li><%= link_to group["username"], "#{@access_token.host}/#{group["username"]}", target: "_blank", rel: "noopener noreferrer", class: "ff-link" %></li>
+              <li><%= link_to group["username"], "#{@access_token.host}/#{group["username"]}", target: "_blank", rel: "noopener noreferrer", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %></li>
             <% end %>
           </ul>
         <% else %>

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -46,7 +46,7 @@
 
   <% if @access_token.access_token_detail.present? %>
     <div class="space-y-4">
-      <h2 class="ff-h2">Publisher</h2>
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Publisher</h2>
       <p class="text-slate-600 mb-4">
         Posts created with this token will appear on FreeFeed on behalf of:
       </p>
@@ -56,7 +56,7 @@
     </div>
 
     <div class="space-y-4">
-      <h2 class="ff-h2">FreeFeed Groups</h2>
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">FreeFeed Groups</h2>
       <% @access_token.access_token_detail.managed_groups.tap do |groups| %>
         <% if groups.any? %>
           <p><%= pluralize(groups.count, "groups") %> available for posting:</p>
@@ -75,7 +75,7 @@
   <% end %>
 
   <div class="space-y-4">
-    <h2 class="ff-h2">Associated Feeds</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Associated Feeds</h2>
     <% if @access_token.feeds.any? %>
       <%= render FeedsListComponent.new(feeds: @access_token.feeds) %>
     <% else %>

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -28,8 +28,8 @@
 <% end %>
 
 <% if @access_token.pending? || @access_token.validating? %>
-  <div class="ff-card">
-    <div class="ff-card__body">
+  <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+    <div class="space-y-6">
       <div class="flex items-center justify-center py-8">
         <%= render SpinnerComponent.new(css_class: "mr-3") %>
         <span class="text-lg text-slate-600">Validating token...</span>

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -20,7 +20,7 @@
   method: :delete,
   modal_id: "delete-token-modal"
 ) do %>
-  <div class="ff-alert ff-alert--warning space-y-2" role="alert">
+  <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
     <p>The token <em><%= @access_token.name %></em> will be permanently removed.</p>
     <p>Any feeds using this token will be automatically disabled.</p>
     <p>This can't be undone.</p>
@@ -37,7 +37,7 @@
     </div>
   </div>
 <% elsif @access_token.active? %>
-  <div class="ff-alert ff-alert--success" data-status="active">
+  <div class="rounded-lg border border-emerald-200 bg-emerald-100 px-4 py-3 text-emerald-800" data-status="active">
     <%= icon("check-circle", aria_hidden: true) %>
     <span>Token is valid and ready to use</span>
   </div>
@@ -85,7 +85,7 @@
     <% end %>
   </div>
 <% elsif @access_token.inactive? %>
-  <div class="ff-alert ff-alert--error" data-status="inactive">
+  <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800" data-status="inactive">
     <%= icon("x-circle", aria_hidden: true) %>
     <span>Token is inactive and cannot be used to access FreeFeed API. This token failed validation. It may be expired, revoked, or incorrectly copied.</span>
   </div>

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -1,13 +1,13 @@
 <%= render PageHeaderComponent.new(title: @access_token.name) do |header| %>
   <% unless @access_token.pending? || @access_token.validating? %>
     <% header.with_action_button do %>
-      <%= link_to "Back to Tokens", access_tokens_path, class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
+      <%= link_to "Back to Tokens", access_tokens_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>
 
     <% header.with_action_button do %>
       <%= link_to "Delete",
                   "#",
-                  class: class_names("ff-button", "ff-button--secondary", "ff-button--compact"),
+                  class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
                   data: { controller: "modal-trigger", modal_trigger_modal_id_value: "delete-token-modal", action: "click->modal-trigger#open" } %>
     <% end %>
   <% end %>

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -67,7 +67,7 @@
           </ul>
         <% else %>
           <%= render EmptyStateComponent.new do %>
-            <p class="ff-text--muted">No groups available for posting.</p>
+            <p class="text-slate-500">No groups available for posting.</p>
           <% end %>
         <% end %>
       <% end %>
@@ -80,7 +80,7 @@
       <%= render FeedsListComponent.new(feeds: @access_token.feeds) %>
     <% else %>
       <%= render EmptyStateComponent.new do %>
-        <p class="ff-text--muted">No associated feeds yet.</p>
+        <p class="text-slate-500">No associated feeds yet.</p>
       <% end %>
     <% end %>
   </div>

--- a/app/views/access_tokens/edit.html.erb
+++ b/app/views/access_tokens/edit.html.erb
@@ -5,7 +5,7 @@
 
   <div class="ff-card">
     <div class="ff-card__body">
-      <p class="ff-text">Access token editing form coming soon...</p>
+      <p class="text-slate-600">Access token editing form coming soon...</p>
     </div>
   </div>
 </div>

--- a/app/views/access_tokens/edit.html.erb
+++ b/app/views/access_tokens/edit.html.erb
@@ -3,8 +3,8 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Edit Access Token") %>
 
-  <div class="ff-card">
-    <div class="ff-card__body">
+  <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+    <div class="space-y-6">
       <p class="text-slate-600">Access token editing form coming soon...</p>
     </div>
   </div>

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -28,7 +28,7 @@
     <% end %>
   <% else %>
     <%= render EmptyStateComponent.new do %>
-      <h2 class="ff-h2 mb-2 text-slate-500">No access tokens yet</h2>
+      <h2 class="text-2xl font-semibold mb-2 text-slate-500">No access tokens yet</h2>
       <p class="ff-text mb-6 text-slate-500">Add a FreeFeed API access token to enable content reposting.</p>
       <%= link_to "Create New Token", new_access_token_path, class: "ff-button" %>
     <% end %>

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -4,7 +4,7 @@
   <%= render PageHeaderComponent.new(title: "Access Tokens") do |header| %>
     <% header.with_context_paragraph("Manage your FreeFeed API tokens used for reposting content.") %>
     <% header.with_action_button do %>
-      <%= link_to "New Token", new_access_token_path, class: class_names("ff-button", "ff-button--compact") %>
+      <%= link_to "New Token", new_access_token_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>
   <% end %>
 
@@ -30,7 +30,7 @@
     <%= render EmptyStateComponent.new do %>
       <h2 class="text-2xl font-semibold mb-2 text-slate-500">No access tokens yet</h2>
       <p class="mb-6 text-slate-500">Add a FreeFeed API access token to enable content reposting.</p>
-      <%= link_to "Create New Token", new_access_token_path, class: "ff-button" %>
+      <%= link_to "Create New Token", new_access_token_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -29,7 +29,7 @@
   <% else %>
     <%= render EmptyStateComponent.new do %>
       <h2 class="text-2xl font-semibold mb-2 text-slate-500">No access tokens yet</h2>
-      <p class="ff-text mb-6 text-slate-500">Add a FreeFeed API access token to enable content reposting.</p>
+      <p class="mb-6 text-slate-500">Add a FreeFeed API access token to enable content reposting.</p>
       <%= link_to "Create New Token", new_access_token_path, class: "ff-button" %>
     <% end %>
   <% end %>

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -19,7 +19,7 @@
         method: :delete,
         modal_id: "delete-token-modal-#{access_token.id}"
       ) do %>
-        <div class="ff-alert ff-alert--warning space-y-2" role="alert">
+        <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
           <p>The token <em><%= access_token.name %></em> will be permanently removed.</p>
           <p>Any feeds using this token will be automatically disabled.</p>
           <p>This can't be undone.</p>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -34,7 +34,7 @@
           </p>
         </div>
 
-        <div class="ff-alert ff-alert--secondary ff-text space-y-2">
+        <div class="ff-alert ff-alert--secondary text-slate-600 space-y-2">
           <p>Why Feeder needs these permissions:</p>
           <ul class="list-none space-y-2">
             <li><strong><code>read-my-info</code></strong> - Allows Feeder to verify your identity and display which FreeFeed account is connected to this token.</li>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -70,8 +70,8 @@
       </div>
 
       <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
-        <%= form.submit "Validate and Save", class: "ff-button" %>
-        <%= link_to "Cancel", access_tokens_path, class: class_names("ff-button", "ff-button--secondary") %>
+        <%= form.submit "Validate and Save", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+        <%= link_to "Cancel", access_tokens_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
       </div>
     <% end %>
   </div>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -6,13 +6,13 @@
   <div class="max-w-2xl">
     <%= form_with model: @access_token, url: access_tokens_path, data: { controller: "token-host", token_host_hosts_value: AccessToken::FREEFEED_HOSTS.to_json } do |form| %>
       <div class="space-y-6">
-        <div class="ff-form-group">
-          <%= form.label :host, "FreeFeed Instance", class: "ff-form-label" %>
+        <div class="space-y-2">
+          <%= form.label :host, "FreeFeed Instance", class: "block font-semibold text-slate-800" %>
           <%= form.select :host,
                           AccessToken.host_options_for_select,
                           { selected: AccessToken::FREEFEED_HOSTS[:production][:url] },
                           {
-                            class: "ff-form-input",
+                            class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                             autofocus: true,
                             data: {
                               token_host_target: "hostSelect",
@@ -42,10 +42,10 @@
           </ul>
         </div>
 
-        <div class="ff-form-group">
-          <%= form.label :token, "Access Token", class: "ff-form-label" %>
+        <div class="space-y-2">
+          <%= form.label :token, "Access Token", class: "block font-semibold text-slate-800" %>
           <%= form.text_field :token,
-                              class: "ff-form-input",
+                              class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                               placeholder: "Paste your FreeFeed access token here",
                               required: true,
                               autocomplete: "off" %>
@@ -54,13 +54,13 @@
           <% end %>
         </div>
 
-        <div class="ff-form-group">
-          <%= form.label :name, "Token Name (optional)", class: "ff-form-label" %>
+        <div class="space-y-2">
+          <%= form.label :name, "Token Name (optional)", class: "block font-semibold text-slate-800" %>
           <%= form.text_field :name,
-                              class: "ff-form-input",
+                              class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                               placeholder: "e.g., My FreeFeed Token",
                               autocomplete: "off" %>
-          <p class="ff-form-help">
+          <p class="text-slate-500">
             Give this token a memorable name. If left blank, a default name will be used.
           </p>
           <% if @access_token.errors[:name].any? %>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -21,7 +21,7 @@
                           } %>
         </div>
 
-        <div class="ff-alert ff-alert--info">
+        <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
           <p>
             Need a token? Create one in
             <%= link_to AccessToken::FREEFEED_HOSTS[:production][:token_url],
@@ -34,7 +34,7 @@
           </p>
         </div>
 
-        <div class="ff-alert ff-alert--secondary text-slate-600 space-y-2">
+        <div class="rounded-lg border border-sky-100 bg-slate-100 px-4 py-3 text-slate-600 space-y-2">
           <p>Why Feeder needs these permissions:</p>
           <ul class="list-none space-y-2">
             <li><strong><code>read-my-info</code></strong> - Allows Feeder to verify your identity and display which FreeFeed account is connected to this token.</li>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -27,7 +27,7 @@
             <%= link_to AccessToken::FREEFEED_HOSTS[:production][:token_url],
                         target: "_blank",
                         rel: "noopener",
-                        class: "ff-link",
+                        class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
                         data: { token_host_target: "link" } do %>
               <span data-token-host-target="linkText"><%= AccessToken::FREEFEED_HOSTS[:production][:domain] %> settings</span>
             <% end %>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -69,7 +69,7 @@
         </div>
       </div>
 
-      <div class="ff-card__footer">
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
         <%= form.submit "Validate and Save", class: "ff-button" %>
         <%= link_to "Cancel", access_tokens_path, class: class_names("ff-button", "ff-button--secondary") %>
       </div>

--- a/app/views/admin/email_updates/edit.html.erb
+++ b/app/views/admin/email_updates/edit.html.erb
@@ -29,7 +29,7 @@
         </div>
       </div>
 
-      <div class="ff-card__footer">
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
         <%= form.submit "Update Email", class: "ff-button", data: { turbo_confirm: "Update email for this user?" } %>
         <%= link_to "Cancel", admin_user_path(@user), class: class_names("ff-button", "ff-button--secondary") %>
       </div>

--- a/app/views/admin/email_updates/edit.html.erb
+++ b/app/views/admin/email_updates/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Change Email for #{@user.email_address}") %>
 
-  <div class="ff-alert ff-alert--info max-w-2xl">
+  <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800 max-w-2xl">
     <strong>How this works:</strong> You can either change the email immediately or send a confirmation email to the new address.
     If confirmation is required, the user must click the link in the email before the change takes effect.
   </div>

--- a/app/views/admin/email_updates/edit.html.erb
+++ b/app/views/admin/email_updates/edit.html.erb
@@ -30,8 +30,8 @@
       </div>
 
       <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
-        <%= form.submit "Update Email", class: "ff-button", data: { turbo_confirm: "Update email for this user?" } %>
-        <%= link_to "Cancel", admin_user_path(@user), class: class_names("ff-button", "ff-button--secondary") %>
+        <%= form.submit "Update Email", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", data: { turbo_confirm: "Update email for this user?" } %>
+        <%= link_to "Cancel", admin_user_path(@user), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/email_updates/edit.html.erb
+++ b/app/views/admin/email_updates/edit.html.erb
@@ -11,17 +11,17 @@
   <div class="max-w-2xl">
     <%= form_with model: @user, url: admin_user_email_update_path(@user), method: :patch do |form| %>
       <div class="space-y-6">
-        <div class="ff-form-group">
-          <label class="ff-form-label">Current email</label>
-          <div class="ff-form-input bg-slate-100"><%= @user.email_address %></div>
+        <div class="space-y-2">
+          <label class="block font-semibold text-slate-800">Current email</label>
+          <div class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 bg-slate-100"><%= @user.email_address %></div>
         </div>
 
-        <div class="ff-form-group">
-          <%= form.label :email_address, "New email", class: "ff-form-label" %>
-          <%= form.email_field :email_address, class: "ff-form-input", placeholder: "Enter new email address", autofocus: true, autocomplete: "email" %>
+        <div class="space-y-2">
+          <%= form.label :email_address, "New email", class: "block font-semibold text-slate-800" %>
+          <%= form.email_field :email_address, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", placeholder: "Enter new email address", autofocus: true, autocomplete: "email" %>
         </div>
 
-        <div class="ff-form-group">
+        <div class="space-y-2">
           <div class="flex items-start gap-3">
             <%= check_box_tag :require_confirmation, "1", false, class: "mt-1 h-4 w-4 rounded border-slate-300 text-cyan-600 focus:ring-cyan-500" %>
             <%= label_tag :require_confirmation, "Require user to confirm new email address before change takes effect", class: "text-base text-slate-700" %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -117,7 +117,7 @@
     <div class="ff-card">
       <div class="ff-card__body text-center py-12">
         <h2 class="text-2xl font-semibold mb-3 text-slate-900">No events found</h2>
-        <p class="ff-text">Events will appear here as they are created.</p>
+        <p class="text-slate-600">Events will appear here as they are created.</p>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -28,19 +28,19 @@
   <% end %>
 
   <% if @events.any? %>
-    <div class="ff-table-container">
-      <table class="ff-table ff-table--dense" data-key="admin.events.table">
-        <thead>
-          <tr>
-            <th scope="col">Event</th>
-            <th scope="col">User</th>
-            <th scope="col">Subject</th>
+    <div class="overflow-x-auto rounded-lg border border-slate-200">
+      <table class="w-full text-left text-sm text-slate-700" data-key="admin.events.table">
+        <thead class="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600">
+          <tr class="hover:bg-slate-50">
+            <th scope="col" class="px-4 py-2">Event</th>
+            <th scope="col" class="px-4 py-2">User</th>
+            <th scope="col" class="px-4 py-2">Subject</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody class="divide-y divide-slate-200 bg-white">
           <% @events.each do |event| %>
-            <tr>
-              <td class="align-top">
+            <tr class="hover:bg-slate-50">
+              <td class="px-4 py-2 align-top">
                 <div class="flex flex-col gap-1">
                   <div class="flex items-center gap-2">
                     <%= link_to admin_event_path(event),
@@ -71,7 +71,7 @@
                   </div>
                 </div>
               </td>
-              <td>
+              <td class="px-4 py-2">
                 <% if event.user_id.present? %>
                   <%= link_to "User ##{event.user_id}",
                               admin_events_path(filter: { user_id: event.user_id }),
@@ -82,7 +82,7 @@
                   <em class="text-slate-500" data-key="admin.events.user">System</em>
                 <% end %>
               </td>
-              <td>
+              <td class="px-4 py-2">
                 <%
                   subject_link = if event.subject_type.present?
                     filter_params = { subject_type: event.subject_type }

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -114,8 +114,8 @@
       <%= render_pagination { |pagination, params| admin_events_path(pagination.merge(@filter.present? ? { filter: @filter.to_h } : {})) } %>
     </div>
   <% else %>
-    <div class="ff-card">
-      <div class="ff-card__body text-center py-12">
+    <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+      <div class="space-y-6 text-center py-12">
         <h2 class="text-2xl font-semibold mb-3 text-slate-900">No events found</h2>
         <p class="text-slate-600">Events will appear here as they are created.</p>
       </div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -116,7 +116,7 @@
   <% else %>
     <div class="ff-card">
       <div class="ff-card__body text-center py-12">
-        <h2 class="ff-h2">No events found</h2>
+        <h2 class="text-2xl font-semibold mb-3 text-slate-900">No events found</h2>
         <p class="ff-text">Events will appear here as they are created.</p>
       </div>
     </div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -19,11 +19,11 @@
     <% end %>
     <% if @filter.present? %>
       <% header.with_action_button do %>
-        <%= link_to "Reset Filter", admin_events_path, class: "ff-button ff-button--secondary ff-button--compact" %>
+        <%= link_to "Reset Filter", admin_events_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
       <% end %>
     <% end %>
     <% header.with_action_button do %>
-      <%= link_to "Back to Admin", admin_path, class: "ff-button ff-button--secondary ff-button--compact" %>
+      <%= link_to "Back to Admin", admin_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>
   <% end %>
 

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -59,7 +59,7 @@
                       }
                       badge_class = level_badge_classes.fetch(level_key, "bg-slate-200 text-slate-600")
                     %>
-                    <span class="ff-event-level <%= badge_class %>" data-key="admin.events.level"><%= level_key.upcase %></span>
+                    <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide <%= badge_class %>" data-key="admin.events.level"><%= level_key.upcase %></span>
                     <%= link_to admin_events_path(filter: { type: [event.type] }), class: "font-semibold", title: "Filter by type: #{event.type}" do %>
                       <code class="text-sm" data-key="admin.events.type"><%= event.type %></code>
                     <% end %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -4,7 +4,7 @@
   <%= render PageHeaderComponent.new(title: "Event ##{@event.id}") do |header| %>
     <% if @previous_event %>
       <% header.with_action_button do %>
-        <%= link_to "← Previous", admin_event_path(@previous_event), class: "ff-button ff-button--secondary ff-button--compact" %>
+        <%= link_to "← Previous", admin_event_path(@previous_event), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
       <% end %>
     <% else %>
       <% header.with_action_button do %>
@@ -13,7 +13,7 @@
     <% end %>
     <% if @next_event %>
       <% header.with_action_button do %>
-        <%= link_to "Next →", admin_event_path(@next_event), class: "ff-button ff-button--secondary ff-button--compact" %>
+        <%= link_to "Next →", admin_event_path(@next_event), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
       <% end %>
     <% else %>
       <% header.with_action_button do %>
@@ -21,7 +21,7 @@
       <% end %>
     <% end %>
     <% header.with_action_button do %>
-      <%= link_to "Back to Events", admin_events_path, class: "ff-button ff-button--secondary ff-button--compact" %>
+      <%= link_to "Back to Events", admin_events_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>
   <% end %>
 

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -33,7 +33,7 @@
 
   <% if @event.metadata.present? && @event.metadata != {} %>
     <section class="space-y-4">
-      <h2 class="ff-h2">Metadata</h2>
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Metadata</h2>
       <pre class="overflow-auto rounded-lg border border-slate-200 bg-slate-50 p-4 font-mono text-sm"><%= highlight_json(@event.metadata) %></pre>
     </section>
   <% end %>

--- a/app/views/admin/system_stats/show.html.erb
+++ b/app/views/admin/system_stats/show.html.erb
@@ -68,12 +68,12 @@
   <% end %>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Deployed Version</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Deployed Version</h2>
     <%= render(release_info_list) %>
   </section>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Disk Usage</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Disk Usage</h2>
 
     <%# Visual disk usage bar %>
     <div class="space-y-3">
@@ -106,12 +106,12 @@
   </section>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Postgres Table Usage</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Postgres Table Usage</h2>
     <%= render(table_usage_list) %>
   </section>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Vacuum Stats</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Vacuum Stats</h2>
     <div class="ff-table-container">
       <table class="ff-table">
         <thead>
@@ -143,7 +143,7 @@
   </section>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Autovacuum Settings</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Autovacuum Settings</h2>
     <%= render(autovacuum_settings_list) %>
   </section>
 </div>

--- a/app/views/admin/system_stats/show.html.erb
+++ b/app/views/admin/system_stats/show.html.erb
@@ -112,29 +112,29 @@
 
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Vacuum Stats</h2>
-    <div class="ff-table-container">
-      <table class="ff-table">
-        <thead>
-          <tr>
-            <th scope="col">Table</th>
-            <th scope="col" class="text-right">Live Tuples</th>
-            <th scope="col" class="text-right">Dead Tuples</th>
-            <th scope="col">Last Vacuum</th>
-            <th scope="col">Last Autovacuum</th>
-            <th scope="col" class="text-right">Vacuum Count</th>
-            <th scope="col" class="text-right">Autovacuum Count</th>
+    <div class="overflow-x-auto rounded-lg border border-slate-200">
+      <table class="w-full text-left text-sm text-slate-700">
+        <thead class="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600">
+          <tr class="hover:bg-slate-50">
+            <th scope="col" class="px-6 py-3">Table</th>
+            <th scope="col" class="px-6 py-3 text-right">Live Tuples</th>
+            <th scope="col" class="px-6 py-3 text-right">Dead Tuples</th>
+            <th scope="col" class="px-6 py-3">Last Vacuum</th>
+            <th scope="col" class="px-6 py-3">Last Autovacuum</th>
+            <th scope="col" class="px-6 py-3 text-right">Vacuum Count</th>
+            <th scope="col" class="px-6 py-3 text-right">Autovacuum Count</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody class="divide-y divide-slate-200 bg-white">
           <% @disk_usage[:vacuum_stats].each do |row| %>
-            <tr>
-              <td class="font-mono text-sm"><%= row["relname"] %></td>
-              <td class="text-right"><%= number_with_delimiter(row["n_live_tup"]) %></td>
-              <td class="text-right"><%= number_with_delimiter(row["n_dead_tup"]) %></td>
-              <td><%= short_time_ago_tag(row["last_vacuum"]) %></td>
-              <td><%= short_time_ago_tag(row["last_autovacuum"]) %></td>
-              <td class="text-right"><%= row["vacuum_count"] %></td>
-              <td class="text-right"><%= row["autovacuum_count"] %></td>
+            <tr class="hover:bg-slate-50">
+              <td class="px-6 py-4 whitespace-nowrap font-mono text-sm"><%= row["relname"] %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-right"><%= number_with_delimiter(row["n_live_tup"]) %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-right"><%= number_with_delimiter(row["n_dead_tup"]) %></td>
+              <td class="px-6 py-4 whitespace-nowrap"><%= short_time_ago_tag(row["last_vacuum"]) %></td>
+              <td class="px-6 py-4 whitespace-nowrap"><%= short_time_ago_tag(row["last_autovacuum"]) %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-right"><%= row["vacuum_count"] %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-right"><%= row["autovacuum_count"] %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/admin/system_stats/show.html.erb
+++ b/app/views/admin/system_stats/show.html.erb
@@ -63,7 +63,7 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "System Stats") do |header| %>
     <% header.with_action_button do %>
-      <%= link_to "Back to Admin", admin_path, class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
+      <%= link_to "Back to Admin", admin_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>
   <% end %>
 

--- a/app/views/admin/users/_available_invites_input.html.erb
+++ b/app/views/admin/users/_available_invites_input.html.erb
@@ -1,1 +1,1 @@
-<%= number_field(:user, :available_invites, value: user.available_invites, min: 0, class: "ff-form-input") %>
+<%= number_field(:user, :available_invites, value: user.available_invites, min: 0, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2") %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -8,22 +8,22 @@
   <% end %>
 
   <% if @users.any? %>
-    <div class="ff-table-container">
-      <table class="ff-table">
-        <thead>
-          <tr>
-            <th scope="col">Email</th>
-            <th scope="col">Name</th>
-            <th scope="col" class="text-center">Feeds</th>
-            <th scope="col" class="text-center">Tokens</th>
-            <th scope="col" class="text-center">Posts</th>
-            <th scope="col" class="text-center">Last Seen</th>
+    <div class="overflow-x-auto rounded-lg border border-slate-200">
+      <table class="w-full text-left text-sm text-slate-700">
+        <thead class="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600">
+          <tr class="hover:bg-slate-50">
+            <th scope="col" class="px-6 py-3">Email</th>
+            <th scope="col" class="px-6 py-3">Name</th>
+            <th scope="col" class="px-6 py-3 text-center">Feeds</th>
+            <th scope="col" class="px-6 py-3 text-center">Tokens</th>
+            <th scope="col" class="px-6 py-3 text-center">Posts</th>
+            <th scope="col" class="px-6 py-3 text-center">Last Seen</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody class="divide-y divide-slate-200 bg-white">
           <% @users.each do |user| %>
-            <tr>
-              <td>
+            <tr class="hover:bg-slate-50">
+              <td class="px-6 py-4 whitespace-nowrap">
                 <%= link_to user.email_address, admin_user_path(user), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
                 <% if user.admin? %>
                   <span class="text-slate-500">(admin)</span>
@@ -32,11 +32,11 @@
                   <span class="ml-2 inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20">email bounced</span>
                 <% end %>
               </td>
-              <td><%= user.name %></td>
-              <td class="text-center"><%= user.feeds_count %></td>
-              <td class="text-center"><%= user.access_tokens_count %></td>
-              <td class="text-center"><%= user.posts_count %></td>
-              <td class="text-center">
+              <td class="px-6 py-4 whitespace-nowrap"><%= user.name %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-center"><%= user.feeds_count %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-center"><%= user.access_tokens_count %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-center"><%= user.posts_count %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-center">
                 <% if user.last_seen_at %>
                   <time class="text-slate-500" datetime="<%= user.last_seen_at.iso8601 %>" title="<%= user.last_seen_at.to_fs(:long) %>">
                     <%= short_time_ago(user.last_seen_at) %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,7 +3,7 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Users") do |header| %>
     <% header.with_action_button do %>
-      <%= link_to "Back to Admin", admin_path, class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
+      <%= link_to "Back to Admin", admin_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>
   <% end %>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -24,7 +24,7 @@
           <% @users.each do |user| %>
             <tr>
               <td>
-                <%= link_to user.email_address, admin_user_path(user), class: "ff-link" %>
+                <%= link_to user.email_address, admin_user_path(user), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
                 <% if user.admin? %>
                   <span class="text-slate-500">(admin)</span>
                 <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -177,18 +177,18 @@
 
   <% if @user.email_deactivated? %>
     <section class="space-y-4">
-      <h2 class="ff-h2">Email Status</h2>
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Email Status</h2>
       <%= render(email_status_list) %>
     </section>
   <% end %>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Statistics</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Statistics</h2>
     <%= render(stats_list) %>
   </section>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Invitations</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Invitations</h2>
     <%= render(invitations_list) %>
   </section>
 
@@ -219,7 +219,7 @@
   <% end %>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Active Sessions</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Active Sessions</h2>
 
     <% if @stats.sessions.any? %>
       <div class="ff-table-container">
@@ -260,7 +260,7 @@
   </section>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Actions</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Actions</h2>
     <div class="flex gap-2">
       <%= link_to "Change Email", edit_admin_user_email_update_path(@user), class: "ff-button ff-button--secondary ff-button--compact" %>
       <%= link_to "Reset Password", "#", class: "ff-button ff-button--secondary ff-button--compact", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "password-reset-modal-#{@user.id}", action: "click->modal-trigger#open" } %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -92,8 +92,8 @@
       list.with_item(ListGroupComponent::StatItemComponent.new(
         label: "Actions",
         value: safe_join([
-          button_to("Reactivate Email", admin_user_email_reactivation_path(@user), method: :post, class: "ff-button ff-button--compact"),
-          link_to("View Email Events", admin_events_path(filter: { user_id: @user.id, type: mail_event_types }), class: "ff-button ff-button--secondary ff-button--compact")
+          button_to("Reactivate Email", admin_user_email_reactivation_path(@user), method: :post, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
+          link_to("View Email Events", admin_events_path(filter: { user_id: @user.id, type: mail_event_types }), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1")
         ], " ")
       ))
     end
@@ -170,7 +170,7 @@
 <div class="space-y-8">
   <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
     <h1 class="text-4xl font-semibold mb-0 text-slate-900"><%= @user.email_address %></h1>
-    <%= link_to "Back to Users", admin_users_path, class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
+    <%= link_to "Back to Users", admin_users_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
   </div>
 
   <%= render(user_info) %>
@@ -262,12 +262,12 @@
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Actions</h2>
     <div class="flex gap-2">
-      <%= link_to "Change Email", edit_admin_user_email_update_path(@user), class: "ff-button ff-button--secondary ff-button--compact" %>
-      <%= link_to "Reset Password", "#", class: "ff-button ff-button--secondary ff-button--compact", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "password-reset-modal-#{@user.id}", action: "click->modal-trigger#open" } %>
+      <%= link_to "Change Email", edit_admin_user_email_update_path(@user), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+      <%= link_to "Reset Password", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "password-reset-modal-#{@user.id}", action: "click->modal-trigger#open" } %>
       <% if @user.suspended? %>
-        <%= link_to "Unsuspend user", "#", class: "ff-button ff-button--secondary ff-button--compact", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "unsuspend-user-modal-#{@user.id}", action: "click->modal-trigger#open" } %>
+        <%= link_to "Unsuspend user", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "unsuspend-user-modal-#{@user.id}", action: "click->modal-trigger#open" } %>
       <% else %>
-        <%= link_to "Suspend user", "#", class: "ff-button ff-button--secondary ff-button--compact", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "suspend-user-modal-#{@user.id}", action: "click->modal-trigger#open" } %>
+        <%= link_to "Suspend user", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "suspend-user-modal-#{@user.id}", action: "click->modal-trigger#open" } %>
       <% end %>
     </div>
   </section>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -195,21 +195,21 @@
   <% if @stats.invited_users.any? %>
     <section class="space-y-4">
       <h3 class="text-xl font-semibold mb-2 text-slate-900">Users Invited by <%= @user.name %></h3>
-      <div class="ff-table-container">
-        <table class="ff-table">
-          <thead>
-            <tr>
-              <th scope="col">Name</th>
-              <th scope="col">Email</th>
-              <th scope="col">Invited</th>
+      <div class="overflow-x-auto rounded-lg border border-slate-200">
+        <table class="w-full text-left text-sm text-slate-700">
+          <thead class="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600">
+            <tr class="hover:bg-slate-50">
+              <th scope="col" class="px-6 py-3">Name</th>
+              <th scope="col" class="px-6 py-3">Email</th>
+              <th scope="col" class="px-6 py-3">Invited</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="divide-y divide-slate-200 bg-white">
             <% @stats.invited_users.each do |invite| %>
-              <tr>
-                <td><%= link_to invite.invited_user.name, admin_user_path(invite.invited_user), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %></td>
-                <td><%= invite.invited_user.email_address %></td>
-                <td><%= short_time_ago(invite.created_at) %></td>
+              <tr class="hover:bg-slate-50">
+                <td class="px-6 py-4 whitespace-nowrap"><%= link_to invite.invited_user.name, admin_user_path(invite.invited_user), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %></td>
+                <td class="px-6 py-4 whitespace-nowrap"><%= invite.invited_user.email_address %></td>
+                <td class="px-6 py-4 whitespace-nowrap"><%= short_time_ago(invite.created_at) %></td>
               </tr>
             <% end %>
           </tbody>
@@ -222,29 +222,29 @@
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Active Sessions</h2>
 
     <% if @stats.sessions.any? %>
-      <div class="ff-table-container">
-        <table class="ff-table">
-          <thead>
-            <tr>
-              <th scope="col">IP Address</th>
-              <th scope="col">User Agent</th>
-              <th scope="col" class="text-center">Created</th>
-              <th scope="col" class="text-center">Last Seen</th>
+      <div class="overflow-x-auto rounded-lg border border-slate-200">
+        <table class="w-full text-left text-sm text-slate-700">
+          <thead class="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600">
+            <tr class="hover:bg-slate-50">
+              <th scope="col" class="px-6 py-3">IP Address</th>
+              <th scope="col" class="px-6 py-3">User Agent</th>
+              <th scope="col" class="px-6 py-3 text-center">Created</th>
+              <th scope="col" class="px-6 py-3 text-center">Last Seen</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="divide-y divide-slate-200 bg-white">
             <% @stats.sessions.each do |session| %>
-              <tr>
-                <td><%= session.ip_address %></td>
-                <td class="max-w-md">
+              <tr class="hover:bg-slate-50">
+                <td class="px-6 py-4 whitespace-nowrap"><%= session.ip_address %></td>
+                <td class="px-6 py-4 whitespace-nowrap max-w-md">
                   <div class="truncate"><%= session.user_agent %></div>
                 </td>
-                <td class="text-center">
+                <td class="px-6 py-4 whitespace-nowrap text-center">
                   <time class="text-slate-500" datetime="<%= session.created_at.iso8601 %>" title="<%= session.created_at.to_fs(:long) %>">
                     <%= short_time_ago(session.created_at) %>
                   </time>
                 </td>
-                <td class="text-center">
+                <td class="px-6 py-4 whitespace-nowrap text-center">
                   <time class="text-slate-500" datetime="<%= session.updated_at.iso8601 %>" title="<%= session.updated_at.to_fs(:long) %>">
                     <%= short_time_ago(session.updated_at) %>
                   </time>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -169,7 +169,7 @@
 
 <div class="space-y-8">
   <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-    <h1 class="ff-h1"><%= @user.email_address %></h1>
+    <h1 class="text-4xl font-semibold mb-0 text-slate-900"><%= @user.email_address %></h1>
     <%= link_to "Back to Users", admin_users_path, class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
   </div>
 

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -149,7 +149,7 @@
       value: tag.span(class: "flex items-center gap-4") {
         safe_join([
           render(partial: "available_invites_value", locals: { user: @user }),
-          link_to("Edit", "#", class: "ff-link text-sm", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "edit-available-invites-modal-#{@user.id}", action: "click->modal-trigger#open" })
+          link_to("Edit", "#", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 text-sm", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "edit-available-invites-modal-#{@user.id}", action: "click->modal-trigger#open" })
         ])
       },
       key: "invitations.available_invites"
@@ -207,7 +207,7 @@
           <tbody>
             <% @stats.invited_users.each do |invite| %>
               <tr>
-                <td><%= link_to invite.invited_user.name, admin_user_path(invite.invited_user), class: "ff-link" %></td>
+                <td><%= link_to invite.invited_user.name, admin_user_path(invite.invited_user), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %></td>
                 <td><%= invite.invited_user.email_address %></td>
                 <td><%= short_time_ago(invite.created_at) %></td>
               </tr>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -194,7 +194,7 @@
 
   <% if @stats.invited_users.any? %>
     <section class="space-y-4">
-      <h3 class="ff-h3">Users Invited by <%= @user.name %></h3>
+      <h3 class="text-xl font-semibold mb-2 text-slate-900">Users Invited by <%= @user.name %></h3>
       <div class="ff-table-container">
         <table class="ff-table">
           <thead>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Admin Panel" %>
 
 <div class="space-y-8">
-  <h1 class="ff-h1">Admin Panel</h1>
+  <h1 class="text-4xl font-semibold mb-0 text-slate-900">Admin Panel</h1>
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
     <%= link_to admin_users_path, class: "ff-card block no-underline hover:shadow-lg transition-shadow" do %>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -10,7 +10,7 @@
           <%= icon("people") %>
           <span>Users</span>
         </h2>
-        <p class="ff-text text-slate-600">Manage user accounts and permissions</p>
+        <p class="text-slate-600">Manage user accounts and permissions</p>
       </div>
     <% end %>
 
@@ -20,7 +20,7 @@
           <%= icon("calendar-event") %>
           <span>System Events</span>
         </h2>
-        <p class="ff-text text-slate-600">View system events, logs, and activity</p>
+        <p class="text-slate-600">View system events, logs, and activity</p>
       </div>
     <% end %>
 
@@ -30,7 +30,7 @@
           <%= icon("hdd") %>
           <span>System Info</span>
         </h2>
-        <p class="ff-text text-slate-600">View disk usage and other system information</p>
+        <p class="text-slate-600">View disk usage and other system information</p>
       </div>
     <% end %>
 
@@ -40,7 +40,7 @@
           <%= icon("stack") %>
           <span>Background Jobs</span>
         </h2>
-        <p class="ff-text text-slate-600">Monitor and manage background job queues</p>
+        <p class="text-slate-600">Monitor and manage background job queues</p>
       </div>
     <% end %>
 
@@ -51,7 +51,7 @@
             <%= icon("inbox") %>
             <span>Sent Emails</span>
           </h2>
-          <p class="ff-text text-slate-600">Review emails captured in development</p>
+          <p class="text-slate-600">Review emails captured in development</p>
         </div>
       <% end %>
 
@@ -61,7 +61,7 @@
             <%= icon("grid") %>
             <span>UI Reference</span>
           </h2>
-          <p class="ff-text text-slate-600">Reference for all reusable UI components.</p>
+          <p class="text-slate-600">Reference for all reusable UI components.</p>
         </div>
       <% end %>
     <% end %>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -4,8 +4,8 @@
   <h1 class="text-4xl font-semibold mb-0 text-slate-900">Admin Panel</h1>
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <%= link_to admin_users_path, class: "ff-card block no-underline hover:shadow-lg transition-shadow" do %>
-      <div class="ff-card__body space-y-4">
+    <%= link_to admin_users_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow" do %>
+      <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("people") %>
           <span>Users</span>
@@ -14,8 +14,8 @@
       </div>
     <% end %>
 
-    <%= link_to admin_events_path, class: "ff-card block no-underline hover:shadow-lg transition-shadow" do %>
-      <div class="ff-card__body space-y-4">
+    <%= link_to admin_events_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow" do %>
+      <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("calendar-event") %>
           <span>System Events</span>
@@ -24,8 +24,8 @@
       </div>
     <% end %>
 
-    <%= link_to admin_system_stats_path, class: "ff-card block no-underline hover:shadow-lg transition-shadow" do %>
-      <div class="ff-card__body space-y-4">
+    <%= link_to admin_system_stats_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow" do %>
+      <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("hdd") %>
           <span>System Info</span>
@@ -34,8 +34,8 @@
       </div>
     <% end %>
 
-    <%= link_to mission_control_jobs.root_path, class: "ff-card block no-underline hover:shadow-lg transition-shadow", target: "_blank", rel: "noopener noreferrer" do %>
-      <div class="ff-card__body space-y-4">
+    <%= link_to mission_control_jobs.root_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow", target: "_blank", rel: "noopener noreferrer" do %>
+      <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("stack") %>
           <span>Background Jobs</span>
@@ -45,8 +45,8 @@
     <% end %>
 
     <% if Rails.env.development? %>
-      <%= link_to development_sent_emails_path, class: "ff-card block no-underline hover:shadow-lg transition-shadow", target: "_blank", rel: "noopener noreferrer" do %>
-        <div class="ff-card__body space-y-4">
+      <%= link_to development_sent_emails_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow", target: "_blank", rel: "noopener noreferrer" do %>
+        <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
             <%= icon("inbox") %>
             <span>Sent Emails</span>
@@ -55,8 +55,8 @@
         </div>
       <% end %>
 
-      <%= link_to development_components_path, class: "ff-card block no-underline hover:shadow-lg transition-shadow", target: "_blank", rel: "noopener noreferrer" do %>
-        <div class="ff-card__body space-y-4">
+      <%= link_to development_components_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow", target: "_blank", rel: "noopener noreferrer" do %>
+        <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
             <%= icon("grid") %>
             <span>UI Reference</span>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -133,10 +133,10 @@
         This is a context paragraph that provides additional information about the page.
       <% end %>
       <% header.with_action_button do %>
-        <a href="#" class="ff-button ff-button--primary ff-button--compact">Primary Action</a>
+        <a href="#" class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">Primary Action</a>
       <% end %>
       <% header.with_action_button do %>
-        <a href="#" class="ff-button ff-button--secondary ff-button--compact">Secondary Action</a>
+        <a href="#" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">Secondary Action</a>
       <% end %>
     <% end %>
   </section>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -164,7 +164,7 @@
       <% sample_post = Post.first || Post.new(id: 1) %>
 
       <%# Feed refresh success %>
-      <div class="ff-alert ff-alert--info">
+      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "feed_refresh",
@@ -175,7 +175,7 @@
       </div>
 
       <%# Feed refresh error %>
-      <div class="ff-alert ff-alert--error">
+      <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "feed_refresh_error",
@@ -188,7 +188,7 @@
       </div>
 
       <%# Access token validation failed with multiple feeds %>
-      <div class="ff-alert ff-alert--warning space-y-2" role="alert">
+      <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "access_token_validation_failed",
@@ -200,7 +200,7 @@
       </div>
 
       <%# Group purge started %>
-      <div class="ff-alert ff-alert--info">
+      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "group_purge_started",
@@ -211,7 +211,7 @@
       </div>
 
       <%# Post withdrawn %>
-      <div class="ff-alert ff-alert--info">
+      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "post_withdrawn",
@@ -222,7 +222,7 @@
       </div>
 
       <%# Email events %>
-      <div class="ff-alert ff-alert--info">
+      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "resend.email.email_sent",
@@ -231,7 +231,7 @@
         ) %>
       </div>
 
-      <div class="ff-alert ff-alert--info">
+      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "resend.email.email_delivered",
@@ -240,7 +240,7 @@
         ) %>
       </div>
 
-      <div class="ff-alert ff-alert--error">
+      <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "resend.email.email_bounced",
@@ -250,7 +250,7 @@
       </div>
 
       <%# User events %>
-      <div class="ff-alert ff-alert--info">
+      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "email_changed",
@@ -259,7 +259,7 @@
         ) %>
       </div>
 
-      <div class="ff-alert ff-alert--warning space-y-2" role="alert">
+      <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "user_suspended",

--- a/app/views/development/sent_emails/index.html.erb
+++ b/app/views/development/sent_emails/index.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 
   <% if @emails.empty? %>
-    <div class="ff-alert ff-alert--info" data-key="development.emails.empty">
+    <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800" data-key="development.emails.empty">
       No emails captured yet. Emails sent in development mode will appear here.
     </div>
   <% else %>

--- a/app/views/development/sent_emails/index.html.erb
+++ b/app/views/development/sent_emails/index.html.erb
@@ -7,7 +7,7 @@
         <%= button_to "Purge All",
                       purge_development_sent_emails_path,
                       method: :delete,
-                      class: class_names("ff-button", "ff-button--secondary", "ff-button--compact", "text-red-600 hover:text-red-700"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", "text-red-600 hover:text-red-700"),
                       data: { turbo_confirm: "Are you sure you want to delete all emails?" } %>
       <% end %>
     <% end %>

--- a/app/views/development/sent_emails/show.html.erb
+++ b/app/views/development/sent_emails/show.html.erb
@@ -3,7 +3,7 @@
 <div class="space-y-8">
   <div class="flex items-center justify-between">
     <h1 class="text-4xl font-semibold mb-0 text-slate-900" data-key="development.emails.subject"><%= h @email[:subject] %></h1>
-    <%= link_to "Back to all emails", development_sent_emails_path, class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
+    <%= link_to "Back to all emails", development_sent_emails_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
   </div>
 
   <%= render SentEmailDetailsComponent.new(email: @email) %>

--- a/app/views/development/sent_emails/show.html.erb
+++ b/app/views/development/sent_emails/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="space-y-8">
   <div class="flex items-center justify-between">
-    <h1 class="ff-h1" data-key="development.emails.subject"><%= h @email[:subject] %></h1>
+    <h1 class="text-4xl font-semibold mb-0 text-slate-900" data-key="development.emails.subject"><%= h @email[:subject] %></h1>
     <%= link_to "Back to all emails", development_sent_emails_path, class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
   </div>
 

--- a/app/views/feed_entries/show.html.erb
+++ b/app/views/feed_entries/show.html.erb
@@ -11,9 +11,9 @@
     <% end %>
     <% header.with_action_button do %>
       <% if @feed_entry.posts.any? %>
-        <%= link_to "Back to Post", post_path(@feed_entry.posts.first), class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
+        <%= link_to "Back to Post", post_path(@feed_entry.posts.first), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
       <% else %>
-        <span class="ff-button ff-button--secondary ff-button--compact opacity-50 cursor-not-allowed">
+        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 opacity-50 cursor-not-allowed">
           Back to Post
         </span>
       <% end %>

--- a/app/views/feed_previews/_completed_status.html.erb
+++ b/app/views/feed_previews/_completed_status.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (feed_preview:) %>
 <% if feed_preview.posts_data.any? %>
-  <p class="ff-text text-slate-600">Showing <%= feed_preview.posts_count %> most recent <%= "post".pluralize(feed_preview.posts_count) %>.</p>
+  <p class="text-slate-600">Showing <%= feed_preview.posts_count %> most recent <%= "post".pluralize(feed_preview.posts_count) %>.</p>
 
   <div class="space-y-6">
   <% feed_preview.posts_data.each_with_index do |post_data, index| %>
@@ -8,5 +8,5 @@
   <% end %>
   </div>
 <% else %>
-  <p class="ff-text text-slate-600">No posts found in this feed.</p>
+  <p class="text-slate-600">No posts found in this feed.</p>
 <% end %>

--- a/app/views/feed_previews/_failed_status.html.erb
+++ b/app/views/feed_previews/_failed_status.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (feed_preview:) %>
 <div data-feed-preview-spinner>
-  <div class="ff-alert ff-alert--error space-y-1" role="alert">
+  <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800 space-y-1" role="alert">
     <p class="font-semibold text-slate-800">Preview generation failed.</p>
     <p class="text-slate-600">There was an error processing this feed. Double-check the feed URL and try again.</p>
   </div>

--- a/app/views/feed_previews/_failed_status.html.erb
+++ b/app/views/feed_previews/_failed_status.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (feed_preview:) %>
 <div data-feed-preview-spinner>
   <div class="ff-alert ff-alert--error space-y-1" role="alert">
-    <p class="ff-text font-semibold text-slate-800">Preview generation failed.</p>
-    <p class="ff-text">There was an error processing this feed. Double-check the feed URL and try again.</p>
+    <p class="font-semibold text-slate-800">Preview generation failed.</p>
+    <p class="text-slate-600">There was an error processing this feed. Double-check the feed URL and try again.</p>
   </div>
 </div>

--- a/app/views/feed_previews/_failed_status.html.erb
+++ b/app/views/feed_previews/_failed_status.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (feed_preview:) %>
 <div data-feed-preview-spinner>
   <div class="ff-alert ff-alert--error space-y-1" role="alert">
-    <p class="ff-text ff-text--heavy">Preview generation failed.</p>
+    <p class="ff-text font-semibold text-slate-800">Preview generation failed.</p>
     <p class="ff-text">There was an error processing this feed. Double-check the feed URL and try again.</p>
   </div>
 </div>

--- a/app/views/feed_previews/_header_actions.html.erb
+++ b/app/views/feed_previews/_header_actions.html.erb
@@ -3,10 +3,10 @@
   <% unless feed_preview.processing? %>
     <%= button_to "Refresh Preview", feed_preview_path(feed_preview),
         method: :patch,
-        class: class_names("ff-button", "ff-button--secondary", "ff-button--compact"),
+        class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
         data: { turbo: false },
         form: { class: "inline-block" } %>
   <% end %>
   <%= link_to "Back to Feeds", feeds_path,
-      class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
+      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
 </div>

--- a/app/views/feed_previews/_processing_status.html.erb
+++ b/app/views/feed_previews/_processing_status.html.erb
@@ -7,7 +7,7 @@
     <%= render SpinnerComponent.new %>
   </div>
   <div class="space-y-1">
-    <p class="ff-text ff-text--heavy">Generating preview...</p>
+    <p class="ff-text font-semibold text-slate-800">Generating preview...</p>
     <p class="ff-text">This usually takes a few seconds while we fetch and format this feed.</p>
   </div>
 <% end %>

--- a/app/views/feed_previews/_processing_status.html.erb
+++ b/app/views/feed_previews/_processing_status.html.erb
@@ -7,7 +7,7 @@
     <%= render SpinnerComponent.new %>
   </div>
   <div class="space-y-1">
-    <p class="ff-text font-semibold text-slate-800">Generating preview...</p>
-    <p class="ff-text">This usually takes a few seconds while we fetch and format this feed.</p>
+    <p class="font-semibold text-slate-800">Generating preview...</p>
+    <p class="text-slate-600">This usually takes a few seconds while we fetch and format this feed.</p>
   </div>
 <% end %>

--- a/app/views/feed_previews/show.html.erb
+++ b/app/views/feed_previews/show.html.erb
@@ -3,7 +3,7 @@
 <div class="flex flex-col gap-3 mb-4 sm:flex-row sm:items-start sm:justify-between">
   <div>
     <h1 class="text-4xl font-semibold mb-0 text-slate-900">Feed Preview</h1>
-    <p class="ff-text mt-2">
+    <p class="text-slate-600 mt-2">
       Source URL: <a href="<%= @feed_preview.url %>" target="_blank" rel="noopener" class="ff-link break-all"><%= @feed_preview.url %></a> (<%= t("feed_profiles.#{@feed_preview.feed_profile_key}") %>)
     </p>
   </div>

--- a/app/views/feed_previews/show.html.erb
+++ b/app/views/feed_previews/show.html.erb
@@ -4,7 +4,7 @@
   <div>
     <h1 class="text-4xl font-semibold mb-0 text-slate-900">Feed Preview</h1>
     <p class="text-slate-600 mt-2">
-      Source URL: <a href="<%= @feed_preview.url %>" target="_blank" rel="noopener" class="ff-link break-all"><%= @feed_preview.url %></a> (<%= t("feed_profiles.#{@feed_preview.feed_profile_key}") %>)
+      Source URL: <a href="<%= @feed_preview.url %>" target="_blank" rel="noopener" class="font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 break-all"><%= @feed_preview.url %></a> (<%= t("feed_profiles.#{@feed_preview.feed_profile_key}") %>)
     </p>
   </div>
   <div id="header-actions" class="flex w-full items-center justify-between gap-5 sm:w-auto sm:justify-end">

--- a/app/views/feed_previews/show.html.erb
+++ b/app/views/feed_previews/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="flex flex-col gap-3 mb-4 sm:flex-row sm:items-start sm:justify-between">
   <div>
-    <h1 class="ff-h1">Feed Preview</h1>
+    <h1 class="text-4xl font-semibold mb-0 text-slate-900">Feed Preview</h1>
     <p class="ff-text mt-2">
       Source URL: <a href="<%= @feed_preview.url %>" target="_blank" rel="noopener" class="ff-link break-all"><%= @feed_preview.url %></a> (<%= t("feed_profiles.#{@feed_preview.feed_profile_key}") %>)
     </p>

--- a/app/views/feeds/_blocked_no_tokens.html.erb
+++ b/app/views/feeds/_blocked_no_tokens.html.erb
@@ -4,7 +4,7 @@
     <p>You need to have an active FreeFeed access token before creating a feed.</p>
   </div>
 
-  <div class="ff-card__footer">
+  <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
     <%= link_to "Add Access Token", new_access_token_path, class: "ff-button" %>
     <%= link_to "Cancel", feeds_path, class: "ff-button ff-button--secondary" %>
   </div>

--- a/app/views/feeds/_blocked_no_tokens.html.erb
+++ b/app/views/feeds/_blocked_no_tokens.html.erb
@@ -5,7 +5,7 @@
   </div>
 
   <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
-    <%= link_to "Add Access Token", new_access_token_path, class: "ff-button" %>
-    <%= link_to "Cancel", feeds_path, class: "ff-button ff-button--secondary" %>
+    <%= link_to "Add Access Token", new_access_token_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+    <%= link_to "Cancel", feeds_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
   </div>
 </div>

--- a/app/views/feeds/_blocked_no_tokens.html.erb
+++ b/app/views/feeds/_blocked_no_tokens.html.erb
@@ -1,6 +1,6 @@
 <%# locals: () %>
 <div id="feed-form">
-  <div class="ff-alert ff-alert--warning space-y-2" role="alert">
+  <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
     <p>You need to have an active FreeFeed access token before creating a feed.</p>
   </div>
 

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -15,9 +15,9 @@
 
     <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
       <%= f.submit "Identify Feed Format",
-                   class: "ff-button",
+                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
                    data: { turbo_submits_with: "Identifying..." } %>
-      <%= link_to "Cancel", feeds_path, class: "ff-button ff-button--secondary" %>
+      <%= link_to "Cancel", feeds_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     </div>
   <% end %>
 </div>

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -13,7 +13,7 @@
       </div>
     </div>
 
-    <div class="ff-card__footer">
+    <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
       <%= f.submit "Identify Feed Format",
                    class: "ff-button",
                    data: { turbo_submits_with: "Identifying..." } %>

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -2,14 +2,14 @@
 <div id="feed-form">
   <%= form_with url: feed_details_path, method: :post do |f| %>
     <div class="space-y-6">
-      <div class="ff-form-group">
-        <%= f.label :url, "Feed URL", class: "ff-form-label" %>
+      <div class="space-y-2">
+        <%= f.label :url, "Feed URL", class: "block font-semibold text-slate-800" %>
         <%= f.text_field :url,
                          placeholder: "https://example.com/feed.xml",
-                         class: "ff-form-input",
+                         class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                          required: true,
                          autofocus: true %>
-        <p class="ff-form-help">Enter the URL of the RSS feed or supported site you want to import.</p>
+        <p class="text-slate-500">Enter the URL of the RSS feed or supported site you want to import.</p>
       </div>
     </div>
 

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -126,11 +126,11 @@
     <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
       <% if edit_mode %>
         <%= f.submit "Update Feed Configuration",
-                     class: "ff-button",
+                     class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
                      data: { turbo_submits_with: "Updating..." } %>
       <% else %>
         <%= f.submit "Create and Enable Feed",
-                     class: "ff-button",
+                     class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
                      data: {
                        feed_form_target: "submitButton",
                        mode: "new",
@@ -138,7 +138,7 @@
                        disabled_label: "Create Feed"
                      } %>
       <% end %>
-      <%= link_to "Cancel", feeds_path, class: "ff-button ff-button--secondary" %>
+      <%= link_to "Cancel", feeds_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     </div>
   <% end %>
 </div>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -12,43 +12,43 @@
                   groups_default_text_value: "The FreeFeed group where posts will be published."
                 } do |f| %>
     <div class="space-y-6">
-      <div class="ff-form-group">
-        <%= f.label :url, "Feed URL", class: "ff-form-label" %>
+      <div class="space-y-2">
+        <%= f.label :url, "Feed URL", class: "block font-semibold text-slate-800" %>
         <%= f.text_field :url_display,
                          value: feed.url,
                          disabled: true,
-                         class: "ff-form-input bg-slate-100",
+                         class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 bg-slate-100",
                          aria: { label: "Feed URL (cannot be changed)" } %>
         <%= f.hidden_field :url %>
         <% if edit_mode %>
-          <p class="ff-form-help">Feed URL and Type cannot be changed after creation. To use a different URL, create a new feed.</p>
+          <p class="text-slate-500">Feed URL and Type cannot be changed after creation. To use a different URL, create a new feed.</p>
         <% end %>
       </div>
 
-      <div class="ff-form-group">
-        <%= label_tag "feed_profile_display", "Feed Type", class: "ff-form-label" %>
+      <div class="space-y-2">
+        <%= label_tag "feed_profile_display", "Feed Type", class: "block font-semibold text-slate-800" %>
         <%= text_field_tag "feed_profile_display",
                            (feed.feed_profile_key.present? ? FeedProfile.display_name_for(feed.feed_profile_key) : "Unknown"),
                            disabled: true,
-                           class: "ff-form-input bg-slate-100",
+                           class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 bg-slate-100",
                            aria: { label: "Feed Type (detected automatically)" } %>
         <%= f.hidden_field :feed_profile_key %>
       </div>
 
-      <div class="ff-form-group">
-        <%= f.label :name, "Feed Name", class: "ff-form-label" %>
+      <div class="space-y-2">
+        <%= f.label :name, "Feed Name", class: "block font-semibold text-slate-800" %>
         <%= f.text_field :name,
                          placeholder: "Enter a name for this feed",
                          maxlength: Feed::NAME_MAX_LENGTH,
-                         class: "ff-form-input",
+                         class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                          required: true %>
         <% if feed.name.present? %>
-          <p class="ff-form-help">You can edit this name if you'd like.</p>
+          <p class="text-slate-500">You can edit this name if you'd like.</p>
         <% else %>
-          <p class="ff-form-help">We couldn't automatically detect a name. Please enter one.</p>
+          <p class="text-slate-500">We couldn't automatically detect a name. Please enter one.</p>
         <% end %>
         <% if f.object.errors[:name].any? %>
-          <p class="ff-form-error"><%= f.object.errors[:name].first %></p>
+          <p class="text-sm text-red-600"><%= f.object.errors[:name].first %></p>
         <% end %>
       </div>
 
@@ -56,8 +56,8 @@
         <h3 class="text-base font-semibold text-slate-900 mb-4">Reposting Settings</h3>
 
         <div class="space-y-6">
-          <div class="ff-form-group">
-            <%= f.label :access_token_id, "FreeFeed Account", class: "ff-form-label" %>
+          <div class="space-y-2">
+            <%= f.label :access_token_id, "FreeFeed Account", class: "block font-semibold text-slate-800" %>
             <%= f.select :access_token_id,
                          options_from_collection_for_select(
                            active_tokens,
@@ -67,7 +67,7 @@
                          ),
                          {},
                          {
-                           class: "ff-form-input pb-2",
+                           class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 pb-2",
                            required: true,
                            data: {
                              action: "change->groups#refresh",
@@ -75,7 +75,7 @@
                            }
                          } %>
             <% if f.object.errors[:access_token].any? %>
-              <p class="ff-form-error"><%= f.object.errors[:access_token].first %></p>
+              <p class="text-sm text-red-600"><%= f.object.errors[:access_token].first %></p>
             <% end %>
           </div>
 
@@ -89,14 +89,14 @@
       <div class="mt-6">
         <h3 class="text-base font-semibold text-slate-900 mb-4">Refresh Schedule</h3>
 
-        <div class="ff-form-group">
-          <%= f.label :schedule_interval, "Check for new posts every", class: "ff-form-label" %>
+        <div class="space-y-2">
+          <%= f.label :schedule_interval, "Check for new posts every", class: "block font-semibold text-slate-800" %>
           <%= f.select :schedule_interval,
                        Feed.schedule_intervals_for_select,
                        { selected: feed.schedule_interval || "1h" },
-                       { class: "ff-form-input", required: true } %>
+                       { class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", required: true } %>
           <% if f.object.errors[:cron_expression].any? %>
-            <p class="ff-form-error"><%= f.object.errors[:cron_expression].first %></p>
+            <p class="text-sm text-red-600"><%= f.object.errors[:cron_expression].first %></p>
           <% end %>
         </div>
       </div>
@@ -109,15 +109,14 @@
                                 "1",
                                 true,
                                 id: "enable_feed",
-                                class: "ff-checkbox",
                                 data: {
                                   action: "change->feed-form#updateSubmitButtonLabel",
                                   feed_form_target: "enableCheckbox"
                                 } %>
             </div>
             <div class="ml-3">
-              <%= label_tag "enable_feed", "Enable feed", class: "ff-form-label mb-0" %>
-              <p class="ff-form-help mt-1">Enabled feeds will automatically check for new posts and publish them to FreeFeed.</p>
+              <%= label_tag "enable_feed", "Enable feed", class: "block font-semibold text-slate-800 mb-0" %>
+              <p class="text-slate-500 mt-1">Enabled feeds will automatically check for new posts and publish them to FreeFeed.</p>
             </div>
           </div>
         </div>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -124,7 +124,7 @@
       <% end %>
     </div>
 
-    <div class="ff-card__footer">
+    <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
       <% if edit_mode %>
         <%= f.submit "Update Feed Configuration",
                      class: "ff-button",

--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -16,9 +16,9 @@
   </div>
 
   <%= form_with url: feed_details_path, method: :post, class: "space-y-6" do |f| %>
-    <div class="ff-form-group">
-      <%= f.label :url, "Feed URL", class: "ff-form-label" %>
-      <%= f.text_field :url, value: url, placeholder: "https://example.com/feed.xml", class: "ff-form-input" %>
+    <div class="space-y-2">
+      <%= f.label :url, "Feed URL", class: "block font-semibold text-slate-800" %>
+      <%= f.text_field :url, value: url, placeholder: "https://example.com/feed.xml", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
     </div>
 
     <div>

--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -22,7 +22,7 @@
     </div>
 
     <div>
-      <%= f.submit "Try Again", class: "ff-button ff-button--compact w-full sm:w-auto" %>
+      <%= f.submit "Try Again", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 w-full sm:w-auto" %>
     </div>
   <% end %>
 </div>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -14,7 +14,7 @@
     <%= render SpinnerComponent.new %>
   </div>
   <div class="space-y-1">
-    <p class="ff-text font-semibold text-slate-800">Checking this feed...</p>
-    <p class="ff-text">This usually takes a few seconds.</p>
+    <p class="font-semibold text-slate-800">Checking this feed...</p>
+    <p class="text-slate-600">This usually takes a few seconds.</p>
   </div>
 <% end %>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -14,7 +14,7 @@
     <%= render SpinnerComponent.new %>
   </div>
   <div class="space-y-1">
-    <p class="ff-text ff-text--heavy">Checking this feed...</p>
+    <p class="ff-text font-semibold text-slate-800">Checking this feed...</p>
     <p class="ff-text">This usually takes a few seconds.</p>
   </div>
 <% end %>

--- a/app/views/feeds/_target_group_selector.html.erb
+++ b/app/views/feeds/_target_group_selector.html.erb
@@ -1,21 +1,21 @@
 <div id="target-group-selector">
-  <div class="ff-form-group">
-    <%= label_tag "feed[target_group]", "Target Group", class: "ff-form-label" %>
+  <div class="space-y-2">
+    <%= label_tag "feed[target_group]", "Target Group", class: "block font-semibold text-slate-800" %>
 
     <% if groups.present? %>
       <%= select_tag "feed[target_group]",
                      options_for_select(groups.sort, feed.target_group),
-                     class: "ff-form-input",
+                     class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                      required: true %>
-      <p class="ff-form-help">
+      <p class="text-slate-500">
         The FreeFeed group where posts will be published. Groups are like channels or communities.
       </p>
     <% else %>
       <%= select_tag "feed[target_group]",
                      options_for_select([[feed.target_group.presence || "Select a group", ""]]),
-                     class: "ff-form-input",
+                     class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                      disabled: true %>
-      <p class="ff-form-error">
+      <p class="text-sm text-red-600">
         <% if token.nil? %>
           Unable to load groups. Please select a FreeFeed account.
         <% elsif !token.active? %>
@@ -36,7 +36,7 @@
       </p>
     <% end %>
     <% if feed.errors[:target_group].any? %>
-      <p class="ff-form-error"><%= feed.errors[:target_group].first %></p>
+      <p class="text-sm text-red-600"><%= feed.errors[:target_group].first %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/feeds/_target_group_selector.html.erb
+++ b/app/views/feeds/_target_group_selector.html.erb
@@ -26,12 +26,12 @@
           This account doesn't manage any groups yet.
           <%= link_to "Retry", access_token_groups_path(token, feed_id: feed.id, retry: 1),
                       data: { turbo_stream: true },
-                      class: "ff-link" %>
+                      class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
         <% else %>
           Could not load groups for this account.
           <%= link_to "Retry", access_token_groups_path(token, feed_id: feed.id, retry: 1),
                       data: { turbo_stream: true },
-                      class: "ff-link" %>
+                      class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
         <% end %>
       </p>
     <% end %>

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -28,7 +28,7 @@
           </button>
           <div
             id="<%= sort_menu_id %>"
-            class="ff-dropdown-panel"
+            class="z-20 hidden w-60 rounded-lg border border-slate-200 bg-white shadow-sm"
             role="menu"
             aria-labelledby="<%= "#{sort_menu_id}-button" %>">
             <ul class="py-1 text-base text-slate-600">
@@ -36,7 +36,7 @@
                 <li>
                   <%= link_to option.path,
                               class: class_names(
-                                "ff-dropdown-item",
+                                "flex items-center justify-between gap-2 px-4 py-2 transition hover:bg-slate-50 focus:bg-slate-100 focus:outline-none",
                                 "font-semibold text-slate-900": option.active?
                               ) do %>
                     <span><%= option.title %></span>

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -16,7 +16,7 @@
             type="button"
             data-dropdown-toggle="<%= sort_menu_id %>"
             data-dropdown-placement="bottom-end"
-            class="<%= class_names('ff-button', 'ff-button--secondary', 'ff-button--compact', 'gap-2') %>"
+            class="<%= class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", 'gap-2') %>"
             aria-haspopup="true"
             aria-expanded="false">
               <%= icon(@sortable_presenter.current_direction == "asc" ? "arrow-up" : "arrow-down", css_class: "text-slate-500", aria_hidden: true) %>
@@ -55,7 +55,7 @@
       <% end %>
     <% end %>
     <% header.with_action_button do %>
-      <%= link_to "New Feed", new_feed_path, class: class_names("ff-button", "ff-button--compact", "w-full sm:w-auto") %>
+      <%= link_to "New Feed", new_feed_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", "w-full sm:w-auto") %>
     <% end %>
   <% end %>
 
@@ -74,7 +74,7 @@
       <h2 class="text-2xl font-semibold text-slate-900">You don't have any feeds yet</h2>
       <p class="mt-2 text-sm text-slate-600">Create your first feed to start refreshing posts and sharing them with your audience.</p>
       <div class="mt-6">
-        <%= link_to "Create your first feed", new_feed_path, class: class_names("ff-button", "ff-button--compact") %>
+        <%= link_to "Create your first feed", new_feed_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
       </div>
     </div>
   <% end %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -58,7 +58,7 @@
     <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
       <h2 class="text-2xl font-semibold mb-0 text-slate-900">Recent posts</h2>
       <% if @recent_posts.any? %>
-        <%= link_to "View all posts", posts_path(feed_id: @feed.id), class: "ff-link text-sm" %>
+        <%= link_to "View all posts", posts_path(feed_id: @feed.id), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 text-sm" %>
       <% end %>
     </div>
 

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -50,13 +50,13 @@
   <% end %>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Stats</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Stats</h2>
     <%= render FeedStatsComponent.new(feed: @feed) %>
   </section>
 
   <section class="space-y-4">
     <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-      <h2 class="ff-h2 mb-0">Recent posts</h2>
+      <h2 class="text-2xl font-semibold mb-0 text-slate-900">Recent posts</h2>
       <% if @recent_posts.any? %>
         <%= link_to "View all posts", posts_path(feed_id: @feed.id), class: "ff-link text-sm" %>
       <% end %>
@@ -66,7 +66,7 @@
   </section>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Danger zone</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Danger zone</h2>
     <div class="flex gap-2">
       <% if @feed.target_group.present? %>
         <%= link_to "Purge feed...", "#", class: "ff-button ff-button--secondary ff-button--compact", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "purge-modal-#{@feed.id}", action: "click->modal-trigger#open" } %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -6,7 +6,7 @@
       <% header.with_context_paragraph(status_summary) %>
     <% end %>
     <% header.with_action_button do %>
-      <%= link_to "Edit", edit_feed_path(@feed), class: "ff-button ff-button--secondary ff-button--compact" %>
+      <%= link_to "Edit", edit_feed_path(@feed), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>
     <% if @feed.enabled? %>
       <% header.with_action_button do %>
@@ -15,7 +15,7 @@
                       method: :patch,
                       params: { status: "disabled" },
                       data: { turbo_confirm: "Disable this feed?" },
-                      class: class_names("ff-button", "ff-button--secondary", "ff-button--compact"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
                       form: { class: "inline-block" } %>
       <% end %>
     <% elsif @feed.can_be_enabled? %>
@@ -24,12 +24,12 @@
                       feed_status_path(@feed),
                       method: :patch,
                       params: { status: "enabled" },
-                      class: class_names("ff-button", "ff-button--secondary", "ff-button--compact"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
                       form: { class: "inline-block" } %>
       <% end %>
     <% else %>
       <% header.with_action_button do %>
-        <span class="ff-button ff-button--secondary ff-button--compact cursor-not-allowed opacity-60" title="Complete setup to enable this feed">Enable</span>
+        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-not-allowed opacity-60" title="Complete setup to enable this feed">Enable</span>
       <% end %>
     <% end %>
     <% if @feed.can_be_previewed? %>
@@ -38,13 +38,13 @@
                       feed_previews_path,
                       params: { url: @feed.url, feed_profile_key: @feed.feed_profile_key },
                       method: :post,
-                      class: class_names("ff-button", "ff-button--secondary", "ff-button--compact"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
                       data: { turbo: false },
                           form: { class: "inline-block" } %>
       <% end %>
     <% else %>
       <% header.with_action_button do %>
-        <span class="ff-button ff-button--secondary ff-button--compact cursor-not-allowed opacity-60" title="Preview requires feed URL and profile">Preview</span>
+        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-not-allowed opacity-60" title="Preview requires feed URL and profile">Preview</span>
       <% end %>
     <% end %>
   <% end %>
@@ -69,9 +69,9 @@
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Danger zone</h2>
     <div class="flex gap-2">
       <% if @feed.target_group.present? %>
-        <%= link_to "Purge feed...", "#", class: "ff-button ff-button--secondary ff-button--compact", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "purge-modal-#{@feed.id}", action: "click->modal-trigger#open" } %>
+        <%= link_to "Purge feed...", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "purge-modal-#{@feed.id}", action: "click->modal-trigger#open" } %>
       <% end %>
-      <%= link_to "Delete feed...", "#", class: "ff-button ff-button--secondary ff-button--compact", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "delete-feed-modal-#{@feed.id}", action: "click->modal-trigger#open" } %>
+      <%= link_to "Delete feed...", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "delete-feed-modal-#{@feed.id}", action: "click->modal-trigger#open" } %>
     </div>
   </section>
 </div>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -84,7 +84,7 @@
     method: :post,
     modal_id: "purge-modal-#{@feed.id}"
   ) do %>
-    <div class="ff-alert ff-alert--warning space-y-2" role="alert">
+    <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
       <p>Every published post in <%= @feed.target_group %> will be withdrawn on FreeFeed.</p>
       <p>They'll remain visible in Feeder import history, and will not be re-imported during the next feed refresh.</p>
       <p>This operation can't be undone.</p>
@@ -99,7 +99,7 @@
   method: :delete,
   modal_id: "delete-feed-modal-#{@feed.id}"
 ) do %>
-  <div class="ff-alert ff-alert--warning space-y-2" role="alert">
+  <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
     <p>This feed will be permanently removed from Feeder, as well as the related reposting history.</p>
     <p>Associated access token will remain untouched.</p>
     <p>All FreeFeed posts will remain published.</p>

--- a/app/views/invites/_create_button.html.erb
+++ b/app/views/invites/_create_button.html.erb
@@ -2,6 +2,6 @@
 <%= button_to "Invite a user",
               invites_path,
               method: :post,
-              class: class_names("ff-button", "ff-button--compact", "opacity-60 cursor-not-allowed": !can_create),
+              class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", "opacity-60 cursor-not-allowed": !can_create),
               disabled: !can_create,
               form: { data: { turbo_frame: "_top" } } %>

--- a/app/views/invites/_summary.html.erb
+++ b/app/views/invites/_summary.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (remaining_invites_count:, invited_users_count:, unused_invites_count:) %>
-<p class="ff-text text-slate-600">
+<p class="text-slate-600">
   You can send <strong><%= remaining_invites_count %></strong> more invites.
   <% verb = invited_users_count.to_i == 1 ? "has" : "have" %>
   <%= pluralize(invited_users_count, "user") %> <%= verb %> joined so far.

--- a/app/views/invites/_table.html.erb
+++ b/app/views/invites/_table.html.erb
@@ -55,8 +55,8 @@
     </table>
   </div>
 <% else %>
-  <div class="ff-card">
-    <div class="ff-card__body text-center">
+  <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+    <div class="space-y-6 text-center">
       <p class="text-slate-600">No invites yet</p>
     </div>
   </div>

--- a/app/views/invites/_table.html.erb
+++ b/app/views/invites/_table.html.erb
@@ -57,7 +57,7 @@
 <% else %>
   <div class="ff-card">
     <div class="ff-card__body text-center">
-      <p class="ff-text">No invites yet</p>
+      <p class="text-slate-600">No invites yet</p>
     </div>
   </div>
 <% end %>

--- a/app/views/invites/_table.html.erb
+++ b/app/views/invites/_table.html.erb
@@ -1,19 +1,19 @@
 <%# locals: (invites:, new_invite_id: nil) %>
 <% if invites.any? %>
-  <div class="ff-table-container">
-    <table class="ff-table">
-      <thead>
-        <tr>
-          <th scope="col">Invitation Link</th>
-          <th scope="col">Invited User</th>
-          <th scope="col" class="text-center">Created</th>
-          <th scope="col" class="text-right"></th>
+  <div class="overflow-x-auto rounded-lg border border-slate-200">
+    <table class="w-full text-left text-sm text-slate-700">
+      <thead class="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600">
+        <tr class="hover:bg-slate-50">
+          <th scope="col" class="px-6 py-3">Invitation Link</th>
+          <th scope="col" class="px-6 py-3">Invited User</th>
+          <th scope="col" class="px-6 py-3 text-center">Created</th>
+          <th scope="col" class="px-6 py-3 text-right"></th>
         </tr>
       </thead>
-      <tbody>
+      <tbody class="divide-y divide-slate-200 bg-white">
         <% invites.each do |invite| %>
           <tr id="<%= dom_id(invite) %>" class="<%= class_names({ 'bg-emerald-50': local_assigns[:new_invite_id] == invite.id }) %>">
-            <td>
+            <td class="px-6 py-4 whitespace-nowrap">
               <div class="flex items-center gap-3">
                 <code class="<%= class_names('font-mono text-sm max-w-[16rem] truncate', 'text-slate-400': invite.invited_user.present?) %>">
                   <%= registration_url(code: invite.id) %>
@@ -30,15 +30,15 @@
                 </button>
               </div>
             </td>
-            <td class="text-sm text-slate-600">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-600">
               <% if invite.invited_user %>
                 <%= invite.invited_user.name %>
               <% else %>
                 <span class="italic text-slate-400">Not used yet</span>
               <% end %>
             </td>
-            <td class="text-center text-sm text-slate-500"><%= short_time_ago(invite.created_at) %></td>
-            <td class="text-right">
+            <td class="px-6 py-4 whitespace-nowrap text-center text-sm text-slate-500"><%= short_time_ago(invite.created_at) %></td>
+            <td class="px-6 py-4 whitespace-nowrap text-right">
               <% if !invite.invited_user && policy(invite).destroy? %>
                 <%= button_to invite_path(invite),
                               method: :delete,

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <div class="flex justify-center">
-      <%= link_to "Sign In", new_session_path, class: "ff-button ff-button--lg" %>
+      <%= link_to "Sign In", new_session_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,13 +1,13 @@
 <%# locals: () %>
 <div class="<%= 'space-y-3 mb-4' if notice || alert %>" id="flash-messages">
   <% if notice %>
-    <div class="ff-alert ff-alert--info alert" role="alert">
+    <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800 alert" role="alert">
       <span><%= sanitize(notice) %></span>
     </div>
   <% end %>
 
   <% if alert %>
-    <div class="ff-alert ff-alert--error alert" role="alert">
+    <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800 alert" role="alert">
       <span><%= sanitize(alert) %></span>
     </div>
   <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -51,9 +51,9 @@
           <%
             # Desktop classes
             desktop_link_classes = class_names(
-              "ff-nav-link",
-              { "ff-nav-link--active" => item[:active] },
-              "rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              "inline-flex items-center rounded-sm px-3 py-2 transition md:px-2 md:py-1",
+              { "bg-slate-900 text-white md:bg-slate-100 md:text-slate-600 md:ring-2 md:ring-slate-600" => item[:active] },
+              "outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             )
           %>
           <li>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,7 +1,7 @@
 <%# locals: () %>
 <nav class="bg-slate-100 border-b border-slate-200">
   <div class="flex flex-wrap items-center justify-between mx-auto px-4 py-4">
-    <%= link_to "F2", root_path, class: class_names("ff-nav-brand", "ff-focus-ring") %>
+    <%= link_to "F2", root_path, class: class_names("inline-flex items-center text-lg font-semibold text-slate-900", "ff-focus-ring") %>
 
     <div class="flex items-center gap-3 md:order-2">
       <% if Current.user.present? %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,7 +1,7 @@
 <%# locals: () %>
 <nav class="bg-slate-100 border-b border-slate-200">
   <div class="flex flex-wrap items-center justify-between mx-auto px-4 py-4">
-    <%= link_to "F2", root_path, class: class_names("inline-flex items-center text-lg font-semibold text-slate-900", "ff-focus-ring") %>
+    <%= link_to "F2", root_path, class: "inline-flex items-center text-lg font-semibold text-slate-900 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
 
     <div class="flex items-center gap-3 md:order-2">
       <% if Current.user.present? %>
@@ -53,7 +53,7 @@
             desktop_link_classes = class_names(
               "ff-nav-link",
               { "ff-nav-link--active" => item[:active] },
-              "ff-focus-ring"
+              "rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             )
           %>
           <li>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -37,7 +37,7 @@
 
       <div class="ff-card__footer flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Save password", class: "ff-button w-full sm:w-auto" %>
-        <%= link_to "Back to sign in", new_session_path, class: "ff-link" %>
+        <%= link_to "Back to sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
       </div>
     <% end %>
   </div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -13,25 +13,25 @@
 
     <%= form_with url: password_path(params[:token]), method: :put, local: true do |form| %>
       <div class="space-y-6">
-        <div class="ff-form-group">
-          <%= form.label :password, "New password", class: "ff-form-label" %>
+        <div class="space-y-2">
+          <%= form.label :password, "New password", class: "block font-semibold text-slate-800" %>
           <%= form.password_field :password,
                                   required: true,
                                   autofocus: true,
                                   autocomplete: "new-password",
                                   placeholder: "Enter a new password",
                                   maxlength: User::PASSWORD_MAX_LENGTH,
-                                  class: "ff-form-input" %>
+                                  class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
 
-        <div class="ff-form-group">
-          <%= form.label :password_confirmation, "Confirm password", class: "ff-form-label" %>
+        <div class="space-y-2">
+          <%= form.label :password_confirmation, "Confirm password", class: "block font-semibold text-slate-800" %>
           <%= form.password_field :password_confirmation,
                                   required: true,
                                   autocomplete: "new-password",
                                   placeholder: "Repeat the new password",
                                   maxlength: User::PASSWORD_MAX_LENGTH,
-                                  class: "ff-form-input" %>
+                                  class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
       </div>
 

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="ff-card">
   <div class="ff-card__body">
     <h1 class="ff-card__title">Choose a new password</h1>
-    <p class="ff-text text-sm text-slate-600">Enter and confirm a new password to finish resetting your account.</p>
+    <p class="text-sm text-slate-600">Enter and confirm a new password to finish resetting your account.</p>
 
     <% if flash[:alert] %>
       <div class="ff-alert ff-alert--error" role="alert">

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -6,7 +6,7 @@
     <p class="text-sm text-slate-600">Enter and confirm a new password to finish resetting your account.</p>
 
     <% if flash[:alert] %>
-      <div class="ff-alert ff-alert--error" role="alert">
+      <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800" role="alert">
         <span><%= flash[:alert] %></span>
       </div>
     <% end %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -36,7 +36,7 @@
       </div>
 
       <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <%= form.submit "Save password", class: "ff-button w-full sm:w-auto" %>
+        <%= form.submit "Save password", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 w-full sm:w-auto" %>
         <%= link_to "Back to sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
       </div>
     <% end %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, "Update Password" %>
 
-<div class="ff-card">
-  <div class="ff-card__body">
-    <h1 class="ff-card__title">Choose a new password</h1>
+<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+  <div class="space-y-6">
+    <h1 class="text-4xl font-semibold mb-6 text-slate-900">Choose a new password</h1>
     <p class="text-sm text-slate-600">Enter and confirm a new password to finish resetting your account.</p>
 
     <% if flash[:alert] %>
@@ -35,7 +35,7 @@
         </div>
       </div>
 
-      <div class="ff-card__footer flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Save password", class: "ff-button w-full sm:w-auto" %>
         <%= link_to "Back to sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
       </div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -20,7 +20,7 @@
       </div>
 
       <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <%= form.submit "Email reset instructions", class: "ff-button w-full sm:w-auto" %>
+        <%= form.submit "Email reset instructions", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 w-full sm:w-auto" %>
         <%= link_to "Back to sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
       </div>
     <% end %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -13,9 +13,9 @@
 
     <%= form_with url: passwords_path, local: true do |form| %>
       <div class="space-y-6">
-        <div class="ff-form-group">
-          <%= form.label :email_address, "Email Address", class: "ff-form-label" %>
-          <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "ff-form-input" %>
+        <div class="space-y-2">
+          <%= form.label :email_address, "Email Address", class: "block font-semibold text-slate-800" %>
+          <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
       </div>
 

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -6,7 +6,7 @@
     <p class="text-slate-600">Enter your email address and we’ll send you a reset link.</p>
 
     <% if flash[:alert] %>
-      <div class="ff-alert ff-alert--error" role="alert">
+      <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800" role="alert">
         <span><%= flash[:alert] %></span>
       </div>
     <% end %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -3,7 +3,7 @@
 <div class="ff-card">
   <div class="ff-card__body">
     <h1 class="ff-card__title">Forgot your password?</h1>
-    <p class="ff-text">Enter your email address and we’ll send you a reset link.</p>
+    <p class="text-slate-600">Enter your email address and we’ll send you a reset link.</p>
 
     <% if flash[:alert] %>
       <div class="ff-alert ff-alert--error" role="alert">

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, "Forgot Password?" %>
 
-<div class="ff-card">
-  <div class="ff-card__body">
-    <h1 class="ff-card__title">Forgot your password?</h1>
+<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+  <div class="space-y-6">
+    <h1 class="text-4xl font-semibold mb-6 text-slate-900">Forgot your password?</h1>
     <p class="text-slate-600">Enter your email address and we’ll send you a reset link.</p>
 
     <% if flash[:alert] %>
@@ -19,7 +19,7 @@
         </div>
       </div>
 
-      <div class="ff-card__footer flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Email reset instructions", class: "ff-button w-full sm:w-auto" %>
         <%= link_to "Back to sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
       </div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -21,7 +21,7 @@
 
       <div class="ff-card__footer flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Email reset instructions", class: "ff-button w-full sm:w-auto" %>
-        <%= link_to "Back to sign in", new_session_path, class: "ff-link" %>
+        <%= link_to "Back to sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
       </div>
     <% end %>
   </div>

--- a/app/views/posts/destroy.turbo_stream.erb
+++ b/app/views/posts/destroy.turbo_stream.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= turbo_stream.prepend "flash-messages" do %>
-  <div class="ff-alert ff-alert--info" role="alert">
+  <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800" role="alert">
     <span>The post will be withdrawn from FreeFeed but will remain here to prevent it from being imported again.</span>
   </div>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -17,7 +17,7 @@
             type="button"
             data-dropdown-toggle="<%= sort_menu_id %>"
             data-dropdown-placement="bottom-end"
-            class="<%= class_names('ff-button', 'ff-button--secondary', 'ff-button--compact', 'gap-2') %>"
+            class="<%= class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", 'gap-2') %>"
             aria-haspopup="true"
             aria-expanded="false">
             <%= icon(@sortable_presenter.current_direction == "asc" ? "arrow-up" : "arrow-down", css_class: "text-slate-500", aria_hidden: true) %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -29,7 +29,7 @@
           </button>
           <div
             id="<%= sort_menu_id %>"
-            class="ff-dropdown-panel"
+            class="z-20 hidden w-60 rounded-lg border border-slate-200 bg-white shadow-sm"
             role="menu"
             aria-labelledby="<%= "#{sort_menu_id}-button" %>">
             <ul class="py-1 text-base text-slate-600">
@@ -37,7 +37,7 @@
                 <li>
                   <%= link_to option.path,
                               class: class_names(
-                                "ff-dropdown-item",
+                                "flex items-center justify-between gap-2 px-4 py-2 transition hover:bg-slate-50 focus:bg-slate-100 focus:outline-none",
                                 "font-semibold text-slate-900": option.active?
                               ) do %>
                     <span><%= option.title %></span>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,16 +10,16 @@
       ) %>
     <% end %>
     <% header.with_action_button do %>
-      <%= link_to "Back to Posts", posts_path, class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
+      <%= link_to "Back to Posts", posts_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>
     <% header.with_action_button do %>
-      <%= link_to "Source", feed_entry_path(@post.feed_entry), class: class_names("ff-button", "ff-button--secondary", "ff-button--compact") %>
+      <%= link_to "Source", feed_entry_path(@post.feed_entry), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>
     <% if policy(@post).destroy? %>
       <% header.with_action_button do %>
         <%= button_to "Withdraw", post_path(@post),
                       method: :delete,
-                      class: class_names("ff-button", "ff-button--compact", "bg-red-600 hover:bg-red-500"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", "bg-red-600 hover:bg-red-500"),
                       data: {
                         turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here."
                       },

--- a/app/views/registration/confirmation_pendings/show.html.erb
+++ b/app/views/registration/confirmation_pendings/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, "Check Your Email" %>
 
-<div class="ff-card">
-  <div class="ff-card__body space-y-6">
+<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+  <div class="space-y-6">
     <div class="space-y-3">
-      <h1 class="ff-card__title">Check your email</h1>
+      <h1 class="text-4xl font-semibold mb-6 text-slate-900">Check your email</h1>
       <p class="text-slate-600">We've sent you a confirmation email. Click the link to activate your account.</p>
     </div>
   </div>

--- a/app/views/registration/confirmation_pendings/show.html.erb
+++ b/app/views/registration/confirmation_pendings/show.html.erb
@@ -4,7 +4,7 @@
   <div class="ff-card__body space-y-6">
     <div class="space-y-3">
       <h1 class="ff-card__title">Check your email</h1>
-      <p class="ff-text">We've sent you a confirmation email. Click the link to activate your account.</p>
+      <p class="text-slate-600">We've sent you a confirmation email. Click the link to activate your account.</p>
     </div>
   </div>
 </div>

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, "Resend Confirmation" %>
 
-<div class="ff-card">
-  <div class="ff-card__body">
-    <h1 class="ff-card__title">Resend Confirmation</h1>
+<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+  <div class="space-y-6">
+    <h1 class="text-4xl font-semibold mb-6 text-slate-900">Resend Confirmation</h1>
     <p class="text-slate-600">Enter your email and we'll send you a new confirmation link.</p>
 
     <%= form_with url: registration_confirmations_path, method: :post, local: true do |form| %>
@@ -13,7 +13,7 @@
         </div>
       </div>
 
-      <div class="ff-card__footer flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="mt-6 flex flex-col items-start justify-start gap-4 text-slate-600 sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Send confirmation email", class: "ff-button w-full sm:w-auto" %>
         <%= link_to "Back to sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
       </div>

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -3,7 +3,7 @@
 <div class="ff-card">
   <div class="ff-card__body">
     <h1 class="ff-card__title">Resend Confirmation</h1>
-    <p class="ff-text">Enter your email and we'll send you a new confirmation link.</p>
+    <p class="text-slate-600">Enter your email and we'll send you a new confirmation link.</p>
 
     <%= form_with url: registration_confirmations_path, method: :post, local: true do |form| %>
       <div class="space-y-6">

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -7,9 +7,9 @@
 
     <%= form_with url: registration_confirmations_path, method: :post, local: true do |form| %>
       <div class="space-y-6">
-        <div class="ff-form-group">
-          <%= form.label :email_address, "Email", class: "ff-form-label" %>
-          <%= form.email_field :email_address, class: "ff-form-input", autofocus: true, required: true %>
+        <div class="space-y-2">
+          <%= form.label :email_address, "Email", class: "block font-semibold text-slate-800" %>
+          <%= form.email_field :email_address, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", autofocus: true, required: true %>
         </div>
       </div>
 

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -14,7 +14,7 @@
       </div>
 
       <div class="mt-6 flex flex-col items-start justify-start gap-4 text-slate-600 sm:flex-row sm:items-center sm:justify-between">
-        <%= form.submit "Send confirmation email", class: "ff-button w-full sm:w-auto" %>
+        <%= form.submit "Send confirmation email", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 w-full sm:w-auto" %>
         <%= link_to "Back to sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
       </div>
     <% end %>

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -15,7 +15,7 @@
 
       <div class="ff-card__footer flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Send confirmation email", class: "ff-button w-full sm:w-auto" %>
-        <%= link_to "Back to sign in", new_session_path, class: "ff-link" %>
+        <%= link_to "Back to sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
       </div>
     <% end %>
   </div>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -64,7 +64,7 @@
         <%= form_with model: @user, url: registration_path(code: params[:code]), method: :post, local: true do |form| %>
           <div class="space-y-6">
             <% if @user.errors.any? %>
-              <div class="ff-alert ff-alert--error" role="alert">
+              <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800" role="alert">
                 <span><%= @user.errors.full_messages.to_sentence.capitalize %></span>
               </div>
             <% end %>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -6,19 +6,19 @@
     <div class="ff-card">
       <div class="ff-card__body">
         <h1 class="ff-card__title">This invite link doesn't look right</h1>
-        <p class="ff-text">We couldn't find an invitation with that code. It might have been removed or copied incorrectly.</p>
+        <p class="text-slate-600">We couldn't find an invitation with that code. It might have been removed or copied incorrectly.</p>
 
         <div class="space-y-2">
-          <p class="ff-text font-semibold text-slate-800">Already have an account?</p>
-          <p class="ff-text">
+          <p class="font-semibold text-slate-800">Already have an account?</p>
+          <p class="text-slate-600">
             <%= link_to "Sign in", new_session_path, class: "ff-link" %>
             with your email and password.
           </p>
         </div>
 
         <div class="space-y-2">
-          <p class="ff-text font-semibold text-slate-800">Need an invitation?</p>
-          <p class="ff-text">Ask someone who already uses Feeder to send you a new link.</p>
+          <p class="font-semibold text-slate-800">Need an invitation?</p>
+          <p class="text-slate-600">Ask someone who already uses Feeder to send you a new link.</p>
         </div>
       </div>
     </div>
@@ -26,10 +26,10 @@
     <div class="ff-card">
       <div class="ff-card__body">
         <h1 class="ff-card__title">This invite was already used</h1>
-        <p class="ff-text">This link has already been used to create an account.</p>
+        <p class="text-slate-600">This link has already been used to create an account.</p>
 
         <div class="space-y-4">
-          <p class="ff-text font-semibold text-slate-800">Already have an account?</p>
+          <p class="font-semibold text-slate-800">Already have an account?</p>
           <ul class="list-disc space-y-1 ps-5 text-slate-600">
             <li>
               Forgot your password?
@@ -44,8 +44,8 @@
         </div>
 
         <div class="space-y-4">
-          <p class="ff-text font-semibold text-slate-800">Need a fresh invitation?</p>
-          <p class="ff-text">Ask the person who sent this link to share a new one.</p>
+          <p class="font-semibold text-slate-800">Need a fresh invitation?</p>
+          <p class="text-slate-600">Ask the person who sent this link to share a new one.</p>
         </div>
       </div>
     </div>
@@ -55,7 +55,7 @@
         <div class="space-y-4">
           <h1 class="ff-card__title">Create your account</h1>
           <% if @invite&.created_by_user %>
-            <p class="ff-text">
+            <p class="text-slate-600">
               <%= @invite.created_by_user.name.presence || "Somebody" %> invited you to join Feeder.
             </p>
           <% end %>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -9,7 +9,7 @@
         <p class="ff-text">We couldn't find an invitation with that code. It might have been removed or copied incorrectly.</p>
 
         <div class="space-y-2">
-          <p class="ff-text ff-text--heavy">Already have an account?</p>
+          <p class="ff-text font-semibold text-slate-800">Already have an account?</p>
           <p class="ff-text">
             <%= link_to "Sign in", new_session_path, class: "ff-link" %>
             with your email and password.
@@ -17,7 +17,7 @@
         </div>
 
         <div class="space-y-2">
-          <p class="ff-text ff-text--heavy">Need an invitation?</p>
+          <p class="ff-text font-semibold text-slate-800">Need an invitation?</p>
           <p class="ff-text">Ask someone who already uses Feeder to send you a new link.</p>
         </div>
       </div>
@@ -29,7 +29,7 @@
         <p class="ff-text">This link has already been used to create an account.</p>
 
         <div class="space-y-4">
-          <p class="ff-text ff-text--heavy">Already have an account?</p>
+          <p class="ff-text font-semibold text-slate-800">Already have an account?</p>
           <ul class="list-disc space-y-1 ps-5 text-slate-600">
             <li>
               Forgot your password?
@@ -44,7 +44,7 @@
         </div>
 
         <div class="space-y-4">
-          <p class="ff-text ff-text--heavy">Need a fresh invitation?</p>
+          <p class="ff-text font-semibold text-slate-800">Need a fresh invitation?</p>
           <p class="ff-text">Ask the person who sent this link to share a new one.</p>
         </div>
       </div>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -69,16 +69,16 @@
               </div>
             <% end %>
 
-            <div class="ff-form-group">
-              <%= form.label :email_address, "Email", class: "ff-form-label" %>
-              <%= form.email_field :email_address, class: "ff-form-input", required: true, autofocus: true %>
-              <p class="ff-form-help">Only used for password resets—we don't send marketing emails.</p>
+            <div class="space-y-2">
+              <%= form.label :email_address, "Email", class: "block font-semibold text-slate-800" %>
+              <%= form.email_field :email_address, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", required: true, autofocus: true %>
+              <p class="text-slate-500">Only used for password resets—we don't send marketing emails.</p>
             </div>
 
-            <div class="ff-form-group">
-              <%= form.label :password, class: "ff-form-label" %>
-              <%= form.password_field :password, class: "ff-form-input", required: true %>
-              <p class="ff-form-help">Choose at least <%= User::PASSWORD_MIN_LENGTH %> characters to keep things secure.</p>
+            <div class="space-y-2">
+              <%= form.label :password, class: "block font-semibold text-slate-800" %>
+              <%= form.password_field :password, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", required: true %>
+              <p class="text-slate-500">Choose at least <%= User::PASSWORD_MIN_LENGTH %> characters to keep things secure.</p>
             </div>
           </div>
           <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -82,7 +82,7 @@
             </div>
           </div>
           <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <%= form.submit "Create account", class: "ff-button w-full sm:w-auto" %>
+            <%= form.submit "Create account", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 w-full sm:w-auto" %>
             <span class="text-slate-600">
               Already use Feeder?
               <%= link_to "Sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -3,9 +3,9 @@
 
 <div class="mx-auto w-full max-w-full space-y-6 sm:max-w-2xl sm:px-0 px-4" data-controller="autofocus">
   <% if @invite.nil? %>
-    <div class="ff-card">
-      <div class="ff-card__body">
-        <h1 class="ff-card__title">This invite link doesn't look right</h1>
+    <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+      <div class="space-y-6">
+        <h1 class="text-4xl font-semibold mb-6 text-slate-900">This invite link doesn't look right</h1>
         <p class="text-slate-600">We couldn't find an invitation with that code. It might have been removed or copied incorrectly.</p>
 
         <div class="space-y-2">
@@ -23,9 +23,9 @@
       </div>
     </div>
   <% elsif @invite.used? %>
-    <div class="ff-card">
-      <div class="ff-card__body">
-        <h1 class="ff-card__title">This invite was already used</h1>
+    <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+      <div class="space-y-6">
+        <h1 class="text-4xl font-semibold mb-6 text-slate-900">This invite was already used</h1>
         <p class="text-slate-600">This link has already been used to create an account.</p>
 
         <div class="space-y-4">
@@ -50,10 +50,10 @@
       </div>
     </div>
   <% else %>
-    <div class="ff-card">
-      <div class="ff-card__body">
+    <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+      <div class="space-y-6">
         <div class="space-y-4">
-          <h1 class="ff-card__title">Create your account</h1>
+          <h1 class="text-4xl font-semibold mb-6 text-slate-900">Create your account</h1>
           <% if @invite&.created_by_user %>
             <p class="text-slate-600">
               <%= @invite.created_by_user.name.presence || "Somebody" %> invited you to join Feeder.
@@ -81,7 +81,7 @@
               <p class="ff-form-help">Choose at least <%= User::PASSWORD_MIN_LENGTH %> characters to keep things secure.</p>
             </div>
           </div>
-          <div class="ff-card__footer flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <%= form.submit "Create account", class: "ff-button w-full sm:w-auto" %>
             <span class="text-slate-600">
               Already use Feeder?

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -11,7 +11,7 @@
         <div class="space-y-2">
           <p class="font-semibold text-slate-800">Already have an account?</p>
           <p class="text-slate-600">
-            <%= link_to "Sign in", new_session_path, class: "ff-link" %>
+            <%= link_to "Sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
             with your email and password.
           </p>
         </div>
@@ -33,11 +33,11 @@
           <ul class="list-disc space-y-1 ps-5 text-slate-600">
             <li>
               Forgot your password?
-              <%= link_to "Reset it here", new_password_path, class: "ff-link" %>.
+              <%= link_to "Reset it here", new_password_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>.
             </li>
             <li>
               Otherwise,
-              <%= link_to "sign in", new_session_path, class: "ff-link" %>
+              <%= link_to "sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
               with your email and password.
             </li>
           </ul>
@@ -85,7 +85,7 @@
             <%= form.submit "Create account", class: "ff-button w-full sm:w-auto" %>
             <span class="text-slate-600">
               Already use Feeder?
-              <%= link_to "Sign in", new_session_path, class: "ff-link" %>
+              <%= link_to "Sign in", new_session_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
             </span>
           </div>
         <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -20,9 +20,9 @@
       <div class="ff-card__footer flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Sign in", class: "ff-button w-full sm:w-auto" %>
         <div class="flex flex-wrap items-center gap-2 text-slate-500">
-          <%= link_to "Forgot password?", new_password_path, class: "ff-link" %>
+          <%= link_to "Forgot password?", new_password_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
           <span aria-hidden="true" class="hidden sm:inline">·</span>
-          <%= link_to "Resend confirmation", new_registration_confirmation_path, class: "ff-link" %>
+          <%= link_to "Resend confirmation", new_registration_confirmation_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
         </div>
       </div>
     <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -6,14 +6,14 @@
 
     <%= form_with url: session_path, local: true do |form| %>
       <div class="space-y-6">
-        <div class="ff-form-group">
-          <%= form.label :email_address, "Email", class: "ff-form-label" %>
-          <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "ff-form-input" %>
+        <div class="space-y-2">
+          <%= form.label :email_address, "Email", class: "block font-semibold text-slate-800" %>
+          <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
 
-        <div class="ff-form-group">
-          <%= form.label :password, "Password", class: "ff-form-label" %>
-          <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: User::PASSWORD_MAX_LENGTH, class: "ff-form-input" %>
+        <div class="space-y-2">
+          <%= form.label :password, "Password", class: "block font-semibold text-slate-800" %>
+          <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: User::PASSWORD_MAX_LENGTH, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
       </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, "Sign In" %>
 
-<div class="ff-card">
-  <div class="ff-card__body">
-    <h1 class="ff-card__title">Sign in to Feeder</h1>
+<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+  <div class="space-y-6">
+    <h1 class="text-4xl font-semibold mb-6 text-slate-900">Sign in to Feeder</h1>
 
     <%= form_with url: session_path, local: true do |form| %>
       <div class="space-y-6">
@@ -17,7 +17,7 @@
         </div>
       </div>
 
-      <div class="ff-card__footer flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Sign in", class: "ff-button w-full sm:w-auto" %>
         <div class="flex flex-wrap items-center gap-2 text-slate-500">
           <%= link_to "Forgot password?", new_password_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -18,7 +18,7 @@
       </div>
 
       <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <%= form.submit "Sign in", class: "ff-button w-full sm:w-auto" %>
+        <%= form.submit "Sign in", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 w-full sm:w-auto" %>
         <div class="flex flex-wrap items-center gap-2 text-slate-500">
           <%= link_to "Forgot password?", new_password_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
           <span aria-hidden="true" class="hidden sm:inline">·</span>

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -28,7 +28,7 @@
         </div>
       </div>
 
-      <div class="ff-card__footer">
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
         <%= form.submit "Update Email", class: "ff-button" %>
         <%= link_to "Cancel", settings_path, class: class_names("ff-button", "ff-button--secondary") %>
       </div>

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -5,7 +5,7 @@
 
   <% if @user.email_deactivated? %>
     <div class="ff-alert ff-alert--danger max-w-2xl space-y-2" role="alert">
-      <p class="ff-text ff-text--heavy">Your email is deactivated.</p>
+      <p class="ff-text font-semibold text-slate-800">Your email is deactivated.</p>
       <% if @user.can_change_email? %>
         <p class="ff-text">Update your email address below to continue receiving notifications.</p>
       <% else %>

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -5,11 +5,11 @@
 
   <% if @user.email_deactivated? %>
     <div class="ff-alert ff-alert--danger max-w-2xl space-y-2" role="alert">
-      <p class="ff-text font-semibold text-slate-800">Your email is deactivated.</p>
+      <p class="font-semibold text-slate-800">Your email is deactivated.</p>
       <% if @user.can_change_email? %>
-        <p class="ff-text">Update your email address below to continue receiving notifications.</p>
+        <p class="text-slate-600">Update your email address below to continue receiving notifications.</p>
       <% else %>
-        <p class="ff-text">You can change your email again in <%= distance_of_time_in_words(@user.time_until_email_change_allowed) %>.</p>
+        <p class="text-slate-600">You can change your email again in <%= distance_of_time_in_words(@user.time_until_email_change_allowed) %>.</p>
       <% end %>
     </div>
   <% end %>

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -4,7 +4,7 @@
   <%= render PageHeaderComponent.new(title: "Change Email Address") %>
 
   <% if @user.email_deactivated? %>
-    <div class="ff-alert ff-alert--danger max-w-2xl space-y-2" role="alert">
+    <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 max-w-2xl space-y-2" role="alert">
       <p class="font-semibold text-slate-800">Your email is deactivated.</p>
       <% if @user.can_change_email? %>
         <p class="text-slate-600">Update your email address below to continue receiving notifications.</p>

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -29,8 +29,8 @@
       </div>
 
       <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
-        <%= form.submit "Update Email", class: "ff-button" %>
-        <%= link_to "Cancel", settings_path, class: class_names("ff-button", "ff-button--secondary") %>
+        <%= form.submit "Update Email", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+        <%= link_to "Cancel", settings_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
       </div>
     <% end %>
   </div>

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -17,14 +17,14 @@
   <div class="max-w-2xl">
     <%= form_with model: @user, url: settings_email_update_path, method: :patch, local: true do |form| %>
       <div class="space-y-6">
-        <div class="ff-form-group">
-          <%= form.label :current_email, "Current email", class: "ff-form-label" %>
-          <%= form.text_field :current_email, value: @user.email_address, disabled: true, class: "ff-form-input bg-slate-100" %>
+        <div class="space-y-2">
+          <%= form.label :current_email, "Current email", class: "block font-semibold text-slate-800" %>
+          <%= form.text_field :current_email, value: @user.email_address, disabled: true, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 bg-slate-100" %>
         </div>
 
-        <div class="ff-form-group">
-          <%= form.label :email_address, "New email", class: "ff-form-label" %>
-          <%= form.email_field :email_address, value: "", class: "ff-form-input", placeholder: "Enter new email address", autofocus: true, autocomplete: "email" %>
+        <div class="space-y-2">
+          <%= form.label :email_address, "New email", class: "block font-semibold text-slate-800" %>
+          <%= form.email_field :email_address, value: "", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", placeholder: "Enter new email address", autofocus: true, autocomplete: "email" %>
         </div>
       </div>
 

--- a/app/views/settings/password_updates/edit.html.erb
+++ b/app/views/settings/password_updates/edit.html.erb
@@ -6,19 +6,19 @@
   <div class="max-w-2xl">
     <%= form_with model: @user, url: settings_password_update_path, method: :patch, local: true do |form| %>
       <div class="space-y-6">
-        <div class="ff-form-group">
-          <%= form.label :current_password, "Current password", class: "ff-form-label" %>
-          <%= form.password_field :current_password, class: "ff-form-input", required: true, autofocus: true, autocomplete: "current-password" %>
+        <div class="space-y-2">
+          <%= form.label :current_password, "Current password", class: "block font-semibold text-slate-800" %>
+          <%= form.password_field :current_password, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", required: true, autofocus: true, autocomplete: "current-password" %>
         </div>
 
-        <div class="ff-form-group">
-          <%= form.label :password, "New password", class: "ff-form-label" %>
-          <%= form.password_field :password, class: "ff-form-input", required: true, autocomplete: "new-password" %>
+        <div class="space-y-2">
+          <%= form.label :password, "New password", class: "block font-semibold text-slate-800" %>
+          <%= form.password_field :password, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", required: true, autocomplete: "new-password" %>
         </div>
 
-        <div class="ff-form-group">
-          <%= form.label :password_confirmation, "Confirm new password", class: "ff-form-label" %>
-          <%= form.password_field :password_confirmation, class: "ff-form-input", required: true, autocomplete: "new-password" %>
+        <div class="space-y-2">
+          <%= form.label :password_confirmation, "Confirm new password", class: "block font-semibold text-slate-800" %>
+          <%= form.password_field :password_confirmation, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", required: true, autocomplete: "new-password" %>
         </div>
       </div>
 

--- a/app/views/settings/password_updates/edit.html.erb
+++ b/app/views/settings/password_updates/edit.html.erb
@@ -22,7 +22,7 @@
         </div>
       </div>
 
-      <div class="ff-card__footer">
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
         <%= form.submit "Change Password", class: "ff-button" %>
         <%= link_to "Cancel", settings_path, class: class_names("ff-button", "ff-button--secondary") %>
       </div>

--- a/app/views/settings/password_updates/edit.html.erb
+++ b/app/views/settings/password_updates/edit.html.erb
@@ -23,8 +23,8 @@
       </div>
 
       <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
-        <%= form.submit "Change Password", class: "ff-button" %>
-        <%= link_to "Cancel", settings_path, class: class_names("ff-button", "ff-button--secondary") %>
+        <%= form.submit "Change Password", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+        <%= link_to "Cancel", settings_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
       </div>
     <% end %>
   </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -8,7 +8,7 @@
       value: tag.span(class: "flex items-center gap-4") {
         safe_join([
           @user.email_address,
-          link_to("Change", edit_settings_email_update_path, class: "ff-link text-sm")
+          link_to("Change", edit_settings_email_update_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 text-sm")
         ])
       },
       key: "settings.email"
@@ -19,7 +19,7 @@
       value: tag.span(class: "flex items-center gap-4") {
         safe_join([
           "Last updated #{time_ago_in_words(@user.password_updated_at || @user.created_at)} ago",
-          link_to("Change", edit_settings_password_update_path, class: "ff-link text-sm")
+          link_to("Change", edit_settings_password_update_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 text-sm")
         ])
       },
       key: "settings.password"

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -39,7 +39,7 @@
   <%= render PageHeaderComponent.new(title: "Settings") %>
 
   <section class="space-y-4">
-    <h2 class="ff-h2">Your Account</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Your Account</h2>
     <%= render(account_list) %>
   </section>
 

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -41,7 +41,7 @@
 
     <% if @recent_events.any? %>
       <section class="space-y-4">
-        <h2 class="ff-h2">Recent Activity</h2>
+        <h2 class="text-2xl font-semibold mb-3 text-slate-900">Recent Activity</h2>
         <%= render RecentEventsComponent.new(events: @recent_events) %>
       </section>
     <% end %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -9,7 +9,7 @@
       <p class="font-semibold text-slate-800">Your email address is not receiving our emails.</p>
       <% if @user.can_change_email? %>
         <p class="text-slate-600">
-          <%= link_to "Update your email address", edit_settings_email_update_path, class: "ff-link" %>
+          <%= link_to "Update your email address", edit_settings_email_update_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
           to continue receiving notifications.
         </p>
       <% else %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -24,7 +24,7 @@
       <p class="text-slate-600">Feeder helps you automatically share content from your favorite sources to FreeFeed.</p>
       <p class="text-slate-600">To get started, add a FreeFeed access token so Feeder can post on your behalf.</p>
       <div class="mt-8">
-        <%= link_to "Add FreeFeed token", new_access_token_path, class: "ff-button" %>
+        <%= link_to "Add FreeFeed token", new_access_token_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
       </div>
     </section>
   <% elsif suggest_adding_feeds %>
@@ -32,7 +32,7 @@
       <h1 class="text-4xl font-semibold mb-0 text-slate-900">Welcome to Feeder</h1>
       <p class="text-slate-600">Great! You've added a FreeFeed access token. Now you can create your first feed.</p>
       <div class="mt-8">
-        <%= link_to "Add feed", new_feed_path, class: "ff-button" %>
+        <%= link_to "Add feed", new_feed_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
       </div>
     </section>
   <% else %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -5,7 +5,7 @@
 
 <div class="space-y-8">
   <% if @user.email_deactivated? %>
-    <div class="ff-alert ff-alert--warning space-y-2" role="alert">
+    <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
       <p class="font-semibold text-slate-800">Your email address is not receiving our emails.</p>
       <% if @user.can_change_email? %>
         <p class="text-slate-600">

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -6,7 +6,7 @@
 <div class="space-y-8">
   <% if @user.email_deactivated? %>
     <div class="ff-alert ff-alert--warning space-y-2" role="alert">
-      <p class="ff-text ff-text--heavy">Your email address is not receiving our emails.</p>
+      <p class="ff-text font-semibold text-slate-800">Your email address is not receiving our emails.</p>
       <% if @user.can_change_email? %>
         <p class="ff-text">
           <%= link_to "Update your email address", edit_settings_email_update_path, class: "ff-link" %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -20,7 +20,7 @@
 
   <% if suggest_to_add_tokens %>
     <section class="space-y-4">
-      <h1 class="ff-h1">Welcome to Feeder</h1>
+      <h1 class="text-4xl font-semibold mb-0 text-slate-900">Welcome to Feeder</h1>
       <p class="ff-text">Feeder helps you automatically share content from your favorite sources to FreeFeed.</p>
       <p class="ff-text">To get started, add a FreeFeed access token so Feeder can post on your behalf.</p>
       <div class="mt-8">
@@ -29,14 +29,14 @@
     </section>
   <% elsif suggest_adding_feeds %>
     <section class="space-y-4">
-      <h1 class="ff-h1">Welcome to Feeder</h1>
+      <h1 class="text-4xl font-semibold mb-0 text-slate-900">Welcome to Feeder</h1>
       <p class="ff-text">Great! You've added a FreeFeed access token. Now you can create your first feed.</p>
       <div class="mt-8">
         <%= link_to "Add feed", new_feed_path, class: "ff-button" %>
       </div>
     </section>
   <% else %>
-    <h1 class="ff-h1">Status</h1>
+    <h1 class="text-4xl font-semibold mb-0 text-slate-900">Status</h1>
     <%= render UserStatsComponent.new(user: @user) %>
 
     <% if @recent_events.any? %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -6,14 +6,14 @@
 <div class="space-y-8">
   <% if @user.email_deactivated? %>
     <div class="ff-alert ff-alert--warning space-y-2" role="alert">
-      <p class="ff-text font-semibold text-slate-800">Your email address is not receiving our emails.</p>
+      <p class="font-semibold text-slate-800">Your email address is not receiving our emails.</p>
       <% if @user.can_change_email? %>
-        <p class="ff-text">
+        <p class="text-slate-600">
           <%= link_to "Update your email address", edit_settings_email_update_path, class: "ff-link" %>
           to continue receiving notifications.
         </p>
       <% else %>
-        <p class="ff-text">You can update your email address in <%= distance_of_time_in_words(@user.time_until_email_change_allowed) %>.</p>
+        <p class="text-slate-600">You can update your email address in <%= distance_of_time_in_words(@user.time_until_email_change_allowed) %>.</p>
       <% end %>
     </div>
   <% end %>
@@ -21,8 +21,8 @@
   <% if suggest_to_add_tokens %>
     <section class="space-y-4">
       <h1 class="text-4xl font-semibold mb-0 text-slate-900">Welcome to Feeder</h1>
-      <p class="ff-text">Feeder helps you automatically share content from your favorite sources to FreeFeed.</p>
-      <p class="ff-text">To get started, add a FreeFeed access token so Feeder can post on your behalf.</p>
+      <p class="text-slate-600">Feeder helps you automatically share content from your favorite sources to FreeFeed.</p>
+      <p class="text-slate-600">To get started, add a FreeFeed access token so Feeder can post on your behalf.</p>
       <div class="mt-8">
         <%= link_to "Add FreeFeed token", new_access_token_path, class: "ff-button" %>
       </div>
@@ -30,7 +30,7 @@
   <% elsif suggest_adding_feeds %>
     <section class="space-y-4">
       <h1 class="text-4xl font-semibold mb-0 text-slate-900">Welcome to Feeder</h1>
-      <p class="ff-text">Great! You've added a FreeFeed access token. Now you can create your first feed.</p>
+      <p class="text-slate-600">Great! You've added a FreeFeed access token. Now you can create your first feed.</p>
       <div class="mt-8">
         <%= link_to "Add feed", new_feed_path, class: "ff-button" %>
       </div>

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -153,7 +153,7 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
 
     result = render_inline(EventDescriptionComponent.new(event: event))
 
-    assert_includes result.to_html, %(<a class="ff-link" href="/feeds/#{feed1.id}">Feed One</a>)
+    assert_includes result.to_html, %(<a class="font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" href="/feeds/#{feed1.id}">Feed One</a>)
     assert_includes result.to_html, "1 deleted feed"
   end
 

--- a/test/controllers/admin/available_invites_controller_test.rb
+++ b/test/controllers/admin/available_invites_controller_test.rb
@@ -24,7 +24,7 @@ class Admin::AvailableInvitesControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-stream[action='replace'][target='available-invites-input-wrapper-#{target_user.id}']"
     assert_select "turbo-stream[action='replace'][target='flash-messages']" do
       assert_select "div[id='flash-messages']"
-      assert_select ".ff-alert--info", text: /Available invites updated successfully/
+      assert_select ".bg-sky-100", text: /Available invites updated successfully/
     end
 
     target_user.reload
@@ -40,7 +40,7 @@ class Admin::AvailableInvitesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "text/vnd.turbo-stream.html", response.media_type
     assert_select "turbo-stream[action='replace'][target='flash-messages']" do
       assert_select "div[id='flash-messages']"
-      assert_select ".ff-alert--error", text: /Failed to update available invites/
+      assert_select ".bg-red-100", text: /Failed to update available invites/
     end
 
     target_user.reload
@@ -56,7 +56,7 @@ class Admin::AvailableInvitesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "text/vnd.turbo-stream.html", response.media_type
     assert_select "turbo-stream[action='replace'][target='flash-messages']" do
       assert_select "div[id='flash-messages']"
-      assert_select ".ff-alert--error", text: /Failed to update available invites/
+      assert_select ".bg-red-100", text: /Failed to update available invites/
     end
 
     target_user.reload
@@ -86,7 +86,7 @@ class Admin::AvailableInvitesControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-stream[action='replace'][target='available-invites-input-wrapper-#{target_user.id}']"
     assert_select "turbo-stream[action='replace'][target='flash-messages']" do
       assert_select "div[id='flash-messages']"
-      assert_select ".ff-alert--info", text: /Available invites updated successfully/
+      assert_select ".bg-sky-100", text: /Available invites updated successfully/
     end
 
     target_user.reload

--- a/test/controllers/admins_controller_test.rb
+++ b/test/controllers/admins_controller_test.rb
@@ -19,10 +19,10 @@ class AdminsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "h1", "Admin Panel"
-    assert_select "a.ff-card[href='#{admin_users_path}']", count: 1
-    assert_select "a.ff-card[href='#{admin_events_path}']", count: 1
-    assert_select "a.ff-card[href='#{admin_system_stats_path}']", count: 1
-    assert_select "a.ff-card[href='#{mission_control_jobs.root_path}']", count: 1
+    assert_select "a[href='#{admin_users_path}']", count: 1
+    assert_select "a[href='#{admin_events_path}']", count: 1
+    assert_select "a[href='#{admin_system_stats_path}']", count: 1
+    assert_select "a[href='#{mission_control_jobs.root_path}']", count: 1
   end
 
   test "should redirect when authenticated as regular user" do

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -164,7 +164,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='feed[name]'][value='Test Feed']"
 
     # Verify validation errors are shown
-    assert_select "p.ff-form-error", text: /can't be blank|must be filled/
+    assert_select "p.text-red-600", text: /can't be blank|must be filled/
   end
 
   test "#show should render feed owned by user" do
@@ -185,10 +185,8 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     get edit_feed_url(feed)
     assert_response :success
-    assert_select ".ff-form-group" do
-      assert_select "label", text: "Feed URL"
-      assert_select ".ff-form-help", text: "Feed URL and Type cannot be changed after creation. To use a different URL, create a new feed."
-    end
+    assert_select "label", text: "Feed URL"
+    assert_select "p.text-slate-500", text: "Feed URL and Type cannot be changed after creation. To use a different URL, create a new feed."
   end
 
   test "#update should update feed with valid params" do

--- a/test/helpers/post_helper_test.rb
+++ b/test/helpers/post_helper_test.rb
@@ -85,7 +85,7 @@ class PostHelperTest < ActionView::TestCase
     assert_equal "https://example.com", link["href"]
     assert_equal "_blank", link["target"]
     assert_equal "noopener", link["rel"]
-    assert_equal "ff-link", link["class"]
+    assert_equal "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500", link["class"]
     assert_equal "https://example.com", link.text
   end
 


### PR DESCRIPTION
Changes:

- Remove unused CSS utility classes from `application.css`: `.ff-focus-ring`, `.ff-nav-brand`, `.ff-nav-link`, `.ff-nav-link--active`, `.ff-dropdown-panel`, `.ff-dropdown-item`, `.ff-h3`, `.ff-event-level`, and icon color classes (`.ff-icon-success`, `.ff-icon-danger`, `.ff-icon-warning`, `.ff-icon-info`, `.ff-icon-secondary`)
- Inline Tailwind classes directly in components and views where these utilities were previously used
- Update navbar component to use inline Tailwind classes instead of `.ff-nav-brand` and `.ff-focus-ring`
- Update dropdown panels in feeds and posts index views to use inline Tailwind classes
- Update access token item component to use inline color classes instead of `.ff-icon-*` utilities
- Update feed and post item components to use inline focus ring styles
- Update admin events view to use inline event level badge classes
- Update admin users show view to use inline heading styles instead of `.ff-h3`

This change consolidates styling by removing the intermediate CSS utility layer and using Tailwind classes directly, making the codebase more maintainable and reducing CSS file size.
