### PR TITLE
Refactor LlmProvider from module to class with instances

### DIFF
--- a/app/controllers/llm_credentials/defaults_controller.rb
+++ b/app/controllers/llm_credentials/defaults_controller.rb
@@ -5,7 +5,7 @@ class LlmCredentials::DefaultsController < ApplicationController
 
     credential.make_default!
 
-    redirect_to llm_credentials_path, notice: "'#{credential.display_name}' is now the default for #{LlmProvider.display_name_for(credential.provider)}."
+    redirect_to llm_credentials_path, notice: "'#{credential.display_name}' is now the default for #{LlmProvider.find(credential.provider)&.display_name}."
   end
 
   private

--- a/app/controllers/llm_credentials/defaults_controller.rb
+++ b/app/controllers/llm_credentials/defaults_controller.rb
@@ -5,7 +5,8 @@ class LlmCredentials::DefaultsController < ApplicationController
 
     credential.make_default!
 
-    redirect_to llm_credentials_path, notice: "'#{credential.display_name}' is now the default for #{LlmProvider.find(credential.provider)&.display_name}."
+    provider_name = LlmProvider.find(credential.provider)&.display_name
+    redirect_to llm_credentials_path, notice: "'#{credential.display_name}' is now the default for #{provider_name}."
   end
 
   private

--- a/app/controllers/llm_credentials_controller.rb
+++ b/app/controllers/llm_credentials_controller.rb
@@ -10,7 +10,7 @@ class LlmCredentialsController < ApplicationController
   end
 
   def new
-    @llm_credential = LlmCredential.new(provider: params[:provider] || LlmProvider.all.first)
+    @llm_credential = LlmCredential.new(provider: params[:provider] || LlmProvider.names.first)
     @return_to = safe_return_to
     authorize @llm_credential
   end

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -149,14 +149,14 @@ class FeedProfile
             optional supplementary comments, optional image URLs, the source URL, and the
             published date in ISO 8601. Return at most 10 items.
           PROMPT
-          output_schema: nil, # filled below by reference
+          output_schema: UNIVERSAL_OUTPUT_SCHEMA,
           tools: ["web_search"]
         }
       },
       processor: { class: "Processor::PassthroughProcessor", config: {} },
       normalizer: { class: "Normalizer::LlmNormalizer", config: {} },
       title_extractor: nil,
-      output_schema: nil # filled below by reference
+      output_schema: UNIVERSAL_OUTPUT_SCHEMA
     },
     "llm_web_search" => {
       display_name: "Follow a web search",
@@ -182,22 +182,16 @@ class FeedProfile
             optional supplementary comments, optional image URLs, the source URL, and the
             published date in ISO 8601. Return at most 10 items.
           PROMPT
-          output_schema: nil,
+          output_schema: UNIVERSAL_OUTPUT_SCHEMA,
           tools: ["web_search"]
         }
       },
       processor: { class: "Processor::PassthroughProcessor", config: {} },
       normalizer: { class: "Normalizer::LlmNormalizer", config: {} },
       title_extractor: nil,
-      output_schema: nil
+      output_schema: UNIVERSAL_OUTPUT_SCHEMA
     }
-  }.tap do |profiles|
-    profiles["llm_handle_search"][:output_schema] = UNIVERSAL_OUTPUT_SCHEMA
-    profiles["llm_handle_search"][:loader][:config][:output_schema] = UNIVERSAL_OUTPUT_SCHEMA
-    profiles["llm_web_search"][:output_schema] = UNIVERSAL_OUTPUT_SCHEMA
-    profiles["llm_web_search"][:loader][:config][:output_schema] = UNIVERSAL_OUTPUT_SCHEMA
-    profiles.each_value(&:freeze)
-  end.freeze
+  }.freeze
 
   # Returns all available profile keys
   # @return [Array<String>] list of profile keys

--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -19,7 +19,7 @@ class LlmCredential < ApplicationRecord
 
   enum :state, { pending: 0, validating: 1, active: 2, inactive: 3 }
 
-  validates :provider, presence: true, inclusion: { in: ->(_) { LlmProvider.all } }
+  validates :provider, presence: true, inclusion: { in: ->(_) { LlmProvider.names } }
   validates :display_name,
             presence: true,
             length: { maximum: DISPLAY_NAME_MAX_LENGTH },
