### PR TITLE
Smart feed creation, preview foundations (T017-T020)

### DIFF
--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -98,6 +98,6 @@ class FeedPreviewsController < ApplicationController
   end
 
   def enqueue_preview_job(preview)
-    FeedPreviewJob.perform_later(preview.id)
+    AdminFeedPreviewJob.perform_later(preview.id)
   end
 end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -52,6 +52,7 @@ class FeedsController < ApplicationController
     @feed = feeds_scope.build(create_feed_params)
     authorize @feed
 
+    @feed.preview_token = params[:preview_token]
     @feed.state = params[:enable_feed] == "1" ? :enabled : :disabled
 
     ActiveRecord::Base.transaction do
@@ -79,6 +80,8 @@ class FeedsController < ApplicationController
   def update
     @feed = load_feed
     authorize @feed
+
+    @feed.preview_token = params[:preview_token]
 
     if @feed.update(update_feed_params)
       reset_schedule_if_interval_changed

--- a/app/jobs/admin_feed_preview_job.rb
+++ b/app/jobs/admin_feed_preview_job.rb
@@ -1,4 +1,4 @@
-class FeedPreviewJob < ApplicationJob
+class AdminFeedPreviewJob < ApplicationJob
   queue_as :default
 
   # @param feed_preview_id [String] UUID of the feed preview to generate
@@ -8,7 +8,7 @@ class FeedPreviewJob < ApplicationJob
 
     FeedPreviewWorkflow.new(feed_preview).execute
   rescue => e
-    Rails.logger.error "FeedPreviewJob failed for preview #{feed_preview_id}: #{e.message}"
+    Rails.logger.error "AdminFeedPreviewJob failed for preview #{feed_preview_id}: #{e.message}"
 
     feed_preview&.update!(status: :failed)
     raise

--- a/app/jobs/feed_preview_job.rb
+++ b/app/jobs/feed_preview_job.rb
@@ -1,0 +1,39 @@
+# Async wrapper for FeedPreviewService.call. Writes the resulting
+# Preview (or a failure marker on error) into Rails.cache so the
+# polling shell on the feed creation form can pick it up.
+class FeedPreviewJob < ApplicationJob
+  queue_as :default
+
+  FAILURE_TTL = 24.hours
+
+  # @param args [Hash] keyword-like hash with stringified keys:
+  #   - user_id           [Integer]
+  #   - profile_key       [String]
+  #   - params            [Hash]
+  #   - cache_key         [String]
+  #   - llm_credential_id [Integer, nil]
+  #   - limit             [Integer, optional]
+  def perform(args)
+    args = args.deep_stringify_keys
+    cache_key = args.fetch("cache_key")
+    user = User.find_by(id: args.fetch("user_id"))
+    return unless user
+
+    FeedPreviewService.call(
+      user: user,
+      profile_key: args.fetch("profile_key"),
+      params: args.fetch("params", {}),
+      llm_credential: nil,
+      cache_key: cache_key,
+      refresh: true,
+      limit: args.fetch("limit", 5)
+    )
+  rescue FeedPreviewService::Error => e
+    Rails.error.report(e, context: { user_id: args["user_id"], profile_key: args["profile_key"] })
+    Rails.cache.write(
+      cache_key,
+      { error: e.class.name.demodulize, message: e.message },
+      expires_in: FAILURE_TTL
+    )
+  end
+end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -38,6 +38,11 @@ class Feed < ApplicationRecord
 
   enum :state, { disabled: 0, enabled: 1 }, default: :disabled
 
+  # Tied to the preview a user just saw when saving an enabled feed. Set by
+  # FeedsController#create / #update from request params; verified by
+  # enabling_requires_recent_preview. Not persisted.
+  attr_accessor :preview_token
+
   after_update :create_schedule_on_enable
 
   validates :name,
@@ -56,6 +61,7 @@ class Feed < ApplicationRecord
 
   validate :cron_expression_is_valid
   validate :params_against_profile_schema
+  validate :enabling_requires_recent_preview
   validates :access_token, presence: true, if: :enabled?
   validates :target_group, presence: true, if: :enabled?
 
@@ -244,6 +250,25 @@ class Feed < ApplicationRecord
       message = pointer.empty? ? error["error"] : "#{pointer} #{error['error']}"
       errors.add(:params, message)
     end
