### PR TITLE
Smart feed creation, preview UI primitives (T021-T027, T029)

### DIFF
--- a/app/controllers/feeds/previews_controller.rb
+++ b/app/controllers/feeds/previews_controller.rb
@@ -1,0 +1,125 @@
+# Renders the live preview pane on the feed creation / edit form.
+#
+# Backed by FeedPreviewService + FeedPreviewJob: cache hits render the
+# preview synchronously, cache misses enqueue the async job and return a
+# loading partial whose polling controller picks the result up from the
+# cache.
+class Feeds::PreviewsController < ApplicationController
+  before_action :require_authentication
+
+  DRAFT_FEED_ID = "draft"
+
+  def show
+    @partial, @partial_locals =
+      case cached_preview
+      when FeedPreviewService::Preview
+        [:preview, { preview: cached_preview, refresh_url: action_url }]
+      when Hash
+        [:preview_failed, { failure: cached_preview, retry_url: action_url }]
+      else
+        enqueue_preview_job
+        [:preview_loading, { poll_url: action_url(format: :turbo_stream) }]
+      end
+
+    render_view_state
+  end
+
+  def create
+    Rails.cache.delete(cache_key)
+    enqueue_preview_job(refresh: true)
+
+    @partial = :preview_loading
+    @partial_locals = { poll_url: action_url(format: :turbo_stream) }
+
+    render_view_state
+  end
+
+  def destroy
+    Rails.cache.delete(cache_key)
+
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.update("feed-preview", "") }
+      format.html { head :no_content }
+    end
+  end
+
+  private
+
+  def render_view_state
+    respond_to do |format|
+      format.html { render "feeds/previews/show" }
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update(
+          "feed-preview",
+          partial: "feeds/#{@partial}",
+          locals: @partial_locals
+        )
+      end
+    end
+  end
+
+  def cached_preview
+    return @cached_preview if defined?(@cached_preview)
+
+    @cached_preview = Rails.cache.read(cache_key)
+  end
+
+  def enqueue_preview_job(refresh: false)
+    FeedPreviewJob.perform_later(
+      "user_id" => Current.user.id,
+      "profile_key" => profile_key,
+      "params" => preview_params,
+      "cache_key" => cache_key,
+      "llm_credential_id" => nil,
+      "limit" => 5,
+      "refresh" => refresh
+    )
+  end
+
+  def cache_key
+    @cache_key ||= "preview:#{cache_namespace}:#{profile_key}:#{params_digest}"
+  end
+
+  def cache_namespace
+    draft? ? "draft:#{Current.user.id}" : "feed:#{feed.id}"
+  end
+
+  def params_digest
+    canonical = preview_params.deep_stringify_keys.sort.to_h.to_json
+    Digest::SHA256.hexdigest(canonical)
+  end
+
+  def preview_params
+    return @preview_params if defined?(@preview_params)
+
+    raw = params[:params]
+    @preview_params =
+      case raw
+      when ActionController::Parameters then raw.to_unsafe_h
+      when Hash then raw
+      else {}
+      end
+  end
+
+  def profile_key
+    @profile_key ||= params[:profile_key].to_s
+  end
+
+  def feed
+    @feed ||= Current.user.feeds.find(params[:feed_id])
+  end
+
+  def draft?
+    params[:feed_id] == DRAFT_FEED_ID
+  end
+
+  def action_url(format: nil)
+    feed_id_segment = draft? ? DRAFT_FEED_ID : feed.id
+    feed_live_preview_path(
+      feed_id_segment,
+      profile_key: profile_key,
+      params: preview_params,
+      format: format
+    )
+  end
+end

