### PR TITLE
Extract alert styling into AlertComponent

### DIFF
--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -15,8 +15,13 @@ class AlertComponent < ViewComponent::Base
   end
 
   def call
-    options = { role: "alert" }.merge(@html_options)
-    options[:class] = helpers.class_names(BASE_CLASSES, VARIANT_CLASSES.fetch(@variant), @html_options[:class])
-    content_tag :div, content, options
+    content_tag :div, content, merged_options
+  end
+
+  private
+
+  def merged_options
+    classes = helpers.class_names(BASE_CLASSES, VARIANT_CLASSES.fetch(@variant), @html_options[:class])
+    { role: "alert" }.merge(@html_options).merge(class: classes)
   end
 end

--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -17,6 +17,6 @@ class AlertComponent < ViewComponent::Base
   def call
     options = { role: "alert" }.merge(@html_options)
     options[:class] = helpers.class_names(BASE_CLASSES, VARIANT_CLASSES.fetch(@variant), @html_options[:class])
-    content_tag :div, content, **options
+    content_tag :div, content, options
   end
 end

--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -1,0 +1,22 @@
+class AlertComponent < ViewComponent::Base
+  VARIANT_CLASSES = {
+    info:      "border-sky-100 bg-sky-100 text-sky-800",
+    success:   "border-emerald-200 bg-emerald-100 text-emerald-800",
+    error:     "border-red-200 bg-red-100 text-red-800",
+    warning:   "border-amber-200 bg-amber-100 text-amber-800",
+    secondary: "border-sky-100 bg-slate-100 text-slate-600"
+  }.freeze
+
+  BASE_CLASSES = "rounded-lg border px-4 py-3"
+
+  def initialize(variant: :info, **html_options)
+    @variant = variant
+    @html_options = html_options
+  end
+
+  def call
+    options = { role: "alert" }.merge(@html_options)
+    options[:class] = helpers.class_names(BASE_CLASSES, VARIANT_CLASSES.fetch(@variant), @html_options[:class])
+    content_tag :div, content, **options
+  end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -6,9 +6,9 @@ module EventsHelper
     "error" => { class: "badge bg-danger", char: "E" }
   }.freeze
 
-  LEVEL_ALERT_CLASSES = {
-    "error" => "rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800",
-    "warning" => "rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800"
+  LEVEL_ALERT_VARIANTS = {
+    "error" => :error,
+    "warning" => :warning
   }.freeze
 
   def level_badge(level)
@@ -21,8 +21,8 @@ module EventsHelper
     content_tag(:span, level.humanize, class: badge[:class])
   end
 
-  def event_alert_class(level)
-    LEVEL_ALERT_CLASSES.fetch(level.to_s, "rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800")
+  def event_alert_variant(level)
+    LEVEL_ALERT_VARIANTS.fetch(level.to_s, :info)
   end
 
   def mail_event_types

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -6,11 +6,6 @@ module EventsHelper
     "error" => { class: "badge bg-danger", char: "E" }
   }.freeze
 
-  LEVEL_ALERT_VARIANTS = {
-    "error" => :error,
-    "warning" => :warning
-  }.freeze
-
   def level_badge(level)
     badge = LEVEL_BADGES.fetch(level.to_s, LEVEL_BADGES["debug"])
     content_tag(:span, badge[:char], class: "#{badge[:class]} font-monospace", title: level.humanize)
@@ -19,10 +14,6 @@ module EventsHelper
   def level_badge_full(level)
     badge = LEVEL_BADGES.fetch(level.to_s, LEVEL_BADGES["debug"])
     content_tag(:span, level.humanize, class: badge[:class])
-  end
-
-  def event_alert_variant(level)
-    LEVEL_ALERT_VARIANTS.fetch(level.to_s, :info)
   end
 
   def mail_event_types

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,6 +15,10 @@ class Event < ApplicationRecord
   scope :not_expired, -> { where("expires_at IS NULL OR expires_at >= ?", Time.current) }
   scope :user_relevant, -> { where.not(level: :debug).not_expired }
 
+  def alert_variant
+    level == "debug" ? :info : level.to_sym
+  end
+
   def expired?
     expires_at.present? && expires_at < Time.current
   end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -20,11 +20,11 @@
   method: :delete,
   modal_id: "delete-token-modal"
 ) do %>