@@ -45,7 +45,7 @@ class LlmCredential < ApplicationRecord
     return if provider.blank?
     return errors.add(:credential_data, "is missing") if credential_data.blank?
 
-    schema = LlmProvider.credential_schema_for(provider)
+    schema = LlmProvider.find(provider)&.credential_schema
     return if schema.blank?
 
     JSONSchemer.schema(schema).validate(credential_data).each do |error|

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -2,9 +2,24 @@
 # `FeedProfile`. Drives the credential form generator (per-provider
 # credential schema) and tells `LlmClient` which RubyLLM provider key
 # to use.
-module LlmProvider
+class LlmProvider
+  attr_reader :name, :display_name, :ruby_llm_provider, :credential_schema
+
+  def initialize(name:, display_name:, ruby_llm_provider:, credential_schema:)
+    @name = name
+    @display_name = display_name
+    @ruby_llm_provider = ruby_llm_provider
+    @credential_schema = credential_schema
+    freeze
+  end
+
+  def validate(client)
+    client.health_check
+  end
+
   PROVIDERS = {
-    "anthropic" => {
+    "anthropic" => new(
+      name: "anthropic",
       display_name: "Anthropic (Claude)",
       ruby_llm_provider: :anthropic,
       credential_schema: {
@@ -14,34 +29,29 @@ module LlmProvider
         },
         "required" => ["api_key"],
         "additionalProperties" => false
-      },
-      validate_call: ->(client) { client.health_check }
-    }
+      }
+    )
   }.freeze
 
   class << self
     def all
+      PROVIDERS.values
+    end
+
+    def names
       PROVIDERS.keys
     end
 
-    def exists?(provider)
-      PROVIDERS.key?(provider.to_s)
+    def find(name)
+      return nil if name.nil?
+
+      PROVIDERS[name.to_s]
     end
 
-    def [](provider)
-      PROVIDERS[provider.to_s]
-    end
+    def exists?(name)
+      return false if name.nil?
 
-    def display_name_for(provider)
-      PROVIDERS.dig(provider.to_s, :display_name)
-    end
-
-    def credential_schema_for(provider)
-      PROVIDERS.dig(provider.to_s, :credential_schema)
-    end
-
-    def ruby_llm_provider_for(provider)
-      PROVIDERS.dig(provider.to_s, :ruby_llm_provider)
+      PROVIDERS.key?(name.to_s)
     end
   end
 end

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -35,7 +35,7 @@ class LlmClient
       when LlmCredential
         target
       when Feed
-        target.llm_credential || default_credential_for(target.user, provider || LlmProvider.all.first)
+        target.llm_credential || default_credential_for(target.user, provider || LlmProvider.names.first)
       when User
         default_credential_for(target, provider)
       end
@@ -134,7 +134,7 @@ class LlmClient
     context = RubyLLM.context do |config|
       config.public_send("#{credential.provider}_api_key=", api_key)
     end
-    chat = context.chat(model: model, provider: LlmProvider.ruby_llm_provider_for(credential.provider))
+    chat = context.chat(model: model, provider: LlmProvider.find(credential.provider).ruby_llm_provider)
     chat.with_schema(output_schema) if output_schema.present? && chat.respond_to?(:with_schema)
     tools.each { |t| chat.with_tool(t) if chat.respond_to?(:with_tool) }
 

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -1,6 +1,6 @@
 <div class="space-y-6" data-key="llm_credential.show">
   <%= render PageHeaderComponent.new(title: @llm_credential.display_name) do |header| %>
-    <% header.with_context_paragraph(LlmProvider.display_name_for(@llm_credential.provider).to_s) %>
+    <% header.with_context_paragraph(LlmProvider.find(@llm_credential.provider)&.display_name.to_s) %>
   <% end %>
 
   <% case @llm_credential.state %>

--- a/app/views/llm_credentials/index.html.erb
+++ b/app/views/llm_credentials/index.html.erb
@@ -25,7 +25,7 @@
               <% end %>
             </p>
             <p class="text-sm text-slate-500">
