### PR TITLE
Remove validation stage from LLM usage enum

### DIFF
--- a/app/models/llm_usage.rb
+++ b/app/models/llm_usage.rb
@@ -6,7 +6,7 @@ class LlmUsage < ApplicationRecord
   belongs_to :feed, optional: true
   belongs_to :llm_credential, optional: true
 
-  enum :stage, { loader: 0, processor: 1, normalizer: 2, validation: 3 }
+  enum :stage, { loader: 0, processor: 1, normalizer: 2 }
   enum :purpose, { scheduled_run: 0, preview: 1, credential_validation: 2 }
   enum :outcome, {
     success: 0,

--- a/app/models/llm_usage.rb
+++ b/app/models/llm_usage.rb
@@ -18,5 +18,6 @@ class LlmUsage < ApplicationRecord
 
   validates :provider, presence: true
   validates :model, presence: true
+  validates :outcome, presence: true
   validates :started_at, :finished_at, presence: true
 end

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -111,7 +111,7 @@ class LlmClient
     call(
       feed: nil,
       profile_key: nil,
-      stage: :validation,
+      stage: nil,
       purpose: :credential_validation,
       model: default_model_for(credential.provider),
       prompt: "Reply with the single word: ok",

--- a/db/migrate/20260521000000_make_llm_usages_stage_nullable.rb
+++ b/db/migrate/20260521000000_make_llm_usages_stage_nullable.rb
@@ -1,0 +1,9 @@
+class MakeLlmUsagesStageNullable < ActiveRecord::Migration[8.1]
+  def up
+    change_column_null :llm_usages, :stage, true
+  end
+
+  def down
+    change_column_null :llm_usages, :stage, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_18_235416) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_21_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -173,7 +173,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_18_235416) do
     t.bigint "feed_id"
     t.bigint "llm_credential_id"
     t.string "profile_key"
-    t.integer "stage", null: false
+    t.integer "stage"
     t.string "provider", null: false
     t.string "model", null: false
     t.integer "purpose", default: 0, null: false

--- a/test/models/llm_usage_test.rb
+++ b/test/models/llm_usage_test.rb
@@ -20,7 +20,7 @@ class LlmUsageTest < ActiveSupport::TestCase
   end
 
   test "should expose stage enum values" do
-    assert_equal({ "loader" => 0, "processor" => 1, "normalizer" => 2, "validation" => 3 }, LlmUsage.stages)
+    assert_equal({ "loader" => 0, "processor" => 1, "normalizer" => 2 }, LlmUsage.stages)
   end
 
   test "should expose purpose enum values" do

--- a/test/models/llm_usage_test.rb
+++ b/test/models/llm_usage_test.rb
@@ -10,11 +10,12 @@ class LlmUsageTest < ActiveSupport::TestCase
     assert usage.valid?, usage.errors.full_messages.inspect
   end
 
-  test "should require provider, model, and timing fields" do
+  test "should require provider, model, outcome, and timing fields" do
     usage = LlmUsage.new
     refute usage.valid?
     assert usage.errors[:provider].any?
     assert usage.errors[:model].any?
+    assert usage.errors[:outcome].any?
     assert usage.errors[:started_at].any?
     assert usage.errors[:finished_at].any?
   end

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -179,7 +179,7 @@ class LlmClientTest < ActiveSupport::TestCase
 
     assert_equal true, client.health_check
     assert_equal "credential_validation", LlmUsage.last.purpose
-    assert_equal "validation", LlmUsage.last.stage
+    assert_nil LlmUsage.last.stage
   end
 
   test "#health_check should raise ProviderError when the provider rejects the call" do


### PR DESCRIPTION
Changes:

- Make `stage` column nullable in `llm_usages` table via migration
- Remove `validation: 3` from the `stage` enum in `LlmUsage` model
- Update `LlmClient#health_check` to use `nil` instead of `:validation` stage
- Update tests to reflect the removed enum value and nullable stage

The `validation` stage was unused and is being removed. Health check calls now explicitly use `nil` for the stage since they don't fit into the loader/processor/normalizer pipeline.
