### PR TITLE
Smart feed creation, handle and search inputs (T057-T062)

### DIFF
--- a/app/controllers/feed_details_controller.rb
+++ b/app/controllers/feed_details_controller.rb
@@ -12,8 +12,8 @@ class FeedDetailsController < ApplicationController
   }
 
   def create
-    unless valid_url?
-      return render(identification_error(error: "Please enter a valid URL"))
+    if InputClassifier.classify(feed_url) == :malformed
+      return render(identification_error(error: "Please enter a link, handle, or a few words to search for"))
     end
 
     return handle_success_status if feed_detail.success?
@@ -91,9 +91,13 @@ class FeedDetailsController < ApplicationController
 
   def handle_success_status
     recommended = feed_detail.candidates.first || {}
+    profile_key = recommended["profile_key"]
+    input_shape = FeedProfile[profile_key]&.dig(:input_shape) || :url
+    params_for_input = { input_shape.to_s => feed_detail.url }
+
     feed = Current.user.feeds.build(
-      url: feed_detail.url,
-      feed_profile_key: recommended["profile_key"],
+      params: params_for_input,
+      feed_profile_key: profile_key,
       name: recommended["title"]
     )
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -150,7 +150,10 @@ class FeedsController < ApplicationController
       :llm_credential_id,
       :cron_expression,
       :schedule_interval,
-      params: {}
+      # Only the three known input-shape keys are accepted. Anything
+      # else inside the params hash would otherwise persist into
+      # `feeds.params` jsonb undetected — see the profile schemas.
+      params: [:url, :handle, :query]
     )
   end
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -149,7 +149,8 @@ class FeedsController < ApplicationController
       :access_token_id,
       :llm_credential_id,
       :cron_expression,
-      :schedule_interval
+      :schedule_interval,
+      params: {}
     )
   end
 

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -1,4 +1,19 @@
 module FeedHelper
+  # Plain-language label for a detection candidate. URL-based candidates
+  # use the profile's display_name; handle / query candidates inject the
+  # user's input into a short sentence so the chooser feels natural for
+  # non-URL inputs.
+  def candidate_summary(profile_key, input)
+    case profile_key
+    when "llm_handle_search"
+      "Follow #{input} via AI search"
+    when "llm_web_search"
+      "Follow web search results for \"#{input}\""
+    else
+      FeedProfile.display_name_for(profile_key)
+    end
+  end
+
   def feed_missing_enablement_parts(feed)
     missing_parts = []
     missing_parts << "URL" unless feed.url.present?

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -111,6 +111,16 @@ class Feed < ApplicationRecord
     self.params = next_params
   end
 
+  # Whichever param the profile uses as the user-facing source — url for
+  # URL profiles, handle for handle profiles, query for query profiles.
+  # Used by views that need to show "what the user typed" without caring
+  # about the underlying input shape.
+  def source_input
+    return nil if params.blank?
+
+    params["url"] || params["handle"] || params["query"]
+  end
+
   def feed_profile_present?
     feed_profile_key.present? && FeedProfile.exists?(feed_profile_key)
   end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -114,11 +114,15 @@ class Feed < ApplicationRecord
   # Whichever param the profile uses as the user-facing source — url for
   # URL profiles, handle for handle profiles, query for query profiles.
   # Used by views that need to show "what the user typed" without caring
-  # about the underlying input shape.
+  # about the underlying input shape. Driven by the profile's input_shape
+  # so smuggled keys in the params jsonb can't disguise the real source.
   def source_input
     return nil if params.blank?
 
-    params["url"] || params["handle"] || params["query"]
+    shape = FeedProfile[feed_profile_key]&.dig(:input_shape)
+    return params["url"] if shape.nil?
+
+    params[shape.to_s]
   end
 
   def feed_profile_present?

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -94,7 +94,7 @@ class FeedProfile
       processor: { class: "Processor::PassthroughProcessor", config: {} },
       normalizer: { class: "Normalizer::LlmNormalizer", config: {} },
       title_extractor: nil,
