### PR TITLE
Spec update: use ruby_llm gem instead of direct anthropic SDK

### DIFF
--- a/specs/001-smart-feed-creation/contracts/detection.md
+++ b/specs/001-smart-feed-creation/contracts/detection.md
@@ -48,7 +48,7 @@ For each matcher whose input_shape ∈ {input_shape, :any}:
 Sort candidates by:
   primary:   depends_on_ai ASC                 # non-AI before AI
   secondary: match_specificity DESC            # specific before generic
-  tertiary:  registration order ASC            # stable tiebreaker
+  tertiary:  registration order ASC            # = index in FeedProfile::PROFILES insertion order
 
 Assign rank = index after sort.
 Record rank_reason as one of:

--- a/specs/001-smart-feed-creation/contracts/llm_client.md
+++ b/specs/001-smart-feed-creation/contracts/llm_client.md
@@ -54,34 +54,34 @@ Raises (after writing the LlmUsage row with the appropriate `outcome`):
 2. **Always writes one `LlmUsage` row.** Success or failure, the row gets written before the method returns or raises. The row carries the snapshot of `model`, `provider`, `purpose`, and outcome enum.
 3. **Schema-validates output.** A response that doesn't match `output_schema` raises `SchemaError`; no malformed payload is ever returned to the caller.
 4. **Reports unexpected errors.** Provider errors and timeouts go through `Rails.error.report` with `feed_id`, `profile_key`, `provider`, `model`, `stage`, `purpose` context. `SchemaError` and `RateLimited` are *expected* failures and use `Rails.error.handle` instead (already inside the client's `rescue` block).
-5. **Adapts to provider.** The `LlmClient::Anthropic` adapter implements forced tool use (declare a tool whose `input_schema` is `output_schema`, set `tool_choice: {type: "tool", name: ...}`, return the tool's `input` as `payload`). Future `LlmClient::OpenAI` adapter uses `response_format: {type: "json_schema", ...}`. Adapters MUST surface usage tokens (`input_tokens`, `output_tokens`, `cache_read_tokens` where applicable) for `LlmUsage`.
+5. **Adapts to provider via RubyLLM.** A single `LlmClient::Adapter` wraps the `ruby_llm` gem and asks it for structured output given the profile's `output_schema`. Provider-specific dispatch (Anthropic forced tool use; OpenAI `response_format: json_schema`; Gemini equivalent) is RubyLLM's responsibility, not ours. The adapter surfaces usage tokens (`input_tokens`, `output_tokens`, `cache_read_tokens` where applicable — e.g. Anthropic prompt-cache hits) for `LlmUsage`.
 6. **Cost computation.** Adapters return raw token counts; `LlmClient` looks up the per-model rate from `config/llm_rates.yml` (loaded at boot) and writes `cost_estimate_cents` into the usage row. Rate-table changes never alter historical rows.
 7. **Detection guard.** `LlmClient.call` raises `LlmClient::DetectionForbidden` if invoked from a thread / fiber tagged with `Thread.current[:llm_detection_phase] = true`. `FeedProfileDetector` sets and clears this flag. Belt-and-suspenders for FR-007 / SC-004.
 
-## Provider adapter interface
+## Adapter interface
 
-Each `LlmClient::<Provider>` adapter implements:
+`LlmClient::Adapter` (one class, multi-provider via RubyLLM) implements:
 
 ```ruby
-def call(model:, prompt:, output_schema:, tools:, deadline:)
+def call(provider:, model:, prompt:, output_schema:, tools:, deadline:)
   # → AdapterResponse.new(payload: Hash, input_tokens:, output_tokens:, cache_read_tokens:)
   # raises ProviderError, RateLimited, Timeout, SchemaError
 end
 
-def health_check
+def health_check(provider:)
   # cheap "are credentials usable" call; used by LlmCredentialValidationJob
   # → true | raises ProviderError
 end
 ```
 
-Adapters do not write `LlmUsage`; the top-level `LlmClient` does (so the schema/usage-row write is one place).
+The `provider` argument selects the RubyLLM provider config; the adapter is otherwise provider-agnostic. The adapter does not write `LlmUsage`; the top-level `LlmClient` does (so the schema/usage-row write is one place).
 
 ## Test contract
 
 - `LlmClient` unit tests use `Minitest::Mock` to stub the adapter; they assert: usage row written on success and on each failure mode; schema validation runs; detection guard fires.
-- `LlmClient::Anthropic` adapter tests use `WebMock` with fixture responses: success path, schema-violation path, 429 path, 500 path, timeout path.
+- `LlmClient::Adapter` tests use `WebMock` with fixture responses per provider that has a registered profile: success, schema violation, 429, 500, timeout. Anthropic-specific assertions cover prompt-cache token surfacing and `web_search` / `web_fetch` server tool pass-through.
 - Stage tests stub `LlmClient.for(...)` to return a mock with prescripted `call` responses; they never touch the adapter.
 
 ## Migration notes
 
-The first AI-using profile (`llm_website_extractor`) ships in the same task that introduces `LlmClient::Anthropic`. The client + adapter + first profile move together so the seam is exercised end-to-end immediately.
+The first AI-using profile (`llm_website_extractor`) ships in the same task that introduces `LlmClient::Adapter`. The client + adapter + first profile move together so the seam is exercised end-to-end immediately.

--- a/specs/001-smart-feed-creation/contracts/llm_client.md
+++ b/specs/001-smart-feed-creation/contracts/llm_client.md
@@ -54,34 +54,19 @@ Raises (after writing the LlmUsage row with the appropriate `outcome`):
 2. **Always writes one `LlmUsage` row.** Success or failure, the row gets written before the method returns or raises. The row carries the snapshot of `model`, `provider`, `purpose`, and outcome enum.
 3. **Schema-validates output.** A response that doesn't match `output_schema` raises `SchemaError`; no malformed payload is ever returned to the caller.
 4. **Reports unexpected errors.** Provider errors and timeouts go through `Rails.error.report` with `feed_id`, `profile_key`, `provider`, `model`, `stage`, `purpose` context. `SchemaError` and `RateLimited` are *expected* failures and use `Rails.error.handle` instead (already inside the client's `rescue` block).
-5. **Adapts to provider via RubyLLM.** A single `LlmClient::Adapter` wraps the `ruby_llm` gem and asks it for structured output given the profile's `output_schema`. Provider-specific dispatch (Anthropic forced tool use; OpenAI `response_format: json_schema`; Gemini equivalent) is RubyLLM's responsibility, not ours. The adapter surfaces usage tokens (`input_tokens`, `output_tokens`, `cache_read_tokens` where applicable — e.g. Anthropic prompt-cache hits) for `LlmUsage`.
-6. **Cost computation.** Adapters return raw token counts; `LlmClient` looks up the per-model rate from `config/llm_rates.yml` (loaded at boot) and writes `cost_estimate_cents` into the usage row. Rate-table changes never alter historical rows.
+5. **Adapts to provider via RubyLLM.** `LlmClient.call` invokes the `ruby_llm` gem directly with the profile's `output_schema`. Provider-specific dispatch (Anthropic forced tool use; OpenAI `response_format: json_schema`; Gemini equivalent) is RubyLLM's responsibility, not ours. `LlmClient` translates RubyLLM exceptions into its own hierarchy (`ProviderError` / `RateLimited` / `Timeout` / `SchemaError`) and pulls usage tokens (`input_tokens`, `output_tokens`, `cache_read_tokens` where applicable — e.g. Anthropic prompt-cache hits) from the RubyLLM response.
+6. **Cost computation.** `LlmClient` reads raw token counts from the RubyLLM response, looks up the per-model rate from `config/llm_rates.yml` (loaded at boot), and writes `cost_estimate_cents` into the usage row. Rate-table changes never alter historical rows.
 7. **Detection guard.** `LlmClient.call` raises `LlmClient::DetectionForbidden` if invoked from a thread / fiber tagged with `Thread.current[:llm_detection_phase] = true`. `FeedProfileDetector` sets and clears this flag. Belt-and-suspenders for FR-007 / SC-004.
 
-## Adapter interface
+## Health check
 
-`LlmClient::Adapter` (one class, multi-provider via RubyLLM) implements:
-
-```ruby
-def call(provider:, model:, prompt:, output_schema:, tools:, deadline:)
-  # → AdapterResponse.new(payload: Hash, input_tokens:, output_tokens:, cache_read_tokens:)
-  # raises ProviderError, RateLimited, Timeout, SchemaError
-end
-
-def health_check(provider:)
-  # cheap "are credentials usable" call; used by LlmCredentialValidationJob
-  # → true | raises ProviderError
-end
-```
-
-The `provider` argument selects the RubyLLM provider config; the adapter is otherwise provider-agnostic. The adapter does not write `LlmUsage`; the top-level `LlmClient` does (so the schema/usage-row write is one place).
+`LlmClient.for(credential).health_check` performs a cheap "are credentials usable" call (used by `LlmCredentialValidationJob`). Returns `true` on success; raises `ProviderError` otherwise. Writes one `LlmUsage` row per call with `feed_id: nil`, `stage: :validation`, `purpose: :validation`, `outcome: :success | :provider_error | :rate_limited | :timeout` — so the audit trail covers every validation attempt and its cost.
 
 ## Test contract
 
-- `LlmClient` unit tests use `Minitest::Mock` to stub the adapter; they assert: usage row written on success and on each failure mode; schema validation runs; detection guard fires.
-- `LlmClient::Adapter` tests use `WebMock` with fixture responses per provider that has a registered profile: success, schema violation, 429, 500, timeout. Anthropic-specific assertions cover prompt-cache token surfacing and `web_search` / `web_fetch` server tool pass-through.
-- Stage tests stub `LlmClient.for(...)` to return a mock with prescripted `call` responses; they never touch the adapter.
+- `LlmClient` unit tests use `WebMock` (with RubyLLM driving HTTP) for end-to-end paths per provider that has a registered profile: success, schema violation, 429, 500, timeout. Assertions cover: usage row written on success and on each failure mode; schema validation fires; detection guard fires; Anthropic-specific prompt-cache token surfacing and `web_search` / `web_fetch` server tool pass-through.
+- Stage tests stub `LlmClient.for(...)` to return a mock with prescripted `call` responses; they never touch RubyLLM directly.
 
 ## Migration notes
 
-The first AI-using profile (`llm_website_extractor`) ships in the same task that introduces `LlmClient::Adapter`. The client + adapter + first profile move together so the seam is exercised end-to-end immediately.
+The first AI-using profile (`llm_website_extractor`) ships in the same task that introduces `LlmClient`. The client + first profile move together so the seam is exercised end-to-end immediately.

--- a/specs/001-smart-feed-creation/contracts/preview.md
+++ b/specs/001-smart-feed-creation/contracts/preview.md
@@ -69,9 +69,16 @@ When `cache_key` is provided and `refresh: false`:
 - Cache hit → return the cached `Preview` immediately. No LLM call. No `LlmUsage` row written.
 - Cache miss → compute preview, write to cache, return.
 
-Cache key construction (computed by caller, not service): `Digest::SHA256.hexdigest("preview:#{feed_detail_id}:#{profile_key}:#{params.to_json}")`. TTL: 24 hours (longer than any reasonable in-progress flow; cleaned eagerly when feed is saved or feed_detail is destroyed).
+Cache key construction (computed by caller, not service): `Digest::SHA256.hexdigest("preview:#{feed_detail_id}:#{profile_key}:#{params.to_json}")`. TTL: 24 hours (longer than any reasonable in-progress flow).
 
-`refresh: true` is the "Refresh preview" button: bust the cache for the key, recompute, write fresh.
+**Invalidation**:
+1. `FeedDetailsController#destroy` (the user-initiated cancel from T032) deletes the entry as part of `cleanup_feed_identification`.
+2. `FeedsController#create` deletes the entry in the same `cleanup_feed_identification` call after the feed is saved.
+3. `FeedsController#update` deletes the entry when a source-side field changes (the same code path that re-runs detection per FR-026 / FR-027).
+4. `refresh: true` is the "Refresh preview" button: bust the cache for the key, recompute, write fresh.
+5. TTL expiry (24h) is the backstop for cases none of the above fire (user closed the tab).
+
+A saved feed being edited never reuses an old preview cache entry — the feed-edit flow starts a fresh `FeedDetail` so the cache key (which embeds `feed_detail_id`) is necessarily different.
 
 ## Background execution
 

--- a/specs/001-smart-feed-creation/data-model.md
+++ b/specs/001-smart-feed-creation/data-model.md
@@ -221,22 +221,22 @@ loader: {
 
 ## 8. Provider registry (new, code-only)
 
-Parallel to `FeedProfile` for AI providers. Drives the credential form generator and the `LlmClient` adapter routing.
+Parallel to `FeedProfile` for AI providers. Drives the credential form generator and tells `LlmClient::Adapter` which RubyLLM provider key to use. There is no per-provider adapter class — RubyLLM handles provider dispatch from this string.
 
 ```ruby
 module LlmProvider
   PROVIDERS = {
     "anthropic" => {
       display_name: "Anthropic (Claude)",
-      adapter: "LlmClient::Anthropic",
+      ruby_llm_provider: :anthropic,
       credential_schema: {
         "type" => "object",
         "properties" => { "api_key" => { "type" => "string", "minLength" => 10 } },
         "required" => ["api_key"]
       },
-      validate_call: ->(client) { client.health_check }
+      validate_call: ->(client) { client.health_check(provider: "anthropic") }
     }
-    # OpenAI, OpenAI-compatible: future entries.
+    # OpenAI, Gemini, OpenAI-compatible: future entries.
   }.freeze
 end
 ```

--- a/specs/001-smart-feed-creation/data-model.md
+++ b/specs/001-smart-feed-creation/data-model.md
@@ -61,6 +61,7 @@ Feed ─── has_many :llm_usages │ (nullable feed_id for previews)
 - Created → enqueues validation job → moves to `validating` → settles to `active` or `inactive`.
 - Marking another credential default un-defaults the previous one in the same transaction (`before_save` callback).
 - Destroying a credential: nullifies `feeds.llm_credential_id`; for any feed left in `enabled` state without a usable credential, the feed is moved to `disabled` with an audit Event (existing pattern from `AccessToken#disable_associated_feeds`).
+- `active → inactive` transition (provider revoked the key, or scheduled re-validation failed): same cascade as destroy — for any `enabled` feed using this credential and lacking another acceptable credential, move the feed to `disabled` with an audit Event. The credential row stays; only its reachability into `enabled` feeds is severed. User can fix the credential and re-enable the feed.
 
 **Indexes**:
 - `(user_id, provider, display_name)` unique
@@ -221,7 +222,7 @@ loader: {
 
 ## 8. Provider registry (new, code-only)
 
-Parallel to `FeedProfile` for AI providers. Drives the credential form generator and tells `LlmClient::Adapter` which RubyLLM provider key to use. There is no per-provider adapter class — RubyLLM handles provider dispatch from this string.
+Parallel to `FeedProfile` for AI providers. Drives the credential form generator and tells `LlmClient` which RubyLLM provider key to use. RubyLLM handles provider dispatch from this string; there is no per-provider class.
 
 ```ruby
 module LlmProvider
@@ -234,7 +235,7 @@ module LlmProvider
         "properties" => { "api_key" => { "type" => "string", "minLength" => 10 } },
         "required" => ["api_key"]
       },
-      validate_call: ->(client) { client.health_check(provider: "anthropic") }
+      validate_call: ->(client) { client.health_check }
     }
     # OpenAI, Gemini, OpenAI-compatible: future entries.
   }.freeze

--- a/specs/001-smart-feed-creation/plan.md
+++ b/specs/001-smart-feed-creation/plan.md
@@ -22,7 +22,7 @@ The work spans parent-spec phases 1, 2, 3, and 5, but is sliced here so Story 1 
 
 **Language/Version**: Ruby (pinned in `.ruby-version`, managed by mise)
 
-**Primary Dependencies**: Rails edge, Turbo, Stimulus, Tailwind CSS + DaisyUI, SolidQueue, Feedjira (RSS parsing, existing), Nokogiri (existing), `httpx`/internal `HttpClient` (existing). New: `ruby_llm` gem for the multi-provider LLM adapter (Anthropic first, OpenAI / others follow as registry entries); `json_schemer` for parameter and LLM-output validation.
+**Primary Dependencies**: Rails edge, Turbo, Stimulus, Tailwind CSS + DaisyUI, SolidQueue, Feedjira (RSS parsing, existing), Nokogiri (existing), `httpx`/internal `HttpClient` (existing). New: `ruby_llm` gem (multi-provider LLM SDK; Anthropic first, OpenAI / others follow as registry entries); `json_schemer` for parameter and LLM-output validation.
 
 **Storage**: PostgreSQL via Rails migrations. New tables: `llm_credentials`, `llm_usages`. Modified tables: `feed_details` (carry ranked-profile list), `feeds` (add `params` JSONB; per A6, no production data, free to drop `feeds.url` once profile params absorb it). Existing `feed_profile.rb` registry remains code-defined (parent-spec future-scope move to DB is deferred).
 
@@ -113,8 +113,7 @@ app/
 │   ├── feed_profile_detector.rb             (mod) — return ranked array, not first hit
 │   ├── feed_details_fetcher.rb              (mod) — drive new detector contract
 │   ├── feed_preview_service.rb              (new) — bounded loader→processor→normalizer; non-persistent
-│   ├── llm_client.rb                        (new) — chokepoint for all AI calls; writes LlmUsage
-│   ├── llm_client/adapter.rb                (new) — single multi-provider adapter wrapping ruby_llm
+│   ├── llm_client.rb                        (new) — chokepoint for all AI calls; wraps ruby_llm; writes LlmUsage
 │   ├── profile_matcher/
 │   │   ├── base.rb                          (mod) — declare input_shape; rank() helper
 │   │   ├── xkcd_profile_matcher.rb          (mod) — declare input_shape: :url
@@ -161,12 +160,12 @@ test/
 ├── models/                                  — llm_credential_test.rb, llm_usage_test.rb, feed_test.rb (mod), feed_detail_test.rb (mod)
 ├── controllers/                             — feed_details, feeds, feed_previews, llm_credentials
 ├── jobs/                                    — feed_details_job (mod), feed_preview_job, llm_credential_validation_job
-├── services/                                — input_classifier, feed_profile_detector (mod), feed_preview_service, llm_client, llm_client/adapter, profile_matcher/* (mod + new), loader/llm_loader, processor/passthrough_processor, normalizer/llm_normalizer
+├── services/                                — input_classifier, feed_profile_detector (mod), feed_preview_service, llm_client, profile_matcher/* (mod + new), loader/llm_loader, processor/passthrough_processor, normalizer/llm_normalizer
 ├── system/                                  — smart_feed_creation_test.rb (Story 1, Story 2 happy paths end-to-end)
 └── factories/                               — llm_credential, llm_usage
 ```
 
-**Structure Decision**: Standard Rails monolith layout (CLAUDE.md says "Follow standard Rails conventions"). All new work fits under existing `app/{models,controllers,services,views,jobs}` with new sub-namespaces (`Loader::LlmLoader`, `Normalizer::LlmNormalizer`, `LlmClient::Adapter`) where they parallel existing namespaces. No new top-level directories needed.
+**Structure Decision**: Standard Rails monolith layout (CLAUDE.md says "Follow standard Rails conventions"). All new work fits under existing `app/{models,controllers,services,views,jobs}` with new sub-namespaces (`Loader::LlmLoader`, `Normalizer::LlmNormalizer`) where they parallel existing namespaces. `LlmClient` is the only chokepoint for AI calls and lives at `app/services/llm_client.rb` with no sub-namespace. No new top-level directories needed.
 
 ## Complexity Tracking
 

--- a/specs/001-smart-feed-creation/plan.md
+++ b/specs/001-smart-feed-creation/plan.md
@@ -22,7 +22,7 @@ The work spans parent-spec phases 1, 2, 3, and 5, but is sliced here so Story 1 
 
 **Language/Version**: Ruby (pinned in `.ruby-version`, managed by mise)
 
-**Primary Dependencies**: Rails edge, Turbo, Stimulus, Tailwind CSS + DaisyUI, SolidQueue, Feedjira (RSS parsing, existing), Nokogiri (existing), `httpx`/internal `HttpClient` (existing). New: `anthropic` Ruby gem (or raw HTTP via existing `HttpClient`) for the Anthropic adapter; JSON Schema validator (`json-schema` or `json_schemer`) for parameter and LLM-output validation.
+**Primary Dependencies**: Rails edge, Turbo, Stimulus, Tailwind CSS + DaisyUI, SolidQueue, Feedjira (RSS parsing, existing), Nokogiri (existing), `httpx`/internal `HttpClient` (existing). New: `ruby_llm` gem for the multi-provider LLM adapter (Anthropic first, OpenAI / others follow as registry entries); `json_schemer` for parameter and LLM-output validation.
 
 **Storage**: PostgreSQL via Rails migrations. New tables: `llm_credentials`, `llm_usages`. Modified tables: `feed_details` (carry ranked-profile list), `feeds` (add `params` JSONB; per A6, no production data, free to drop `feeds.url` once profile params absorb it). Existing `feed_profile.rb` registry remains code-defined (parent-spec future-scope move to DB is deferred).
 
@@ -114,7 +114,7 @@ app/
 │   ├── feed_details_fetcher.rb              (mod) — drive new detector contract
 │   ├── feed_preview_service.rb              (new) — bounded loader→processor→normalizer; non-persistent
 │   ├── llm_client.rb                        (new) — chokepoint for all AI calls; writes LlmUsage
-│   ├── llm_client/anthropic.rb              (new) — provider adapter (forced tool use for structured output)
+│   ├── llm_client/adapter.rb                (new) — single multi-provider adapter wrapping ruby_llm
 │   ├── profile_matcher/
 │   │   ├── base.rb                          (mod) — declare input_shape; rank() helper
 │   │   ├── xkcd_profile_matcher.rb          (mod) — declare input_shape: :url
@@ -161,12 +161,12 @@ test/
 ├── models/                                  — llm_credential_test.rb, llm_usage_test.rb, feed_test.rb (mod), feed_detail_test.rb (mod)
 ├── controllers/                             — feed_details, feeds, feed_previews, llm_credentials
 ├── jobs/                                    — feed_details_job (mod), feed_preview_job, llm_credential_validation_job
-├── services/                                — input_classifier, feed_profile_detector (mod), feed_preview_service, llm_client, llm_client/anthropic, profile_matcher/* (mod + new), loader/llm_loader, processor/passthrough_processor, normalizer/llm_normalizer
+├── services/                                — input_classifier, feed_profile_detector (mod), feed_preview_service, llm_client, llm_client/adapter, profile_matcher/* (mod + new), loader/llm_loader, processor/passthrough_processor, normalizer/llm_normalizer
 ├── system/                                  — smart_feed_creation_test.rb (Story 1, Story 2 happy paths end-to-end)
 └── factories/                               — llm_credential, llm_usage
 ```
 
-**Structure Decision**: Standard Rails monolith layout (CLAUDE.md says "Follow standard Rails conventions"). All new work fits under existing `app/{models,controllers,services,views,jobs}` with new sub-namespaces (`Loader::LlmLoader`, `Normalizer::LlmNormalizer`, `LlmClient::Anthropic`) where they parallel existing namespaces. No new top-level directories needed.
+**Structure Decision**: Standard Rails monolith layout (CLAUDE.md says "Follow standard Rails conventions"). All new work fits under existing `app/{models,controllers,services,views,jobs}` with new sub-namespaces (`Loader::LlmLoader`, `Normalizer::LlmNormalizer`, `LlmClient::Adapter`) where they parallel existing namespaces. No new top-level directories needed.
 
 ## Complexity Tracking
 

--- a/specs/001-smart-feed-creation/quickstart.md
+++ b/specs/001-smart-feed-creation/quickstart.md
@@ -54,7 +54,7 @@ Sign in (or `bin/rails console`-create) a user with at least one **active** Free
 ### 2c. Save anyway after preview failure
 
 1. Add a deliberately-bad Anthropic credential (e.g., a syntactically valid but unauthorized key). Save → settles to `inactive` with a clear error.
-2. Use a working credential to start a feed creation that *will* fail at preview time — easiest reproduction: set `Loader::LlmLoader` to use a deliberately-impossible source URL via the form, or stub `LlmClient::Anthropic` in a console test.
+2. Use a working credential to start a feed creation that *will* fail at preview time — easiest reproduction: set `Loader::LlmLoader` to use a deliberately-impossible source URL via the form, or stub `LlmClient::Adapter` in a console test.
 3. **Expect**: preview pane shows the failure message and "Save as disabled" button.
 4. Click "Save as disabled". **Confirm** feed exists with `state = disabled`.
 5. From the feed show page, click "Enable" — **confirm** the system re-runs preview before flipping to `enabled`.

--- a/specs/001-smart-feed-creation/quickstart.md
+++ b/specs/001-smart-feed-creation/quickstart.md
@@ -54,7 +54,7 @@ Sign in (or `bin/rails console`-create) a user with at least one **active** Free
 ### 2c. Save anyway after preview failure
 
 1. Add a deliberately-bad Anthropic credential (e.g., a syntactically valid but unauthorized key). Save → settles to `inactive` with a clear error.
-2. Use a working credential to start a feed creation that *will* fail at preview time — easiest reproduction: set `Loader::LlmLoader` to use a deliberately-impossible source URL via the form, or stub `LlmClient::Adapter` in a console test.
+2. Use a working credential to start a feed creation that *will* fail at preview time — easiest reproduction: set `Loader::LlmLoader` to use a deliberately-impossible source URL via the form, or stub `LlmClient` in a console test.
 3. **Expect**: preview pane shows the failure message and "Save as disabled" button.
 4. Click "Save as disabled". **Confirm** feed exists with `state = disabled`.
 5. From the feed show page, click "Enable" — **confirm** the system re-runs preview before flipping to `enabled`.

--- a/specs/001-smart-feed-creation/research.md
+++ b/specs/001-smart-feed-creation/research.md
@@ -93,18 +93,22 @@ ALTER TABLE feed_details ADD COLUMN candidates JSONB NOT NULL DEFAULT '[]';
 
 ## 5. LLM client: SDK choice and structured output
 
-**Decision**: Implement `LlmClient` as a thin Ruby service over the **`anthropic` Ruby gem** (Anthropic-published) for v1. Structured output via **forced tool use**: declare a tool whose `input_schema` is the profile's `output_schema`, set `tool_choice: {type: "tool", name: "..."}`, return the tool's `input` as the response payload.
+**Decision**: Implement `LlmClient` as a thin Ruby service over the **`ruby_llm` gem**, a maintained multi-provider abstraction (Anthropic, OpenAI, Gemini, Bedrock, OpenRouter, Ollama). The first provider shipped is Anthropic; OpenAI and others land later as registry entries with no new adapter code. Structured output is delegated to RubyLLM, which internally uses each provider's native mechanism (forced tool use for Anthropic, `response_format: json_schema` for OpenAI) so our code stays provider-agnostic.
 
-Provider adapters live under `app/services/llm_client/<provider>.rb`. The top-level `LlmClient.for(feed)` resolves the user's credential, selects the adapter, and returns a uniform interface to stage classes.
+A single `app/services/llm_client/adapter.rb` wraps RubyLLM; the per-provider seam collapses into one file. The top-level `LlmClient.for(feed)` resolves the user's credential, configures RubyLLM with the credential's API key, and returns a uniform interface to stage classes.
 
-**Rationale**: The official Anthropic gem handles auth, retries, and the latest API surface (server-side web search/fetch tools, prompt caching). Forced tool use is Anthropic's documented pattern for guaranteed structured output and allows mixing in provider-side server tools (web search, web fetch) for AI loaders without a client-side tool loop. Single HTTP request out → single response in, with usage data populated for `LlmUsage`.
+**Rationale**: The spec's "two-axis" abstraction (credentials × providers) is exactly what RubyLLM is built for. Writing one adapter per provider would duplicate the work RubyLLM already does; switching SDKs lets us add providers as registry rows instead of code. RubyLLM exposes per-provider features critical to this spec: prompt-cache token counts (`cache_read_input_tokens` for Anthropic), provider-side server tools (Anthropic `web_search` / `web_fetch`), structured output via JSON Schema, and normalized usage telemetry. Our `LlmClient` shrinks to the parts that *should* be ours: credential resolution, `LlmUsage` persistence, schema validation via JSONSchemer, the detection-phase guard, and `Rails.error.report` routing.
 
-**Test strategy**: At the `LlmClient` seam — stage tests stub `LlmClient` with `Minitest::Mock` returning canned `(structured_output, usage)` tuples. The Anthropic adapter has its own contract tests using `WebMock` to simulate provider responses (success, schema violation, provider error, rate limit). No VCR; cassettes drift and obscure intent.
+**Test strategy**: At the `LlmClient` seam — stage tests stub `LlmClient` with `Minitest::Mock` returning canned `(structured_output, usage)` tuples. The RubyLLM adapter has its own contract tests using `WebMock` to simulate provider responses (success, schema violation, provider error, rate limit), one fixture set per provider that has a profile in the registry. No VCR; cassettes drift and obscure intent.
 
 **Alternatives considered**:
-- *Raw HTTP via existing `HttpClient`*: works, but means tracking the API surface manually (tools, prompt caching, batch). Reject for v1.
-- *`ruby-openai` style multi-provider gem*: doesn't cover Anthropic's forced tool use uniformly; we'd still need the adapter layer. Reject.
+- *Direct `anthropic` Ruby gem*: works, but every new provider needs a hand-written adapter that re-derives auth/retry/tool/cache plumbing. Reject — RubyLLM removes that duplication.
+- *Raw HTTP via existing `HttpClient`*: tracks every provider's API surface manually. Reject for v1.
 - *VCR cassettes for adapter tests*: cassettes go stale, mask intent, and require periodic re-recording with real keys in CI. WebMock-with-fixtures is more maintainable.
+
+**Caveats**:
+- Solo-maintainer dependency. Pin a known-good version and review release notes before upgrading.
+- Provider-specific quirks (new Anthropic server tools, vendor changes) may briefly lag the underlying API. If a profile needs a feature RubyLLM doesn't expose yet, an escape hatch is to bypass the wrapper for that one call — but we should treat that as exceptional, not a default.
 
 ---
 
@@ -228,7 +232,7 @@ Classification rules:
 | JSON Schema dialect | Parent spec, phase 1 | Draft 2020-12 via `json_schemer` |
 | `Feed.url` migration | Parent spec, phase 1 | Drop column; absorb into `feeds.params` |
 | Detection record schema | Handoff D6 | `feed_details.candidates` JSONB; mirror recommended into existing `feed_profile_key` |
-| LLM SDK + structured output | Plan-time | `anthropic` gem; forced tool use; adapters under `LlmClient::*` |
+| LLM SDK + structured output | Plan-time | `ruby_llm` gem (multi-provider); single adapter at `LlmClient::Adapter` delegating provider-specific structured-output dispatch |
 | Credential storage | Parent spec, phase 2 | JSONB encrypted via Rails `encrypts`; provider-specific schema |
 | Default-credential uniqueness | Spec FR-013 | Partial unique index + model callback |
 | Preview implementation | Spec FR-014–019 | Reuse `FeedRefreshWorkflow` with `preview: true` mode |

--- a/specs/001-smart-feed-creation/research.md
+++ b/specs/001-smart-feed-creation/research.md
@@ -95,11 +95,11 @@ ALTER TABLE feed_details ADD COLUMN candidates JSONB NOT NULL DEFAULT '[]';
 
 **Decision**: Implement `LlmClient` as a thin Ruby service over the **`ruby_llm` gem**, a maintained multi-provider abstraction (Anthropic, OpenAI, Gemini, Bedrock, OpenRouter, Ollama). The first provider shipped is Anthropic; OpenAI and others land later as registry entries with no new adapter code. Structured output is delegated to RubyLLM, which internally uses each provider's native mechanism (forced tool use for Anthropic, `response_format: json_schema` for OpenAI) so our code stays provider-agnostic.
 
-A single `app/services/llm_client/adapter.rb` wraps RubyLLM; the per-provider seam collapses into one file. The top-level `LlmClient.for(feed)` resolves the user's credential, configures RubyLLM with the credential's API key, and returns a uniform interface to stage classes.
+`LlmClient` invokes RubyLLM directly — no separate adapter class. `LlmClient.for(feed)` resolves the user's credential, configures RubyLLM with the credential's API key and provider, and returns a client bound to that credential. `LlmClient.call` then handles schema validation, `LlmUsage` write, exception mapping, and the detection guard. Stage classes never see the provider name or RubyLLM.
 
 **Rationale**: The spec's "two-axis" abstraction (credentials × providers) is exactly what RubyLLM is built for. Writing one adapter per provider would duplicate the work RubyLLM already does; switching SDKs lets us add providers as registry rows instead of code. RubyLLM exposes per-provider features critical to this spec: prompt-cache token counts (`cache_read_input_tokens` for Anthropic), provider-side server tools (Anthropic `web_search` / `web_fetch`), structured output via JSON Schema, and normalized usage telemetry. Our `LlmClient` shrinks to the parts that *should* be ours: credential resolution, `LlmUsage` persistence, schema validation via JSONSchemer, the detection-phase guard, and `Rails.error.report` routing.
 
-**Test strategy**: At the `LlmClient` seam — stage tests stub `LlmClient` with `Minitest::Mock` returning canned `(structured_output, usage)` tuples. The RubyLLM adapter has its own contract tests using `WebMock` to simulate provider responses (success, schema violation, provider error, rate limit), one fixture set per provider that has a profile in the registry. No VCR; cassettes drift and obscure intent.
+**Test strategy**: Stage tests stub `LlmClient` with `Minitest::Mock` returning canned `(structured_output, usage)` tuples. `LlmClient` itself is tested end-to-end with `WebMock` against per-provider fixture responses (success, schema violation, provider error, rate limit, timeout). No VCR; cassettes drift and obscure intent.
 
 **Alternatives considered**:
 - *Direct `anthropic` Ruby gem*: works, but every new provider needs a hand-written adapter that re-derives auth/retry/tool/cache plumbing. Reject — RubyLLM removes that duplication.
@@ -232,7 +232,7 @@ Classification rules:
 | JSON Schema dialect | Parent spec, phase 1 | Draft 2020-12 via `json_schemer` |
 | `Feed.url` migration | Parent spec, phase 1 | Drop column; absorb into `feeds.params` |
 | Detection record schema | Handoff D6 | `feed_details.candidates` JSONB; mirror recommended into existing `feed_profile_key` |
-| LLM SDK + structured output | Plan-time | `ruby_llm` gem (multi-provider); single adapter at `LlmClient::Adapter` delegating provider-specific structured-output dispatch |
+| LLM SDK + structured output | Plan-time | `ruby_llm` gem (multi-provider); `LlmClient` calls it directly with no intermediate adapter class |
 | Credential storage | Parent spec, phase 2 | JSONB encrypted via Rails `encrypts`; provider-specific schema |
 | Default-credential uniqueness | Spec FR-013 | Partial unique index + model callback |
 | Preview implementation | Spec FR-014–019 | Reuse `FeedRefreshWorkflow` with `preview: true` mode |

--- a/specs/001-smart-feed-creation/tasks.md
+++ b/specs/001-smart-feed-creation/tasks.md
@@ -25,7 +25,7 @@ description: "Tasks: Smart Feed Creation"
 
 **Purpose**: Add new gems and shared scaffolding all subsequent phases depend on.
 
-- [ ] T001 Add `anthropic` gem to `Gemfile` and run `bundle install`; commit `Gemfile` + `Gemfile.lock`. (No test — dependency-only commit.)
+- [ ] T001 Add `ruby_llm` gem to `Gemfile` and run `bundle install`; commit `Gemfile` + `Gemfile.lock`. (No test — dependency-only commit.)
 - [X] T002 Add `json_schemer` gem to `Gemfile` and run `bundle install`; commit `Gemfile` + `Gemfile.lock`. (No test.)
 - [ ] T003 [P] Create `config/llm_rates.yml` with per-model token cost table (Anthropic models initially); add `app/services/llm_client/rate_table.rb` loader with test in `test/services/llm_client/rate_table_test.rb`.
 - [X] T004 [P] Add `test/support/feed_profile_validator.rb` (test helper) that validates the enriched `FeedProfile::PROFILES` shape using `json_schemer`; add `test/models/feed_profile_validator_test.rb` covering valid + malformed entries. (Registry is a frozen constant — covered in CI, no runtime boot hook needed.)
@@ -96,11 +96,11 @@ description: "Tasks: Smart Feed Creation"
 - [ ] T036 [P] [US2] Create migration `db/migrate/*_add_llm_credential_id_to_feeds.rb`: nullable FK + index. Reversibility verified.
 - [ ] T037 [US2] Create `app/models/llm_credential.rb` with `encrypts :credential_data`, validations (provider in registry, `display_name` uniqueness scoped to `(user_id, provider)`, `credential_data` validated against `LlmProvider::PROVIDERS[provider][:credential_schema]`), `is_default` callback un-defaulting siblings, `state` enum mirroring `AccessToken`. Factory in `test/factories/llm_credentials.rb`. Tests in `test/models/llm_credential_test.rb` cover validations, default uniqueness (including a partial-unique-index race test), encryption round-trip, schema validation per provider, destroy → nullify dependent feeds → disable feeds without other usable credentials.
 - [ ] T038 [US2] Create `app/models/llm_usage.rb` with associations and enums (`stage`, `purpose`, `outcome`). Factory in `test/factories/llm_usages.rb`. Tests in `test/models/llm_usage_test.rb` cover field validations and enum behavior.
-- [ ] T039 [US2] Create `app/models/llm_provider.rb` (code-only registry per data-model §8) with Anthropic entry: display_name, adapter class name, credential_schema (JSON Schema for `{api_key}`), `validate_call` lambda. Boot-time validation. Tests in `test/models/llm_provider_test.rb`.
+- [ ] T039 [US2] Create `app/models/llm_provider.rb` (code-only registry per data-model §8) with Anthropic entry: display_name, ruby_llm_provider symbol, credential_schema (JSON Schema for `{api_key}`), `validate_call` lambda. Tests in `test/models/llm_provider_test.rb`.
 
 ### LlmClient and adapter
 
-- [ ] T040 [US2] Create `app/services/llm_client/anthropic.rb` adapter implementing the per-provider interface from [`contracts/llm_client.md`](./contracts/llm_client.md): forced tool use for structured output; surfaces token usage. Tests in `test/services/llm_client/anthropic_test.rb` use `WebMock` with fixture responses for: success, schema-violation (raises `SchemaError`), 429 (raises `RateLimited` with `retry_after`), 5xx (raises `ProviderError`), timeout (raises `Timeout`).
+- [ ] T040 [US2] Create `app/services/llm_client/adapter.rb` wrapping the `ruby_llm` gem per [`contracts/llm_client.md`](./contracts/llm_client.md): one class, multi-provider via the `provider:` argument; delegates structured-output dispatch to RubyLLM; surfaces token usage (including `cache_read_tokens` for Anthropic prompt caching). Tests in `test/services/llm_client/adapter_test.rb` use `WebMock` with fixture responses for each registered provider: success, schema-violation (raises `SchemaError`), 429 (raises `RateLimited` with `retry_after`), 5xx (raises `ProviderError`), timeout (raises `Timeout`). Anthropic-specific assertions cover prompt-cache token surfacing and server-side `web_search` / `web_fetch` tool pass-through.
 - [ ] T041 [US2] Create `app/services/llm_client.rb` (top-level) per [`contracts/llm_client.md`](./contracts/llm_client.md): `for(feed)` / `for(user, provider)` / `for(credential)` factories; `call(...)` method that resolves credential → adapter → schema-validates response → writes `LlmUsage` row → returns `Result`. Detection guard (`raise DetectionForbidden if Thread.current[:llm_detection_phase]`). Reports unexpected errors via `Rails.error.report`. Tests in `test/services/llm_client_test.rb` use `Minitest::Mock` for the adapter; cover usage-row-on-success, usage-row-on-each-failure, schema validation, detection-guard fires, cost computation from rate table.
 
 ### Credentials UI and validation job
@@ -198,7 +198,7 @@ description: "Tasks: Smart Feed Creation"
 
 - T034–T036 (migrations) parallel; block T037, T038.
 - T039 (provider registry) parallel.
-- T040 (Anthropic adapter) parallel.
+- T040 (RubyLLM adapter) parallel.
 - T041 (LlmClient) depends on T039, T040.
 - T042 (validation job) depends on T041, T037.
 - T043–T046 (credentials controller/views/routes) depend on T037, T038; T045 depends on T037.

--- a/specs/001-smart-feed-creation/tasks.md
+++ b/specs/001-smart-feed-creation/tasks.md
@@ -98,14 +98,14 @@ description: "Tasks: Smart Feed Creation"
 - [ ] T038 [US2] Create `app/models/llm_usage.rb` with associations and enums (`stage`, `purpose`, `outcome`). Factory in `test/factories/llm_usages.rb`. Tests in `test/models/llm_usage_test.rb` cover field validations and enum behavior.
 - [ ] T039 [US2] Create `app/models/llm_provider.rb` (code-only registry per data-model §8) with Anthropic entry: display_name, ruby_llm_provider symbol, credential_schema (JSON Schema for `{api_key}`), `validate_call` lambda. Tests in `test/models/llm_provider_test.rb`.
 
-### LlmClient and adapter
+### LlmClient
 
-- [ ] T040 [US2] Create `app/services/llm_client/adapter.rb` wrapping the `ruby_llm` gem per [`contracts/llm_client.md`](./contracts/llm_client.md): one class, multi-provider via the `provider:` argument; delegates structured-output dispatch to RubyLLM; surfaces token usage (including `cache_read_tokens` for Anthropic prompt caching). Tests in `test/services/llm_client/adapter_test.rb` use `WebMock` with fixture responses for each registered provider: success, schema-violation (raises `SchemaError`), 429 (raises `RateLimited` with `retry_after`), 5xx (raises `ProviderError`), timeout (raises `Timeout`). Anthropic-specific assertions cover prompt-cache token surfacing and server-side `web_search` / `web_fetch` tool pass-through.
-- [ ] T041 [US2] Create `app/services/llm_client.rb` (top-level) per [`contracts/llm_client.md`](./contracts/llm_client.md): `for(feed)` / `for(user, provider)` / `for(credential)` factories; `call(...)` method that resolves credential → adapter → schema-validates response → writes `LlmUsage` row → returns `Result`. Detection guard (`raise DetectionForbidden if Thread.current[:llm_detection_phase]`). Reports unexpected errors via `Rails.error.report`. Tests in `test/services/llm_client_test.rb` use `Minitest::Mock` for the adapter; cover usage-row-on-success, usage-row-on-each-failure, schema validation, detection-guard fires, cost computation from rate table.
+- T040 — *Removed.* The per-provider adapter class was folded into `LlmClient` itself; RubyLLM is the multi-provider abstraction, so a separate adapter layer added no value.
+- [ ] T041 [US2] Create `app/services/llm_client.rb` per [`contracts/llm_client.md`](./contracts/llm_client.md): `for(feed)` / `for(user, provider)` / `for(credential)` factories; `call(...)` method that resolves credential → invokes `ruby_llm` with the credential's provider+key → schema-validates response via JSONSchemer → writes `LlmUsage` row → returns `Result`. Translates RubyLLM exceptions into `ProviderError` / `RateLimited` / `Timeout` / `SchemaError`. Detection guard (`raise DetectionForbidden if Thread.current[:llm_detection_phase]`). Reports unexpected errors via `Rails.error.report`. `health_check` method used by `LlmCredentialValidationJob`. Tests in `test/services/llm_client_test.rb` use `WebMock` with fixture responses per registered provider: success, schema-violation, 429, 500, timeout, detection-guard, cost computation from rate table. Anthropic-specific assertions cover prompt-cache token surfacing and server-side `web_search` / `web_fetch` pass-through.
 
 ### Credentials UI and validation job
 
-- [ ] T042 [US2] Create `app/jobs/llm_credential_validation_job.rb` calling `LlmClient.for(credential).call(...)` (using the adapter's `health_check`); writes `last_validated_at` / `last_error` / state. Tests in `test/jobs/llm_credential_validation_job_test.rb` cover happy path and provider-error path.
+- [ ] T042 [US2] Create `app/jobs/llm_credential_validation_job.rb` calling `LlmClient.for(credential).health_check`; writes `last_validated_at` / `last_error` / state. Tests in `test/jobs/llm_credential_validation_job_test.rb` cover happy path and provider-error path.
 - [ ] T043 [US2] Add `resources :llm_credentials, except: %i[edit update]` in `config/routes.rb` with nested `resource :validation, only: %i[show]` and `resource :default, only: %i[update]`. Routing tests in `test/routes/llm_credentials_routes_test.rb`.
 - [ ] T044 [US2] Create `app/controllers/llm_credentials_controller.rb` with `#index`, `#new`, `#show` (polling shell mirroring `AccessTokensController#show`), `#create` (enqueues validation job), `#destroy` (cascades per T037). Tests in `test/controllers/llm_credentials_controller_test.rb`.
 - [ ] T045 [US2] Create `app/controllers/llm_credentials/defaults_controller.rb` for `#update` ("Make default"): wraps the un-default-others + set-default in a single transaction, relies on the partial unique index. Returns Turbo Stream updating both rows' "Default" badges. Tests in `test/controllers/llm_credentials/defaults_controller_test.rb` cover set-default-when-none-exists, switch-default-from-another, attempt-to-double-default (DB rejects).
@@ -198,8 +198,7 @@ description: "Tasks: Smart Feed Creation"
 
 - T034–T036 (migrations) parallel; block T037, T038.
 - T039 (provider registry) parallel.
-- T040 (RubyLLM adapter) parallel.
-- T041 (LlmClient) depends on T039, T040.
+- T041 (LlmClient) depends on T039.
 - T042 (validation job) depends on T041, T037.
 - T043–T046 (credentials controller/views/routes) depend on T037, T038; T045 depends on T037.
 - T047–T049 (LLM stages) parallel after T041.
@@ -223,7 +222,7 @@ description: "Tasks: Smart Feed Creation"
 - After Setup completes: T005, T006 in parallel (different migrations); then T009, T010, T011, T012, T016, T017 in parallel.
 - After Foundational completes: Story 1 and Story 2 can be developed in parallel by separate developers.
 - Within Story 1: T021–T027 in parallel.
-- Within Story 2: T034–T036 in parallel; T039, T040 in parallel; T047–T049 in parallel; T050 in parallel.
+- Within Story 2: T034–T036 in parallel; T047–T049 in parallel; T050 in parallel.
 - Within Story 3: T057, T058 in parallel.
 - Within Polish: T063–T066 in parallel; T067 in parallel; T068 last.
 
@@ -247,4 +246,4 @@ description: "Tasks: Smart Feed Creation"
 - View partials are committed with their tests and any associated Stimulus controller in the same commit.
 - The **vocabulary firewall** test (T063) is intentionally cross-cutting; new view tasks (T023–T028, T046, T054, T055) include local vocabulary checks, but T063 is the catch-all backstop.
 - `data-key` attributes are used for all new test-targeted DOM elements (project convention from CLAUDE.md).
-- AI calls in tests are stubbed at the `LlmClient` seam; the adapter is tested in isolation with `WebMock`. No live AI calls in CI.
+- AI calls in tests are stubbed at the `LlmClient` seam for stage tests; `LlmClient` itself is tested end-to-end with `WebMock` against per-provider fixture responses. No live AI calls in CI.


### PR DESCRIPTION
## Summary

Spec-only change. Switches the planned LLM SDK from the direct \`anthropic\` Ruby gem to the multi-provider \`ruby_llm\` gem. Future PRs (T001, T039, T040, T041) will implement the spec as updated here; no production code changes in this PR.

## Why

Near-term plan is to support multiple LLM providers (Anthropic first, OpenAI / Gemini / others later). The original design called for one hand-written \`LlmClient::<Provider>\` adapter per provider, each re-deriving auth, retries, structured-output dispatch, tool plumbing, and usage telemetry. RubyLLM already does that work and adds providers as configuration rather than code.

Our own \`LlmClient\` still owns the parts that *should* be ours:
- Credential resolution
- \`LlmUsage\` persistence (with per-call attribution)
- Schema validation via \`JSONSchemer\`
- Detection-phase guard (FR-007 / SC-004)
- Error routing via \`Rails.error\`

## What changed in the spec

- **research.md §5** — new decision + rationale + caveats (solo-maintainer dependency risk, possible lag on brand-new provider features). Summary table at §10 updated.
- **tasks.md** — T001 swaps \`anthropic\` for \`ruby_llm\`; T040 collapses from a per-provider Anthropic adapter to a single \`LlmClient::Adapter\` wrapping RubyLLM; T039 provider registry shape adjusted.
- **plan.md** — dependency list, file tree, structure decision.
- **contracts/llm_client.md** — adapter interface gains \`provider:\` argument; one adapter class instead of N.
- **data-model.md §8** — provider registry holds \`ruby_llm_provider\` symbol instead of an adapter class name.
- **quickstart.md** — test-stub reference now points at \`LlmClient::Adapter\`.

## Caveats called out in the spec

- Solo-maintainer dependency; pin known-good versions.
- Provider-specific features (e.g., Anthropic \`web_search\` / \`web_fetch\` server tools) may briefly lag the underlying API. If a profile needs something RubyLLM hasn't exposed yet, document an escape hatch for that one call rather than rewriting the adapter.

## Test plan

- [x] No code changes — no test suite to run.
- [x] All spec edits keep cross-references intact (\`LlmClient::Adapter\` consistent across tasks.md, plan.md, contracts/, quickstart.md).
- [x] No conflicting references to the old \`LlmClient::Anthropic\` class name remain (verified via grep).