### PR TITLE
Extract empty state into shared partial

### DIFF
--- a/app/views/feeds/_empty_state.html.erb
+++ b/app/views/feeds/_empty_state.html.erb
@@ -1,0 +1,7 @@
+<div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-6 py-12 text-center text-slate-600">
+  <h2 class="text-2xl font-semibold text-slate-900">You don't have any feeds yet</h2>
+  <p class="mt-2 text-sm text-slate-600">Create your first feed to start refreshing posts and sharing them with your audience.</p>
+  <div class="mt-6">
+    <%= link_to "Create your first feed", new_feed_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
+  </div>
+</div>

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -26,12 +26,6 @@
 
     <%= render_pagination { |pagination| feeds_path(pagination) } %>
   <% else %>
-    <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-6 py-12 text-center text-slate-600">
-      <h2 class="text-2xl font-semibold text-slate-900">You don't have any feeds yet</h2>
-      <p class="mt-2 text-sm text-slate-600">Create your first feed to start refreshing posts and sharing them with your audience.</p>
-      <div class="mt-6">
-        <%= link_to "Create your first feed", new_feed_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
-      </div>
-    </div>
+    <%= render "empty_state" %>
   <% end %>
 </div>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -28,13 +28,7 @@
       </div>
     </section>
   <% elsif suggest_adding_feeds %>
-    <section class="space-y-4">
-      <h1 class="text-4xl font-semibold mb-0 text-slate-900">Welcome to Feeder</h1>
-      <p class="text-slate-600">Great! You've added a FreeFeed access token. Now you can create your first feed.</p>
-      <div class="mt-8">
-        <%= link_to "Add feed", new_feed_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
-      </div>
-    </section>
+    <%= render "feeds/empty_state" %>
   <% else %>
     <h1 class="text-4xl font-semibold mb-0 text-slate-900">Status</h1>
     <%= render UserStatsComponent.new(user: @user) %>


### PR DESCRIPTION
Changes:

- Create `app/views/feeds/_empty_state.html.erb` partial to consolidate the empty state UI
- Replace inline empty state markup in `app/views/feeds/index.html.erb` with `render "empty_state"`
- Replace inline empty state markup in `app/views/statuses/show.html.erb` with `render "feeds/empty_state"`

This refactoring eliminates duplicate empty state markup and makes it easier to maintain consistent UI across the application.
