### PR TITLE
Smart feed creation, MVP flow (T028, T030-T033)

### DIFF
--- a/app/controllers/feed_details_controller.rb
+++ b/app/controllers/feed_details_controller.rb
@@ -52,6 +52,17 @@ class FeedDetailsController < ApplicationController
     end
   end
 
+  def destroy
+    original_url = feed_detail.url if feed_detail.persisted?
+    feed_detail.destroy if feed_detail.persisted?
+
+    render turbo_stream: turbo_stream.replace(
+      "feed-form",
+      partial: "feeds/form_collapsed",
+      locals: { url: original_url }
+    )
+  end
+
   private
 
   def feed_detail

--- a/app/controllers/feed_details_controller.rb
+++ b/app/controllers/feed_details_controller.rb
@@ -53,7 +53,7 @@ class FeedDetailsController < ApplicationController
   end
 
   def destroy
-    original_url = feed_detail.url if feed_detail.persisted?
+    original_url = feed_detail.persisted? ? feed_detail.url : feed_url
     feed_detail.destroy if feed_detail.persisted?
 
     render turbo_stream: turbo_stream.replace(

--- a/app/controllers/feeds/previews_controller.rb
+++ b/app/controllers/feeds/previews_controller.rb
@@ -18,7 +18,7 @@ class Feeds::PreviewsController < ApplicationController
         [:preview_failed, { failure: cached_preview, retry_url: action_url }]
       else
         enqueue_preview_job
-        [:preview_loading, { poll_url: action_url(format: :turbo_stream) }]
+        [:preview_loading, { poll_url: action_url(format: :turbo_stream), cancel_url: cancel_url }]
       end
 
     render_view_state
@@ -29,7 +29,7 @@ class Feeds::PreviewsController < ApplicationController
     enqueue_preview_job(refresh: true)
 
     @partial = :preview_loading
-    @partial_locals = { poll_url: action_url(format: :turbo_stream) }
+    @partial_locals = { poll_url: action_url(format: :turbo_stream), cancel_url: cancel_url }
 
     render_view_state
   end
@@ -121,5 +121,12 @@ class Feeds::PreviewsController < ApplicationController
       params: preview_params,
       format: format
     )
+  end
+
+  def cancel_url
+    return nil unless draft?
+
+    source = preview_params["url"].presence
+    source ? feed_details_path(url: source) : nil
   end
 end

--- a/app/controllers/feeds/previews_controller.rb
+++ b/app/controllers/feeds/previews_controller.rb
@@ -93,12 +93,13 @@ class Feeds::PreviewsController < ApplicationController
     return @preview_params if defined?(@preview_params)
 
     raw = params[:params]
-    @preview_params =
+    hash =
       case raw
       when ActionController::Parameters then raw.to_unsafe_h
       when Hash then raw
       else {}
       end
+    @preview_params = hash.deep_stringify_keys
   end
 
   def profile_key

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -77,6 +77,11 @@ class FeedsController < ApplicationController
     authorize @feed
   end
 
+  # Per FR-026/FR-027/FR-028 operational fields (name, target_group, schedule,
+  # access_token) edit freely; source-side fields (url, feed_profile_key,
+  # params) are not editable from this form and stay anchored to the original
+  # detection result. Re-pointing a feed at a different source means creating
+  # a new feed.
   def update
     @feed = load_feed
     authorize @feed

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -53,7 +53,7 @@ class FeedsController < ApplicationController
     authorize @feed
 
     @feed.preview_token = params[:preview_token]
-    @feed.state = params[:enable_feed] == "1" ? :enabled : :disabled
+    @feed.state = initial_state_for(@feed)
 
     ActiveRecord::Base.transaction do
       @feed.save!
@@ -170,6 +170,22 @@ class FeedsController < ApplicationController
 
   def cleanup_feed_identification(url)
     FeedDetail.find_by(user: current_user, url: url)&.destroy
