### PR TITLE
Enhance CardComponent with href support and refactor styling

### DIFF
--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,17 +1,25 @@
 class CardComponent < ViewComponent::Base
-  DEFAULT_BASE_CLASSES = "rounded-lg border border-slate-200 px-4 py-3 shadow-sm"
+  BASE_CLASSES = "w-full rounded-none border-0 bg-white p-0 " \
+                 "sm:rounded-lg sm:border sm:border-slate-200 sm:p-6 sm:shadow-xs"
+  LINKED_CLASSES = "block no-underline hover:shadow-lg transition-shadow"
 
-  def initialize(**html_options)
+  def initialize(href: nil, **html_options)
+    @href = href
     @html_options = html_options
   end
 
   def call
-    content_tag :div, content, merged_options
+    if @href
+      link_to(@href, **merged_options) { content }
+    else
+      content_tag(:div, content, merged_options)
+    end
   end
 
   private
 
   def merged_options
-    @html_options.merge(class: helpers.class_names(DEFAULT_BASE_CLASSES, @html_options[:class]))
+    classes = helpers.class_names(BASE_CLASSES, (@href && LINKED_CLASSES), @html_options[:class])
+    @html_options.merge(class: classes)
   end
 end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -28,14 +28,14 @@
 <% end %>
 
 <% if @access_token.pending? || @access_token.validating? %>
-  <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+  <%= render CardComponent.new do %>
     <div class="space-y-6">
       <div class="flex items-center justify-center py-8">
         <%= render SpinnerComponent.new(css_class: "mr-3") %>
         <span class="text-lg text-slate-600">Validating token...</span>
       </div>
     </div>
-  </div>
+  <% end %>
 <% elsif @access_token.active? %>
   <%= render AlertComponent.new(variant: :success, data: { status: "active" }) do %>
     <%= icon("check-circle", aria_hidden: true) %>

--- a/app/views/access_tokens/edit.html.erb
+++ b/app/views/access_tokens/edit.html.erb
@@ -3,9 +3,9 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Edit Access Token") %>
 
-  <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+  <%= render CardComponent.new do %>
     <div class="space-y-6">
       <p class="text-slate-600">Access token editing form coming soon...</p>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -114,11 +114,11 @@
       <%= render_pagination { |pagination, params| admin_events_path(pagination.merge(@filter.present? ? { filter: @filter.to_h } : {})) } %>
     </div>
   <% else %>
-    <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+    <%= render CardComponent.new do %>
       <div class="space-y-6 text-center py-12">
         <h2 class="text-2xl font-semibold mb-3 text-slate-900">No events found</h2>
         <p class="text-slate-600">Events will appear here as they are created.</p>
       </div>