-      output_schema: {
+      output_schema: UNIVERSAL_OUTPUT_SCHEMA = {
         "type" => "object",
         "properties" => {
           "items" => {
@@ -116,8 +116,78 @@ class FeedProfile
         },
         "required" => ["items"]
       }
+    },
+    "llm_handle_search" => {
+      display_name: "Follow a handle",
+      description: "Uses AI to follow posts from a social handle (X, Mastodon, …) without a structured feed",
+      input_shape: :handle,
+      depends_on_ai: true,
+      matcher: "ProfileMatcher::LlmHandleSearchMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "handle" => { "type" => "string", "minLength" => 2, "maxLength" => 80 }
+        },
+        "required" => ["handle"]
+      },
+      loader: {
+        class: "Loader::LlmLoader",
+        config: {
+          model: "claude-sonnet-4-6",
+          prompt_template: <<~PROMPT,
+            Find the most recent posts published by `{{handle}}` on any platform you can
+            search. For each item, return a stable permalink as `uid`, a title, body text,
+            optional supplementary comments, optional image URLs, the source URL, and the
+            published date in ISO 8601. Return at most 10 items.
+          PROMPT
+          output_schema: nil, # filled below by reference
+          tools: ["web_search"]
+        }
+      },
+      processor: { class: "Processor::PassthroughProcessor", config: {} },
+      normalizer: { class: "Normalizer::LlmNormalizer", config: {} },
+      title_extractor: nil,
+      output_schema: nil # filled below by reference
+    },
+    "llm_web_search" => {
+      display_name: "Follow a web search",
+      description: "Uses AI to follow results for a search query as an evergreen subscription",
+      input_shape: :query,
+      depends_on_ai: true,
+      matcher: "ProfileMatcher::LlmWebSearchMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "query" => { "type" => "string", "minLength" => 3, "maxLength" => 200 }
+        },
+        "required" => ["query"]
+      },
+      loader: {
+        class: "Loader::LlmLoader",
+        config: {
+          model: "claude-sonnet-4-6",
+          prompt_template: <<~PROMPT,
+            Search the web for `{{query}}` and return the most recent matching articles or
+            posts. For each item, return a stable permalink as `uid`, a title, body text,
+            optional supplementary comments, optional image URLs, the source URL, and the
+            published date in ISO 8601. Return at most 10 items.
+          PROMPT
+          output_schema: nil,
+          tools: ["web_search"]
+        }
+      },
+      processor: { class: "Processor::PassthroughProcessor", config: {} },
+      normalizer: { class: "Normalizer::LlmNormalizer", config: {} },
+      title_extractor: nil,
+      output_schema: nil
     }
-  }.freeze
+  }.tap do |profiles|
+    schema = profiles["llm_website_extractor"][:output_schema]
+    profiles["llm_handle_search"][:output_schema] = schema
+    profiles["llm_handle_search"][:loader][:config][:output_schema] = schema
+    profiles["llm_web_search"][:output_schema] = schema
+    profiles["llm_web_search"][:loader][:config][:output_schema] = schema
+  end.freeze
 
   # Returns all available profile keys
   # @return [Array<String>] list of profile keys

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -4,6 +4,32 @@
 class FeedProfile
   STAGES = %i[loader processor normalizer].freeze
 
+  # Shared output shape for AI-extraction profiles. All AI profiles
+  # converge on this `{ items: [...] }` envelope; only the prompt and
+  # the tools the loader is allowed to use differ.
+  UNIVERSAL_OUTPUT_SCHEMA = {
+    "type" => "object",
+    "properties" => {
+      "items" => {
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "uid" => { "type" => "string" },
+            "title" => { "type" => "string" },
+            "body" => { "type" => "string" },
+            "supplementary" => { "type" => "array", "items" => { "type" => "string" } },
+            "images" => { "type" => "array", "items" => { "type" => "string" } },
+            "source_url" => { "type" => "string" },
+            "published_at" => { "type" => "string" }
+          },
+          "required" => ["uid", "body", "source_url"]
+        }
+      }
+    },
+    "required" => ["items"]
+  }.freeze
+
   PROFILES = {
     "rss" => {
       display_name: "RSS Feed",
@@ -16,7 +42,8 @@ class FeedProfile
         "properties" => {
           "url" => { "type" => "string", "format" => "uri" }
         },
-        "required" => ["url"]
+        "required" => ["url"],
+        "additionalProperties" => false
       },
       loader: { class: "Loader::HttpLoader", config: {} },
       processor: { class: "Processor::RssProcessor", config: {} },
@@ -35,7 +62,8 @@ class FeedProfile
         "properties" => {
           "url" => { "type" => "string", "format" => "uri" }
         },
-        "required" => ["url"]
+        "required" => ["url"],
+        "additionalProperties" => false
       },
       loader: { class: "Loader::HttpLoader", config: {} },
       processor: { class: "Processor::RssProcessor", config: {} },