+  end
+
+  # A user who ticked "Enable feed" still only saves enabled when the request
+  # carries a valid preview_token bound to (profile_key, params). Anything
+  # else degrades gracefully to disabled so the feed still gets saved.
+  def initial_state_for(feed)
+    return :disabled unless params[:enable_feed] == "1"
+
+    token_valid = PreviewToken.verify(
+      params[:preview_token],
+      user_id: current_user.id,
+      profile_key: feed.feed_profile_key,
+      params: feed.params || {}
+    )
+
+    token_valid ? :enabled : :disabled
   end
 
   def success_message

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -1,10 +1,11 @@
-<%# locals: () %>
+<%# locals: (url: nil) %>
 <div id="feed-form">
   <%= form_with url: feed_details_path, method: :post do |f| %>
     <div class="space-y-6">
       <div class="space-y-2">
         <%= f.label :url, "What do you want to follow?", class: "block font-semibold text-slate-800" %>
         <%= f.text_field :url,
+                         value: url,
                          placeholder: "Paste a link, handle, or a few words",
                          class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                          required: true,

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -68,7 +68,8 @@
                          profile_key: feed.feed_profile_key,
                          params: { url: feed.url },
                          format: :turbo_stream
-                       ) %>
+                       ),
+                       cancel_url: feed_details_path(url: feed.url) %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -1,5 +1,6 @@
 <%# locals: (edit_mode: false, feed: @feed, candidates: []) %>
 <% active_tokens = Current.user.access_tokens.active.order(:host) %>
+<% multi_candidate = !edit_mode && candidates.size > 1 %>
 
 <div id="feed-form"
      data-identification-state="complete"
@@ -14,27 +15,24 @@
                   groups_default_text_value: "The FreeFeed group where posts will be published."
                 } do |f| %>
     <div class="space-y-6">
+      <% if multi_candidate %>
+        <%= render "feeds/candidate_chooser", candidates: candidates %>
+      <% else %>
+        <%= f.hidden_field :feed_profile_key %>
+      <% end %>
+
       <div class="space-y-2">
-        <%= f.label :url, "Feed URL", class: "block font-semibold text-slate-800" %>
+        <%= f.label :url, "Source", class: "block font-semibold text-slate-800" %>
         <%= f.text_field :url_display,
                          value: feed.url,
                          disabled: true,
                          class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 bg-slate-100",
-                         aria: { label: "Feed URL (cannot be changed)" } %>
+                         aria: { label: "Source (cannot be changed)" },
+                         data: { key: "form.source-display" } %>
         <%= f.hidden_field :url %>
-        <% if edit_mode %>
-          <p class="text-slate-500">Feed URL and Type cannot be changed after creation. To use a different URL, create a new feed.</p>
+        <% unless multi_candidate %>
+          <p class="text-slate-500"><%= edit_mode ? "Source and type can't be changed after creation. Start a new feed to follow a different source." : FeedProfile.display_name_for(feed.feed_profile_key).to_s %></p>
         <% end %>
-      </div>
-
-      <div class="space-y-2">
-        <%= label_tag "feed_profile_display", "Feed Type", class: "block font-semibold text-slate-800" %>
-        <%= text_field_tag "feed_profile_display",
-                           (feed.feed_profile_key.present? ? FeedProfile.display_name_for(feed.feed_profile_key) : "Unknown"),
-                           disabled: true,
-                           class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 bg-slate-100",
-                           aria: { label: "Feed Type (detected automatically)" } %>
-        <%= f.hidden_field :feed_profile_key %>
       </div>
 
       <div class="space-y-2">
@@ -43,7 +41,8 @@
                          placeholder: "Enter a name for this feed",
                          maxlength: Feed::NAME_MAX_LENGTH,
                          class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
-                         required: true %>
+                         required: true,
+                         data: { key: "form.name" } %>
         <% if feed.name.present? %>
           <p class="text-slate-500">You can edit this name if you'd like.</p>
         <% else %>
@@ -53,6 +52,26 @@
           <p class="text-sm text-red-600"><%= f.object.errors[:name].first %></p>
         <% end %>
       </div>
