### PR TITLE
Document error reporting conventions using Rails.error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,24 @@ When writing instructions or explanations:
 
 - Follow standard Rails conventions.
 
+## Error Reporting
+
+Report handled exceptions through `Rails.error`, not the Honeybadger API directly. Honeybadger subscribes to `ActiveSupport::ErrorReporter` automatically, so reports still reach it without coupling call sites to the vendor.
+
+```ruby
+# Good: vendor-agnostic, testable with assert_error_reported
+Rails.error.report(e, context: { feed_id: feed.id })
+
+Rails.error.handle(SomeExpectedError, context: { ... }) do
+  do_work
+end
+
+# Avoid in app code:
+Honeybadger.notify(e, context: { ... })
+```
+
+Keep the `Honeybadger.configure` block in `config/initializers/honeybadger.rb` — only call sites should be vendor-agnostic.
+
 ## PR description
 
 Use `.github/pull_request_template.md` for PR descriptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,21 +81,15 @@ When writing instructions or explanations:
 
 ## Error Reporting
 
-Report handled exceptions through `Rails.error`, not the Honeybadger API directly. Honeybadger subscribes to `ActiveSupport::ErrorReporter` automatically, so reports still reach it without coupling call sites to the vendor.
+Report handled exceptions through `Rails.error`.
 
 ```ruby
-# Good: vendor-agnostic, testable with assert_error_reported
 Rails.error.report(e, context: { feed_id: feed.id })
 
 Rails.error.handle(SomeExpectedError, context: { ... }) do
   do_work
 end
-
-# Avoid in app code:
-Honeybadger.notify(e, context: { ... })
 ```
-
-Keep the `Honeybadger.configure` block in `config/initializers/honeybadger.rb` — only call sites should be vendor-agnostic.
 
 ## PR description
 


### PR DESCRIPTION
Changes:

- Add error reporting guidelines to CLAUDE.md documenting the preferred approach of using `Rails.error` instead of calling the Honeybadger API directly
- Explain that Honeybadger automatically subscribes to `ActiveSupport::ErrorReporter`, making call sites vendor-agnostic and testable
- Provide examples of `Rails.error.report()` and `Rails.error.handle()` patterns
- Clarify that `Honeybadger.configure` should remain in the initializer while call sites stay vendor-neutral

References:

- Closes #334