--- a/app/javascript/controllers/candidate_chooser_controller.js
+++ b/app/javascript/controllers/candidate_chooser_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Manages the candidate-chooser radio group on the feed creation form.
+// On selection change, emits a `feed:candidate-changed` event carrying the
+// chosen profile key so the preview controller can reload its frame.
+export default class extends Controller {
+  static targets = ["option"]
+
+  switch(event) {
+    const profileKey = event.target.value
+    if (!profileKey) return
+
+    this.element.dispatchEvent(new CustomEvent("feed:candidate-changed", {
+      bubbles: true,
+      detail: { profileKey }
+    }))
+  }
+}

--- a/app/javascript/controllers/preview_controller.js
+++ b/app/javascript/controllers/preview_controller.js
@@ -1,0 +1,66 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Manages the preview pane on the feed creation form.
+//
+// - Reloads the embedded turbo-frame when the user picks a different
+//   candidate profile (event from candidate-chooser).
+// - Refreshes the frame on demand via the explicit "Refresh preview"
+//   button (posts to the preview controller, which busts the cache).
+export default class extends Controller {
+  static targets = ["frame"]
+  static values = {
+    refreshUrl: String
+  }
+
+  connect() {
+    this._onCandidateChanged = this._onCandidateChanged.bind(this)
+    document.addEventListener("feed:candidate-changed", this._onCandidateChanged)
+  }
+
+  disconnect() {
+    document.removeEventListener("feed:candidate-changed", this._onCandidateChanged)
+  }
+
+  async refresh(event) {
+    event?.preventDefault()
+    if (!this.hasRefreshUrlValue) return
+
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
+
+    await fetch(this.refreshUrlValue, {
+      method: "POST",
+      headers: {
+        Accept: "text/html",
+        "X-CSRF-Token": csrfToken,
+        "X-Requested-With": "XMLHttpRequest"
+      },
+      credentials: "same-origin"
+    })
+
+    this._reloadFrame()
+  }
+
+  _onCandidateChanged(event) {
+    const profileKey = event.detail?.profileKey
+    if (!profileKey || !this.hasFrameTarget) return
+
+    const src = this.frameTarget.getAttribute("src")
+    if (!src) return
+
+    const url = new URL(src, window.location.origin)
+    url.searchParams.set("profile_key", profileKey)
+    this.frameTarget.setAttribute("src", url.toString())
+  }
+
+  _reloadFrame() {
+    if (!this.hasFrameTarget) return
+
+    if (typeof this.frameTarget.reload === "function") {
+      this.frameTarget.reload()
+    } else {
+      const src = this.frameTarget.getAttribute("src")
+      this.frameTarget.setAttribute("src", "")
+      this.frameTarget.setAttribute("src", src)
+    }
+  }
+}

--- a/app/views/feeds/_candidate_chooser.html.erb
+++ b/app/views/feeds/_candidate_chooser.html.erb
@@ -1,0 +1,44 @@
+<%# locals: (candidates: []) %>
+<% selected_key = candidates.first&.dig("profile_key") %>
+
+<div class="space-y-2"
+     data-controller="candidate-chooser"
+     data-key="candidates">
+  <%= label_tag nil, "How should we fetch posts?", class: "block font-semibold text-slate-800" %>
+
+  <div class="space-y-2">
+    <% candidates.each_with_index do |candidate, index| %>
+      <% profile_key = candidate["profile_key"] %>
+      <% display_name = FeedProfile.display_name_for(profile_key) %>
+      <% description = FeedProfile[profile_key]&.dig(:description) %>
+      <% uses_ai = !!candidate["depends_on_ai"] %>
+      <% is_first = index.zero? %>
+      <label class="flex items-start gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 cursor-pointer hover:border-sky-400 transition"
+             data-key="candidate.<%= profile_key %>">
+        <input type="radio"
+               name="feed[feed_profile_key]"
+               value="<%= profile_key %>"
+               <%= "checked" if is_first %>
+               class="mt-1"
+               data-action="change->candidate-chooser#switch"
+               data-candidate-chooser-target="option">
+        <span class="flex flex-col gap-1">
+          <span class="flex flex-wrap items-center gap-2">
+            <span class="font-semibold text-slate-800"><%= display_name %></span>
+            <% if is_first %>
+              <span class="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-700"
+                    data-key="candidate.recommended-badge">Recommended</span>
+            <% end %>
+            <% if uses_ai %>
+              <span class="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700"
+                    data-key="candidate.ai-badge">AI</span>
+            <% end %>
+          </span>
+          <% if description.present? %>
+            <span class="text-slate-600 text-sm"><%= description %></span>
+          <% end %>
+        </span>
+      </label>
+    <% end %>
+  </div>
+</div>

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -3,20 +3,21 @@
   <%= form_with url: feed_details_path, method: :post do |f| %>
     <div class="space-y-6">
       <div class="space-y-2">
