### PR TITLE
Smart feed creation, AI extraction (T047-T056)

### DIFF
--- a/app/controllers/feeds/previews_controller.rb
+++ b/app/controllers/feeds/previews_controller.rb
@@ -12,7 +12,11 @@ class Feeds::PreviewsController < ApplicationController
   def show
     @partial, @partial_locals =
       if needs_credential_gate?
-        [:credential_gate, { profile_key: profile_key, new_credential_path: new_llm_credential_path }]
+        [:credential_gate, {
+          profile_key: profile_key,
+          new_credential_path: new_llm_credential_path,
+          return_to: draft? && preview_params["url"].present? ? feed_details_path(url: preview_params["url"]) : nil
+        }]
       else
         case cached_preview
         when FeedPreviewService::Preview

--- a/app/controllers/feeds/previews_controller.rb
+++ b/app/controllers/feeds/previews_controller.rb
@@ -11,14 +11,18 @@ class Feeds::PreviewsController < ApplicationController
 
   def show
     @partial, @partial_locals =
-      case cached_preview
-      when FeedPreviewService::Preview
-        [:preview, { preview: cached_preview, refresh_url: action_url }]
-      when Hash
-        [:preview_failed, { failure: cached_preview, retry_url: action_url }]
+      if needs_credential_gate?
+        [:credential_gate, { profile_key: profile_key, new_credential_path: new_llm_credential_path }]
       else
-        enqueue_preview_job
-        [:preview_loading, { poll_url: action_url(format: :turbo_stream), cancel_url: cancel_url }]
+        case cached_preview
+        when FeedPreviewService::Preview
+          [:preview, { preview: cached_preview, refresh_url: action_url }]
+        when Hash
+          [:preview_failed, { failure: cached_preview, retry_url: action_url }]
+        else
+          enqueue_preview_job
+          [:preview_loading, { poll_url: action_url(format: :turbo_stream), cancel_url: cancel_url }]
+        end
       end
 
     render_view_state
@@ -129,5 +133,22 @@ class Feeds::PreviewsController < ApplicationController
 
     source = preview_params["url"].presence
     source ? feed_details_path(url: source) : nil
+  end
+
+  def needs_credential_gate?
+    return false unless FeedProfile.exists?(profile_key)
+    return false unless FeedProfile.depends_on_ai?(profile_key)
+
+    !user_has_usable_credential?
+  end
+
+  def user_has_usable_credential?
+    return false unless Current.user
+
+    if draft?
+      Current.user.llm_credentials.active.exists?
+    else
+      feed.llm_credential&.active? || Current.user.llm_credentials.active.exists?
+    end
   end
 end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -147,6 +147,7 @@ class FeedsController < ApplicationController
       :description,
       :target_group,
       :access_token_id,
+      :llm_credential_id,
       :cron_expression,
       :schedule_interval
     )
@@ -162,6 +163,7 @@ class FeedsController < ApplicationController
       :description,
       :target_group,
       :access_token_id,
+      :llm_credential_id,
       :schedule_interval
     )
   end

--- a/app/controllers/llm_credentials_controller.rb
+++ b/app/controllers/llm_credentials_controller.rb
@@ -11,6 +11,7 @@ class LlmCredentialsController < ApplicationController
 
   def new
     @llm_credential = LlmCredential.new(provider: params[:provider] || LlmProvider.all.first)
+    @return_to = safe_return_to
     authorize @llm_credential
   end
 
@@ -20,7 +21,7 @@ class LlmCredentialsController < ApplicationController
 
     if @llm_credential.save
       LlmCredentialValidationJob.perform_later(@llm_credential)
-      redirect_to llm_credential_path(@llm_credential)
+      redirect_to llm_credential_path(@llm_credential, return_to: safe_return_to)
     else
       render :new, status: :unprocessable_entity
     end
@@ -63,5 +64,12 @@ class LlmCredentialsController < ApplicationController
     when Hash then raw
     else {}
     end
+  end
+
+  # Only accept same-host paths so a hostile redirect can't smuggle
+  # users off-site after they save a credential.
+  def safe_return_to
+    candidate = params[:return_to].to_s
+    candidate if candidate.start_with?("/") && !candidate.start_with?("//")
   end
 end

--- a/app/jobs/feed_preview_job.rb
+++ b/app/jobs/feed_preview_job.rb
@@ -19,11 +19,13 @@ class FeedPreviewJob < ApplicationJob
     user = User.find_by(id: args.fetch("user_id"))
     return unless user
 
+    llm_credential = LlmCredential.find_by(id: args["llm_credential_id"]) if args["llm_credential_id"]
+
     FeedPreviewService.call(
       user: user,
       profile_key: args.fetch("profile_key"),
       params: args.fetch("params", {}),
-      llm_credential: nil,
+      llm_credential: llm_credential,
       cache_key: cache_key,
       refresh: true,
       limit: args.fetch("limit", 5)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -63,6 +63,7 @@ class Feed < ApplicationRecord
   validate :cron_expression_is_valid
   validate :params_against_profile_schema
   validate :enabling_requires_recent_preview
+  validate :llm_credential_belongs_to_user
   validates :access_token, presence: true, if: :enabled?
   validates :target_group, presence: true, if: :enabled?
 
@@ -270,6 +271,14 @@ class Feed < ApplicationRecord
     )
 
     errors.add(:state, :preview_required, message: "requires a recent preview") unless valid_token
+  end
+
+  def llm_credential_belongs_to_user
+    return if llm_credential.nil?
+    return if user_id.nil?
+    return if llm_credential.user_id == user_id
+
+    errors.add(:llm_credential, "must belong to the same user")
   end
 
   def create_schedule_on_enable

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -94,7 +94,28 @@ class FeedProfile
       processor: { class: "Processor::PassthroughProcessor", config: {} },
       normalizer: { class: "Normalizer::LlmNormalizer", config: {} },
       title_extractor: nil,
-      output_schema: nil
+      output_schema: {
+        "type" => "object",
+        "properties" => {
+          "items" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "properties" => {
+                "uid" => { "type" => "string" },
+                "title" => { "type" => "string" },
+                "body" => { "type" => "string" },
+                "supplementary" => { "type" => "array", "items" => { "type" => "string" } },
+                "images" => { "type" => "array", "items" => { "type" => "string" } },
+                "source_url" => { "type" => "string" },
+                "published_at" => { "type" => "string" }
+              },
+              "required" => ["uid", "body", "source_url"]
+            }
+          }
+        },
+        "required" => ["items"]
+      }
     }
   }.freeze
 

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -42,6 +42,59 @@ class FeedProfile
       normalizer: { class: "Normalizer::XkcdNormalizer", config: {} },
       title_extractor: "TitleExtractor::RssTitleExtractor",
       output_schema: nil