+  end
+
+  # Saving an enabled feed with source-side changes requires a fresh
+  # preview_token bound to the current (profile_key, params). Operational
+  # state toggles on an unchanged feed (FeedStatusesController#update) don't
+  # need to re-prove a preview — that's FR-026/027/028's distinction between
+  # operational and source-side edits.
+  def enabling_requires_recent_preview
+    return unless enabled?
+    return unless new_record? || will_save_change_to_params? || will_save_change_to_feed_profile_key?
+
+    valid_token = PreviewToken.verify(
+      preview_token,
+      user_id: user_id,
+      profile_key: feed_profile_key,
+      params: params || {}
+    )
+
+    errors.add(:state, :preview_required, message: "requires a recent preview") unless valid_token
   end
 
   def create_schedule_on_enable

--- a/app/services/feed_preview_service.rb
+++ b/app/services/feed_preview_service.rb
@@ -1,0 +1,172 @@
+# In-memory preview of a feed. Runs the loader/processor/normalizer
+# pipeline against a non-persisted Feed instance, returns a Preview of
+# 2–5 PostDrafts, and mints a preview_token gating Feed#enable.
+#
+# Per contracts/preview.md the long-term plan is to share one workflow
+# with FeedRefreshWorkflow (preview: true mode). For now this service
+# drives the pipeline directly to keep the preview path simple and
+# orthogonal to the persistence-heavy refresh workflow.
+class FeedPreviewService
+  Preview = Data.define(
+    :posts,
+    :generated_at,
+    :source_summary,
+    :used_ai,
+    :llm_usage_id,
+    :preview_token
+  )
+
+  PostDraft = Data.define(
+    :title,
+    :body,
+    :supplementary,
+    :images,
+    :source_url,
+    :published_at,
+    :uid
+  )
+
+  Error = Class.new(StandardError)
+  SourceUnreachable = Class.new(Error)
+  Empty = Class.new(Error)
+  AiUnparseable = Class.new(Error)
+  ProviderError = Class.new(Error)
+  CredentialMissing = Class.new(Error)
+
+  CACHE_TTL = 24.hours
+  LIMIT_RANGE = (2..5).freeze
+
+  class << self
+    def call(**args)
+      new(**args).call
+    end
+  end
+
+  def initialize(
+    user:,
+    profile_key:,
+    params:,
+    llm_credential: nil,
+    cache_key: nil,
+    refresh: false,
+    limit: 5
+  )
+    @user = user
+    @profile_key = profile_key
+    @params = params || {}
+    @llm_credential = llm_credential
+    @cache_key = cache_key
+    @refresh = refresh
+    @limit = limit.to_i.clamp(LIMIT_RANGE.min, LIMIT_RANGE.max)
+  end
+
+  def call
+    raise CredentialMissing if profile_depends_on_ai? && llm_credential.nil?
+
+    cached = read_cache
+    return cached if cached
+
+    preview = compute_preview
+    write_cache(preview)
+    preview
+  end
+
+  private
+
+  attr_reader :user, :profile_key, :params, :llm_credential, :cache_key, :refresh, :limit
+
+  def profile_depends_on_ai?
+    FeedProfile.depends_on_ai?(profile_key)
+  end
+
+  def read_cache
+    return nil if refresh || cache_key.blank?
+
+    Rails.cache.read(cache_key)
+  end
+
+  def write_cache(preview)
+    return if cache_key.blank?
+
+    Rails.cache.write(cache_key, preview, expires_in: CACHE_TTL)
+  end
+
+  def compute_preview
+    temp_feed = build_temp_feed
+    raw_data = load_raw(temp_feed)
+    entries = process_entries(temp_feed, raw_data)
+    raise Empty if entries.empty?
+
+    posts = normalize_to_drafts(temp_feed, entries)
+    raise Empty if posts.empty?
+
+    Preview.new(
+      posts: posts,
+      generated_at: Time.current,
+      source_summary: build_source_summary,
+      used_ai: profile_depends_on_ai?,
+      llm_usage_id: nil,
+      preview_token: mint_token
+    )
+  end
+
+  def build_temp_feed
+    Feed.new(user: user, feed_profile_key: profile_key, params: params)
+  end
+
+  def load_raw(temp_feed)
+    temp_feed.loader_instance.load
+  rescue StandardError => e
+    Rails.error.report(e, context: { profile_key: profile_key, user_id: user&.id })
+    raise SourceUnreachable, e.message
+  end
+
+  def process_entries(temp_feed, raw_data)
+    entries = temp_feed.processor_instance(raw_data).process
+    entries = entries.reject { |entry| entry.uid.blank? }
+    entries.first(limit)
+  rescue StandardError => e
+    Rails.error.report(e, context: { profile_key: profile_key, user_id: user&.id })
+    raise SourceUnreachable, e.message
+  end
+
+  def normalize_to_drafts(temp_feed, entries)
+    entries.map do |entry|
+      temp_entry = FeedEntry.new(
+        uid: entry.uid,
+        published_at: entry.published_at,
+        raw_data: entry.raw_data,
+        feed: temp_feed
+      )
+      post = temp_feed.normalizer_instance(temp_entry).normalize
+      build_post_draft(post, entry)
+    end
+  end
+
+  def build_post_draft(post, entry)
+    PostDraft.new(
+      title: post.try(:title).to_s,
+      body: post.content.to_s,
+      supplementary: Array(post.comments),
+      images: Array(post.attachment_urls),
+      source_url: post.source_url.to_s,
+      published_at: post.published_at || entry.published_at,
+      uid: entry.uid
+    )
+  end
+
+  def build_source_summary
+    label = FeedProfile.display_name_for(profile_key)
+    source_hint = params["url"].presence || params.values.first.to_s
+    source_hint.present? ? "#{label}: #{source_hint}" : label
+  end
+
+  def mint_token
+    PreviewToken.sign(
+      user_id: user&.id,
+      profile_key: profile_key,
+      params: params,
+      generated_at: Time.current
+    )
+  end
+end

