### PR TITLE
Left-align feeds/new form layout

### DIFF
--- a/app/views/feeds/new.html.erb
+++ b/app/views/feeds/new.html.erb
@@ -3,7 +3,7 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "New Feed") %>
 
-  <div class="max-w-3xl mx-auto">
+  <div class="max-w-2xl">
     <% if !active_access_tokens? %>
       <%= render "blocked_no_tokens" %>
     <% elsif @feed.url.present? %>


### PR DESCRIPTION
Changes:

- Switch `/feeds/new` form container from `max-w-3xl mx-auto` to `max-w-2xl` so the form aligns on the left with a limited max width, matching `/access_tokens/new`, `/admin/users/:id/email_update/edit`, `/settings/email_update/edit`, and `/settings/password_update/edit`.