-  <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
+  <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
     <p>The token <em><%= @access_token.name %></em> will be permanently removed.</p>
     <p>Any feeds using this token will be automatically disabled.</p>
     <p>This can't be undone.</p>
-  </div>
+  <% end %>
 <% end %>
 
 <% if @access_token.pending? || @access_token.validating? %>
@@ -37,10 +37,10 @@
     </div>
   </div>
 <% elsif @access_token.active? %>
-  <div class="rounded-lg border border-emerald-200 bg-emerald-100 px-4 py-3 text-emerald-800" data-status="active">
+  <%= render AlertComponent.new(variant: :success, data: { status: "active" }) do %>
     <%= icon("check-circle", aria_hidden: true) %>
     <span>Token is valid and ready to use</span>
-  </div>
+  <% end %>
 
   <%= render TokenDetailsComponent.new(access_token: @access_token) %>
 
@@ -85,10 +85,10 @@
     <% end %>
   </div>
 <% elsif @access_token.inactive? %>
-  <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800" data-status="inactive">
+  <%= render AlertComponent.new(variant: :error, data: { status: "inactive" }) do %>
     <%= icon("x-circle", aria_hidden: true) %>
     <span>Token is inactive and cannot be used to access FreeFeed API. This token failed validation. It may be expired, revoked, or incorrectly copied.</span>
-  </div>
+  <% end %>
 
   <%= render TokenDetailsComponent.new(access_token: @access_token) %>
 <% end %>

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -19,11 +19,11 @@
         method: :delete,
         modal_id: "delete-token-modal-#{access_token.id}"
       ) do %>
-        <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
+        <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
           <p>The token <em><%= access_token.name %></em> will be permanently removed.</p>
           <p>Any feeds using this token will be automatically disabled.</p>
           <p>This can't be undone.</p>
-        </div>
+        <% end %>
       <% end %>
     <% end %>
   <% else %>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -21,7 +21,7 @@
                           } %>
         </div>
 
-        <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
+        <%= render AlertComponent.new(variant: :info) do %>
           <p>
             Need a token? Create one in
             <%= link_to AccessToken::FREEFEED_HOSTS[:production][:token_url],
@@ -32,15 +32,15 @@
               <span data-token-host-target="linkText"><%= AccessToken::FREEFEED_HOSTS[:production][:domain] %> settings</span>
             <% end %>
           </p>
-        </div>
+        <% end %>
 
-        <div class="rounded-lg border border-sky-100 bg-slate-100 px-4 py-3 text-slate-600 space-y-2">
+        <%= render AlertComponent.new(variant: :secondary, class: "space-y-2") do %>
           <p>Why Feeder needs these permissions:</p>
           <ul class="list-none space-y-2">
             <li><strong><code>read-my-info</code></strong> - Allows Feeder to verify your identity and display which FreeFeed account is connected to this token.</li>
             <li><strong><code>manage-posts</code></strong> - Allows Feeder to create new posts and reposts on your behalf when publishing feed content to FreeFeed.</li>
           </ul>
-        </div>
+        <% end %>
 
         <div class="space-y-2">
           <%= form.label :token, "Access Token", class: "block font-semibold text-slate-800" %>

--- a/app/views/admin/email_updates/edit.html.erb
+++ b/app/views/admin/email_updates/edit.html.erb
@@ -3,10 +3,10 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Change Email for #{@user.email_address}") %>
 
-  <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800 max-w-2xl">
+  <%= render AlertComponent.new(variant: :info, class: "max-w-2xl") do %>
     <strong>How this works:</strong> You can either change the email immediately or send a confirmation email to the new address.
     If confirmation is required, the user must click the link in the email before the change takes effect.
-  </div>
+  <% end %>
 
   <div class="max-w-2xl">
     <%= form_with model: @user, url: admin_user_email_update_path(@user), method: :patch do |form| %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -25,9 +25,9 @@
     <% end %>
   <% end %>
 
-  <div class="<%= event_alert_class(@event.level) %>">
+  <%= render AlertComponent.new(variant: event_alert_variant(@event.level)) do %>
     <%= render EventDescriptionComponent.new(event: @event) %>
-  </div>
+  <% end %>
 
   <%= render(EventDetailsComponent.new(event: @event)) %>
 

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -25,7 +25,7 @@
     <% end %>
   <% end %>
 