+    },
+    "llm_website_extractor" => {
+      display_name: "AI page reader",
+      description: "Uses AI to extract recent posts from a webpage that doesn't expose an RSS feed",
+      input_shape: :url,
+      depends_on_ai: true,
+      matcher: "ProfileMatcher::LlmWebsiteExtractorMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "format" => "uri" }
+        },
+        "required" => ["url"]
+      },
+      loader: {
+        class: "Loader::LlmLoader",
+        config: {
+          model: "claude-sonnet-4-6",
+          prompt_template: <<~PROMPT,
+            Visit {{url}} and extract up to 10 of the most recent posts or articles.
+            For each item, return a stable permalink as `uid`, a title, body text,
+            an optional list of supplementary comments, an optional list of image URLs,
+            the source URL, and the published date in ISO 8601.
+          PROMPT
+          output_schema: {
+            "type" => "object",
+            "properties" => {
+              "items" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "uid" => { "type" => "string" },
+                    "title" => { "type" => "string" },
+                    "body" => { "type" => "string" },
+                    "supplementary" => { "type" => "array", "items" => { "type" => "string" } },
+                    "images" => { "type" => "array", "items" => { "type" => "string" } },
+                    "source_url" => { "type" => "string" },
+                    "published_at" => { "type" => "string" }
+                  },
+                  "required" => ["uid", "body", "source_url"]
+                }
+              }
+            },
+            "required" => ["items"]
+          },
+          tools: ["web_search", "web_fetch"]
+        }
+      },
+      processor: { class: "Processor::PassthroughProcessor", config: {} },
+      normalizer: { class: "Normalizer::LlmNormalizer", config: {} },
+      title_extractor: nil,
+      output_schema: nil
     }
   }.freeze
 

--- a/app/services/feed_preview_service.rb
+++ b/app/services/feed_preview_service.rb
@@ -111,13 +111,26 @@ class FeedPreviewService
   end
 
   def build_temp_feed
-    Feed.new(user: user, feed_profile_key: profile_key, params: params)
+    Feed.new(
+      user: user,
+      feed_profile_key: profile_key,
+      params: params,
+      llm_credential: llm_credential
+    )
   end
 
   def load_raw(temp_feed)
     temp_feed.loader_instance.load
+  rescue LlmClient::SchemaError => e
+    Rails.error.report(e, context: error_context)
+    raise AiUnparseable, e.message
+  rescue LlmClient::RateLimited, LlmClient::ProviderError, LlmClient::Timeout => e
+    Rails.error.report(e, context: error_context)
+    raise ProviderError, e.message
+  rescue LlmClient::CredentialMissing => e
+    raise CredentialMissing, e.message
   rescue StandardError => e
-    Rails.error.report(e, context: { profile_key: profile_key, user_id: user&.id })
+    Rails.error.report(e, context: error_context)
     raise SourceUnreachable, e.message
   end
 
@@ -126,8 +139,12 @@ class FeedPreviewService
     entries = entries.reject { |entry| entry.uid.blank? }
     entries.first(limit)
   rescue StandardError => e
-    Rails.error.report(e, context: { profile_key: profile_key, user_id: user&.id })
+    Rails.error.report(e, context: error_context)
     raise SourceUnreachable, e.message
+  end
+
+  def error_context
+    { profile_key: profile_key, user_id: user&.id }
   end
 
   def normalize_to_drafts(temp_feed, entries)

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -1,0 +1,42 @@
+module Loader
+  # LLM-backed loader. Asks `LlmClient` to extract a list of post-like
+  # items from the source URL (or other input shape) using a profile-
+  # provided prompt + output schema. Returns the structured payload
+  # `{ "items" => [...] }` directly; PassthroughProcessor unpacks it
+  # into FeedEntry instances downstream.
+  #
+  # The profile entry must declare `loader: { class: "Loader::LlmLoader",
+  # config: { model:, prompt_template:, output_schema:, tools? } }`.
+  class LlmLoader < Base
+    def load
+      llm_client = options.fetch(:llm_client) { LlmClient.for(feed) }
+      result = llm_client.call(
+        feed: feed.persisted? ? feed : nil,
+        profile_key: feed.feed_profile_key,
+        stage: :loader,
+        purpose: options.fetch(:purpose, :scheduled_run),
+        model: config.fetch(:model),
+        prompt: rendered_prompt,
+        output_schema: config.fetch(:output_schema),
+        tools: config.fetch(:tools, [])
+      )
+
+      payload = result.payload
+      raise StandardError, "LlmLoader payload missing 'items' array" unless payload.is_a?(Hash) && payload["items"].is_a?(Array)
+
+      limit = options[:limit]
+      limit ? payload["items"].first(limit) : payload["items"]
+    end
+
+    private
+
+    def config
+      @config ||= FeedProfile.config_for(feed.feed_profile_key, :loader).symbolize_keys
+    end
+
+    def rendered_prompt
+      template = config.fetch(:prompt_template).to_s
+      template.gsub("{{url}}", feed.url.to_s).gsub("{{input}}", feed.url.to_s)
+    end
+  end
+end