-        <%= f.label :url, "Feed URL", class: "block font-semibold text-slate-800" %>
+        <%= f.label :url, "What do you want to follow?", class: "block font-semibold text-slate-800" %>
         <%= f.text_field :url,
-                         placeholder: "https://example.com/feed.xml",
+                         placeholder: "Paste a link, handle, or a few words",
                          class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                          required: true,
-                         autofocus: true %>
-        <p class="text-slate-500">Enter the URL of the RSS feed or supported site you want to import.</p>
+                         autofocus: true,
+                         data: { key: "form.entry-input" } %>
+        <p class="text-slate-500">We'll figure out the best way to fetch posts from it.</p>
       </div>
     </div>
 
     <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
-      <%= f.submit "Identify Feed Format",
+      <%= f.submit "Continue",
                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
-                   data: { turbo_submits_with: "Identifying..." } %>
+                   data: { turbo_submits_with: "Checking..." } %>
       <%= link_to "Cancel", feeds_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     </div>
   <% end %>

--- a/app/views/feeds/_preview.html.erb
+++ b/app/views/feeds/_preview.html.erb
@@ -1,0 +1,65 @@
+<%# locals: (preview:, refresh_url: nil) %>
+<div class="space-y-4"
+     data-controller="preview"
+     data-preview-refresh-url-value="<%= refresh_url %>"
+     data-key="preview.success">
+  <div class="flex flex-wrap items-center justify-between gap-2">
+    <div class="space-y-1">
+      <p class="font-semibold text-slate-800">Here's what we'd post</p>
+      <p class="text-sm text-slate-500">Showing <%= preview.posts.size %> recent <%= "post".pluralize(preview.posts.size) %><% if preview.used_ai %> · fetched with AI<% end %>.</p>
+    </div>
+    <% if refresh_url.present? %>
+      <button type="button"
+              class="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50"
+              data-action="click->preview#refresh"
+              data-key="preview.refresh">
+        Refresh preview
+      </button>
+    <% end %>
+  </div>
+
+  <div class="space-y-4">
+    <% preview.posts.each_with_index do |post, index| %>
+      <article class="rounded-lg border border-slate-200 bg-white p-4 shadow-xs"
+               data-key="preview.post.<%= index %>">
+        <% if post.title.present? %>
+          <h4 class="text-base font-semibold text-slate-900 mb-2"><%= post.title %></h4>
+        <% end %>
+        <div class="prose prose-sm max-w-none text-slate-700 break-words">
+          <%= simple_format(truncate(post.body, length: 500, separator: " "), {}, sanitize: true) %>
+        </div>
+
+        <% if post.images.any? %>
+          <div class="mt-3 flex flex-wrap gap-2" data-key="preview.post.<%= index %>.images">
+            <% post.images.each do |image_url| %>
+              <a href="<%= image_url %>" target="_blank" rel="noopener" class="block">
+                <img src="<%= image_url %>" alt="" class="h-20 w-20 rounded object-cover border border-slate-200">
+              </a>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if post.supplementary.any? %>
+          <details class="mt-3 text-sm text-slate-600" data-key="preview.post.<%= index %>.supplementary">
+            <summary class="cursor-pointer font-medium text-slate-700">
+              <%= pluralize(post.supplementary.size, "comment") %>
+            </summary>
+            <ul class="mt-2 space-y-1 list-disc list-inside">
+              <% post.supplementary.each do |comment| %>
+                <li><%= comment %></li>
+              <% end %>
+            </ul>
+          </details>
+        <% end %>
+
+        <% if post.source_url.present? %>
+          <div class="mt-3 text-sm">
+            <a href="<%= post.source_url %>" target="_blank" rel="noopener"
+               class="text-sky-600 underline underline-offset-4 transition hover:text-sky-500 break-all"
+               data-key="preview.post.<%= index %>.source-link">View source</a>
+          </div>
+        <% end %>
+      </article>
+    <% end %>
+  </div>
+</div>

