### PR TITLE
Remove solargraph gem from development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,6 @@ group :development, :test do
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 
-  gem "solargraph"
-
   # Test data factories [https://github.com/thoughtbot/factory_bot]
   gem "factory_bot_rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,13 +109,11 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     attr_extras (7.1.0)
-    backport (1.2.0)
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     bcrypt_pbkdf (1.1.2-arm64-darwin)
     bcrypt_pbkdf (1.1.2-x86_64-darwin)
-    benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.24.3)
@@ -189,7 +187,6 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jaro_winkler (1.7.0)
     json (2.19.5)
     kamal (2.11.0)
       activesupport (>= 7.0)
@@ -202,10 +199,6 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
-    kramdown (2.5.2)
-      rexml (>= 3.4.4)
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -271,8 +264,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
-    observer (0.1.2)
-    open3 (0.2.1)
     optimist (3.2.1)
     ostruct (0.6.3)
     parallel (2.1.0)
@@ -337,8 +328,6 @@ GEM
     resend (1.3.0)
       base64
       httparty (>= 0.22.0)
-    reverse_markdown (3.0.2)
-      nokogiri
     rexml (3.4.4)
     rouge (4.7.0)
     rubocop (1.86.2)
@@ -385,29 +374,6 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    solargraph (0.59.0)
-      ast (~> 2.4.3)
-      backport (~> 1.2)
-      benchmark (~> 0.4)
-      bundler (>= 2.0)
-      diff-lcs (~> 1.4)
-      jaro_winkler (~> 1.6, >= 1.6.1)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      logger (~> 1.6)
-      observer (~> 0.1)
-      open3 (~> 0.2.1)
-      ostruct (~> 0.6)
-      parser (~> 3.0)
-      prism (~> 1.4)
-      rbs (>= 3.10.0)
-      reverse_markdown (~> 3.0)
-      rubocop (~> 1.76)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9, >= 0.9.24)
-      yard-activesupport-concern (~> 0.0)
-      yard-solargraph (~> 0.1)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -447,7 +413,6 @@ GEM
     thruster (0.1.20-arm64-darwin)
     thruster (0.1.20-x86_64-darwin)
     thruster (0.1.20-x86_64-linux)
-    tilt (2.7.0)
     timeout (0.6.1)
     tsort (0.2.0)
     turbo-rails (2.0.23)
@@ -479,11 +444,6 @@ GEM
     with_advisory_lock (7.5.0)
       activerecord (>= 7.2)
       zeitwerk (>= 2.7)
-    yard (0.9.43)
-    yard-activesupport-concern (0.0.1)
-      yard (>= 0.8)
-    yard-solargraph (0.1.0)
-      yard (~> 0.9)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -528,7 +488,6 @@ DEPENDENCIES
   ruby-lsp
   simplecov
   simplecov-cobertura
-  solargraph
   solid_cable
   solid_cache
   solid_queue (~> 1.2)
@@ -544,4 +503,4 @@ DEPENDENCIES
   with_advisory_lock
 
 BUNDLED WITH
-   4.0.11
+  4.0.11


### PR DESCRIPTION
Changes:

- Remove `solargraph` from the `:development, :test` group in the Gemfile
- Regenerate `Gemfile.lock` (drops `solargraph` and its transitive `yard-solargraph`)
