### PR TITLE
Unfold per-stage assertions in FeedProfile test

### DIFF
--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -38,20 +38,23 @@ class FeedProfileTest < ActiveSupport::TestCase
       assert_kind_of String, entry[:matcher], "#{key}: matcher"
       assert_kind_of Hash, entry[:parameter_schema], "#{key}: parameter_schema"
 
-      %i[loader processor normalizer].each do |stage|
-        assert_kind_of Hash, entry[stage], "#{key}: #{stage} entry must be a hash"
-        assert_kind_of String, entry[stage][:class], "#{key}: #{stage}.class"
-        assert_kind_of Hash, entry[stage][:config], "#{key}: #{stage}.config"
-      end
+      assert_kind_of Hash, entry[:loader], "#{key}: loader entry must be a hash"
+      assert_kind_of String, entry[:loader][:class], "#{key}: loader.class"
+      assert_kind_of Hash, entry[:loader][:config], "#{key}: loader.config"
+
+      assert_kind_of Hash, entry[:processor], "#{key}: processor entry must be a hash"
+      assert_kind_of String, entry[:processor][:class], "#{key}: processor.class"
+      assert_kind_of Hash, entry[:processor][:config], "#{key}: processor.config"
+
+      assert_kind_of Hash, entry[:normalizer], "#{key}: normalizer entry must be a hash"
+      assert_kind_of String, entry[:normalizer][:class], "#{key}: normalizer.class"
+      assert_kind_of Hash, entry[:normalizer][:config], "#{key}: normalizer.config"
 
       if entry[:depends_on_ai]
-        # AI profiles either declare the universal-post output_schema at
-        # the top level or carry it on the AI-using stage's config.
-        ai_stage_config = %i[loader processor normalizer]
-          .map { |stage| entry[stage][:config] }
-          .find { |c| c[:output_schema].is_a?(Hash) }
-        assert_kind_of Hash, ai_stage_config&.dig(:output_schema) || entry[:output_schema],
-                       "#{key}: output_schema required for AI profile"
+        # AI profiles declare the universal-post output_schema at the
+        # top level or on the loader stage that calls the LLM.
+        schema = entry[:loader][:config][:output_schema] || entry[:output_schema]
+        assert_kind_of Hash, schema, "#{key}: output_schema required for AI profile"
       end
     end
   end


### PR DESCRIPTION
Iterating over a stage-name array in the per-profile shape test reads as if loader, processor, and normalizer share an abstraction. They don't — no common base class, and each stage plays a distinct role. Writing each stage's assertions out separately stops the test from suggesting otherwise.

The AI-profile output_schema check unfolds the same way: the loader is the LLM-using stage, so look there directly instead of scanning all three.

Touches the test only. `FeedProfile::STAGES` is now unused; removal is in #412.