--- a/app/views/feeds/_preview_failed.html.erb
+++ b/app/views/feeds/_preview_failed.html.erb
@@ -1,0 +1,33 @@
+<%# locals: (failure:, retry_url:) %>
+<div class="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-3"
+     role="alert"
+     data-controller="preview"
+     data-preview-refresh-url-value="<%= retry_url %>"
+     data-key="preview.failed">
+  <div class="flex gap-3">
+    <div class="flex-shrink-0 pt-0.5">
+      <%= icon("exclamation-triangle", css_class: "h-5 w-5 text-amber-500", aria_hidden: true) %>
+    </div>
+    <div class="space-y-1">
+      <p class="font-semibold text-amber-900">We couldn't put together a preview</p>
+      <p class="text-amber-800 text-sm"><%= failure[:message].presence || "Something went wrong while fetching a sample of posts." %></p>
+    </div>
+  </div>
+
+  <div class="flex flex-wrap items-center gap-2">
+    <button type="button"
+            class="inline-flex items-center gap-1 rounded-md bg-amber-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500"
+            data-action="click->preview#refresh"
+            data-key="preview.failed.retry">
+      Try again
+    </button>
+    <button type="submit"
+            form="feed-form-submit"
+            name="enable_feed"
+            value="0"
+            class="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-3 py-1.5 text-sm font-semibold text-amber-800 shadow-sm transition hover:bg-amber-100"
+            data-key="preview.failed.save-disabled">
+      Save as disabled
+    </button>
+  </div>
+</div>

--- a/app/views/feeds/_preview_loading.html.erb
+++ b/app/views/feeds/_preview_loading.html.erb
@@ -1,0 +1,18 @@
+<%# locals: (poll_url:) %>
+<div class="flex items-center gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-xs"
+     role="status"
+     data-controller="polling"
+     data-polling-endpoint-value="<%= poll_url %>"
+     data-polling-interval-value="2000"
+     data-polling-max-polls-value="30"
+     data-polling-stop-condition-value="[data-key='preview.success'], [data-key='preview.failed']"
+     data-polling-scope-value="document"
+     data-key="preview.loading">
+  <div class="flex-shrink-0">
+    <%= render SpinnerComponent.new %>
+  </div>
+  <div class="space-y-1">
+    <p class="font-semibold text-slate-800">Fetching a preview...</p>
+    <p class="text-slate-600">This usually takes a few seconds.</p>
+  </div>
+</div>

--- a/app/views/feeds/previews/show.html.erb
+++ b/app/views/feeds/previews/show.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "feed-preview" do %>
+  <%= render partial: "feeds/#{@partial}", locals: @partial_locals %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   resources :feeds do
     resource :status, only: :update, controller: "feed_statuses"
     resource :purge, only: :create, controller: "feeds/purges"
+    resource :preview, only: [:show, :create, :destroy], controller: "feeds/previews", as: :live_preview
   end
 
   namespace :admin do