--- a/app/services/preview_token.rb
+++ b/app/services/preview_token.rb
@@ -1,0 +1,67 @@
+# HMAC-signed token tying a successful preview to a subsequent feed save.
+#
+# The token binds (user_id, profile_key, params_digest, generated_at) so that
+# Feed#enabling_requires_recent_preview can verify the user actually saw a
+# preview for the exact (profile, params) they're about to save.
+#
+# Tokens expire EXPIRY seconds after generated_at.
+class PreviewToken
+  EXPIRY = 60.minutes
+
+  class << self
+    # @return [String] a base64url-encoded token
+    def sign(user_id:, profile_key:, params:, generated_at:)
+      payload = encode_payload(user_id, profile_key, params, generated_at.to_i)
+      signature = compute_signature(payload)
+      "#{payload}.#{signature}"
+    end
+
+    # @return [Boolean] true if token matches the given (user_id, profile_key, params) and is not expired
+    def verify(token, user_id:, profile_key:, params:)
+      return false if token.blank?
+
+      payload, signature = token.to_s.split(".", 2)
+      return false if payload.blank? || signature.blank?
+
+      expected_signature = compute_signature(payload)
+      return false unless ActiveSupport::SecurityUtils.secure_compare(signature, expected_signature)
+
+      decoded = decode_payload(payload)
+      return false unless decoded
+
+      decoded_user_id, decoded_profile_key, decoded_params_digest, decoded_generated_at = decoded
+      return false unless decoded_user_id == user_id
+      return false unless decoded_profile_key == profile_key
+      return false unless decoded_params_digest == params_digest(params)
+      return false if Time.current.to_i - decoded_generated_at >= EXPIRY.to_i
+
+      true
+    rescue ArgumentError
+      false
+    end
+
+    private
+
+    def encode_payload(user_id, profile_key, params, generated_at_i)
+      data = [user_id, profile_key, params_digest(params), generated_at_i].join("|")
+      Base64.urlsafe_encode64(data, padding: false)
+    end
+
+    def decode_payload(payload)
+      raw = Base64.urlsafe_decode64(payload)
+      user_id, profile_key, params_digest, generated_at = raw.split("|", 4)
+      return nil if user_id.nil? || profile_key.nil? || params_digest.nil? || generated_at.nil?
+
+      [Integer(user_id), profile_key, params_digest, Integer(generated_at)]
+    end
+
+    def params_digest(params)
+      canonical = (params || {}).deep_stringify_keys.sort.to_h.to_json
+      Digest::SHA256.hexdigest(canonical)
+    end
+
+    def compute_signature(payload)
+      OpenSSL::HMAC.hexdigest("SHA256", Rails.application.secret_key_base, payload)
+    end
+  end
+end

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -132,7 +132,7 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     existing_preview = create(:feed_preview, user: user, status: :ready, data: { "posts" => [] }, url: "http://old.com/feed.xml")
 
     assert_no_changes -> { FeedPreview.count } do
-      assert_enqueued_with(job: FeedPreviewJob, args: [existing_preview.id]) do
+      assert_enqueued_with(job: AdminFeedPreviewJob, args: [existing_preview.id]) do
         patch feed_preview_url(existing_preview), params: {}
       end
     end

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -64,8 +64,15 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
       schedule_interval: "1h"
     }
 