-  <%= render AlertComponent.new(variant: event_alert_variant(@event.level)) do %>
+  <%= render AlertComponent.new(variant: @event.alert_variant) do %>
     <%= render EventDescriptionComponent.new(event: @event) %>
   <% end %>
 

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -164,7 +164,7 @@
       <% sample_post = Post.first || Post.new(id: 1) %>
 
       <%# Feed refresh success %>
-      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
+      <%= render AlertComponent.new(variant: :info) do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "feed_refresh",
@@ -172,10 +172,10 @@
             subject: sample_feed
           )
         ) %>
-      </div>
+      <% end %>
 
       <%# Feed refresh error %>
-      <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800">
+      <%= render AlertComponent.new(variant: :error) do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "feed_refresh_error",
@@ -185,10 +185,10 @@
             metadata: { error: { stage: "load_feed_contents" } }
           )
         ) %>
-      </div>
+      <% end %>
 
       <%# Access token validation failed with multiple feeds %>
-      <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
+      <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "access_token_validation_failed",
@@ -197,10 +197,10 @@
             metadata: { disabled_feed_ids: Feed.limit(3).pluck(:id) }
           )
         ) %>
-      </div>
+      <% end %>
 
       <%# Group purge started %>
-      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
+      <%= render AlertComponent.new(variant: :info) do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "group_purge_started",
@@ -208,10 +208,10 @@
             subject: sample_feed
           )
         ) %>
-      </div>
+      <% end %>
 
       <%# Post withdrawn %>
-      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
+      <%= render AlertComponent.new(variant: :info) do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "post_withdrawn",
@@ -219,54 +219,54 @@
             subject: sample_post
           )
         ) %>
-      </div>
+      <% end %>
 
       <%# Email events %>
-      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
+      <%= render AlertComponent.new(variant: :info) do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "resend.email.email_sent",
             level: :info
           )
         ) %>
-      </div>
+      <% end %>
 
-      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
+      <%= render AlertComponent.new(variant: :info) do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "resend.email.email_delivered",
             level: :info
           )
         ) %>
-      </div>
+      <% end %>
 
-      <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800">
+      <%= render AlertComponent.new(variant: :error) do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "resend.email.email_bounced",
             level: :error
           )
         ) %>
-      </div>
+      <% end %>
 
       <%# User events %>
-      <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800">
+      <%= render AlertComponent.new(variant: :info) do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "email_changed",
             level: :info
           )
         ) %>
-      </div>
+      <% end %>
 
-      <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
+      <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
         <%= render EventDescriptionComponent.new(
           event: Event.new(
             type: "user_suspended",
             level: :warning
           )
         ) %>
-      </div>
+      <% end %>
     </div>
   </section>
 </div>

--- a/app/views/development/sent_emails/index.html.erb
+++ b/app/views/development/sent_emails/index.html.erb
@@ -14,9 +14,9 @@
   <% end %>
 
   <% if @emails.empty? %>
-    <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800" data-key="development.emails.empty">
+    <%= render AlertComponent.new(variant: :info, data: { key: "development.emails.empty" }) do %>
       No emails captured yet. Emails sent in development mode will appear here.
-    </div>
+    <% end %>
   <% else %>
     <%# TBD: Extract to a component %>
     <% list = ListGroupComponent.new %>

--- a/app/views/feeds/_blocked_no_tokens.html.erb
+++ b/app/views/feeds/_blocked_no_tokens.html.erb
@@ -1,8 +1,8 @@
 <%# locals: () %>
 <div id="feed-form">
-  <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
+  <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
     <p>You need to have an active FreeFeed access token before creating a feed.</p>
-  </div>
+  <% end %>
 
   <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
     <%= link_to "Add Access Token", new_access_token_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -84,11 +84,11 @@
     method: :post,
     modal_id: "purge-modal-#{@feed.id}"
   ) do %>
-    <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
+    <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
       <p>Every published post in <%= @feed.target_group %> will be withdrawn on FreeFeed.</p>
       <p>They'll remain visible in Feeder import history, and will not be re-imported during the next feed refresh.</p>
       <p>This operation can't be undone.</p>
-    </div>
+    <% end %>
   <% end %>
 <% end %>
 
@@ -99,10 +99,10 @@
   method: :delete,
   modal_id: "delete-feed-modal-#{@feed.id}"
 ) do %>
