### PR TITLE
Add GitHub Actions workflow for staging deployment

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,61 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches: [ staging ]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      POSTGRES_PASSWORD_STAGING: ${{ secrets.POSTGRES_PASSWORD_STAGING }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Configure SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H dev.fffeeder.com >> ~/.ssh/known_hosts
+
+      - name: Write Rails master key
+        env:
+          RAILS_MASTER_KEY_STAGING: ${{ secrets.RAILS_MASTER_KEY_STAGING }}
+        run: |
+          mkdir -p config/credentials
+          printf '%s' "$RAILS_MASTER_KEY_STAGING" > config/credentials/staging.key
+          chmod 600 config/credentials/staging.key
+
+      - name: Deploy to staging
+        run: bin/kamal deploy -d staging


### PR DESCRIPTION
Changes:

- Add `deploy-staging.yml` GitHub Actions workflow that automatically deploys to staging environment on pushes to the `staging` branch
- Configure workflow to build and push Docker images to GitHub Container Registry (GHCR)
- Set up SSH access to staging server (`dev.fffeeder.com`) for remote deployment
- Configure Rails master key for staging environment credentials
- Use Kamal for orchestrating the deployment process
- Enable manual workflow dispatch for on-demand deployments
- Implement concurrency control to prevent simultaneous deployments