+
+      <% unless edit_mode %>
+        <div class="mt-2" data-key="form.preview">
+          <%= turbo_frame_tag "feed-preview",
+                              src: feed_live_preview_path(
+                                "draft",
+                                profile_key: feed.feed_profile_key,
+                                params: { url: feed.url }
+                              ),
+                              loading: "lazy" do %>
+            <%= render "feeds/preview_loading",
+                       poll_url: feed_live_preview_path(
+                         "draft",
+                         profile_key: feed.feed_profile_key,
+                         params: { url: feed.url },
+                         format: :turbo_stream
+                       ) %>
+          <% end %>
+        </div>
+      <% end %>
 
       <div class="mt-6">
         <h3 class="text-base font-semibold text-slate-900 mb-4">Reposting Settings</h3>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -9,8 +9,14 @@
   <div class="flex-shrink-0">
     <%= render SpinnerComponent.new %>
   </div>
-  <div class="space-y-1">
+  <div class="space-y-1 flex-1">
     <p class="font-semibold text-slate-800">Checking this feed...</p>
     <p class="text-slate-600">This usually takes a few seconds.</p>
   </div>
+  <%= button_to "Cancel",
+                feed_details_path(url: url),
+                method: :delete,
+                form: { data: { turbo_frame: "_top" } },
+                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-50",
+                data: { key: "loading.cancel" } %>
 </div>

--- a/app/views/feeds/_preview.html.erb
+++ b/app/views/feeds/_preview.html.erb
@@ -3,6 +3,7 @@
      data-controller="preview"
      data-preview-refresh-url-value="<%= refresh_url %>"
      data-key="preview.success">
+  <input type="hidden" name="preview_token" value="<%= preview.preview_token %>" data-key="preview.token">
   <div class="flex flex-wrap items-center justify-between gap-2">
     <div class="space-y-1">
       <p class="font-semibold text-slate-800">Here's what we'd post</p>

--- a/app/views/feeds/_preview_loading.html.erb
+++ b/app/views/feeds/_preview_loading.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (poll_url:) %>
+<%# locals: (poll_url:, cancel_url: nil) %>
 <div class="flex items-center gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-xs"
      role="status"
      data-controller="polling"
@@ -11,8 +11,14 @@
   <div class="flex-shrink-0">
     <%= render SpinnerComponent.new %>
   </div>
-  <div class="space-y-1">
+  <div class="space-y-1 flex-1">
     <p class="font-semibold text-slate-800">Fetching a preview...</p>
     <p class="text-slate-600">This usually takes a few seconds.</p>
   </div>
+  <% if cancel_url.present? %>
+    <%= link_to "Cancel",
+                cancel_url,
+                data: { turbo_method: :delete, turbo_frame: "_top", key: "loading.cancel" },
+                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-50" %>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   resources :feed_previews, only: [:create, :show, :update], path: "previews"
   resource :admin, only: :show
 
-  resource :feed_details, only: [:create, :show]
+  resource :feed_details, only: [:create, :show, :destroy]
 
   resources :feeds do
     resource :status, only: :update, controller: "feed_statuses"

--- a/test/controllers/feed_details_controller_test.rb
+++ b/test/controllers/feed_details_controller_test.rb
@@ -329,16 +329,42 @@ class FeedDetailsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, url
   end
 
-  test "#destroy should be idempotent when no feed_detail exists" do
+  test "#destroy should be idempotent and echo the typed URL when no feed_detail exists" do
     sign_in_as(user)
+    url = "http://example.com/feed.xml"
 
     assert_no_difference("FeedDetail.count") do
       delete feed_details_path,
-             params: { url: "http://example.com/feed.xml" },
+             params: { url: url },
              headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
     assert_response :success
+    assert_includes response.body, url
+  end
+
+  test "#show should render the candidate chooser when multiple candidates exist" do
+    sign_in_as(user)
+    url = "http://example.com/feed.xml"
+    create(
+      :feed_detail,
+      user: user,
+      url: url,
+      started_at: Time.current,
+      status: :success,
+      candidates: [
+        { "profile_key" => "rss", "title" => "Example", "depends_on_ai" => false, "rank" => 0, "rank_reason" => "specific_match" },
+        { "profile_key" => "llm_website_extractor", "title" => "Example", "depends_on_ai" => true, "rank" => 1, "rank_reason" => "ai_fallback" }
+      ]
+    )
+
+    get feed_details_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_includes response.body, "data-key=\"candidates\""
+    assert_includes response.body, "data-key=\"candidate.rss\""
+    assert_includes response.body, "data-key=\"candidate.llm_website_extractor\""
+    assert_includes response.body, "data-key=\"candidate.ai-badge\""
   end
 
   private

