### PR TITLE
Fix staging deploy host key verification

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -47,7 +47,7 @@ jobs:
           chmod 700 ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H dev.fffeeder.com >> ~/.ssh/known_hosts
+          ssh-keyscan dev.fffeeder.com >> ~/.ssh/known_hosts
 
       - name: Write Rails master key
         env:


### PR DESCRIPTION
Changes:

- Drop the `-H` flag from `ssh-keyscan` in the staging deploy workflow so `~/.ssh/known_hosts` entries are stored in plain text.

Context:

The deploy was failing with `Net::SSH::HostKeyMismatch` even though the host key `ssh-keyscan` captured matched the one the server presented during the handshake. `net-ssh` verifies against a combined `hostname,ip` lookup string. Hashed entries (`-H`) hash only the literal argument passed to `ssh-keyscan` (the hostname), so the hash never matches the combined lookup, and `net-ssh` reports a mismatch rather than a missing entry. Storing the entry in plain text lets `net-ssh` match either the hostname or the IP against the entry's host pattern.

References:

- Related PR: #386
