### PR TITLE
Extract sort dropdown into reusable component

### DIFF
--- a/app/components/sort_dropdown_component.html.erb
+++ b/app/components/sort_dropdown_component.html.erb
@@ -1,0 +1,38 @@
+<div class="relative">
+  <button
+    id="<%= button_id %>"
+    type="button"
+    data-dropdown-toggle="<%= menu_id %>"
+    data-dropdown-placement="bottom-end"
+    class="<%= trigger_classes %>"
+    aria-haspopup="true"
+    aria-expanded="false">
+    <%= icon(direction_icon, css_class: "text-slate-500", aria_hidden: true) %>
+    <span class="flex items-center gap-2">
+      <span><%= presenter.current_title %></span>
+      <span class="sr-only"><%= direction_label %></span>
+    </span>
+    <%= icon("chevron-down", css_class: "text-xs text-slate-400", aria_hidden: true) %>
+  </button>
+  <div
+    id="<%= menu_id %>"
+    class="<%= panel_classes %>"
+    role="menu"
+    aria-labelledby="<%= button_id %>">
+    <ul class="py-1 text-base text-slate-600">
+      <% presenter.options.each do |option| %>
+        <li>
+          <%= link_to option.path, class: option_classes(option) do %>
+            <span><%= option.title %></span>
+            <% if option.icon_name.present? %>
+              <span class="flex items-center text-slate-500">
+                <%= icon(option.icon_name, css_class: "text-slate-400", aria_hidden: true) %>
+                <span class="sr-only"><%= option.active_direction == "asc" ? "Ascending" : "Descending" %></span>
+              </span>
+            <% end %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/components/sort_dropdown_component.rb
+++ b/app/components/sort_dropdown_component.rb
@@ -1,0 +1,42 @@
+class SortDropdownComponent < ViewComponent::Base
+  include ApplicationHelper
+
+  def initialize(presenter:, menu_id:)
+    @presenter = presenter
+    @menu_id = menu_id
+  end
+
+  private
+
+  attr_reader :presenter, :menu_id
+
+  def button_id
+    "#{menu_id}-button"
+  end
+
+  def direction_icon
+    presenter.current_direction == "asc" ? "arrow-up" : "arrow-down"
+  end
+
+  def direction_label
+    presenter.current_direction == "asc" ? "Ascending" : "Descending"
+  end
+
+  def trigger_classes
+    "inline-flex items-center justify-center whitespace-nowrap rounded-md " \
+      "border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 " \
+      "shadow-sm transition hover:bg-slate-50 " \
+      "focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 gap-2"
+  end
+
+  def panel_classes
+    "z-20 hidden w-60 rounded-lg border border-slate-200 bg-white shadow-sm"
+  end
+
+  def option_classes(option)
+    helpers.class_names(
+      "flex items-center justify-between gap-2 px-4 py-2 transition hover:bg-slate-50 focus:bg-slate-100 focus:outline-none",
+      "font-semibold text-slate-900": option.active?
+    )
+  end
+end

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -1,57 +1,13 @@
 <% content_for :title, "Feeds" %>
 
-<% sort_menu_id = "feed-sort-menu" %>
-
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Feeds") do |header| %>
     <% if (summary_line = feed_summary_line(active_count: @active_feed_count, inactive_count: @inactive_feed_count)) %>
       <% header.with_context_paragraph(summary_line) %>
     <% end %>
-    <%# Sorting dropdown %>
     <% if @feeds.any? %>
       <% header.with_action_button do %>
-        <div class="relative">
-          <button
-            id="<%= "#{sort_menu_id}-button" %>"
-            type="button"
-            data-dropdown-toggle="<%= sort_menu_id %>"
-            data-dropdown-placement="bottom-end"
-            class="<%= class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", 'gap-2') %>"
-            aria-haspopup="true"
-            aria-expanded="false">
-              <%= icon(@sortable_presenter.current_direction == "asc" ? "arrow-up" : "arrow-down", css_class: "text-slate-500", aria_hidden: true) %>
-              <span class="flex items-center gap-2">
-                <span><%= @sortable_presenter.current_title %></span>
-                <span class="sr-only"><%= @sortable_presenter.current_direction == "asc" ? "Ascending" : "Descending" %></span>
-              </span>
-              <%= icon("chevron-down", css_class: "text-xs text-slate-400", aria_hidden: true) %>
-          </button>
-          <div
-            id="<%= sort_menu_id %>"
-            class="z-20 hidden w-60 rounded-lg border border-slate-200 bg-white shadow-sm"
-            role="menu"
-            aria-labelledby="<%= "#{sort_menu_id}-button" %>">
-            <ul class="py-1 text-base text-slate-600">
-              <% @sortable_presenter.options.each do |option| %>
-                <li>
-                  <%= link_to option.path,
-                              class: class_names(
-                                "flex items-center justify-between gap-2 px-4 py-2 transition hover:bg-slate-50 focus:bg-slate-100 focus:outline-none",
-                                "font-semibold text-slate-900": option.active?
-                              ) do %>
-                    <span><%= option.title %></span>
-                    <% if option.icon_name.present? %>
-                      <span class="flex items-center text-slate-500">
-                        <%= icon(option.icon_name, css_class: "text-slate-400", aria_hidden: true) %>
-                        <span class="sr-only"><%= option.active_direction == "asc" ? "Ascending" : "Descending" %></span>
-                      </span>
-                    <% end %>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
+        <%= render SortDropdownComponent.new(presenter: @sortable_presenter, menu_id: "feed-sort-menu") %>
       <% end %>
     <% end %>
     <% header.with_action_button do %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,49 +10,7 @@
     <% end %>
     <% if @posts.any? %>
       <% header.with_action_button do %>