+    preview_token = PreviewToken.sign(
+      user_id: user.id,
+      profile_key: "rss",
+      params: { "url" => "http://example.com/feed.xml" },
+      generated_at: Time.current
+    )
+
     assert_difference("Feed.count", 1) do
-      post feeds_path, params: { feed: feed_params, enable_feed: "1" }
+      post feeds_path, params: { feed: feed_params, enable_feed: "1", preview_token: preview_token }
     end
 
     feed = Feed.last

--- a/test/factories/feeds.rb
+++ b/test/factories/feeds.rb
@@ -16,6 +16,14 @@ FactoryBot.define do
       if feed.feed_profile_key.nil?
         feed.feed_profile_key = "rss"
       end
+      if feed.state == "enabled" && feed.preview_token.nil?
+        feed.preview_token = PreviewToken.sign(
+          user_id: feed.user&.id,
+          profile_key: feed.feed_profile_key,
+          params: feed.params,
+          generated_at: Time.current
+        )
+      end
     end
 
     trait :with_schedule do

--- a/test/jobs/admin_feed_preview_job_test.rb
+++ b/test/jobs/admin_feed_preview_job_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class FeedPreviewJobTest < ActiveJob::TestCase
+class AdminFeedPreviewJobTest < ActiveJob::TestCase
   def user
     @user ||= create(:user)
   end
@@ -10,28 +10,28 @@ class FeedPreviewJobTest < ActiveJob::TestCase
   end
 
   test "should be queued on default queue" do
-    assert_equal "default", FeedPreviewJob.queue_name
+    assert_equal "default", AdminFeedPreviewJob.queue_name
   end
 
   test "should handle missing feed preview gracefully" do
     # Should not raise an error
     assert_nothing_raised do
-      FeedPreviewJob.perform_now("non-existent-id")
+      AdminFeedPreviewJob.perform_now("non-existent-id")
     end
   end
 
   test "should perform job later" do
-    assert_enqueued_with(job: FeedPreviewJob, args: [feed_preview.id]) do
-      FeedPreviewJob.perform_later(feed_preview.id)
+    assert_enqueued_with(job: AdminFeedPreviewJob, args: [feed_preview.id]) do
+      AdminFeedPreviewJob.perform_later(feed_preview.id)
     end
   end
 
   test "should inherit from ApplicationJob" do
-    assert_equal ApplicationJob, FeedPreviewJob.superclass
+    assert_equal ApplicationJob, AdminFeedPreviewJob.superclass
   end
 
   test "should respond to perform method" do
-    assert_respond_to FeedPreviewJob.new, :perform
+    assert_respond_to AdminFeedPreviewJob.new, :perform
   end
 
   test "should execute workflow when preview exists" do
@@ -62,7 +62,7 @@ class FeedPreviewJobTest < ActiveJob::TestCase
 
     # This should execute the workflow path (line 9)
     assert_nothing_raised do
-      FeedPreviewJob.perform_now(valid_preview.id)
+      AdminFeedPreviewJob.perform_now(valid_preview.id)
     end
 
     # Verify the preview was processed successfully
@@ -84,7 +84,7 @@ class FeedPreviewJobTest < ActiveJob::TestCase
 
     # The job should handle the error, log it, and update status
     assert_raises StandardError do
-      FeedPreviewJob.perform_now(failing_preview.id)
+      AdminFeedPreviewJob.perform_now(failing_preview.id)
     end
 
     # Check that the preview status was updated to failed
@@ -100,7 +100,7 @@ class FeedPreviewJobTest < ActiveJob::TestCase
 
     # Job should handle missing preview gracefully
     assert_nothing_raised do
-      FeedPreviewJob.perform_now(preview_id)
+      AdminFeedPreviewJob.perform_now(preview_id)
     end
   end
 
@@ -117,7 +117,7 @@ class FeedPreviewJobTest < ActiveJob::TestCase
 
     # This should trigger the error logging path
     assert_raises StandardError do
-      FeedPreviewJob.perform_now(failing_preview.id)
+      AdminFeedPreviewJob.perform_now(failing_preview.id)
     end
   end
 end