--- a/app/services/normalizer/llm_normalizer.rb
+++ b/app/services/normalizer/llm_normalizer.rb
@@ -1,0 +1,50 @@
+module Normalizer
+  # Normalizer for AI-backed profiles. Two modes, selected by the
+  # profile's normalizer config:
+  #
+  # * Passthrough (no `prompt_template`): the raw_data already has all
+  #   universal-post fields; map them straight onto Post. Used by the
+  #   `llm_website_extractor` profile where the AI work happens at the
+  #   loader stage.
+  #
+  # * LLM rewrite (`prompt_template` present in config): runs raw_data
+  #   through `LlmClient` so a second prompt can clean up / translate /
+  #   summarise the content before it lands in Post. Reserved for
+  #   future rewrite profiles; the website-extractor MVP doesn't use
+  #   this branch.
+  class LlmNormalizer < Base
+    private
+
+    def normalize_source_url
+      raw_data["source_url"].to_s
+    end
+
+    def normalize_content
+      raw_data["body"].to_s
+    end
+
+    def normalize_attachment_urls
+      Array(raw_data["images"]).map(&:to_s)
+    end
+
+    def normalize_comments
+      Array(raw_data["supplementary"]).map(&:to_s)
+    end
+
+    def normalize_published_at(value)
+      return value if value.is_a?(Time) || value.is_a?(ActiveSupport::TimeWithZone)
+      return nil if value.blank?
+
+      Time.parse(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+
+    def validate_content
+      errors = []
+      errors << "missing source_url" if normalize_source_url.blank?
+      errors << "missing content" if normalize_content.blank?
+      errors
+    end
+  end
+end

--- a/app/services/normalizer/llm_normalizer.rb
+++ b/app/services/normalizer/llm_normalizer.rb
@@ -33,11 +33,11 @@ module Normalizer
 
     def normalize_published_at(value)
       return value if value.is_a?(Time) || value.is_a?(ActiveSupport::TimeWithZone)
-      return nil if value.blank?
+      return Time.current if value.blank?
 
       Time.parse(value.to_s)
     rescue ArgumentError
-      nil
+      Time.current
     end
 
     def validate_content

--- a/app/services/processor/passthrough_processor.rb
+++ b/app/services/processor/passthrough_processor.rb
@@ -1,0 +1,35 @@
+module Processor
+  # Wraps loader-emitted structured items as FeedEntry instances without
+  # any further parsing. Used by AI-extraction profiles where the loader
+  # already produced the universal post shape.
+  class PassthroughProcessor < Base
+    def process
+      items = Array(raw_data)
+      items.filter_map do |item|
+        next unless item.is_a?(Hash)
+
+        uid = item["uid"].presence || item[:uid].presence
+        next if uid.blank?
+
+        FeedEntry.new(
+          feed: feed,
+          uid: uid,
+          published_at: parse_time(item["published_at"] || item[:published_at]),
+          status: :pending,
+          raw_data: item.deep_stringify_keys
+        )
+      end
+    end
+
+    private
+
+    def parse_time(value)
+      return value if value.is_a?(Time) || value.is_a?(ActiveSupport::TimeWithZone)
+      return nil if value.blank?
+
+      Time.parse(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/services/processor/passthrough_processor.rb
+++ b/app/services/processor/passthrough_processor.rb
@@ -14,7 +14,9 @@ module Processor
         FeedEntry.new(
           feed: feed,
           uid: uid,
-          published_at: parse_time(item["published_at"] || item[:published_at]),
+          # AI-extracted items rarely come with a reliable published_at;
+          # fall back to the current time so downstream invariants hold.
+          published_at: parse_time(item["published_at"] || item[:published_at]) || Time.current,
           status: :pending,
           raw_data: item.deep_stringify_keys
         )

--- a/app/services/profile_matcher/llm_website_extractor_matcher.rb
+++ b/app/services/profile_matcher/llm_website_extractor_matcher.rb
@@ -1,0 +1,22 @@
+module ProfileMatcher
+  # Universal URL fallback. Matches any URL the user pastes and offers
+  # AI extraction. Lowest specificity, so it always ranks below
+  # structured matchers (RSS, XKCD, …) for the same URL.
+  class LlmWebsiteExtractorMatcher < Base
+    input_shape :url
+    match_specificity 1
+    depends_on_ai true
+
+    def self.profile_key
+      "llm_website_extractor"
+    end
+
+    def match?
+      return false if input.blank?
+
+      URI.parse(input).is_a?(URI::HTTP)
+    rescue URI::InvalidURIError
+      false
+    end
+  end
+end

--- a/app/views/feeds/_credential_gate.html.erb
+++ b/app/views/feeds/_credential_gate.html.erb
@@ -1,0 +1,22 @@
+<%# locals: (profile_key:, new_credential_path:) %>
+<div class="rounded-lg border border-sky-200 bg-sky-50 p-4 space-y-3"
+     data-key="credentials.gate">
+  <div class="flex gap-3">
+    <div class="flex-shrink-0 pt-0.5">
+      <%= icon("key", css_class: "h-5 w-5 text-sky-500", aria_hidden: true) %>
+    </div>
+    <div class="space-y-1">
+      <p class="font-semibold text-sky-900">AI extraction needs your API key</p>
+      <p class="text-sky-800 text-sm">
+        To let AI fetch posts on your behalf, add an API key from your AI provider. We'll come back to this feed once you're set up.
+      </p>
+    </div>
+  </div>
+
+  <div>
+    <%= link_to "Add AI credentials",
+                new_credential_path,
+                data: { turbo_frame: "_top", key: "credentials.gate.add" },
+                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500" %>
+  </div>
+</div>

--- a/app/views/feeds/_credential_gate.html.erb
+++ b/app/views/feeds/_credential_gate.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (profile_key:, new_credential_path:) %>
+<%# locals: (profile_key:, new_credential_path:, return_to: nil) %>
 <div class="rounded-lg border border-sky-200 bg-sky-50 p-4 space-y-3"
      data-key="credentials.gate">
   <div class="flex gap-3">
@@ -15,7 +15,7 @@
 
   <div>
     <%= link_to "Add AI credentials",
-                new_credential_path,
+                return_to ? "#{new_credential_path}?return_to=#{CGI.escape(return_to)}" : new_credential_path,
                 data: { turbo_frame: "_top", key: "credentials.gate.add" },
                 class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500" %>
   </div>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -21,6 +21,13 @@
         <%= f.hidden_field :feed_profile_key %>
       <% end %>
 
+      <% if FeedProfile.exists?(feed.feed_profile_key) && FeedProfile.depends_on_ai?(feed.feed_profile_key) %>
+        <p class="rounded-md bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-900"
+           data-key="ai-cost.notice">
+          AI fetches (including this preview) cost tokens — you'll see your spend on the feed page.
+        </p>
+      <% end %>
+
       <div class="space-y-2">
         <%= f.label :url, "Source", class: "block font-semibold text-slate-800" %>
         <%= f.text_field :url_display,

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -36,6 +36,13 @@
   <% end %>
 
   <div class="flex flex-wrap gap-3">
+    <% return_to = params[:return_to].to_s %>
+    <% if @llm_credential.active? && return_to.start_with?("/") && !return_to.start_with?("//") %>
+      <%= link_to "Continue setting up your feed",
+                  return_to,
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500",
+                  data: { key: "llm_credential.return-to" } %>
+    <% end %>
     <%= link_to "Back to credentials",
                 llm_credentials_path,
                 class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50" %>

--- a/test/controllers/feed_details_controller_test.rb
+++ b/test/controllers/feed_details_controller_test.rb
@@ -230,8 +230,10 @@ class FeedDetailsControllerTest < ActionDispatch::IntegrationTest
     get feed_details_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_includes response.body, "Unsupported feed profile"
-    assert_includes response.body, 'data-identification-state="error"'
+    # When no structured profile matches, the AI fallback now fires and the
+    # form lands in the complete state instead of the error state.
+    assert_includes response.body, 'data-identification-state="complete"'
+    assert_includes response.body, "llm_website_extractor"
   end
 
   test "#show should return error when feed detail is missing" do
@@ -256,9 +258,10 @@ class FeedDetailsControllerTest < ActionDispatch::IntegrationTest
     get feed_details_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     payload = extract_candidates_payload(response.body)
-    assert_equal 1, payload.size
-    assert_equal "rss", payload.first["profile_key"]
+    # RSS plus the AI fallback. RSS ranks first.
+    assert_equal %w[rss llm_website_extractor], payload.map { |c| c["profile_key"] }
     assert_equal "specific_match", payload.first["rank_reason"]
+    assert_equal "ai_fallback", payload.last["rank_reason"]
   end
 
   test "#show should surface a multi-candidate payload ranked recommended first" do
@@ -273,10 +276,10 @@ class FeedDetailsControllerTest < ActionDispatch::IntegrationTest
     get feed_details_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     payload = extract_candidates_payload(response.body)
-    assert_equal %w[xkcd rss], payload.map { |c| c["profile_key"] }
+    assert_equal %w[xkcd rss llm_website_extractor], payload.map { |c| c["profile_key"] }
     assert_equal 0, payload.first["rank"]
     assert_equal "specific_match", payload.first["rank_reason"]
-    assert_equal "generic_match", payload.last["rank_reason"]
+    assert_equal "ai_fallback", payload.last["rank_reason"]
   end
 
   test "#show should surface an AI-only fallback payload when only an AI matcher fires" do

--- a/test/controllers/feeds/previews_controller_test.rb
+++ b/test/controllers/feeds/previews_controller_test.rb
@@ -159,6 +159,32 @@ class Feeds::PreviewsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "#show should render the credential gate when an AI profile is selected but the user has no credentials" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      get feed_live_preview_path("draft"),
+          params: { profile_key: "llm_website_extractor", params: { url: "https://example.com" } }
+
+      assert_response :success
+      assert_select "[data-key='credentials.gate']"
+      assert_select "[data-key='credentials.gate.add']"
+    end
+  end
+
+  test "#show should not render the credential gate when the user has an active AI credential" do
+    sign_in_as(user)
+    create(:llm_credential, :active, user: user)
+
+    with_memory_cache do
+      get feed_live_preview_path("draft"),
+          params: { profile_key: "llm_website_extractor", params: { url: "https://example.com" } }
+
+      assert_response :success
+      assert_select "[data-key='credentials.gate']", false
+    end
+  end
+
   test "#destroy should clear the cached preview" do
     sign_in_as(user)
 

--- a/test/integration/smart_feed_creation_ai_website_test.rb
+++ b/test/integration/smart_feed_creation_ai_website_test.rb
@@ -1,0 +1,157 @@
+require "test_helper"
+
+# Integration test for User Story 2 (AI website extraction).
+# Covers the credential-present path, the credential-gate path, and the
+# preview-failure "save anyway" path. Stubs the LLM call at the
+# Loader::LlmLoader seam (per LlmClient contract: stage tests stub the
+# client, not RubyLLM directly).
+class SmartFeedCreationAiWebsiteTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  teardown { restore_llm_loader }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def access_token
+    @access_token ||= create(:access_token, :active, user: user)
+  end
+
+  def credential
+    @credential ||= create(:llm_credential, :active, user: user)
+  end
+
+  def ai_url
+    "https://no-rss-example.com/blog"
+  end
+
+  def sample_items
+    [
+      { "uid" => "https://no-rss-example.com/blog/post-1",
+        "title" => "First post",
+        "body" => "Hello world",
+        "source_url" => "https://no-rss-example.com/blog/post-1",
+        "supplementary" => [],
+        "images" => [],
+        "published_at" => "2026-05-10T00:00:00Z" }
+    ]
+  end
+
+  def with_memory_cache
+    previous = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = previous
+  end
+
+  def stub_loader(result)
+    @llm_loader_stubbed = true
+    Loader::LlmLoader.define_method(:load) do
+      case result
+      when Exception then raise result
+      else result
+      end
+    end
+  end
+
+  def restore_llm_loader
+    return unless @llm_loader_stubbed
+
+    Loader::LlmLoader.send(:remove_method, :load) if Loader::LlmLoader.method_defined?(:load)
+    load Rails.root.join("app/services/loader/llm_loader.rb")
+    @llm_loader_stubbed = false
+  end
+
+  def detect(url)
+    stub_request(:get, url).to_return(status: 200, body: "<html><body>no rss here</body></html>")
+    post feed_details_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    perform_enqueued_jobs
+  end
+
+  test "#post should walk the AI happy path: detect, preview, save enabled" do
+    sign_in_as(user)
+    access_token
+    credential
+    stub_loader(sample_items)
+
+    with_memory_cache do
+      detect(ai_url)
+
+      get feed_details_path, params: { url: ai_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      assert_response :success
+      assert_includes response.body, "AI page reader"
+
+      get feed_live_preview_path("draft"),
+          params: { profile_key: "llm_website_extractor", params: { url: ai_url } }
+      assert_response :success
+      perform_enqueued_jobs
+
+      preview = FeedPreviewService.call(
+        user: user,
+        profile_key: "llm_website_extractor",
+        params: { "url" => ai_url },
+        llm_credential: credential
+      )
+      assert preview.preview_token.present?
+
+      assert_difference("Feed.count", 1) do
+        post feeds_path, params: {
+          feed: {
+            url: ai_url,
+            name: "No-RSS Blog",
+            feed_profile_key: "llm_website_extractor",
+            access_token_id: access_token.id,
+            target_group: "testgroup",
+            schedule_interval: "1h",
+            llm_credential_id: credential.id
+          },
+          enable_feed: "1",
+          preview_token: preview.preview_token
+        }
+      end
+
+      assert_equal "enabled", Feed.last.state
+    end
+  end
+
+  test "#show should gate on credentials when an AI profile has no usable credential" do
+    sign_in_as(user)
+    # no credential created
+
+    with_memory_cache do
+      get feed_live_preview_path("draft"),
+          params: { profile_key: "llm_website_extractor", params: { url: ai_url } }
+
+      assert_response :success
+      assert_select "[data-key='credentials.gate']"
+      assert_no_enqueued_jobs
+    end
+  end
+
+  test "#post should accept save-anyway after a preview failure and land disabled" do
+    sign_in_as(user)
+    access_token
+    credential
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: {
+        feed: {
+          url: ai_url,
+          name: "No-RSS Blog",
+          feed_profile_key: "llm_website_extractor",
+          access_token_id: access_token.id,
+          target_group: "testgroup",
+          schedule_interval: "1h",
+          llm_credential_id: credential.id
+        },
+        enable_feed: "0"
+      }
+    end
+
+    assert_equal "disabled", Feed.last.state
+  end
+end

--- a/test/integration/smart_feed_creation_ai_website_test.rb
+++ b/test/integration/smart_feed_creation_ai_website_test.rb
@@ -10,8 +10,6 @@ class SmartFeedCreationAiWebsiteTest < ActionDispatch::IntegrationTest
 
   setup { clear_enqueued_jobs }
 
-  teardown { restore_llm_loader }
-
   def user
     @user ||= create(:user)
   end
@@ -48,22 +46,22 @@ class SmartFeedCreationAiWebsiteTest < ActionDispatch::IntegrationTest
     Rails.cache = previous
   end
 
-  def stub_loader(result)
-    @llm_loader_stubbed = true
-    Loader::LlmLoader.define_method(:load) do
-      case result
-      when Exception then raise result
-      else result
+  # Stubs LlmClient.for so the loader receives a fake client whose #call
+  # returns / raises the prescripted result. Block-scoped, no
+  # monkey-patching of stage classes.
+  def with_llm_client(result, &block)
+    fake_client = Class.new do
+      def initialize(result) = (@result = result)
+      def call(**_args)
+        case @result
+        when Exception then raise @result
+        when Hash then LlmClient::Result.new(payload: @result, usage_id: 1)
+        else raise ArgumentError, "unsupported stub result: #{@result.class}"
+        end
       end
-    end
-  end
+    end.new(result)
 
-  def restore_llm_loader
-    return unless @llm_loader_stubbed
-
-    Loader::LlmLoader.send(:remove_method, :load) if Loader::LlmLoader.method_defined?(:load)
-    load Rails.root.join("app/services/loader/llm_loader.rb")
-    @llm_loader_stubbed = false
+    LlmClient.stub(:for, ->(*_args) { fake_client }, &block)
   end
 
   def detect(url)
@@ -76,10 +74,10 @@ class SmartFeedCreationAiWebsiteTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     access_token
     credential
-    stub_loader(sample_items)
 
-    with_memory_cache do
-      detect(ai_url)
+    with_llm_client({ "items" => sample_items }) do
+      with_memory_cache do
+        detect(ai_url)
 
       get feed_details_path, params: { url: ai_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
       assert_response :success
@@ -115,6 +113,7 @@ class SmartFeedCreationAiWebsiteTest < ActionDispatch::IntegrationTest
       end
 
       assert_equal "enabled", Feed.last.state
+      end
     end
   end
 

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
-    assert_equal ["rss", "xkcd"], FeedProfile.all.sort
+    assert_equal ["llm_website_extractor", "rss", "xkcd"], FeedProfile.all.sort
   end
 
   test ".exists? returns true for valid profile key" do
@@ -45,7 +45,13 @@ class FeedProfileTest < ActiveSupport::TestCase
       end
 
       if entry[:depends_on_ai]
-        assert_kind_of Hash, entry[:output_schema], "#{key}: output_schema required for AI profile"
+        # AI profiles either declare the universal-post output_schema at
+        # the top level or carry it on the AI-using stage's config.
+        ai_stage_config = FeedProfile::STAGES
+          .map { |stage| entry[stage][:config] }
+          .find { |c| c[:output_schema].is_a?(Hash) }
+        assert_kind_of Hash, ai_stage_config&.dig(:output_schema) || entry[:output_schema],
+                       "#{key}: output_schema required for AI profile"
       end
     end
   end
@@ -81,8 +87,12 @@ class FeedProfileTest < ActiveSupport::TestCase
     end
   end
 
-  test "all PROFILES have resolvable title extractor classes" do
-    FeedProfile::PROFILES.each_key do |key|
+  test "all non-AI PROFILES have resolvable title extractor classes" do
+    # AI-backed profiles emit the universal post shape directly, so they
+    # skip the title-extractor stage.
+    FeedProfile::PROFILES.each do |key, entry|
+      next if entry[:depends_on_ai]
+
       title_extractor_class = FeedProfile.title_extractor_class_for(key)
       assert title_extractor_class.present?, "Profile '#{key}' should have a resolvable title extractor class"
       assert title_extractor_class < TitleExtractor::Base, "Profile '#{key}' title extractor should inherit from TitleExtractor::Base"
@@ -133,6 +143,7 @@ class FeedProfileTest < ActiveSupport::TestCase
   end
 
   test ".depends_on_ai? returns true for AI-backed profiles" do
+    assert FeedProfile.depends_on_ai?("llm_website_extractor")
     assert_not FeedProfile.depends_on_ai?("rss")
     assert_not FeedProfile.depends_on_ai?("xkcd")
     assert_not FeedProfile.depends_on_ai?("nonexistent")

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -673,4 +673,32 @@ class FeedTest < ActiveSupport::TestCase
 
     assert feed.valid?, feed.errors.full_messages.inspect
   end
+
+  test "should reject an llm_credential belonging to a different user" do
+    owner = create(:user)
+    stranger = create(:user)
+    foreign_credential = create(:llm_credential, user: stranger)
+
+    feed = build(:feed,
+                 user: owner,
+                 llm_credential: foreign_credential,
+                 feed_profile_key: "rss",
+                 params: { "url" => "https://example.com/feed.xml" })
+
+    refute feed.valid?
+    assert_includes feed.errors[:llm_credential], "must belong to the same user"
+  end
+
+  test "should accept its own user's llm_credential" do
+    user = create(:user)
+    credential = create(:llm_credential, user: user)
+
+    feed = build(:feed,
+                 user: user,
+                 llm_credential: credential,
+                 feed_profile_key: "rss",
+                 params: { "url" => "https://example.com/feed.xml" })
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
 end

--- a/test/services/feed_details_fetcher_test.rb
+++ b/test/services/feed_details_fetcher_test.rb
@@ -93,7 +93,7 @@ class FeedDetailsFetcherTest < ActiveSupport::TestCase
     assert_nil feed_detail.candidates.first["title"]
   end
 
-  test "#identify should update record with failed status when profile not identified" do
+  test "#identify should fall back to AI extraction when no structured profile matches" do
     url = "http://example.com/unknown.txt"
 
     stub_request(:get, url)
@@ -104,8 +104,8 @@ class FeedDetailsFetcherTest < ActiveSupport::TestCase
 
     feed_detail = FeedDetail.find_by(user: user, url: url)
     assert_not_nil feed_detail
-    assert_equal "failed", feed_detail.status
-    assert_equal "Unsupported feed profile", feed_detail.error
+    assert_equal "success", feed_detail.status
+    assert_equal "llm_website_extractor", feed_detail.candidates.first["profile_key"]
   end
 
   test "#identify should update record with failed status on HTTP errors" do
@@ -155,7 +155,7 @@ class FeedDetailsFetcherTest < ActiveSupport::TestCase
     FeedDetailsFetcher.new(user: user, url: url, logger: @logger).identify
 
     feed_detail = FeedDetail.find_by(user: user, url: url)
-    assert_equal 1, feed_detail.candidates.size
+    assert_equal %w[rss llm_website_extractor], feed_detail.candidates.map { |c| c["profile_key"] }
 
     candidate = feed_detail.candidates.first
     assert_equal "rss", candidate["profile_key"]
@@ -183,17 +183,18 @@ class FeedDetailsFetcherTest < ActiveSupport::TestCase
 
     feed_detail = FeedDetail.find_by(user: user, url: url)
     profile_keys = feed_detail.candidates.map { |c| c["profile_key"] }
-    assert_equal %w[xkcd rss], profile_keys, "xkcd outranks rss for xkcd.com URLs"
+    assert_equal %w[xkcd rss llm_website_extractor], profile_keys, "xkcd > rss > AI fallback for xkcd.com URLs"
   end
 
-  test "#identify should persist an empty candidates array when no profile matches" do
+  test "#identify should record the AI fallback as the only candidate when no structured profile matches" do
     url = "http://example.com/page.html"
     stub_request(:get, url).to_return(status: 200, body: "<html><body/></html>")
 
     FeedDetailsFetcher.new(user: user, url: url, logger: @logger).identify
 
     feed_detail = FeedDetail.find_by(user: user, url: url)
-    assert_equal "failed", feed_detail.status
-    assert_equal [], feed_detail.candidates
+    assert_equal "success", feed_detail.status
+    assert_equal ["llm_website_extractor"], feed_detail.candidates.map { |c| c["profile_key"] }
+    assert_equal true, feed_detail.candidates.first["depends_on_ai"]
   end
 end

--- a/test/services/feed_preview_service_test.rb
+++ b/test/services/feed_preview_service_test.rb
@@ -174,4 +174,63 @@ class FeedPreviewServiceTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test ".call should raise CredentialMissing when an AI profile has no credential" do
+    assert_raises FeedPreviewService::CredentialMissing do
+      FeedPreviewService.call(
+        user: user,
+        profile_key: "llm_website_extractor",
+        params: { "url" => "https://example.com" }
+      )
+    end
+  end
+
+  test ".call should map LlmClient::SchemaError to AiUnparseable" do
+    with_loader_stub(LlmClient::SchemaError.new("bad shape")) do
+      assert_raises FeedPreviewService::AiUnparseable do
+        FeedPreviewService.call(
+          user: user,
+          profile_key: "llm_website_extractor",
+          params: { "url" => "https://example.com" },
+          llm_credential: create(:llm_credential, :active, user: user)
+        )
+      end
+    end
+  end
+
+  test ".call should map LlmClient::ProviderError to FeedPreviewService::ProviderError" do
+    with_loader_stub(LlmClient::ProviderError.new("boom")) do
+      assert_raises FeedPreviewService::ProviderError do
+        FeedPreviewService.call(
+          user: user,
+          profile_key: "llm_website_extractor",
+          params: { "url" => "https://example.com" },
+          llm_credential: create(:llm_credential, :active, user: user)
+        )
+      end
+    end
+  end
+
+  test ".call should map LlmClient::RateLimited to FeedPreviewService::ProviderError" do
+    with_loader_stub(LlmClient::RateLimited.new("429")) do
+      assert_raises FeedPreviewService::ProviderError do
+        FeedPreviewService.call(
+          user: user,
+          profile_key: "llm_website_extractor",
+          params: { "url" => "https://example.com" },
+          llm_credential: create(:llm_credential, :active, user: user)
+        )
+      end
+    end
+  end
+
+  private
+
+  def with_loader_stub(error)
+    Loader::LlmLoader.define_method(:load) { raise error }
+    yield
+  ensure
+    Loader::LlmLoader.send(:remove_method, :load) if Loader::LlmLoader.method_defined?(:load)
+    load Rails.root.join("app/services/loader/llm_loader.rb")
+  end
 end

--- a/test/services/feed_preview_service_test.rb
+++ b/test/services/feed_preview_service_test.rb
@@ -226,11 +226,17 @@ class FeedPreviewServiceTest < ActiveSupport::TestCase
 
   private
 
+  # Stubs LlmClient.for so the loader receives a fake client whose
+  # #call raises `error`. Confined to the block — no monkey-patching
+  # or source-file reloading.
   def with_loader_stub(error)
-    Loader::LlmLoader.define_method(:load) { raise error }
-    yield
-  ensure
-    Loader::LlmLoader.send(:remove_method, :load) if Loader::LlmLoader.method_defined?(:load)
-    load Rails.root.join("app/services/loader/llm_loader.rb")
+    fake_client = Class.new do
+      def initialize(err) = (@err = err)
+      def call(**_) = raise(@err)
+    end.new(error)
+
+    LlmClient.stub(:for, ->(*_args) { fake_client }) do
+      yield
+    end
   end
 end

--- a/test/services/feed_profile_detector_test.rb
+++ b/test/services/feed_profile_detector_test.rb
@@ -23,33 +23,36 @@ class FeedProfileDetectorTest < ActiveSupport::TestCase
     assert_empty result.candidates
   end
 
-  test ".call should return empty candidates when no matcher fires" do
+  test ".call should fall back to AI extraction when no non-AI matcher fires for a URL" do
     result = FeedProfileDetector.call(input: "https://example.com/page", fetched_body: "<html><body/></html>")
     assert_equal :url, result.input_shape
-    assert_empty result.candidates
+    assert_equal ["llm_website_extractor"], result.candidates.map(&:profile_key)
+    assert_equal :ai_fallback, result.candidates.first.rank_reason
   end
 
-  test ".call should return a ranked candidate for a generic RSS feed" do
+  test ".call should rank a generic RSS feed above the AI fallback" do
     result = FeedProfileDetector.call(input: "https://example.com/feed.xml", fetched_body: rss_feed_body)
-    assert_equal ["rss"], result.candidates.map(&:profile_key)
+    assert_equal ["rss", "llm_website_extractor"], result.candidates.map(&:profile_key)
 
-    candidate = result.candidates.first
-    assert_equal 0, candidate.rank
-    assert_equal false, candidate.depends_on_ai
-    assert_equal :specific_match, candidate.rank_reason
+    rss = result.candidates.first
+    assert_equal 0, rss.rank
+    assert_equal false, rss.depends_on_ai
+    assert_equal :specific_match, rss.rank_reason
   end
 
-  test ".call should rank specific matchers above generic ones" do
+  test ".call should rank specific matchers above generic ones, with AI fallback last" do
     result = FeedProfileDetector.call(input: "https://xkcd.com/rss.xml", fetched_body: rss_feed_body)
 
     profile_keys = result.candidates.map(&:profile_key)
-    assert_equal %w[xkcd rss], profile_keys, "xkcd (specificity 100) outranks rss (specificity 10)"
+    assert_equal %w[xkcd rss llm_website_extractor], profile_keys, "xkcd (100) > rss (10) > AI (1)"
 
-    xkcd, rss = result.candidates
+    xkcd, rss, ai = result.candidates
     assert_equal 0, xkcd.rank
     assert_equal 1, rss.rank
+    assert_equal 2, ai.rank
     assert_equal :specific_match, xkcd.rank_reason
     assert_equal :generic_match, rss.rank_reason
+    assert_equal :ai_fallback, ai.rank_reason
   end
 
   test ".call should place AI-backed candidates after non-AI candidates" do

--- a/test/services/loader/llm_loader_test.rb
+++ b/test/services/loader/llm_loader_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class Loader::LlmLoaderTest < ActiveSupport::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def credential
+    @credential ||= create(:llm_credential, :active, user: user)
+  end
+
+  def feed
+    @feed ||= create(:feed,
+                     user: user,
+                     llm_credential: credential,
+                     feed_profile_key: "llm_website_extractor",
+                     params: { "url" => "https://example.com" })
+  end
+
+  def fake_client(payload)
+    Class.new do
+      def initialize(payload) = (@payload = payload)
+      def call(**_args)
+        LlmClient::Result.new(payload: @payload, usage_id: 42)
+      end
+    end.new(payload)
+  end
+
+  test "#load should return the items array from the LLM response" do
+    items = [
+      { "title" => "Post A", "uid" => "https://example.com/a" },
+      { "title" => "Post B", "uid" => "https://example.com/b" }
+    ]
+    loader = Loader::LlmLoader.new(feed, llm_client: fake_client({ "items" => items }))
+
+    assert_equal items, loader.load
+  end
+
+  test "#load should respect the limit option" do
+    items = (1..10).map { |i| { "title" => "Post #{i}", "uid" => "https://example.com/#{i}" } }
+    loader = Loader::LlmLoader.new(feed, llm_client: fake_client({ "items" => items }), limit: 3)
+
+    assert_equal 3, loader.load.size
+  end
+
+  test "#load should raise when the payload is missing the items key" do
+    loader = Loader::LlmLoader.new(feed, llm_client: fake_client({ "wrong" => "shape" }))
+
+    error = assert_raises(StandardError) { loader.load }
+    assert_match(/items/, error.message)
+  end
+end

--- a/test/services/normalizer/llm_normalizer_test.rb
+++ b/test/services/normalizer/llm_normalizer_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Normalizer::LlmNormalizerTest < ActiveSupport::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed
+    @feed ||= create(:feed,
+                     user: user,
+                     llm_credential: create(:llm_credential, :active, user: user),
+                     feed_profile_key: "llm_website_extractor",
+                     params: { "url" => "https://example.com" })
+  end
+
+  def feed_entry(overrides = {})
+    raw = {
+      "uid" => "https://example.com/post-1",
+      "title" => "Post 1",
+      "body" => "Hello world",
+      "source_url" => "https://example.com/post-1",
+      "supplementary" => ["A comment"],
+      "images" => ["https://example.com/cover.png"],
+      "published_at" => "2026-05-10T10:00:00Z"
+    }.merge(overrides)
+    FeedEntry.new(
+      feed: feed,
+      uid: raw["uid"],
+      published_at: Time.parse(raw["published_at"]),
+      raw_data: raw,
+      status: :pending
+    )
+  end
+
+  test "#normalize should map raw_data fields onto a Post" do
+    post = Normalizer::LlmNormalizer.new(feed_entry).normalize
+
+    assert_equal "Hello world", post.content
+    assert_equal "https://example.com/post-1", post.source_url
+    assert_equal ["https://example.com/cover.png"], post.attachment_urls
+    assert_equal ["A comment"], post.comments
+    assert_equal "enqueued", post.status
+  end
+
+  test "#normalize should reject when source_url is missing" do
+    post = Normalizer::LlmNormalizer.new(feed_entry("source_url" => "")).normalize
+
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "missing source_url"
+  end
+
+  test "#normalize should reject when content is missing" do
+    post = Normalizer::LlmNormalizer.new(feed_entry("body" => "")).normalize
+
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "missing content"
+  end
+end

--- a/test/services/processor/passthrough_processor_test.rb
+++ b/test/services/processor/passthrough_processor_test.rb
@@ -48,12 +48,12 @@ class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
     assert_equal 2026, entries[0].published_at.year
   end
 
-  test "#process should tolerate invalid published_at strings" do
+  test "#process should default to the current time when published_at is invalid" do
     items = [{ "uid" => "u1", "published_at" => "not a date" }]
 
     entries = Processor::PassthroughProcessor.new(feed, items).process
 
-    assert_nil entries[0].published_at
+    assert_in_delta Time.current.to_f, entries[0].published_at.to_f, 5.0
   end
 
   test "#process should accept symbol keys as well as strings" do

--- a/test/services/processor/passthrough_processor_test.rb
+++ b/test/services/processor/passthrough_processor_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed
+    @feed ||= create(:feed,
+                     user: user,
+                     llm_credential: create(:llm_credential, :active, user: user),
+                     feed_profile_key: "llm_website_extractor",
+                     params: { "url" => "https://example.com" })
+  end
+
+  test "#process should build a FeedEntry for each item with a uid" do
+    items = [
+      { "uid" => "https://example.com/a", "title" => "A", "published_at" => "2026-05-01T00:00:00Z" },
+      { "uid" => "https://example.com/b", "title" => "B" }
+    ]
+
+    entries = Processor::PassthroughProcessor.new(feed, items).process
+
+    assert_equal 2, entries.size
+    assert_equal "https://example.com/a", entries[0].uid
+    assert_equal "https://example.com/b", entries[1].uid
+    assert_kind_of FeedEntry, entries[0]
+  end
+
+  test "#process should skip items missing a uid" do
+    items = [
+      { "title" => "no uid" },
+      { "uid" => "https://example.com/ok" }
+    ]
+
+    entries = Processor::PassthroughProcessor.new(feed, items).process
+
+    assert_equal 1, entries.size
+    assert_equal "https://example.com/ok", entries[0].uid
+  end
+
+  test "#process should parse published_at from ISO 8601" do
+    items = [{ "uid" => "u1", "published_at" => "2026-04-15T12:30:00Z" }]
+
+    entries = Processor::PassthroughProcessor.new(feed, items).process
+
+    assert_kind_of Time, entries[0].published_at
+    assert_equal 2026, entries[0].published_at.year
+  end
+
+  test "#process should tolerate invalid published_at strings" do
+    items = [{ "uid" => "u1", "published_at" => "not a date" }]
+
+    entries = Processor::PassthroughProcessor.new(feed, items).process
+
+    assert_nil entries[0].published_at
+  end
+
+  test "#process should accept symbol keys as well as strings" do
+    items = [{ uid: "u-sym", title: "Sym" }]
+
+    entries = Processor::PassthroughProcessor.new(feed, items).process
+
+    assert_equal "u-sym", entries[0].uid
+    assert_equal "u-sym", entries[0].raw_data["uid"]
+  end
+end

--- a/test/services/profile_matcher/llm_website_extractor_matcher_test.rb
+++ b/test/services/profile_matcher/llm_website_extractor_matcher_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class ProfileMatcher::LlmWebsiteExtractorMatcherTest < ActiveSupport::TestCase
+  def matcher(input, body = nil)
+    ProfileMatcher::LlmWebsiteExtractorMatcher.new(input, body)
+  end
+
+  test "should declare url input_shape" do
+    assert_equal :url, ProfileMatcher::LlmWebsiteExtractorMatcher.input_shape
+  end
+
+  test "should declare the lowest specificity so it always ranks below structured matchers" do
+    assert_equal 1, ProfileMatcher::LlmWebsiteExtractorMatcher.match_specificity
+    assert_operator ProfileMatcher::LlmWebsiteExtractorMatcher.match_specificity, :<, ProfileMatcher::RssProfileMatcher.match_specificity
+    assert_operator ProfileMatcher::LlmWebsiteExtractorMatcher.match_specificity, :<, ProfileMatcher::XkcdProfileMatcher.match_specificity
+  end
+
+  test "should be flagged as AI-dependent" do
+    assert ProfileMatcher::LlmWebsiteExtractorMatcher.depends_on_ai
+  end
+
+  test "#match? should return true for any HTTP URL" do
+    assert matcher("http://example.com").match?
+    assert matcher("https://example.com/page").match?
+    assert matcher("https://sub.example.com/path?q=1").match?
+  end
+
+  test "#match? should return false for blank input" do
+    refute matcher(nil).match?
+    refute matcher("").match?
+  end
+
+  test "#match? should return false for non-HTTP inputs" do
+    refute matcher("just text").match?
+    refute matcher("@handle").match?
+  end
+end


### PR DESCRIPTION
Changes:

- T047 `Loader::LlmLoader` — invokes `LlmClient.call`, returns the `items` array.
- T048 `Processor::PassthroughProcessor` — wraps structured items as FeedEntry rows.
- T049 `Normalizer::LlmNormalizer` — maps raw_data straight to Post (passthrough mode for website-extractor; the rewrite mode is reserved for future profiles).
- T050 `LlmWebsiteExtractorMatcher` — input_shape `:url`, specificity 1, `depends_on_ai: true`, matches any HTTP(S) URL.
- T051 `llm_website_extractor` profile entry — Anthropic Sonnet, prompt template, output schema, `web_search` + `web_fetch` server tools.
- T052 `FeedPreviewService` maps `LlmClient::SchemaError` → `AiUnparseable`, `ProviderError` / `RateLimited` / `Timeout` → `ProviderError`, and threads the credential through.
- T053-T054 `Feeds::PreviewsController` short-circuits to a credential-gate partial when the chosen profile needs AI and the user has no usable credential.
- T055 AI cost notice in `_form_expanded.html.erb`.
- T056 `test/integration/smart_feed_creation_ai_website_test.rb` covering happy path, gate path, save-as-disabled path.
- Updated existing detector / fetcher / controller tests now that the AI fallback rides along whenever no structured profile matches.

After self-review, also addressed:
- Cross-tenant credential validation: `Feed#llm_credential_belongs_to_user` rejects assigning another user's credential through mass-assignment.
- Return-path through the credential gate: `_credential_gate` passes a `return_to` query, `LlmCredentialsController` propagates it, and `_show_content` renders a "Continue setting up your feed" link once the credential lands `active`.
- Safer test stubbing: replaced the `define_method` + source-reload pattern with block-scoped `LlmClient.stub(:for, ...)`.
- Time fallbacks: `PassthroughProcessor` and `LlmNormalizer` default to `Time.current` when AI doesn't return a parseable `published_at`, preventing `MissingPublishedAtError` from blowing up the preview.

`bin/rails test` and `bin/rubocop` clean (two pre-existing `WorkflowTest` failures on `main` are unrelated).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHmmVFcTvFLjfJxvTibLu9)_