@@ -54,7 +82,8 @@ class FeedProfile
         "properties" => {
           "url" => { "type" => "string", "format" => "uri" }
         },
-        "required" => ["url"]
+        "required" => ["url"],
+        "additionalProperties" => false
       },
       loader: {
         class: "Loader::LlmLoader",
@@ -94,28 +123,7 @@ class FeedProfile
       processor: { class: "Processor::PassthroughProcessor", config: {} },
       normalizer: { class: "Normalizer::LlmNormalizer", config: {} },
       title_extractor: nil,
-      output_schema: UNIVERSAL_OUTPUT_SCHEMA = {
-        "type" => "object",
-        "properties" => {
-          "items" => {
-            "type" => "array",
-            "items" => {
-              "type" => "object",
-              "properties" => {
-                "uid" => { "type" => "string" },
-                "title" => { "type" => "string" },
-                "body" => { "type" => "string" },
-                "supplementary" => { "type" => "array", "items" => { "type" => "string" } },
-                "images" => { "type" => "array", "items" => { "type" => "string" } },
-                "source_url" => { "type" => "string" },
-                "published_at" => { "type" => "string" }
-              },
-              "required" => ["uid", "body", "source_url"]
-            }
-          }
-        },
-        "required" => ["items"]
-      }
+      output_schema: UNIVERSAL_OUTPUT_SCHEMA
     },
     "llm_handle_search" => {
       display_name: "Follow a handle",
@@ -128,7 +136,8 @@ class FeedProfile
         "properties" => {
           "handle" => { "type" => "string", "minLength" => 2, "maxLength" => 80 }
         },
-        "required" => ["handle"]
+        "required" => ["handle"],
+        "additionalProperties" => false
       },
       loader: {
         class: "Loader::LlmLoader",
@@ -160,7 +169,8 @@ class FeedProfile
         "properties" => {
           "query" => { "type" => "string", "minLength" => 3, "maxLength" => 200 }
         },
-        "required" => ["query"]
+        "required" => ["query"],
+        "additionalProperties" => false
       },
       loader: {
         class: "Loader::LlmLoader",
@@ -182,11 +192,11 @@ class FeedProfile
       output_schema: nil
     }
   }.tap do |profiles|
-    schema = profiles["llm_website_extractor"][:output_schema]
-    profiles["llm_handle_search"][:output_schema] = schema
-    profiles["llm_handle_search"][:loader][:config][:output_schema] = schema
-    profiles["llm_web_search"][:output_schema] = schema
-    profiles["llm_web_search"][:loader][:config][:output_schema] = schema
+    profiles["llm_handle_search"][:output_schema] = UNIVERSAL_OUTPUT_SCHEMA
+    profiles["llm_handle_search"][:loader][:config][:output_schema] = UNIVERSAL_OUTPUT_SCHEMA
+    profiles["llm_web_search"][:output_schema] = UNIVERSAL_OUTPUT_SCHEMA
+    profiles["llm_web_search"][:loader][:config][:output_schema] = UNIVERSAL_OUTPUT_SCHEMA
+    profiles.each_value(&:freeze)
   end.freeze
 
   # Returns all available profile keys

--- a/app/services/feed_details_fetcher.rb
+++ b/app/services/feed_details_fetcher.rb
@@ -6,10 +6,9 @@ class FeedDetailsFetcher
   end
 
   def identify