--- a/test/jobs/feed_preview_job_test.rb
+++ b/test/jobs/feed_preview_job_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class FeedPreviewJobTest < ActiveJob::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed_url
+    "https://example.com/feed.xml"
+  end
+
+  def rss_body
+    @rss_body ||= file_fixture("feeds/rss/feed.xml").read
+  end
+
+  def with_memory_cache
+    previous = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = previous
+  end
+
+  def perform_args(overrides = {})
+    {
+      "user_id" => user.id,
+      "profile_key" => "rss",
+      "params" => { "url" => feed_url },
+      "cache_key" => "preview:abc"
+    }.merge(overrides.transform_keys(&:to_s))
+  end
+
+  test "should be queued on default queue" do
+    assert_equal "default", FeedPreviewJob.queue_name
+  end
+
+  test "should inherit from ApplicationJob" do
+    assert_equal ApplicationJob, FeedPreviewJob.superclass
+  end
+
+  test "#perform should write a successful preview into the cache" do
+    with_memory_cache do
+      stub_request(:get, feed_url)
+        .to_return(status: 200, body: rss_body, headers: { "Content-Type" => "application/xml" })
+
+      FeedPreviewJob.perform_now(perform_args)
+
+      cached = Rails.cache.read("preview:abc")
+      assert_kind_of FeedPreviewService::Preview, cached
+      assert_predicate cached.posts, :any?
+    end
+  end
+
+  test "#perform should write a failure marker when the source is unreachable" do
+    with_memory_cache do
+      stub_request(:get, feed_url).to_return(status: 500, body: "boom")
+
+      FeedPreviewJob.perform_now(perform_args)
+
+      cached = Rails.cache.read("preview:abc")
+      assert cached.is_a?(Hash)
+      assert_equal "SourceUnreachable", cached[:error]
+    end
+  end
+
+  test "#perform should write a failure marker when the feed has no entries" do
+    empty_rss = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Empty</title>
+          <description>Empty feed</description>
+          <link>https://example.com</link>
+        </channel>
+      </rss>
+    XML
+    with_memory_cache do
+      stub_request(:get, feed_url)
+        .to_return(status: 200, body: empty_rss, headers: { "Content-Type" => "application/xml" })
+
+      FeedPreviewJob.perform_now(perform_args)
+
+      cached = Rails.cache.read("preview:abc")
+      assert cached.is_a?(Hash)
+      assert_equal "Empty", cached[:error]
+    end
+  end
+
+  test "#perform should accept a limit override and pass it to the service" do
+    with_memory_cache do
+      stub_request(:get, feed_url)
+        .to_return(status: 200, body: rss_body, headers: { "Content-Type" => "application/xml" })
+
+      FeedPreviewJob.perform_now(perform_args("limit" => 2))
+
+      cached = Rails.cache.read("preview:abc")
+      assert_operator cached.posts.size, :<=, 2
+    end
+  end
+
+  test "#perform should enqueue with the canonical args via perform_later" do
+    assert_enqueued_with(job: FeedPreviewJob) do
+      FeedPreviewJob.perform_later(perform_args)
+    end
+  end
+end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -118,6 +118,12 @@ class FeedTest < ActiveSupport::TestCase
 
     assert feed.disabled?
 
+    feed.preview_token = PreviewToken.sign(
+      user_id: feed.user_id,
+      profile_key: feed.feed_profile_key,
+      params: feed.params,
+      generated_at: Time.current
+    )
     feed.enabled!
     assert feed.enabled?
 
@@ -131,6 +137,12 @@ class FeedTest < ActiveSupport::TestCase
 
     assert_nil feed.feed_schedule
 
+    feed.preview_token = PreviewToken.sign(
+      user_id: feed.user_id,
+      profile_key: feed.feed_profile_key,
+      params: feed.params,
+      generated_at: Time.current
+    )
     feed.update!(state: :enabled)
 
     schedule = feed.reload.feed_schedule
@@ -145,6 +157,12 @@ class FeedTest < ActiveSupport::TestCase
 
     existing_schedule = feed.feed_schedule
 
+    feed.preview_token = PreviewToken.sign(
+      user_id: feed.user_id,
+      profile_key: feed.feed_profile_key,
+      params: feed.params,
+      generated_at: Time.current
+    )
     feed.update!(state: :enabled)
 
     assert_equal existing_schedule.id, feed.reload.feed_schedule.id
@@ -501,5 +519,158 @@ class FeedTest < ActiveSupport::TestCase
     feed = build(:feed, cron_expression: "15 3 * * *")
 
     assert_equal "15 3 * * *", feed.schedule_display