--- a/specs/001-smart-feed-creation/plan-prs.md
+++ b/specs/001-smart-feed-creation/plan-prs.md
@@ -1,0 +1,102 @@
+# PR Slicing Plan: Smart Feed Creation
+
+**Status**: in-progress
+
+This document slices the remaining `tasks.md` work into reviewable PRs.
+It is a companion to [`plan.md`](./plan.md) and [`tasks.md`](./tasks.md),
+not a substitute — task-level requirements and acceptance still live in
+those documents.
+
+## Already merged
+
+| PR     | Title                                                  | Tasks      |
+| ------ | ------------------------------------------------------ | ---------- |
+| `#388` | Smart feed creation foundations                        | T002, T004–T008 |
+| `#390` | Smart feed creation — detection slice                  | T009–T016  |
+| `#391` | Smart feed creation, preview foundations               | T017–T020  |
+
+After `#391`, detection returns ranked candidates and the preview
+service / job / token / state-gate validation are in place but not yet
+wired into the UI.
+
+## Remaining PRs
+
+### PR 4 — Story 1: Preview UI primitives and preview controller
+
+**Tasks**: T021, T022, T023, T024, T025, T026, T027, T029.
+
+The Stimulus controllers (`candidate-chooser`, `preview`), the four
+view partials (`_candidate_chooser`, `_preview`, `_preview_loading`,
+`_preview_failed`), the `_form_collapsed` placeholder rewording, and
+the new `Feeds::PreviewsController` (nested `resource :preview`).
+Partials render in isolation and the controller exercises the cache /
+enqueue / refresh / destroy paths, but `_form_expanded` does not yet
+embed them. No user-visible change in the feed-creation flow yet.
+
+### PR 5 — Story 1: Feed creation flow + MVP system test
+
+**Tasks**: T028, T030, T031, T032, T033.
+
+Assemble the partials into `_form_expanded` (chooser + lazy
+`<turbo-frame>` + schema-driven params), wire preview-token gating
+into `FeedsController#create`, split operational vs source-side edits
+in `#update`, add the cancel-during-detection affordance, and ship
+`smart_feed_creation_rss_test.rb`. **MVP shippable at this checkpoint.**
+
+### PR 6 — Story 2: LLM credentials backend
+
+**Tasks**: T001, T003, T034, T035, T036, T037, T038, T039.
+
+Add the `ruby_llm` gem, the per-model rate table at
+`config/llm_rates.yml`, three migrations (`llm_credentials`,
+`llm_usages`, `feeds.llm_credential_id`), the `LlmCredential` /
+`LlmUsage` / `LlmProvider` models with factories, and the
+encryption + default-uniqueness partial-index constraints.
+
+### PR 7 — Story 2: `LlmClient` + credentials UI
+
+**Tasks**: T041, T042, T043, T044, T045, T046.
+
+The `LlmClient` chokepoint (WebMock-driven tests, detection guard,
+one `LlmUsage` row per call), `LlmCredentialValidationJob`, routes,
+`LlmCredentialsController`, the nested defaults controller, and the
+`llm_credentials/*` views. After this PR, users can add, validate,
+default, and revoke credentials in isolation from feed creation.
+
+### PR 8 — Story 2: AI extraction profile + UI gate
+
+**Tasks**: T047, T048, T049, T050, T051, T052, T053, T054, T055, T056.
+
+The three LLM stages (`Loader::LlmLoader`,
+`Processor::PassthroughProcessor`, `Normalizer::LlmNormalizer`), the
+`LlmWebsiteExtractorMatcher`, the `llm_website_extractor` profile
+entry, AI failure-mode mapping in `FeedPreviewService`, the
+credential-gate partial, the cost message, and the system test.
+Story 2 ships.
+
+### PR 9 — Story 3: Handle / search-query inputs
+
+**Tasks**: T057, T058, T059, T060, T061, T062.
+
+The handle and query matchers, the two AI profile entries, the
+candidate-chooser helper for plain-language non-URL descriptions,
+and the Story 3 system test. Story 3 ships.
+
+### PR 10 — Polish & cross-cutting
+
+**Tasks**: T063, T064, T065, T066, T067, T068.
+
+Vocabulary firewall system test, state-gating system test,
+reload-doesn't-rerun test, edit-rerun test, full
+`bin/rubocop -f github` pass, and the `quickstart.md` drift check.
+
+## Dependency notes
+
+- PR 4 → PR 5 are sequential (PR 5 wires PR 4's partials into the form).
+- PR 6 → PR 7 → PR 8 are sequential — each unlocks the next.
+- After PR 5 lands, PR 6 can start in parallel with the MVP release;
+  PR 5 and PR 6 only collide in `feed_preview_service.rb` (PR 8's
+  T052) and `_form_expanded.html.erb` (PR 8's T054–T055).
+- PR 9 depends on PR 8 (reuses `LlmClient` and the three LLM stages).
+- PR 10's tests each depend on the story they assert against;
+  the rubocop / quickstart-drift sweep is last.

--- a/test/controllers/feeds/previews_controller_test.rb
+++ b/test/controllers/feeds/previews_controller_test.rb
@@ -1,0 +1,188 @@
+require "test_helper"
+
+class Feeds::PreviewsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def other_user
+    @other_user ||= create(:user)
+  end
+
+  def feed
+    @feed ||= create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
+  end
+
+  def show_params
+    { profile_key: "rss", params: { url: "https://example.com/feed.xml" } }
+  end
+
+  def with_memory_cache
+    previous = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = previous
+  end
+
+  def sample_preview
+    FeedPreviewService::Preview.new(
+      posts: [
+        FeedPreviewService::PostDraft.new(
+          title: "Sample title",
+          body: "Sample body",
+          supplementary: [],
+          images: [],
+          source_url: "https://example.com/post-1",
+          published_at: Time.current,
+          uid: "uid-1"
+        )
+      ],
+      generated_at: Time.current,
+      source_summary: "RSS: example.com",
+      used_ai: false,
+      llm_usage_id: nil,
+      preview_token: "token-abc"
+    )
+  end
+
+  test "#show should require authentication" do
+    get feed_live_preview_path(feed), params: show_params
+    assert_redirected_to new_session_path
+  end
+
+  test "#show should 404 for another user's feed" do
+    sign_in_as(other_user)
+    get feed_live_preview_path(feed), params: show_params
+    assert_response :not_found
+  end
+
+  test "#show should enqueue preview job and render loading partial on cache miss" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      assert_enqueued_with(job: FeedPreviewJob) do
+        get feed_live_preview_path(feed), params: show_params
+      end
+
+      assert_response :success
+      assert_select "[data-key='preview.loading']"
+      assert_select "turbo-frame#feed-preview"
+    end
+  end
+
+  test "#show should render preview partial on cache hit" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      # Warm the cache by hitting show once to learn its cache key
+      get feed_live_preview_path(feed), params: show_params
+      cache_key = cache_key_from_logs(user_id: user.id, feed_id: feed.id, profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
+      Rails.cache.write(cache_key, sample_preview)
+      clear_enqueued_jobs
+
+      assert_no_enqueued_jobs do
+        get feed_live_preview_path(feed), params: show_params
+      end
+
+      assert_response :success
+      assert_select "[data-key='preview.success']"
+      assert_select "[data-key='preview.post.0']"
+    end
+  end
+
+  test "#show should render failed partial when cache holds a failure marker" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      get feed_live_preview_path(feed), params: show_params
+      cache_key = cache_key_from_logs(user_id: user.id, feed_id: feed.id, profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
+      Rails.cache.write(cache_key, { error: "SourceUnreachable", message: "Could not reach the source." })
+      clear_enqueued_jobs
+
+      get feed_live_preview_path(feed), params: show_params
+
+      assert_response :success
+      assert_select "[data-key='preview.failed']"
+      assert_select "[data-key='preview.failed.retry']"
+      assert_select "[data-key='preview.failed.save-disabled']"
+    end
+  end
+
+  test "#show should accept the draft sentinel for new feeds" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      assert_enqueued_with(job: FeedPreviewJob) do
+        get feed_live_preview_path("draft"), params: show_params
+      end
+
+      assert_response :success
+      assert_select "[data-key='preview.loading']"
+    end
+  end
+
+  test "#show should answer turbo_stream requests with a frame update" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      get feed_live_preview_path(feed),
+          params: show_params,
+          headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      assert_response :success
+      assert_equal "text/vnd.turbo-stream.html; charset=utf-8", response.content_type
+      assert_includes response.body, "feed-preview"
+    end
+  end
+
+  test "#create should bust cache and re-enqueue with refresh" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      get feed_live_preview_path(feed), params: show_params
+      cache_key = cache_key_from_logs(user_id: user.id, feed_id: feed.id, profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
+      Rails.cache.write(cache_key, sample_preview)
+      clear_enqueued_jobs
+
+      assert_enqueued_with(job: FeedPreviewJob) do
+        post feed_live_preview_path(feed), params: show_params
+      end
+
+      assert_response :success
+      assert_select "[data-key='preview.loading']"
+      assert_nil Rails.cache.read(cache_key)
+    end
+  end
+
+  test "#destroy should clear the cached preview" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      get feed_live_preview_path(feed), params: show_params
+      cache_key = cache_key_from_logs(user_id: user.id, feed_id: feed.id, profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
+      Rails.cache.write(cache_key, sample_preview)
+
+      delete feed_live_preview_path(feed),
+             params: show_params,
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      assert_response :success
+      assert_nil Rails.cache.read(cache_key)
+    end
+  end
+
+  private
+
+  # Mirrors the cache key built by Feeds::PreviewsController so the test can
+  # populate the cache without depending on private controller helpers.
+  def cache_key_from_logs(user_id:, feed_id:, profile_key:, params:)
+    namespace = feed_id == "draft" ? "draft:#{user_id}" : "feed:#{feed_id}"
+    canonical = params.deep_stringify_keys.sort.to_h.to_json
+    "preview:#{namespace}:#{profile_key}:#{Digest::SHA256.hexdigest(canonical)}"
+  end
+end


### PR DESCRIPTION
Changes:

- Add `specs/001-smart-feed-creation/plan-prs.md` slicing the remaining work across PRs 4–10.
- T021: `candidate-chooser` Stimulus controller — emits `feed:candidate-changed` on radio change.
- T022: `preview` Stimulus controller — listens for candidate changes to reload the preview frame and POSTs the refresh URL on demand.
- T023: rewords `_form_collapsed` so the entry input no longer assumes a URL.
- T024: `_candidate_chooser` partial — recommended + alternates list with AI badge.
- T025: `_preview` partial — 2–5 `PostDraft` cards with body, images, supplementary comments, source link, and refresh button.
- T026: `_preview_loading` partial — polling shell that watches for `[data-key='preview.success'], [data-key='preview.failed']`.
- T027: `_preview_failed` partial — friendly error with "Try again" and "Save as disabled".
- T029: `Feeds::PreviewsController` (nested `resource :live_preview`) — cache hit renders preview, cache miss enqueues `FeedPreviewJob` + renders loading, POST busts cache and refreshes, DELETE clears it. Responds with a wrapped `turbo-frame` on HTML and `turbo_stream.update` on Turbo Stream. Supports the `"draft"` sentinel for new-feed previews.

Note: the new nested route uses `as: :live_preview` to avoid colliding with the existing top-level `feed_previews` resource (admin previews).

The partials are not yet embedded in `_form_expanded`; that wiring + the create/update flow are PR 5.

`bin/rails test` and `bin/rubocop` green (two pre-existing `WorkflowTest` failures on `main` are unrelated).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHmmVFcTvFLjfJxvTibLu9)_