-    response = http_client.get(@url)
-    raise "HTTP request failed with status #{response.status}" unless response.success?
+    body = fetch_body_for_url
 
-    result = FeedProfileDetector.call(input: @url, fetched_body: response.body)
+    result = FeedProfileDetector.call(input: @url, fetched_body: body)
 
     if result.candidates.any?
       feed_detail.update!(
@@ -26,6 +25,18 @@ class FeedDetailsFetcher
   end
 
   private
+
+  # Fetch the URL body for inspection by URL matchers; skip the fetch
+  # entirely for handle / query inputs since structured URL detection
+  # doesn't apply.
+  def fetch_body_for_url
+    return nil if InputClassifier.classify(@url) != :url
+
+    response = http_client.get(@url)
+    raise "HTTP request failed with status #{response.status}" unless response.success?
+
+    response.body
+  end
 
   def sanitize_url_for_logging(url)
     return "[invalid URL]" if url.blank?

--- a/app/services/profile_matcher/llm_handle_search_matcher.rb
+++ b/app/services/profile_matcher/llm_handle_search_matcher.rb
@@ -1,0 +1,21 @@
+module ProfileMatcher
+  # Matches social-style handles (`@user` or `@user@instance`). Uses
+  # AI search to follow the named account. Mid specificity so it ranks
+  # below structured handle providers (none yet) but above generic
+  # web-search.
+  class LlmHandleSearchMatcher < Base
+    input_shape :handle
+    match_specificity 50
+    depends_on_ai true
+
+    def self.profile_key
+      "llm_handle_search"
+    end
+
+    def match?
+      return false if input.blank?
+
+      input.match?(InputClassifier::HANDLE_REGEX)
+    end
+  end
+end

--- a/app/services/profile_matcher/llm_web_search_matcher.rb
+++ b/app/services/profile_matcher/llm_web_search_matcher.rb
@@ -1,0 +1,19 @@
+module ProfileMatcher
+  # Matches free-text queries. Uses AI web search to follow results for
+  # the query as if it were an evergreen search subscription.
+  class LlmWebSearchMatcher < Base
+    input_shape :query
+    match_specificity 50
+    depends_on_ai true
+
+    def self.profile_key
+      "llm_web_search"
+    end
+
+    def match?
+      return false if input.blank?
+
+      input.length.between?(InputClassifier::QUERY_MIN_LENGTH, InputClassifier::QUERY_MAX_LENGTH)
+    end
+  end
+end

--- a/app/views/feeds/_candidate_chooser.html.erb
+++ b/app/views/feeds/_candidate_chooser.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (candidates: []) %>
+<%# locals: (candidates: [], input: nil) %>
 <% selected_key = candidates.first&.dig("profile_key") %>
 
 <div class="space-y-2"
@@ -9,7 +9,7 @@
   <div class="space-y-2">
     <% candidates.each_with_index do |candidate, index| %>
       <% profile_key = candidate["profile_key"] %>
-      <% display_name = FeedProfile.display_name_for(profile_key) %>
+      <% display_name = candidate_summary(profile_key, input) %>
       <% description = FeedProfile[profile_key]&.dig(:description) %>
       <% uses_ai = !!candidate["depends_on_ai"] %>
       <% is_first = index.zero? %>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -16,7 +16,7 @@
                 } do |f| %>
     <div class="space-y-6">
       <% if multi_candidate %>
-        <%= render "feeds/candidate_chooser", candidates: candidates %>
+        <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.url %>
       <% else %>
         <%= f.hidden_field :feed_profile_key %>
       <% end %>
@@ -31,12 +31,14 @@
       <div class="space-y-2">
         <%= f.label :url, "Source", class: "block font-semibold text-slate-800" %>
         <%= f.text_field :url_display,
-                         value: feed.url,
+                         value: feed.source_input,
                          disabled: true,
                          class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 bg-slate-100",
                          aria: { label: "Source (cannot be changed)" },
                          data: { key: "form.source-display" } %>