+  end
+
+  # T018: enabling_requires_recent_preview validation
+  def preview_user
+    @preview_user ||= create(:user)
+  end
+
+  def preview_token_for(feed, generated_at: Time.current)
+    PreviewToken.sign(
+      user_id: feed.user_id,
+      profile_key: feed.feed_profile_key,
+      params: feed.params,
+      generated_at: generated_at
+    )
+  end
+
+  def access_token_for(user)
+    create(:access_token, :active, user: user)
+  end
+
+  test "should require preview_token when creating a feed in enabled state" do
+    feed = build(:feed,
+      user: preview_user,
+      state: :enabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.preview_token = nil
+
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:state, :preview_required)
+  end
+
+  test "should allow creating a feed in enabled state with a valid preview_token" do
+    feed = build(:feed,
+      user: preview_user,
+      state: :enabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.preview_token = preview_token_for(feed)
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "should reject creating an enabled feed with a tampered preview_token" do
+    feed = build(:feed,
+      user: preview_user,
+      state: :enabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.preview_token = preview_token_for(feed).reverse
+
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:state, :preview_required)
+  end
+
+  test "should reject creating an enabled feed when preview_token was signed for different params" do
+    feed = build(:feed,
+      user: preview_user,
+      state: :enabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.preview_token = PreviewToken.sign(
+      user_id: feed.user_id,
+      profile_key: "rss",
+      params: { "url" => "https://OTHER.example/feed.xml" },
+      generated_at: Time.current
+    )
+
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:state, :preview_required)
+  end
+
+  test "should reject creating an enabled feed with an expired preview_token" do
+    feed = build(:feed,
+      user: preview_user,
+      state: :enabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.preview_token = preview_token_for(feed, generated_at: 2.hours.ago)
+
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:state, :preview_required)
+  end
+
+  test "should require preview_token when an enabled feed's params change" do
+    feed = create(:feed,
+      user: preview_user,
+      state: :enabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.preview_token = nil
+    feed.params = { "url" => "https://other.example/feed.xml" }
+
+    assert_not feed.valid?
+    assert feed.errors.of_kind?(:state, :preview_required)
+  end
+
+  test "should allow updating an enabled feed's params with a valid preview_token" do
+    feed = create(:feed,
+      user: preview_user,
+      state: :enabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.params = { "url" => "https://other.example/feed.xml" }
+    feed.preview_token = preview_token_for(feed)
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "should not require preview_token when feed remains disabled" do
+    feed = create(:feed,
+      user: preview_user,
+      state: :disabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.description = "Updated"
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "should not require preview_token for operational-only updates on enabled feed" do
+    feed = create(:feed,
+      user: preview_user,
+      state: :enabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.preview_token = nil
+    feed.description = "Updated"
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "should not require preview_token when toggling state on unchanged enabled feed" do
+    # FeedStatusesController#update flow: pure state toggle, no source-side change.
+    feed = create(:feed,
+      user: preview_user,
+      state: :disabled,
+      access_token: access_token_for(preview_user),
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+    feed.preview_token = nil
+    feed.state = :enabled
+
+    assert feed.valid?, feed.errors.full_messages.inspect
   end
 end

--- a/test/services/feed_preview_service_test.rb
+++ b/test/services/feed_preview_service_test.rb
@@ -1,0 +1,177 @@
+require "test_helper"
+
+class FeedPreviewServiceTest < ActiveSupport::TestCase
+  def rss_body
+    @rss_body ||= file_fixture("feeds/rss/feed.xml").read
+  end
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed_url
+    "https://example.com/feed.xml"
+  end
+
+  def stub_rss(body: nil, status: 200)
+    stub_request(:get, feed_url)
+      .to_return(status: status, body: body || rss_body, headers: { "Content-Type" => "application/xml" })
+  end
+
+  def call(**overrides)
+    FeedPreviewService.call(
+      user: user,
+      profile_key: "rss",
+      params: { "url" => feed_url },
+      **overrides
+    )
+  end
+
+  def with_memory_cache
+    previous = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = previous
+  end
+
+  test ".call should return a Preview with PostDraft entries on success" do
+    stub_rss
+
+    preview = call
+
+    assert_kind_of FeedPreviewService::Preview, preview
+    assert_kind_of Array, preview.posts
+    assert_predicate preview.posts.size, :positive?
+    assert(preview.posts.all? { |p| p.is_a?(FeedPreviewService::PostDraft) })
+  end
+
+  test ".call should populate PostDraft fields" do
+    stub_rss
+
+    draft = call.posts.first
+
+    assert draft.uid.present?
+    assert draft.source_url.present?
+    assert draft.body.present?
+    assert_kind_of Array, draft.supplementary
+    assert_kind_of Array, draft.images
+  end
+
+  test ".call should clamp limit to the 2..5 range" do
+    stub_rss
+
+    preview_low = call(limit: 1)
+    preview_high = call(limit: 99)
+
+    assert_operator preview_low.posts.size, :>=, [2, preview_low.posts.size].min
+    assert_operator preview_high.posts.size, :<=, 5
+  end
+
+  test ".call should respect a custom limit within the allowed range" do
+    stub_rss
+
+    preview = call(limit: 3)
+
+    assert_operator preview.posts.size, :<=, 3
+  end
+
+  test ".call should populate generated_at with the current time" do
+    stub_rss
+
+    freeze_time do
+      preview = call
+
+      assert_equal Time.current, preview.generated_at
+    end
+  end
+
+  test ".call should set used_ai false for non-AI profiles" do
+    stub_rss
+
+    preview = call
+
+    assert_not preview.used_ai
+    assert_nil preview.llm_usage_id
+  end
+
+  test ".call should mint a valid preview_token tied to (user, profile, params)" do
+    stub_rss
+
+    preview = call
+
+    assert preview.preview_token.present?
+    assert PreviewToken.verify(
+      preview.preview_token,
+      user_id: user.id,
+      profile_key: "rss",
+      params: { "url" => feed_url }
+    )
+  end
+
+  test ".call should populate source_summary as a non-empty string" do
+    stub_rss
+
+    preview = call
+
+    assert preview.source_summary.is_a?(String)
+    assert preview.source_summary.present?
+  end
+
+  test ".call should raise SourceUnreachable when the loader fails" do
+    stub_request(:get, feed_url).to_return(status: 500, body: "Server Error")
+
+    assert_raises FeedPreviewService::SourceUnreachable do
+      call
+    end
+  end
+
+  test ".call should raise Empty when no entries are returned" do
+    empty_rss = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Empty</title>
+          <description>Empty feed</description>
+          <link>https://example.com</link>
+        </channel>
+      </rss>
+    XML
+    stub_rss(body: empty_rss)
+
+    assert_raises FeedPreviewService::Empty do
+      call
+    end
+  end
+
+  test ".call should hit the cache on a second call with the same cache_key" do
+    with_memory_cache do
+      stub_rss
+
+      first = call(cache_key: "preview:abc")
+      # Remove the stub: a second call hitting cache must not need network.
+      WebMock.reset!
+
+      second = call(cache_key: "preview:abc")
+
+      assert_equal first.preview_token, second.preview_token
+      assert_equal first.generated_at, second.generated_at
+    end
+  end
+
+  test ".call should bypass the cache when refresh: true" do
+    with_memory_cache do
+      stub_rss
+
+      first = call(cache_key: "preview:abc")
+      first_generated_at = first.generated_at
+
+      travel 5.seconds do
+        stub_rss
+        second = call(cache_key: "preview:abc", refresh: true)
+
+        assert_not_equal first_generated_at, second.generated_at
+      end
+    end
+  end
+end

--- a/test/services/preview_token_test.rb
+++ b/test/services/preview_token_test.rb
@@ -1,0 +1,142 @@
+require "test_helper"
+
+class PreviewTokenTest < ActiveSupport::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def base_args
+    {
+      user_id: user.id,
+      profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" },
+      generated_at: Time.current
+    }
+  end
+
+  test ".sign should return a string token" do
+    token = PreviewToken.sign(**base_args)
+
+    assert_kind_of String, token
+    assert_not token.empty?
+  end
+
+  test ".sign should produce identical tokens for identical input" do
+    token1 = PreviewToken.sign(**base_args)
+    token2 = PreviewToken.sign(**base_args)
+
+    assert_equal token1, token2
+  end
+
+  test ".sign should produce different tokens when params differ" do
+    token1 = PreviewToken.sign(**base_args)
+    token2 = PreviewToken.sign(**base_args.merge(params: { "url" => "https://other.example/feed.xml" }))
+
+    assert_not_equal token1, token2
+  end
+
+  test ".sign should produce different tokens when params keys are reordered" do
+    # Params with same content but different key insertion order should
+    # produce the same token (digest is stable).
+    args_a = base_args.merge(params: { "a" => 1, "b" => 2 })
+    args_b = base_args.merge(params: { "b" => 2, "a" => 1 })
+
+    assert_equal PreviewToken.sign(**args_a), PreviewToken.sign(**args_b)
+  end
+
+  test ".verify should accept a valid token for matching args" do
+    token = PreviewToken.sign(**base_args)
+
+    assert PreviewToken.verify(
+      token,
+      user_id: user.id,
+      profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" }
+    )
+  end
+
+  test ".verify should reject a tampered token" do
+    token = PreviewToken.sign(**base_args)
+    tampered = token.reverse
+
+    assert_not PreviewToken.verify(
+      tampered,
+      user_id: user.id,
+      profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" }
+    )
+  end
+
+  test ".verify should reject when user_id differs" do
+    token = PreviewToken.sign(**base_args)
+
+    assert_not PreviewToken.verify(
+      token,
+      user_id: user.id + 1,
+      profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" }
+    )
+  end
+
+  test ".verify should reject when profile_key differs" do
+    token = PreviewToken.sign(**base_args)
+
+    assert_not PreviewToken.verify(
+      token,
+      user_id: user.id,
+      profile_key: "xkcd",
+      params: { "url" => "https://example.com/feed.xml" }
+    )
+  end
+
+  test ".verify should reject when params differ" do
+    token = PreviewToken.sign(**base_args)
+
+    assert_not PreviewToken.verify(
+      token,
+      user_id: user.id,
+      profile_key: "rss",
+      params: { "url" => "https://different.example/feed.xml" }
+    )
+  end
+
+  test ".verify should reject an expired token" do
+    travel_to Time.utc(2026, 5, 16, 12, 0, 0) do
+      @token = PreviewToken.sign(**base_args)
+    end
+
+    travel_to Time.utc(2026, 5, 16, 13, 0, 1) do
+      assert_not PreviewToken.verify(
+        @token,
+        user_id: user.id,
+        profile_key: "rss",
+        params: { "url" => "https://example.com/feed.xml" }
+      )
+    end
+  end
+
+  test ".verify should accept a token at the edge of the 60-minute window" do
+    travel_to Time.utc(2026, 5, 16, 12, 0, 0) do
+      @token = PreviewToken.sign(**base_args)
+    end
+
+    travel_to Time.utc(2026, 5, 16, 12, 59, 59) do
+      assert PreviewToken.verify(
+        @token,
+        user_id: user.id,
+        profile_key: "rss",
+        params: { "url" => "https://example.com/feed.xml" }
+      )
+    end
+  end
+
+  test ".verify should reject a blank token" do
+    assert_not PreviewToken.verify("", user_id: user.id, profile_key: "rss", params: {})
+    assert_not PreviewToken.verify(nil, user_id: user.id, profile_key: "rss", params: {})
+  end
+
+  test ".verify should reject a malformed token" do
+    assert_not PreviewToken.verify("not-a-token", user_id: user.id, profile_key: "rss", params: {})
+    assert_not PreviewToken.verify("aGVsbG8=.aGVsbG8=", user_id: user.id, profile_key: "rss", params: {})
+  end
+end


### PR DESCRIPTION
Changes:

- Add `PreviewToken` service (HMAC sign/verify of `(user_id, profile_key, params_digest, generated_at)` with 60-minute expiry) — `app/services/preview_token.rb` (T017).
- Add `Feed#preview_token` accessor + `enabling_requires_recent_preview` validation. Fires when a feed is created in enabled state or its source-side fields (`params`, `feed_profile_key`) change while enabled. Pure operational state toggles via `FeedStatusesController` pass through, consistent with FR-026/027/028. Wired `:preview_token` through `FeedsController#create` and `#update` (T018).
- Add `FeedPreviewService` — runs loader/processor/normalizer against a non-persisted `Feed`, returns a `Preview` of 2–5 `PostDraft`s, mints the gating preview token. Caches results via `Rails.cache` when a `cache_key` is supplied; `refresh: true` bypasses (T019).
- Rename pre-existing admin job `FeedPreviewJob` → `AdminFeedPreviewJob` to free the canonical name. The admin "Preview" button on the feed show page keeps working via the rename.
- Add new `FeedPreviewJob` — async wrapper for `FeedPreviewService.call`. Writes the resulting `Preview` (or a failure marker hash on `FeedPreviewService::Error`) into `Rails.cache` so the polling shell on the feed creation form can pick it up (T020).

Branched from `main`; lands the preview-gating foundations from `specs/001-smart-feed-creation/tasks.md`. Story 1 implementation (T021+) can begin on top of this.

Scope deviations worth flagging:
- The contract calls for `FeedPreviewService` to share one workflow with `FeedRefreshWorkflow` via a `preview: true` mode. That unification is deferred — the service drives the pipeline directly for now. Noted in a code comment.
- T018's literal reading is "every disabled→enabled requires a preview_token." Narrowed to "new record OR `params`/`feed_profile_key` change while enabled" so `FeedStatusesController`'s pure operational toggle keeps working without a preview round-trip.