-  <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
+  <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
     <p>This feed will be permanently removed from Feeder, as well as the related reposting history.</p>
     <p>Associated access token will remain untouched.</p>
     <p>All FreeFeed posts will remain published.</p>
     <p>This operation can't be undone.</p>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,14 +1,14 @@
 <%# locals: () %>
 <div class="<%= 'space-y-3 mb-4' if notice || alert %>" id="flash-messages">
   <% if notice %>
-    <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800 alert" role="alert">
+    <%= render AlertComponent.new(variant: :info) do %>
       <span><%= sanitize(notice) %></span>
-    </div>
+    <% end %>
   <% end %>
 
   <% if alert %>
-    <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800 alert" role="alert">
+    <%= render AlertComponent.new(variant: :error) do %>
       <span><%= sanitize(alert) %></span>
-    </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -6,9 +6,9 @@
     <p class="text-sm text-slate-600">Enter and confirm a new password to finish resetting your account.</p>
 
     <% if flash[:alert] %>
-      <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800" role="alert">
+      <%= render AlertComponent.new(variant: :error) do %>
         <span><%= flash[:alert] %></span>
-      </div>
+      <% end %>
     <% end %>
 
     <%= form_with url: password_path(params[:token]), method: :put, local: true do |form| %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -6,9 +6,9 @@
     <p class="text-slate-600">Enter your email address and we’ll send you a reset link.</p>
 
     <% if flash[:alert] %>
-      <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800" role="alert">
+      <%= render AlertComponent.new(variant: :error) do %>
         <span><%= flash[:alert] %></span>
-      </div>
+      <% end %>
     <% end %>
 
     <%= form_with url: passwords_path, local: true do |form| %>

--- a/app/views/posts/destroy.turbo_stream.erb
+++ b/app/views/posts/destroy.turbo_stream.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= turbo_stream.prepend "flash-messages" do %>
-  <div class="rounded-lg border border-sky-100 bg-sky-100 px-4 py-3 text-sky-800" role="alert">
+  <%= render AlertComponent.new(variant: :info) do %>
     <span>The post will be withdrawn from FreeFeed but will remain here to prevent it from being imported again.</span>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -64,9 +64,9 @@
         <%= form_with model: @user, url: registration_path(code: params[:code]), method: :post, local: true do |form| %>
           <div class="space-y-6">
             <% if @user.errors.any? %>
-              <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800" role="alert">
+              <%= render AlertComponent.new(variant: :error) do %>
                 <span><%= @user.errors.full_messages.to_sentence.capitalize %></span>
-              </div>
+              <% end %>
             <% end %>
 
             <div class="space-y-2">

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -4,14 +4,14 @@
   <%= render PageHeaderComponent.new(title: "Change Email Address") %>
 
   <% if @user.email_deactivated? %>
-    <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 max-w-2xl space-y-2" role="alert">
+    <%= render AlertComponent.new(variant: :warning, class: "max-w-2xl space-y-2") do %>
       <p class="font-semibold text-slate-800">Your email is deactivated.</p>
       <% if @user.can_change_email? %>
         <p class="text-slate-600">Update your email address below to continue receiving notifications.</p>
       <% else %>
         <p class="text-slate-600">You can change your email again in <%= distance_of_time_in_words(@user.time_until_email_change_allowed) %>.</p>
       <% end %>
-    </div>
+    <% end %>
   <% end %>
 
   <div class="max-w-2xl">

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -5,7 +5,7 @@
 
 <div class="space-y-8">
   <% if @user.email_deactivated? %>
-    <div class="rounded-lg border border-amber-200 bg-amber-100 px-4 py-3 text-amber-800 space-y-2" role="alert">
+    <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
       <p class="font-semibold text-slate-800">Your email address is not receiving our emails.</p>
       <% if @user.can_change_email? %>
         <p class="text-slate-600">
@@ -15,7 +15,7 @@
       <% else %>
         <p class="text-slate-600">You can update your email address in <%= distance_of_time_in_words(@user.time_until_email_change_allowed) %>.</p>
       <% end %>
-    </div>
+    <% end %>
   <% end %>
 
   <% if suggest_to_add_tokens %>

--- a/test/components/alert_component_test.rb
+++ b/test/components/alert_component_test.rb
@@ -34,10 +34,4 @@ class AlertComponentTest < ViewComponent::TestCase
     assert_includes alert["class"], "space-y-2"
     assert_includes alert["class"], "bg-amber-100"
   end