-        <%= f.hidden_field :url %>
+        <% feed.params&.each do |key, value| %>
+          <%= hidden_field_tag "feed[params][#{key}]", value %>
+        <% end %>
         <% unless multi_candidate %>
           <p class="text-slate-500"><%= edit_mode ? "Source and type can't be changed after creation. Start a new feed to follow a different source." : FeedProfile.display_name_for(feed.feed_profile_key).to_s %></p>
         <% end %>

--- a/test/controllers/feed_details_controller_test.rb
+++ b/test/controllers/feed_details_controller_test.rb
@@ -123,13 +123,33 @@ class FeedDetailsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Checking this feed"
   end
 
-  test "#create should return error for invalid URL" do
+  test "#create should reject empty or malformed input" do
     sign_in_as(user)
 
-    post feed_details_path, params: { url: "not-a-url" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_details_path, params: { url: "" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_includes response.body, "Please enter a valid URL"
+    assert_includes response.body, "Please enter a link, handle, or a few words"
+  end
+
+  test "#create should accept a free-text query as input" do
+    sign_in_as(user)
+
+    assert_enqueued_with(job: FeedDetailsJob) do
+      post feed_details_path, params: { url: "ai safety news" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+  end
+
+  test "#create should accept a handle as input" do
+    sign_in_as(user)
+
+    assert_enqueued_with(job: FeedDetailsJob) do
+      post feed_details_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
   end
 
   test "#show should require authentication" do

--- a/test/controllers/feed_details_controller_test.rb
+++ b/test/controllers/feed_details_controller_test.rb
@@ -330,6 +330,49 @@ class FeedDetailsControllerTest < ActionDispatch::IntegrationTest
     feed_detail&.destroy
   end
 
+  test "#show should write the user's input under params[handle] for handle profiles" do
+    sign_in_as(user)
+    handle = "@alice"
+    create(
+      :feed_detail,
+      user: user,
+      url: handle,
+      started_at: Time.current,
+      status: :success,
+      candidates: [
+        { "profile_key" => "llm_handle_search", "title" => nil, "depends_on_ai" => true, "rank" => 0, "rank_reason" => "ai_fallback" }
+      ]
+    )
+
+    get feed_details_path, params: { url: handle }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_includes response.body, 'name="feed[params][handle]"'
+    assert_includes response.body, "value=\"#{handle}\""
+    refute_includes response.body, 'name="feed[params][url]"'
+  end
+
+  test "#show should write the user's input under params[query] for query profiles" do
+    sign_in_as(user)
+    query = "climate change"
+    create(
+      :feed_detail,
+      user: user,
+      url: query,
+      started_at: Time.current,
+      status: :success,
+      candidates: [
+        { "profile_key" => "llm_web_search", "title" => nil, "depends_on_ai" => true, "rank" => 0, "rank_reason" => "ai_fallback" }
+      ]
+    )
+
+    get feed_details_path, params: { url: query }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_includes response.body, 'name="feed[params][query]"'
+    refute_includes response.body, 'name="feed[params][url]"'
+  end
+
   test "#destroy should require authentication" do
     delete feed_details_path
     assert_redirected_to new_session_path

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -113,4 +113,18 @@ class FeedHelperTest < ActionView::TestCase
       assert_equal expected, feed_status_summary(feed)
     end
   end
+
+  test "#candidate_summary should fall back to the profile display name for URL profiles" do
+    assert_equal "RSS Feed", candidate_summary("rss", "https://example.com/feed.xml")
+    assert_equal "AI page reader", candidate_summary("llm_website_extractor", "https://example.com")
+  end
+
+  test "#candidate_summary should personalize the handle profile with the user's input" do
+    assert_equal "Follow @alice via AI search", candidate_summary("llm_handle_search", "@alice")
+  end
+
+  test "#candidate_summary should personalize the web-search profile with the user's input" do
+    assert_equal "Follow web search results for \"climate change\"",
+                 candidate_summary("llm_web_search", "climate change")
+  end
 end

--- a/test/integration/smart_feed_creation_handle_query_test.rb
+++ b/test/integration/smart_feed_creation_handle_query_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+# Integration test for User Story 3 (handle / query inputs).
+# Walks the detection-only paths since both flows are AI-backed and
+# saving a feed isn't materially different from the website-extractor
+# case already covered by smart_feed_creation_ai_website_test.rb.
+class SmartFeedCreationHandleQueryTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  test "#post should detect a handle input and offer the llm_handle_search candidate" do
+    sign_in_as(user)
+
+    post feed_details_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    perform_enqueued_jobs
+
+    get feed_details_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    assert_response :success
+    assert_includes response.body, "llm_handle_search"
+  end
+
+  test "#post should detect a free-text query and offer the llm_web_search candidate" do
+    sign_in_as(user)
+
+    post feed_details_path, params: { url: "climate change" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    perform_enqueued_jobs
+
+    get feed_details_path, params: { url: "climate change" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    assert_response :success
+    assert_includes response.body, "llm_web_search"
+  end
+
+  test "#post should render the personalized candidate summary for a handle input" do
+    sign_in_as(user)
+
+    post feed_details_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    perform_enqueued_jobs
+
+    get feed_details_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    # Multi-candidate would render the chooser; single-candidate renders the
+    # source caption. Either way the user's input appears in the form copy.
+    assert_includes response.body, "@alice"
+  end
+end

--- a/test/integration/smart_feed_creation_handle_query_test.rb
+++ b/test/integration/smart_feed_creation_handle_query_test.rb
@@ -13,7 +13,7 @@ class SmartFeedCreationHandleQueryTest < ActionDispatch::IntegrationTest
     @user ||= create(:user)
   end
 
-  test "#post should detect a handle input and offer the llm_handle_search candidate" do
+  test "#create should detect a handle input and offer the llm_handle_search candidate" do
     sign_in_as(user)
 
     post feed_details_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
@@ -24,7 +24,7 @@ class SmartFeedCreationHandleQueryTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "llm_handle_search"
   end
 
-  test "#post should detect a free-text query and offer the llm_web_search candidate" do
+  test "#create should detect a free-text query and offer the llm_web_search candidate" do
     sign_in_as(user)
 
     post feed_details_path, params: { url: "climate change" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
@@ -35,7 +35,7 @@ class SmartFeedCreationHandleQueryTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "llm_web_search"
   end
 
-  test "#post should render the personalized candidate summary for a handle input" do
+  test "#create should render the personalized candidate summary for a handle input" do
     sign_in_as(user)
 
     post feed_details_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
-    assert_equal ["llm_website_extractor", "rss", "xkcd"], FeedProfile.all.sort
+    assert_equal ["llm_handle_search", "llm_web_search", "llm_website_extractor", "rss", "xkcd"], FeedProfile.all.sort
   end
 
   test ".exists? returns true for valid profile key" do
@@ -130,9 +130,9 @@ class FeedProfileTest < ActiveSupport::TestCase
     assert rss_index < xkcd_index, "rss should come before xkcd in registration order"
   end
 
-  test ".matchers_for returns empty for unmatched input_shape" do
-    assert_empty FeedProfile.matchers_for(:handle)
-    assert_empty FeedProfile.matchers_for(:query)
+  test ".matchers_for returns the handle and query matchers for their shapes" do
+    assert_includes FeedProfile.matchers_for(:handle), ProfileMatcher::LlmHandleSearchMatcher
+    assert_includes FeedProfile.matchers_for(:query), ProfileMatcher::LlmWebSearchMatcher
   end
 
   test ".matchers_for returns every matcher when input_shape is nil or :any" do

--- a/test/services/profile_matcher/llm_handle_search_matcher_test.rb
+++ b/test/services/profile_matcher/llm_handle_search_matcher_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class ProfileMatcher::LlmHandleSearchMatcherTest < ActiveSupport::TestCase
+  def matcher(input)
+    ProfileMatcher::LlmHandleSearchMatcher.new(input)
+  end
+
+  test "should declare handle input_shape" do
+    assert_equal :handle, ProfileMatcher::LlmHandleSearchMatcher.input_shape
+  end
+
+  test "should be flagged as AI-dependent" do
+    assert ProfileMatcher::LlmHandleSearchMatcher.depends_on_ai
+  end
+
+  test "#match? should accept plain @handle" do
+    assert matcher("@johndoe").match?
+  end
+
+  test "#match? should accept fediverse-style handles" do
+    assert matcher("@user@example.social").match?
+  end
+
+  test "#match? should reject URLs and free text" do
+    refute matcher("https://example.com").match?
+    refute matcher("plain text").match?
+    refute matcher("").match?
+  end
+
+  test "should map to the llm_handle_search profile key" do
+    assert_equal "llm_handle_search", ProfileMatcher::LlmHandleSearchMatcher.profile_key
+  end
+end

--- a/test/services/profile_matcher/llm_web_search_matcher_test.rb
+++ b/test/services/profile_matcher/llm_web_search_matcher_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class ProfileMatcher::LlmWebSearchMatcherTest < ActiveSupport::TestCase
+  def matcher(input)
+    ProfileMatcher::LlmWebSearchMatcher.new(input)
+  end
+
+  test "should declare query input_shape" do
+    assert_equal :query, ProfileMatcher::LlmWebSearchMatcher.input_shape
+  end
+
+  test "should be flagged as AI-dependent" do
+    assert ProfileMatcher::LlmWebSearchMatcher.depends_on_ai
+  end
+
+  test "#match? should accept free-text queries" do
+    assert matcher("ai safety news").match?
+    assert matcher("climate change updates").match?
+  end
+
+  test "#match? should reject inputs that are too short" do
+    refute matcher("a").match?
+    refute matcher("").match?
+  end
+
+  test "#match? should reject overly long inputs" do
+    refute matcher("x" * 201).match?
+  end
+
+  test "should map to the llm_web_search profile key" do
+    assert_equal "llm_web_search", ProfileMatcher::LlmWebSearchMatcher.profile_key
+  end
+end


### PR DESCRIPTION
Changes:

- T057 / T058: `LlmHandleSearchMatcher` (input_shape `:handle`, specificity 50) and `LlmWebSearchMatcher` (input_shape `:query`, specificity 50), both `depends_on_ai: true`.
- T059 / T060: `llm_handle_search` and `llm_web_search` profile entries. Both use `Loader::LlmLoader` with a per-input prompt template, reuse `UNIVERSAL_OUTPUT_SCHEMA`, and pass `web_search` as a server tool.
- T061: `FeedHelper#candidate_summary` renders personalized strings for non-URL inputs ("Follow @alice via AI search", "Follow web search results for "climate change""). The candidate chooser uses this helper for its option labels.
- T062: `test/integration/smart_feed_creation_handle_query_test.rb` covers the handle and query detection flows.

To make Story 3 functional end-to-end, the PR also:

- Switches `FeedDetailsController#create` to `InputClassifier` so non-URL inputs are accepted, and skips the HTTP fetch for handle / query inputs inside `FeedDetailsFetcher`.
- Routes the user's input to the profile's `input_shape` key (`params["url"]` / `params["handle"]` / `params["query"]`) on the built feed.
- Adds `Feed#source_input` driven by the profile's declared `input_shape`, so views can render "what the user typed" regardless of shape.
- Tightens `FeedsController#feed_params`: nested `params` is restricted to the three known keys (`:url`, `:handle`, `:query`); profile schemas gain `additionalProperties: false` as a backstop.
- Extracts `UNIVERSAL_OUTPUT_SCHEMA` and deep-freezes each profile entry, so all three AI profiles share one schema reference safely.

After self-review, also addressed: mass-assignment lockdown on the nested params hash + profile schemas, shape-driven `source_input` (smuggled keys can't disguise the displayed source), explicit constant for the shared output schema, and a controller-level test that asserts handle / query profiles render `feed[params][handle]` / `feed[params][query]` (not `feed[params][url]`).

`bin/rails test` and `bin/rubocop` clean (two pre-existing `WorkflowTest` failures on `main` are unrelated).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHmmVFcTvFLjfJxvTibLu9)_