--- a/test/controllers/feed_details_controller_test.rb
+++ b/test/controllers/feed_details_controller_test.rb
@@ -100,7 +100,6 @@ class FeedDetailsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, 'data-identification-state="complete"'
-    assert_includes response.body, "Feed Type"
     assert_includes response.body, "RSS Feed"
   end
 

--- a/test/controllers/feed_details_controller_test.rb
+++ b/test/controllers/feed_details_controller_test.rb
@@ -307,6 +307,40 @@ class FeedDetailsControllerTest < ActionDispatch::IntegrationTest
     feed_detail&.destroy
   end
 
+  test "#destroy should require authentication" do
+    delete feed_details_path
+    assert_redirected_to new_session_path
+  end
+
+  test "#destroy should remove the user's in-progress feed_detail and re-render collapsed form" do
+    sign_in_as(user)
+    url = "http://example.com/feed.xml"
+    create(:feed_detail, user: user, url: url, status: :processing, started_at: Time.current)
+
+    assert_difference("FeedDetail.count", -1) do
+      delete feed_details_path,
+             params: { url: url },
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html; charset=utf-8", response.content_type
+    assert_includes response.body, 'id="feed-form"'
+    assert_includes response.body, url
+  end
+
+  test "#destroy should be idempotent when no feed_detail exists" do
+    sign_in_as(user)
+
+    assert_no_difference("FeedDetail.count") do
+      delete feed_details_path,
+             params: { url: "http://example.com/feed.xml" },
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+  end
+
   private
 
   def extract_candidates_payload(body)

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -314,11 +314,13 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     original_url = feed.url
     original_profile = feed.feed_profile_key
+    original_params = feed.params
 
     patch feed_url(feed), params: {
       feed: {
         url: "https://evil.com/feed.xml",
         feed_profile_key: "xkcd",
+        params: { url: "https://evil.com/feed.xml", smuggled: "yes" },
         name: "Updated Name"
       }
     }
@@ -327,6 +329,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     feed.reload
     assert_equal original_url, feed.url
     assert_equal original_profile, feed.feed_profile_key
+    assert_equal original_params, feed.params, "raw params jsonb must not be mass-assignable on update"
     assert_equal "Updated Name", feed.name
   end
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -192,8 +192,8 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     get edit_feed_url(feed)
     assert_response :success
-    assert_select "label", text: "Feed URL"
-    assert_select "p.text-slate-500", text: "Feed URL and Type cannot be changed after creation. To use a different URL, create a new feed."
+    assert_select "label", text: "Source"
+    assert_select "p.text-slate-500", text: "Source and type can't be changed after creation. Start a new feed to follow a different source."
   end
 
   test "#update should update feed with valid params" do

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -107,6 +107,49 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_match "currently disabled", flash[:notice]
   end
 
+  test "#create should downgrade to disabled when enable_feed=1 but preview_token is absent" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "Test Feed",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: { feed: feed_params, enable_feed: "1" }
+    end
+
+    feed = Feed.last
+    assert_equal "disabled", feed.state
+    assert_redirected_to feed_path(feed)
+    assert_match "currently disabled", flash[:notice]
+  end
+
+  test "#create should downgrade to disabled when preview_token is tampered" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "Test Feed",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: { feed: feed_params, enable_feed: "1", preview_token: "not-a-real-token" }
+    end
+
+    assert_equal "disabled", Feed.last.state
+  end
+
   test "#create should ignore state param and use enable_feed instead" do
     sign_in_as(user)
     access_token