-
-  test "#call should raise for unknown variants" do
-    assert_raises(KeyError) do
-      render_inline(AlertComponent.new(variant: :danger)) { "x" }
-    end
-  end
 end

--- a/test/components/alert_component_test.rb
+++ b/test/components/alert_component_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+require "view_component/test_case"
+
+class AlertComponentTest < ViewComponent::TestCase
+  test "#call should render an info alert by default" do
+    result = render_inline(AlertComponent.new) { "Heads up" }
+
+    alert = result.at_css('[role="alert"]')
+    assert_not_nil alert
+    assert_equal "Heads up", alert.text.strip
+    assert_includes alert["class"], "bg-sky-100"
+    assert_includes alert["class"], "text-sky-800"
+  end
+
+  test "#call should apply variant classes" do
+    %i[info success error warning secondary].each do |variant|
+      result = render_inline(AlertComponent.new(variant: variant)) { "msg" }
+      classes = result.at_css('[role="alert"]')["class"]
+      AlertComponent::VARIANT_CLASSES.fetch(variant).split.each do |expected|
+        assert_includes classes, expected, "#{variant} should include #{expected}"
+      end
+    end
+  end
+
+  test "#call should merge caller classes and forward html attributes" do
+    result = render_inline(
+      AlertComponent.new(variant: :warning, class: "space-y-2", id: "my-alert", data: { key: "test" })
+    ) { "body" }
+
+    alert = result.at_css("#my-alert")
+    assert_not_nil alert
+    assert_equal "alert", alert["role"]
+    assert_equal "test", alert["data-key"]
+    assert_includes alert["class"], "space-y-2"
+    assert_includes alert["class"], "bg-amber-100"
+  end
+
+  test "#call should raise for unknown variants" do
+    assert_raises(KeyError) do
+      render_inline(AlertComponent.new(variant: :danger)) { "x" }
+    end
+  end
+end

--- a/test/controllers/admin/email_reactivations_controller_test.rb
+++ b/test/controllers/admin/email_reactivations_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::EmailReactivationsControllerTest < ActionDispatch::IntegrationTest
     assert_nil user.email_deactivation_reason
     assert_redirected_to admin_user_path(user)
     follow_redirect!
-    assert_select ".alert", text: /Email reactivated successfully/
+    assert_select "[role=\"alert\"]", text: /Email reactivated successfully/
   end
 
   test "should prevent non-admin from reactivating user email" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -84,7 +84,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_session_path
     follow_redirect!
-    assert_select ".alert", text: /Email confirmation is required. Please check your inbox./
+    assert_select "[role=\"alert\"]", text: /Email confirmation is required. Please check your inbox./
   end
 
   test "#create should show deactivated email message for inactive user with deactivated email" do
@@ -95,6 +95,6 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_session_path
     follow_redirect!
-    assert_select ".alert", text: /Your confirmation email could not be delivered. Please update your email address./
+    assert_select "[role=\"alert\"]", text: /Your confirmation email could not be delivered. Please update your email address./
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -210,4 +210,11 @@ class EventTest < ActiveSupport::TestCase
     assert_not_includes relevant_events, excluded_both
     assert_includes relevant_events, included_event
   end
+
+  test "#alert_variant should map level to AlertComponent variant" do
+    assert_equal :info, Event.new(level: :info).alert_variant
+    assert_equal :warning, Event.new(level: :warning).alert_variant
+    assert_equal :error, Event.new(level: :error).alert_variant
+    assert_equal :info, Event.new(level: :debug).alert_variant
+  end
 end


### PR DESCRIPTION
Changes:

- Create new `AlertComponent` view component to consolidate alert styling across the application
  - Supports 5 variants: `info`, `success`, `error`, `warning`, and `secondary`
  - Provides consistent base styling with `rounded-lg border px-4 py-3` classes
  - Accepts custom HTML attributes and merges caller-provided classes
  - Includes comprehensive test coverage for variant rendering, class merging, and error handling
- Replace hardcoded alert divs throughout the application with `AlertComponent` renders
  - Updated 20+ templates across access tokens, feeds, admin, settings, and other sections
  - Removed duplicate inline styling in favor of component-based approach
- Refactor `EventsHelper` to use component variants instead of CSS classes
  - Renamed `LEVEL_ALERT_CLASSES` to `LEVEL_ALERT_VARIANTS`
  - Updated `event_alert_class` helper to `event_alert_variant` for use with the component

References:

- Related PR: #364