-        <div class="relative">
-          <% sort_menu_id = "posts-sort-menu" %>
-          <button
-            id="<%= "#{sort_menu_id}-button" %>"
-            type="button"
-            data-dropdown-toggle="<%= sort_menu_id %>"
-            data-dropdown-placement="bottom-end"
-            class="<%= class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", 'gap-2') %>"
-            aria-haspopup="true"
-            aria-expanded="false">
-            <%= icon(@sortable_presenter.current_direction == "asc" ? "arrow-up" : "arrow-down", css_class: "text-slate-500", aria_hidden: true) %>
-            <span class="flex items-center gap-2">
-              <span><%= @sortable_presenter.current_title %></span>
-              <span class="sr-only"><%= @sortable_presenter.current_direction == "asc" ? "Ascending" : "Descending" %></span>
-            </span>
-            <%= icon("chevron-down", css_class: "text-xs text-slate-400", aria_hidden: true) %>
-          </button>
-          <div
-            id="<%= sort_menu_id %>"
-            class="z-20 hidden w-60 rounded-lg border border-slate-200 bg-white shadow-sm"
-            role="menu"
-            aria-labelledby="<%= "#{sort_menu_id}-button" %>">
-            <ul class="py-1 text-base text-slate-600">
-              <% @sortable_presenter.options.each do |option| %>
-                <li>
-                  <%= link_to option.path,
-                              class: class_names(
-                                "flex items-center justify-between gap-2 px-4 py-2 transition hover:bg-slate-50 focus:bg-slate-100 focus:outline-none",
-                                "font-semibold text-slate-900": option.active?
-                              ) do %>
-                    <span><%= option.title %></span>
-                    <% if option.icon_name.present? %>
-                      <span class="flex items-center text-slate-500">
-                        <%= icon(option.icon_name, css_class: "text-slate-400", aria_hidden: true) %>
-                        <span class="sr-only"><%= option.active_direction == "asc" ? "Ascending" : "Descending" %></span>
-                      </span>
-                    <% end %>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
+        <%= render SortDropdownComponent.new(presenter: @sortable_presenter, menu_id: "posts-sort-menu") %>
       <% end %>
     <% end %>
   <% end %>

--- a/test/components/sort_dropdown_component_test.rb
+++ b/test/components/sort_dropdown_component_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+require "view_component/test_case"
+
+class SortDropdownComponentTest < ViewComponent::TestCase
+  def presenter
+    @presenter ||= SortablePresenter.new(
+      params: { sort: "name", direction: "asc" },
+      fields: { name: { title: "Name", direction: :asc }, created_at: { title: "Created", direction: :desc } },
+      path_builder: ->(params) { "/things?#{params.to_query}" }
+    )
+  end
+
+  test "#call should render the trigger button with the current sort title and direction" do
+    result = render_inline(SortDropdownComponent.new(presenter: presenter, menu_id: "things-menu"))
+
+    button = result.at_css("#things-menu-button")
+    assert_not_nil button
+    assert_equal "things-menu", button["data-dropdown-toggle"]
+    assert_includes button.text, "Name"
+    assert_includes button.text, "Ascending"
+  end
+
+  test "#call should render the menu panel with each sort option" do
+    result = render_inline(SortDropdownComponent.new(presenter: presenter, menu_id: "things-menu"))
+
+    panel = result.at_css("#things-menu")
+    assert_not_nil panel
+    assert_equal "menu", panel["role"]
+    assert_equal "things-menu-button", panel["aria-labelledby"]
+    assert_equal 2, panel.css("a").size
+    titles = panel.css("a span").map(&:text)
+    assert_includes titles, "Name"
+    assert_includes titles, "Created"
+  end
+
+  test "#call should mark the active option with bolder styling" do
+    result = render_inline(SortDropdownComponent.new(presenter: presenter, menu_id: "things-menu"))
+
+    active_link = result.at_css("#things-menu a.font-semibold")
+    assert_not_nil active_link
+    assert_includes active_link.text, "Name"
+  end
+end


### PR DESCRIPTION
Changes:

- Create new `SortDropdownComponent` to encapsulate sort dropdown UI and logic used across multiple views
- Replace inline sort dropdown markup in `feeds/index.html.erb` with component render
- Replace inline sort dropdown markup in `posts/index.html.erb` with component render
- Add comprehensive test coverage for `SortDropdownComponent` with tests for button rendering, menu panel, and active state styling

This refactoring eliminates ~90 lines of duplicated dropdown markup and improves maintainability by centralizing the sort dropdown implementation.

References:

- Related PR: #364