-    </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -4,7 +4,7 @@
   <h1 class="text-4xl font-semibold mb-0 text-slate-900">Admin Panel</h1>
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <%= link_to admin_users_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow" do %>
+    <%= render CardComponent.new(href: admin_users_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("people") %>
@@ -14,7 +14,7 @@
       </div>
     <% end %>
 
-    <%= link_to admin_events_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow" do %>
+    <%= render CardComponent.new(href: admin_events_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("calendar-event") %>
@@ -24,7 +24,7 @@
       </div>
     <% end %>
 
-    <%= link_to admin_system_stats_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow" do %>
+    <%= render CardComponent.new(href: admin_system_stats_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("hdd") %>
@@ -34,7 +34,7 @@
       </div>
     <% end %>
 
-    <%= link_to mission_control_jobs.root_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow", target: "_blank", rel: "noopener noreferrer" do %>
+    <%= render CardComponent.new(href: mission_control_jobs.root_path, target: "_blank", rel: "noopener noreferrer") do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("stack") %>
@@ -45,7 +45,7 @@
     <% end %>
 
     <% if Rails.env.development? %>
-      <%= link_to development_sent_emails_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow", target: "_blank", rel: "noopener noreferrer" do %>
+      <%= render CardComponent.new(href: development_sent_emails_path, target: "_blank", rel: "noopener noreferrer") do %>
         <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
             <%= icon("inbox") %>
@@ -55,7 +55,7 @@
         </div>
       <% end %>
 
-      <%= link_to development_components_path, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm block no-underline hover:shadow-lg transition-shadow", target: "_blank", rel: "noopener noreferrer" do %>
+      <%= render CardComponent.new(href: development_components_path, target: "_blank", rel: "noopener noreferrer") do %>
         <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
             <%= icon("grid") %>

--- a/app/views/feed_previews/_processing_status.html.erb
+++ b/app/views/feed_previews/_processing_status.html.erb
@@ -1,8 +1,5 @@
 <%# locals: (feed_preview:) %>
-<%= render CardComponent.new(
-      class: "flex items-center gap-3",
-      role: "status"
-    ) do %>
+<div class="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 shadow-xs" role="status">
   <div class="flex-shrink-0">
     <%= render SpinnerComponent.new %>
   </div>
@@ -10,4 +7,4 @@
     <p class="font-semibold text-slate-800">Generating preview...</p>
     <p class="text-slate-600">This usually takes a few seconds while we fetch and format this feed.</p>
   </div>
-<% end %>
+</div>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -1,15 +1,11 @@
-<%= render CardComponent.new(
-      id: "feed-form",
-      class: "flex items-center gap-3",
-      role: "status",
-      data: {
-        controller: "polling",
-        polling_endpoint_value: feed_details_path(url: url),
-        polling_interval_value: Feed::IDENTIFICATION_POLLING_INTERVAL_MS,
-        polling_max_polls_value: FeedDetailsController::IDENTIFICATION_TIMEOUT_SECONDS / 2,
-        polling_stop_condition_value: "[data-identification-state='complete'], [data-identification-state='error']"
-      }
-    ) do %>
+<div id="feed-form"
+     class="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 shadow-xs"
+     role="status"
+     data-controller="polling"
+     data-polling-endpoint-value="<%= feed_details_path(url: url) %>"
+     data-polling-interval-value="<%= Feed::IDENTIFICATION_POLLING_INTERVAL_MS %>"
+     data-polling-max-polls-value="<%= FeedDetailsController::IDENTIFICATION_TIMEOUT_SECONDS / 2 %>"
+     data-polling-stop-condition-value="[data-identification-state='complete'], [data-identification-state='error']">
   <div class="flex-shrink-0">
     <%= render SpinnerComponent.new %>
   </div>
@@ -17,4 +13,4 @@
     <p class="font-semibold text-slate-800">Checking this feed...</p>
     <p class="text-slate-600">This usually takes a few seconds.</p>
   </div>
-<% end %>
+</div>

--- a/app/views/invites/_table.html.erb
+++ b/app/views/invites/_table.html.erb
@@ -55,9 +55,9 @@
     </table>
   </div>
 <% else %>
-  <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+  <%= render CardComponent.new do %>
     <div class="space-y-6 text-center">
       <p class="text-slate-600">No invites yet</p>
     </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Update Password" %>
 
-<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+<%= render CardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-slate-900">Choose a new password</h1>
     <p class="text-sm text-slate-600">Enter and confirm a new password to finish resetting your account.</p>
@@ -41,4 +41,4 @@
       </div>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Forgot Password?" %>
 
-<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+<%= render CardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-slate-900">Forgot your password?</h1>
     <p class="text-slate-600">Enter your email address and we’ll send you a reset link.</p>
@@ -25,4 +25,4 @@
       </div>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/registration/confirmation_pendings/show.html.erb
+++ b/app/views/registration/confirmation_pendings/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for :title, "Check Your Email" %>
 
-<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+<%= render CardComponent.new do %>
   <div class="space-y-6">
     <div class="space-y-3">
       <h1 class="text-4xl font-semibold mb-6 text-slate-900">Check your email</h1>
       <p class="text-slate-600">We've sent you a confirmation email. Click the link to activate your account.</p>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Resend Confirmation" %>
 
-<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+<%= render CardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-slate-900">Resend Confirmation</h1>
     <p class="text-slate-600">Enter your email and we'll send you a new confirmation link.</p>
@@ -19,4 +19,4 @@
       </div>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="mx-auto w-full max-w-full space-y-6 sm:max-w-2xl sm:px-0 px-4" data-controller="autofocus">
   <% if @invite.nil? %>
-    <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+    <%= render CardComponent.new do %>
       <div class="space-y-6">
         <h1 class="text-4xl font-semibold mb-6 text-slate-900">This invite link doesn't look right</h1>
         <p class="text-slate-600">We couldn't find an invitation with that code. It might have been removed or copied incorrectly.</p>
@@ -21,9 +21,9 @@
           <p class="text-slate-600">Ask someone who already uses Feeder to send you a new link.</p>
         </div>
       </div>
-    </div>
+    <% end %>
   <% elsif @invite.used? %>
-    <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+    <%= render CardComponent.new do %>
       <div class="space-y-6">
         <h1 class="text-4xl font-semibold mb-6 text-slate-900">This invite was already used</h1>
         <p class="text-slate-600">This link has already been used to create an account.</p>
@@ -48,9 +48,9 @@
           <p class="text-slate-600">Ask the person who sent this link to share a new one.</p>
         </div>
       </div>
-    </div>
+    <% end %>
   <% else %>
-    <div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+    <%= render CardComponent.new do %>
       <div class="space-y-6">
         <div class="space-y-4">
           <h1 class="text-4xl font-semibold mb-6 text-slate-900">Create your account</h1>
@@ -90,6 +90,6 @@
           </div>
         <% end %>
       </div>
-    </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Sign In" %>
 
-<div class="w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-slate-200 sm:bg-white sm:p-6 sm:shadow-sm">
+<%= render CardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-slate-900">Sign in to Feeder</h1>
 
@@ -27,4 +27,4 @@
       </div>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/test/components/card_component_test.rb
+++ b/test/components/card_component_test.rb
@@ -2,15 +2,17 @@ require "test_helper"
 require "view_component/test_case"
 
 class CardComponentTest < ViewComponent::TestCase
-  test "renders content with default styling" do
+  test "#call should render a div with default styling" do
     result = render_inline(CardComponent.new) { "Card body" }
 
-    card = result.css("div.rounded-lg").first
+    card = result.at_css("div")
     assert_not_nil card
     assert_equal "Card body", card.text.strip
+    assert_includes card["class"], "bg-white"
+    assert_includes card["class"], "sm:rounded-lg"
   end
 
-  test "merges classes and forwards html attributes" do
+  test "#call should merge classes and forward html attributes" do
     result = render_inline(
       CardComponent.new(
         class: "test",
@@ -26,5 +28,19 @@ class CardComponentTest < ViewComponent::TestCase
     assert_equal "test-card", card["id"]
     assert_equal "Polling...", card.css("p").first.text
     assert_includes card["class"], "test"
+  end
+
+  test "#call should render an anchor when href is given" do
+    result = render_inline(
+      CardComponent.new(href: "/somewhere", target: "_blank", rel: "noopener")
+    ) { "Linked card" }
+
+    card = result.at_css("a")
+    assert_not_nil card
+    assert_equal "/somewhere", card["href"]
+    assert_equal "_blank", card["target"]
+    assert_equal "noopener", card["rel"]
+    assert_includes card["class"], "hover:shadow-lg"
+    assert_includes card["class"], "no-underline"
   end
 end


### PR DESCRIPTION
Changes:

- Enhanced `CardComponent` to support rendering as an anchor tag when `href` parameter is provided, enabling clickable card patterns
- Refactored `CardComponent` styling to use responsive Tailwind classes with mobile-first approach (no styling on mobile, full styling on `sm:` breakpoint and up)
- Added `LINKED_CLASSES` constant for anchor-specific styling including hover effects and transitions
- Replaced hardcoded card styling strings across multiple views with `CardComponent` calls, improving maintainability and consistency
- Updated views: `admins/show`, `registrations/show`, `access_tokens/_show_content`, `access_tokens/edit`, `admin/events/index`, `invites/_table`, `passwords/edit`, `passwords/new`, `registration/confirmation_pendings/show`, `registration/confirmations/new`, and `sessions/new`
- Removed `CardComponent` usage from `feeds/_identification_loading` and `feed_previews/_processing_status` where inline styling is more appropriate for status indicators
- Added comprehensive test coverage for the new `href` functionality and anchor rendering behavior
- Updated existing tests to reflect new default styling and selector patterns

References:

- Related PR: #364