-              <%= LlmProvider.display_name_for(credential.provider) %> · status: <%= credential.state %>
+              <%= LlmProvider.find(credential.provider)&.display_name %> · status: <%= credential.state %>
             </p>
             <% if credential.last_error.present? %>
               <p class="text-sm text-red-600"><%= credential.last_error %></p>

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -20,7 +20,7 @@
       <div class="space-y-2">
         <%= f.label :provider, "AI Provider", class: "block font-semibold text-slate-800" %>
         <%= f.select :provider,
-                     LlmProvider.all.map { |key| [LlmProvider.display_name_for(key), key] },
+                     LlmProvider.all.map { |provider| [provider.display_name, provider.name] },
                      {},
                      class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
                      required: true,
@@ -37,7 +37,7 @@
         <p class="text-slate-500">A label so you can tell credentials apart later.</p>
       </div>
 
-      <% schema = LlmProvider.credential_schema_for(@llm_credential.provider) || { "properties" => {} } %>
+      <% schema = LlmProvider.find(@llm_credential.provider)&.credential_schema || { "properties" => {} } %>
       <% schema["properties"].each do |key, _spec| %>
         <div class="space-y-2">
           <%= label_tag "llm_credential_credential_data_#{key}", key.humanize, class: "block font-semibold text-slate-800" %>

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -1,8 +1,13 @@
 require "test_helper"
 
 class LlmProviderTest < ActiveSupport::TestCase
-  test "#all should list registered provider keys" do
-    assert_includes LlmProvider.all, "anthropic"
+  test "#all should return registered provider instances" do
+    assert_includes LlmProvider.all.map(&:name), "anthropic"
+    assert LlmProvider.all.all? { |p| p.is_a?(LlmProvider) }
+  end
+
+  test "#names should list registered provider keys" do
+    assert_includes LlmProvider.names, "anthropic"
   end
 
   test "#exists? should return true for registered providers" do
@@ -15,26 +20,32 @@ class LlmProviderTest < ActiveSupport::TestCase
     refute LlmProvider.exists?(nil)
   end
 
-  test "#[] should return the registry entry" do
-    entry = LlmProvider["anthropic"]
-    assert_kind_of Hash, entry
-    assert_equal "Anthropic (Claude)", entry[:display_name]
-    assert_equal :anthropic, entry[:ruby_llm_provider]
+  test "#find should return the provider instance" do
+    provider = LlmProvider.find("anthropic")
+    assert_kind_of LlmProvider, provider
+    assert_equal "anthropic", provider.name
+    assert_equal "Anthropic (Claude)", provider.display_name
+    assert_equal :anthropic, provider.ruby_llm_provider
   end
 
-  test "#display_name_for should return the human-readable label" do
-    assert_equal "Anthropic (Claude)", LlmProvider.display_name_for("anthropic")
+  test "#find should accept symbol keys" do
+    assert_equal "anthropic", LlmProvider.find(:anthropic).name
   end
 
-  test "#credential_schema_for should return a JSON Schema requiring api_key" do
-    schema = LlmProvider.credential_schema_for("anthropic")
+  test "#find should return nil for unknown providers" do
+    assert_nil LlmProvider.find("does-not-exist")
+    assert_nil LlmProvider.find(nil)
+  end
+
+  test "#credential_schema should require api_key" do
+    schema = LlmProvider.find("anthropic").credential_schema
     assert_equal "object", schema["type"]
     assert_includes schema["required"], "api_key"
     assert_equal false, schema["additionalProperties"]
   end
 
-  test "#ruby_llm_provider_for should return the RubyLLM provider symbol" do
-    assert_equal :anthropic, LlmProvider.ruby_llm_provider_for("anthropic")
+  test "instances should be frozen" do
+    assert LlmProvider.find("anthropic").frozen?
   end
 
   test "registry should be frozen" do


### PR DESCRIPTION
`LlmProvider` becomes a class of frozen value-object instances instead of a module wrapping a hash. Behavior that lived as a lambda in the registry (`validate_call`) becomes a real method.

Lookup goes through `LlmProvider.find(name)`; `.all` returns instances, `.names` returns keys. The per-attribute `*_for` helpers are gone — callers ask the instance.

`FeedProfile` is unchanged and still uses the hash-of-hashes style, so the two registries are now stylistically divergent. Aligning them is a separate, larger pass.