@@ -152,15 +195,15 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
 
     feed_params = {
       url: "http://example.com/feed.xml",
-      name: "Test Feed",
+      name: "",  # Missing required field (validated regardless of state)
       feed_profile_key: "rss",
       access_token_id: access_token.id,
-      target_group: "",  # Missing required field
+      target_group: "testgroup",
       schedule_interval: "1h"
     }
 
     assert_no_difference("Feed.count") do
-      post feeds_path, params: { feed: feed_params, enable_feed: "1" }
+      post feeds_path, params: { feed: feed_params, enable_feed: "0" }
     end
 
     assert_response :unprocessable_entity
@@ -168,7 +211,6 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
 
     # Verify expanded form is shown, not collapsed form
     assert_select "input[name='feed[url_display]'][disabled]"
-    assert_select "input[name='feed[name]'][value='Test Feed']"
 
     # Verify validation errors are shown
     assert_select "p.text-red-600", text: /can't be blank|must be filled/

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -292,6 +292,24 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "form"
   end
 
+  test "#update should not require preview_token for operational-only edits on enabled feed" do
+    sign_in_as(user)
+    enabled_feed = create(:feed,
+                          user: user,
+                          state: :enabled,
+                          access_token: access_token,
+                          target_group: "tg",
+                          feed_profile_key: "rss",
+                          params: { "url" => "http://example.com/feed.xml" })
+
+    patch feed_url(enabled_feed), params: { feed: { name: "Renamed Feed" } }
+
+    assert_redirected_to feed_path(enabled_feed)
+    enabled_feed.reload
+    assert_equal "Renamed Feed", enabled_feed.name
+    assert_equal "enabled", enabled_feed.state
+  end
+
   test "#update should not allow changing url or feed_profile_key" do
     sign_in_as(user)
     original_url = feed.url

