### PR TITLE
Smart feed creation, polish and cross-cutting tests (T063-T068)

### DIFF
--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -44,7 +44,7 @@
       <% end %>
     <% else %>
       <% header.with_action_button do %>
-        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-not-allowed opacity-60" title="Preview requires feed URL and profile">Preview</span>
+        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-not-allowed opacity-60" title="Preview requires feed URL and source type">Preview</span>
       <% end %>
     <% end %>
   <% end %>

--- a/specs/001-smart-feed-creation/quickstart.md
+++ b/specs/001-smart-feed-creation/quickstart.md
@@ -82,7 +82,7 @@ Sign in (or `bin/rails console`-create) a user with at least one **active** Free
 2. Note the count of `LlmUsage` rows with `purpose: :preview` for your user.
 3. Refresh the browser tab (Cmd-R). **Expect**: same form-expanded state, same preview, **same `LlmUsage` count** — no new row.
 4. Click "Refresh preview". **Expect**: a new `LlmUsage` row with `purpose: :preview` appears.
-5. Change the "AI prompt refinement" parameter (if the profile exposes one). **Expect**: preview auto-re-runs; new `LlmUsage` row.
+5. **(deferred)** Auto-re-running the preview when a profile-specific parameter changes is not yet wired (the AI profiles ship with a single `url` / `handle` / `query` parameter, so there's nothing to change mid-flow). The "Refresh preview" button is the only path to a fresh preview.
 
 ## 5. Edit feed source (FR-026, FR-027, FR-028)
 

--- a/specs/001-smart-feed-creation/quickstart.md
+++ b/specs/001-smart-feed-creation/quickstart.md
@@ -1,9 +1,9 @@
 # Quickstart: Smart Feed Creation
 
 **Audience**: anyone verifying this feature locally — author, reviewer, QA.
-**Plan**: [`plan.md`](./plan.md) · **Spec**: [`spec.md`](./spec.md)
+**Plan**: [`plan.md`](./plan.md) · **Spec**: [`spec.md`](./spec.md) · **PR plan**: [`plan-prs.md`](./plan-prs.md)
 
-This walkthrough exercises each user story end-to-end against a local dev environment. It assumes the implementation is fully landed; treat it as a definition-of-done checklist.
+This walkthrough exercises each user story end-to-end against a local dev environment. It assumes the implementation is fully landed; treat it as a definition-of-done checklist. Items deferred past the v1 cut are flagged inline with **(deferred)**.
 
 ## 0. Prerequisites
 
@@ -89,16 +89,16 @@ Sign in (or `bin/rails console`-create) a user with at least one **active** Free
 **Goal**: confirm operational vs source-side edit semantics.
 
 1. Edit an `enabled` RSS feed: change its name and target group, save. **Confirm** state stays `enabled`; no `LlmUsage` rows added; no preview re-run.
-2. Edit the same feed: change the URL to a different RSS source. **Expect**: detection re-runs, preview re-runs, save button labelled appropriately. **Confirm** state stays `enabled` after a successful re-preview.
-3. Edit an RSS feed: change the URL to one whose detection now matches the *AI website extractor* profile. **Expect**: warning ("This change switches the source type to AI extraction. Past dedup history won't transfer.") with explicit confirm/cancel. On confirm + successful preview, save → state stays `enabled`.
+2. **(deferred)** In-form source-side edits (changing the URL of an existing feed) are not exposed in v1 — the edit form keeps source and type read-only. To follow a different source, create a new feed. The model-level gate (`Feed#enabling_requires_recent_preview`) is in place for when the edit-source UI ships.
 
-## 6. Multi-credential picker (FR-013)
+## 6. Multi-credential default (FR-013)
 
 **Goal**: confirm default-credential behavior.
 
 1. Add a second Anthropic credential ("Work"). On `/llm_credentials`, click "Make default" on it.
-2. Start a new AI-backed feed. **Expect**: confirmation step shows a credential picker preselecting "Work".
-3. Switch to "Personal" via the picker — **expect**: this changes the feed's credential without changing the user's default. **Confirm** at the DB level that the user's default is still "Work".
+2. **Confirm** at the DB level that the partial unique index has un-defaulted the previous credential.
+3. Start a new AI-backed feed; **expect** the preview uses the user's default credential.
+4. **(deferred)** A per-feed credential picker on the creation form is not yet exposed; the feed always uses the user's active default for the required provider.
 
 ## 7. Vocabulary firewall (FR-022)
 
@@ -106,8 +106,8 @@ Sign in (or `bin/rails console`-create) a user with at least one **active** Free
 
 ```bash
 # From repo root, in your browser, view-source on /feeds/new at each state.
-# Or run the specific lint check the team adds during this feature:
-bin/rails test test/system/smart_feed_creation_vocabulary_test.rb
+# Or run the integration-level vocabulary check shipped with this feature:
+bin/rails test test/integration/smart_feed_creation_vocabulary_test.rb
 ```
 
 Banned: "profile", "matcher", "pipeline", "stage", "loader", "processor", "normalizer", "LLM" (any case). Allowed: "AI", "AI credentials", provider brand names.
@@ -131,8 +131,8 @@ bin/rails db:migrate:redo STEP=$(git diff --name-only main... | grep -c db/migra
 
 **Goal**: confirm the user can see what AI cost them.
 
-1. Navigate to a feed's show page. **Expect**: an "AI usage" panel showing this feed's lifetime + current-period spend.
-2. Navigate to `/settings/llm_usage` (or wherever the parent-spec phase 4 surfaces it). **Expect**: rollup by feed/profile/day; preview-purpose spend separated from scheduled-run spend.
+1. The cost notice on the new-feed form is in place ("AI fetches cost tokens..."), and `LlmUsage` rows are written with `cost_estimate_cents` for every call.
+2. **(deferred)** The per-feed "AI usage" panel on the feed show page and the `/settings/llm_usage` rollup are parent-spec phase 4 — the data they need is already captured.
 
 ## Done
 

--- a/test/integration/smart_feed_creation_edit_test.rb
+++ b/test/integration/smart_feed_creation_edit_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+# FR-026 / FR-027 / FR-028 edit semantics: operational fields can be
+# edited freely; source-side fields stay anchored after creation.
+# Updates never re-run detection or preview because the create-time
+# detection is authoritative (the form keeps the URL and profile key
+# read-only on edit).
+class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def access_token
+    @access_token ||= create(:access_token, :active, user: user)
+  end
+
+  def feed
+    @feed ||= create(:feed,
+                     user: user,
+                     access_token: access_token,
+                     state: :enabled,
+                     target_group: "testgroup",
+                     feed_profile_key: "rss",
+                     params: { "url" => "http://example.com/feed.xml" })
+  end
+
+  test "#patch should accept an operational-only edit on an enabled feed without re-running detection" do
+    sign_in_as(user)
+    feed
+
+    assert_no_enqueued_jobs do
+      patch feed_url(feed), params: { feed: { name: "Renamed" } }
+    end
+
+    assert_redirected_to feed_path(feed)
+    feed.reload
+    assert_equal "Renamed", feed.name
+    assert_equal "enabled", feed.state
+  end
+
+  test "#patch should ignore attempts to mass-assign url through the edit form" do
+    sign_in_as(user)
+    original_url = feed.url
+
+    patch feed_url(feed), params: {
+      feed: {
+        url: "http://attacker.example/feed.xml",
+        name: "Renamed"
+      }
+    }
+
+    assert_redirected_to feed_path(feed)
+    feed.reload
+    assert_equal original_url, feed.url
+    assert_equal "Renamed", feed.name
+  end
+
+  test "#patch should ignore attempts to mass-assign the params jsonb" do
+    sign_in_as(user)
+    original_params = feed.params
+
+    patch feed_url(feed), params: {
+      feed: {
+        params: { url: "http://attacker.example/feed.xml" },
+        name: "Renamed"
+      }
+    }
+
+    feed.reload
+    assert_equal original_params, feed.params
+    assert_equal "Renamed", feed.name
+  end
+
+  test "#patch should ignore attempts to mass-assign the feed_profile_key" do
+    sign_in_as(user)
+    original_profile = feed.feed_profile_key
+
+    patch feed_url(feed), params: {
+      feed: {
+        feed_profile_key: "xkcd",
+        name: "Renamed"
+      }
+    }
+
+    feed.reload
+    assert_equal original_profile, feed.feed_profile_key
+  end
+end

--- a/test/integration/smart_feed_creation_reload_test.rb
+++ b/test/integration/smart_feed_creation_reload_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+# FR-018 + FR-019 reload semantics: reloading an in-progress confirmation
+# does not re-run detection or the preview. An explicit Refresh control
+# re-runs the preview on demand.
+class SmartFeedCreationReloadTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed_url
+    "http://example.com/feed.xml"
+  end
+
+  def rss_body
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Example Feed</title>
+          <link>http://example.com</link>
+          <item>
+            <title>Post</title>
+            <link>http://example.com/post</link>
+            <guid>http://example.com/post</guid>
+            <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+          </item>
+        </channel>
+      </rss>
+    XML
+  end
+
+  def with_memory_cache
+    previous = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = previous
+  end
+
+  test "#get should not re-enqueue detection when the feed_detail is already success" do
+    sign_in_as(user)
+    stub_request(:get, feed_url).to_return(status: 200, body: rss_body)
+
+    post feed_details_path, params: { url: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    perform_enqueued_jobs
+
+    assert_no_enqueued_jobs do
+      get feed_details_path, params: { url: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+  end
+
+  test "#get on the live preview should not re-enqueue the preview job on a cache hit" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      stub_request(:get, feed_url).to_return(status: 200, body: rss_body)
+      # First fetch warms the cache via the preview service.
+      FeedPreviewService.call(
+        user: user,
+        profile_key: "rss",
+        params: { "url" => feed_url },
+        cache_key: cache_key
+      )
+
+      assert_no_enqueued_jobs do
+        get feed_live_preview_path("draft"),
+            params: { profile_key: "rss", params: { url: feed_url } }
+      end
+    end
+  end
+
+  test "#post on the live preview should re-enqueue the job with refresh" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      stub_request(:get, feed_url).to_return(status: 200, body: rss_body)
+      FeedPreviewService.call(
+        user: user,
+        profile_key: "rss",
+        params: { "url" => feed_url },
+        cache_key: cache_key
+      )
+
+      assert_enqueued_with(job: FeedPreviewJob) do
+        post feed_live_preview_path("draft"),
+             params: { profile_key: "rss", params: { url: feed_url } }
+      end
+    end
+  end
+
+  private
+
+  def cache_key
+    canonical = { "url" => feed_url }.deep_stringify_keys.sort.to_h.to_json
+    "preview:draft:#{user.id}:rss:#{Digest::SHA256.hexdigest(canonical)}"
+  end
+end

--- a/test/integration/smart_feed_creation_state_gating_test.rb
+++ b/test/integration/smart_feed_creation_state_gating_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+# FR-016 + FR-017 state gating: saving an enabled feed requires a fresh
+# preview_token tied to (user, profile, params). Anything else lands the
+# feed in `disabled` state.
+class SmartFeedCreationStateGatingTest < ActionDispatch::IntegrationTest
+  def user
+    @user ||= create(:user)
+  end
+
+  def access_token
+    @access_token ||= create(:access_token, :active, user: user)
+  end
+
+  def feed_params(preview_token: nil)
+    feed_attrs = {
+      url: "http://example.com/feed.xml",
+      name: "Example",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+    {
+      feed: feed_attrs,
+      enable_feed: "1",
+      preview_token: preview_token
+    }
+  end
+
+  def valid_preview_token
+    PreviewToken.sign(
+      user_id: user.id,
+      profile_key: "rss",
+      params: { "url" => "http://example.com/feed.xml" },
+      generated_at: Time.current
+    )
+  end
+
+  test "#post should land in enabled state with a valid preview token" do
+    sign_in_as(user)
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: feed_params(preview_token: valid_preview_token)
+    end
+
+    assert_equal "enabled", Feed.last.state
+  end
+
+  test "#post should degrade to disabled when no preview token is supplied" do
+    sign_in_as(user)
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: feed_params(preview_token: nil)
+    end
+
+    assert_equal "disabled", Feed.last.state
+  end
+
+  test "#post should reject a tampered preview token and land disabled" do
+    sign_in_as(user)
+    tampered = valid_preview_token.split(".").first + ".not-a-real-signature"
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: feed_params(preview_token: tampered)
+    end
+
+    assert_equal "disabled", Feed.last.state
+  end
+
+  test "#post should reject an expired preview token and land disabled" do
+    sign_in_as(user)
+
+    expired = PreviewToken.sign(
+      user_id: user.id,
+      profile_key: "rss",
+      params: { "url" => "http://example.com/feed.xml" },
+      generated_at: 2.hours.ago
+    )
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: feed_params(preview_token: expired)
+    end
+
+    assert_equal "disabled", Feed.last.state
+  end
+
+  test "#post should reject a preview token for different params and land disabled" do
+    sign_in_as(user)
+
+    mismatched_token = PreviewToken.sign(
+      user_id: user.id,
+      profile_key: "rss",
+      params: { "url" => "http://different.com/feed.xml" },
+      generated_at: Time.current
+    )
+
+    post feeds_path, params: feed_params(preview_token: mismatched_token)
+
+    assert_equal "disabled", Feed.last.state
+  end
+end

--- a/test/integration/smart_feed_creation_vocabulary_test.rb
+++ b/test/integration/smart_feed_creation_vocabulary_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+# FR-022 + SC-005 vocabulary firewall: no implementation jargon in any
+# user-visible string on the feed-creation surface or the AI-credentials
+# pages. "AI", "AI credentials", and provider brand names are allowed.
+class SmartFeedCreationVocabularyTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  BANNED_WORDS = %w[profile matcher pipeline stage loader processor normalizer LLM].freeze
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def credential
+    @credential ||= create(:llm_credential, :active, user: user)
+  end
+
+  def visible_text(body)
+    # Strip script and style payloads (which may legitimately mention
+    # banned words in selectors / class names) and HTML tags. Leaves
+    # only what the user actually reads on screen.
+    body
+      .gsub(/<script\b[^>]*>.*?<\/script>/mi, "")
+      .gsub(/<style\b[^>]*>.*?<\/style>/mi, "")
+      .gsub(/<[^>]+>/, " ")
+      .gsub(/\s+/, " ")
+  end
+
+  def assert_no_banned_vocabulary(body, page:)
+    text = visible_text(body)
+    BANNED_WORDS.each do |word|
+      assert_no_match(
+        /\b#{Regexp.escape(word)}\b/i,
+        text,
+        "Banned word '#{word}' appeared in user-visible text on #{page}"
+      )
+    end
+  end
+
+  test "#feeds_new should not leak implementation vocabulary" do
+    sign_in_as(user)
+    get new_feed_url
+    assert_response :success
+    assert_no_banned_vocabulary(response.body, page: "/feeds/new")
+  end
+
+  test "#llm_credentials_index should not leak implementation vocabulary" do
+    sign_in_as(user)
+    credential
+    get llm_credentials_url
+    assert_response :success
+    assert_no_banned_vocabulary(response.body, page: "/llm_credentials")
+  end
+
+  test "#llm_credentials_new should not leak implementation vocabulary" do
+    sign_in_as(user)
+    get new_llm_credential_url
+    assert_response :success
+    assert_no_banned_vocabulary(response.body, page: "/llm_credentials/new")
+  end
+
+  test "#llm_credentials_show should not leak implementation vocabulary" do
+    sign_in_as(user)
+    get llm_credential_url(credential)
+    assert_response :success
+    assert_no_banned_vocabulary(response.body, page: "/llm_credentials/:id")
+  end
+end

--- a/test/integration/smart_feed_creation_vocabulary_test.rb
+++ b/test/integration/smart_feed_creation_vocabulary_test.rb
@@ -68,4 +68,38 @@ class SmartFeedCreationVocabularyTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_no_banned_vocabulary(response.body, page: "/llm_credentials/:id")
   end
+
+  test "feed_details success response (form-expanded) should not leak implementation vocabulary" do
+    sign_in_as(user)
+    url = "http://example.com/feed.xml"
+    rss_body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Example Feed</title>
+          <item><title>Post</title><link>http://example.com/p1</link><guid>http://example.com/p1</guid></item>
+        </channel>
+      </rss>
+    XML
+    stub_request(:get, url).to_return(status: 200, body: rss_body)
+
+    post feed_details_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    perform_enqueued_jobs
+
+    get feed_details_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    assert_response :success
+    assert_no_banned_vocabulary(response.body, page: "feed_details (success / form-expanded)")
+  end
+
+  test "feed show page should not leak implementation vocabulary" do
+    sign_in_as(user)
+    feed = create(:feed,
+                  user: user,
+                  feed_profile_key: "rss",
+                  params: { "url" => "http://example.com/feed.xml" })
+
+    get feed_url(feed)
+    assert_response :success
+    assert_no_banned_vocabulary(response.body, page: "/feeds/:id")
+  end
 end


### PR DESCRIPTION
Changes:

- T063 vocabulary firewall integration test — asserts no banned implementation vocabulary (profile, matcher, pipeline, stage, loader, processor, normalizer, LLM) leaks into user-visible HTML on `/feeds/new`, `/llm_credentials`, `/llm_credentials/new`, `/llm_credentials/:id`, the form-expanded Turbo Stream response from `/feed_details`, and `/feeds/:id`.
- T064 state-gating test — valid preview_token saves enabled; absent, tampered, expired, and params-mismatched tokens all degrade to disabled.
- T065 reload test — re-fetching a successful detection record doesn't enqueue another `FeedDetailsJob`; a cached preview doesn't enqueue another `FeedPreviewJob`; an explicit refresh (POST) does.
- T066 edit semantics test — operational-only patches save without re-running anything; mass-assigned `url`, `params`, and `feed_profile_key` are stripped at the strong-params layer.
- T067 — `bin/rubocop` clean (has been throughout the smart-feed-creation series).
- T068 quickstart drift update — flags items past the v1 cut (in-form source-side edits, per-feed credential picker on the create form, per-feed AI-usage panel) as **(deferred)** and points at the integration-tests directory instead of a system tests directory.

After self-review, also addressed: fixed a vocabulary leak on the feed show page (`title="Preview requires feed URL and profile"` → `"…source type"`); extended the vocabulary firewall to cover the form-expanded Turbo Stream response and `/feeds/:id`; dropped the deferred "AI prompt refinement" step from the quickstart.

`bin/rails test` and `bin/rubocop` clean (two pre-existing `WorkflowTest` failures on `main` are unrelated).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHmmVFcTvFLjfJxvTibLu9)_