--- a/test/integration/smart_feed_creation_rss_test.rb
+++ b/test/integration/smart_feed_creation_rss_test.rb
@@ -1,0 +1,133 @@
+require "test_helper"
+
+# Integration test for User Story 1 (RSS happy path).
+# Walks paste → detection → preview cache → save → enabled feed.
+class SmartFeedCreationRssTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def access_token
+    @access_token ||= create(:access_token, :active, user: user)
+  end
+
+  def feed_url
+    "http://example.com/feed.xml"
+  end
+
+  def rss_body
+    @rss_body ||= <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Example Feed</title>
+          <description>A sample feed</description>
+          <item>
+            <title>First post</title>
+            <link>http://example.com/post1</link>
+            <description>Hello world</description>
+            <guid>http://example.com/post1</guid>
+            <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+          </item>
+        </channel>
+      </rss>
+    XML
+  end
+
+  def with_memory_cache
+    previous = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = previous
+  end
+
+  test "RSS happy path: paste → detect → preview → save enabled" do
+    sign_in_as(user)
+    access_token
+    stub_request(:get, feed_url)
+      .to_return(status: 200, body: rss_body, headers: { "Content-Type" => "application/xml" })
+
+    with_memory_cache do
+      post feed_details_path, params: { url: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      assert_response :success
+
+      perform_enqueued_jobs
+
+      get feed_details_path, params: { url: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      assert_response :success
+      assert_includes response.body, 'data-identification-state="complete"'
+      assert_includes response.body, "RSS Feed"
+
+      get feed_live_preview_path("draft"),
+          params: { profile_key: "rss", params: { url: feed_url } }
+      assert_response :success
+
+      perform_enqueued_jobs
+
+      preview = FeedPreviewService.call(
+        user: user,
+        profile_key: "rss",
+        params: { "url" => feed_url }
+      )
+      assert preview.preview_token.present?, "preview should issue a token"
+
+      assert_difference("Feed.count", 1) do
+        post feeds_path, params: {
+          feed: {
+            url: feed_url,
+            name: "Example Feed",
+            feed_profile_key: "rss",
+            access_token_id: access_token.id,
+            target_group: "testgroup",
+            schedule_interval: "1h"
+          },
+          enable_feed: "1",
+          preview_token: preview.preview_token
+        }
+      end
+
+      feed = Feed.last
+      assert_equal "enabled", feed.state
+      assert_equal "Example Feed", feed.name
+      assert_equal feed_url, feed.url
+      assert_nil FeedDetail.find_by(user: user, url: feed_url), "FeedDetail should be cleaned up after save"
+    end
+  end
+
+  test "XKCD URL outranks generic RSS" do
+    sign_in_as(user)
+    xkcd_url = "https://xkcd.com/"
+    stub_request(:get, xkcd_url)
+      .to_return(status: 200, body: rss_body, headers: { "Content-Type" => "application/xml" })
+
+    with_memory_cache do
+      post feed_details_path, params: { url: xkcd_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      perform_enqueued_jobs
+
+      get feed_details_path, params: { url: xkcd_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      assert_response :success
+      assert_includes response.body, "XKCD"
+    end
+  end
+
+  test "cancel during detection returns user to collapsed form with input preserved" do
+    sign_in_as(user)
+    create(:feed_detail, user: user, url: feed_url, status: :processing, started_at: Time.current)
+
+    assert_difference("FeedDetail.count", -1) do
+      delete feed_details_path,
+             params: { url: feed_url },
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_includes response.body, 'id="feed-form"'
+    assert_includes response.body, feed_url
+    assert_includes response.body, "What do you want to follow?"
+  end
+end

--- a/test/integration/smart_feed_creation_rss_test.rb
+++ b/test/integration/smart_feed_creation_rss_test.rb
@@ -46,7 +46,7 @@ class SmartFeedCreationRssTest < ActionDispatch::IntegrationTest
     Rails.cache = previous
   end
 
-  test "RSS happy path: paste → detect → preview → save enabled" do
+  test "#post should drive RSS happy path: paste, detect, preview, save enabled" do
     sign_in_as(user)
     access_token
     stub_request(:get, feed_url)
@@ -99,7 +99,7 @@ class SmartFeedCreationRssTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "XKCD URL outranks generic RSS" do
+  test "#post should rank XKCD profile above generic RSS for an xkcd.com URL" do
     sign_in_as(user)
     xkcd_url = "https://xkcd.com/"
     stub_request(:get, xkcd_url)
@@ -115,7 +115,7 @@ class SmartFeedCreationRssTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "cancel during detection returns user to collapsed form with input preserved" do
+  test "#delete should return user to collapsed form with their input preserved" do
     sign_in_as(user)
     create(:feed_detail, user: user, url: feed_url, status: :processing, started_at: Time.current)
 


### PR DESCRIPTION
Changes:

- T028: `_form_expanded` renders the candidate chooser when multiple candidates exist and embeds a lazy `<turbo-frame id="feed-preview">`; the URL caption now shows the chosen profile name. `_preview` includes a hidden `preview_token` input that travels with the form submit.
- T030: `FeedsController#create` derives the initial feed state from preview-token validity — saving with `enable_feed=1` but an absent or invalid token now degrades gracefully to `disabled` instead of returning a validation error.
- T031: documents the operational-vs-source-side update contract (FR-026/27/28); source-side fields stay anchored after creation. Added a test that explicitly asserts `params` jsonb is not mass-assignable through update.
- T032: cancel-during-detection. New `FeedDetailsController#destroy` clears the in-progress `FeedDetail` and re-renders `_form_collapsed` with the typed URL preserved. Both `_identification_loading` and `_preview_loading` show a Cancel control (button_to for the standalone loading partial, `link_to` with `turbo_method: :delete` for the preview-loading partial that lives inside the create form).
- T033: `test/integration/smart_feed_creation_rss_test.rb` walks the RSS happy path end-to-end and the XKCD specificity case. Plus a multi-candidate chooser render assertion in `feed_details_controller_test.rb`.

After self-review, also addressed: idempotent cancel echoes the typed URL when no FeedDetail exists; `preview_params` stringifies keys for consistent cache + URL behavior; integration test names follow CLAUDE.md's `#method should ...` convention.

`bin/rails test` and `bin/rubocop` clean (two pre-existing `WorkflowTest` failures on `main` are unrelated).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHmmVFcTvFLjfJxvTibLu9)_