### PR TITLE
Refactor ResendWebhookEvent to remove individual accessors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,11 @@ end
 
 Use `.github/pull_request_template.md` for PR descriptions.
 
+Keep the description focused on purpose and conceptual level — what the
+change accomplishes and why. Don't enumerate every technical detail in
+the diff; reviewers can read the diff. A few bullets or a short paragraph
+is usually enough.
+
 ## Tooling Notes
 
 - Use mise for managing Ruby and Node runtimes.

--- a/app/models/resend_webhook_event.rb
+++ b/app/models/resend_webhook_event.rb
@@ -3,62 +3,28 @@ class ResendWebhookEvent
     @data = data
   end
 
-  def email_id
-    @email_id ||= @data[:email_id]
-  end
-
-  def from
-    @from ||= @data[:from]
-  end
-
-  def to
-    @to ||= Array(@data[:to])
-  end
-
-  def subject
-    @subject ||= @data[:subject]
-  end
-
-  def created_at
-    @created_at ||= @data[:created_at]
-  end
-
-  def broadcast_id
-    @broadcast_id ||= @data[:broadcast_id]
-  end
-
-  def tags
-    @tags ||= @data[:tags] || {}
-  end
-
-  def bounce
-    @bounce ||= @data[:bounce]
-  end
-
-  def click
-    @click ||= @data[:click]
-  end
-
-  def failed
-    @failed ||= @data[:failed]
-  end
-
   def recipient_email
     to.first
   end
 
   def raw_data
     {
-      email_id: email_id,
-      from: from,
+      email_id: @data[:email_id],
+      from: @data[:from],
       to: to,
-      subject: subject,
-      created_at: created_at,
-      broadcast_id: broadcast_id,
-      tags: tags,
-      bounce: bounce,
-      click: click,
-      failed: failed
+      subject: @data[:subject],
+      created_at: @data[:created_at],
+      broadcast_id: @data[:broadcast_id],
+      tags: @data[:tags] || {},
+      bounce: @data[:bounce],
+      click: @data[:click],
+      failed: @data[:failed]
     }.compact
+  end
+
+  private
+
+  def to
+    Array(@data[:to])
   end
 end

--- a/test/models/resend_webhook_event_test.rb
+++ b/test/models/resend_webhook_event_test.rb
@@ -1,7 +1,25 @@
 require "test_helper"
 
 class ResendWebhookEventTest < ActiveSupport::TestCase
-  test "initializes with data hash" do
+  test "#recipient_email should return first recipient" do
+    event = ResendWebhookEvent.new(to: ["first@example.com", "second@example.com"])
+
+    assert_equal "first@example.com", event.recipient_email
+  end
+
+  test "#recipient_email should handle string to field" do
+    event = ResendWebhookEvent.new(to: "single@example.com")
+
+    assert_equal "single@example.com", event.recipient_email
+  end
+
+  test "#recipient_email should be nil when to is missing" do
+    event = ResendWebhookEvent.new({})
+
+    assert_nil event.recipient_email
+  end
+
+  test "#raw_data should include all provided fields" do
     data = {
       email_id: "abc123",
       from: "sender@example.com",
@@ -9,115 +27,40 @@ class ResendWebhookEventTest < ActiveSupport::TestCase
       subject: "Test Email",
       created_at: "2024-01-01T00:00:00Z",
       broadcast_id: "broadcast123",
-      tags: { category: "test" }
-    }
-
-    event = ResendWebhookEvent.new(data)
-
-    assert_equal "abc123", event.email_id
-    assert_equal "sender@example.com", event.from
-    assert_equal ["recipient@example.com"], event.to
-    assert_equal "Test Email", event.subject
-    assert_equal "2024-01-01T00:00:00Z", event.created_at
-    assert_equal "broadcast123", event.broadcast_id
-    assert_equal({ category: "test" }, event.tags)
-  end
-
-  test "normalizes to to array" do
-    event = ResendWebhookEvent.new({ to: "single@example.com" })
-
-    assert_equal ["single@example.com"], event.to
-  end
-
-  test "returns first recipient email" do
-    event = ResendWebhookEvent.new({ to: ["first@example.com", "second@example.com"] })
-
-    assert_equal "first@example.com", event.recipient_email
-  end
-
-  test "handles missing to field" do
-    event = ResendWebhookEvent.new({})
-
-    assert_equal [], event.to
-    assert_nil event.recipient_email
-  end
-
-  test "defaults tags to empty hash" do
-    event = ResendWebhookEvent.new({})
-
-    assert_equal({}, event.tags)
-  end
-
-  test "includes bounce data" do
-    data = {
-      to: ["bounced@example.com"],
-      bounce: {
-        message: "Address not found",
-        subType: "Suppressed",
-        type: "Permanent"
-      }
-    }
-
-    event = ResendWebhookEvent.new(data)
-
-    assert_equal "Address not found", event.bounce[:message]
-    assert_equal "Suppressed", event.bounce[:subType]
-    assert_equal "Permanent", event.bounce[:type]
-  end
-
-  test "includes click data" do
-    data = {
-      to: ["clicked@example.com"],
-      click: {
-        ipAddress: "192.168.1.1",
-        link: "https://example.com",
-        timestamp: "2024-01-01T00:00:00Z",
-        userAgent: "Mozilla/5.0"
-      }
-    }
-
-    event = ResendWebhookEvent.new(data)
-
-    assert_equal "192.168.1.1", event.click[:ipAddress]
-    assert_equal "https://example.com", event.click[:link]
-  end
-
-  test "includes failed data" do
-    data = {
-      to: ["failed@example.com"],
+      tags: { category: "test" },
+      bounce: { type: "Permanent" },
+      click: { link: "https://example.com" },
       failed: { reason: "Invalid recipient" }
     }
 
-    event = ResendWebhookEvent.new(data)
-
-    assert_equal "Invalid recipient", event.failed[:reason]
-  end
-
-  test "raw_data returns compact hash" do
-    data = {
-      email_id: "abc123",
-      to: ["recipient@example.com"],
-      subject: "Test"
-    }
-
-    event = ResendWebhookEvent.new(data)
-    raw = event.raw_data
+    raw = ResendWebhookEvent.new(data).raw_data
 
     assert_equal "abc123", raw[:email_id]
+    assert_equal "sender@example.com", raw[:from]
     assert_equal ["recipient@example.com"], raw[:to]
-    assert_equal "Test", raw[:subject]
-    assert_equal({}, raw[:tags])
-    assert_nil raw[:bounce]
-    assert_nil raw[:click]
+    assert_equal "Test Email", raw[:subject]
+    assert_equal "2024-01-01T00:00:00Z", raw[:created_at]
+    assert_equal "broadcast123", raw[:broadcast_id]
+    assert_equal({ category: "test" }, raw[:tags])
+    assert_equal({ type: "Permanent" }, raw[:bounce])
+    assert_equal({ link: "https://example.com" }, raw[:click])
+    assert_equal({ reason: "Invalid recipient" }, raw[:failed])
   end
 
-  test "raw_data excludes nil values" do
-    event = ResendWebhookEvent.new({ to: ["test@example.com"] })
-    raw = event.raw_data
+  test "#raw_data should exclude nil values" do
+    raw = ResendWebhookEvent.new(to: ["test@example.com"]).raw_data
 
     assert_not raw.key?(:email_id)
     assert_not raw.key?(:from)
     assert_not raw.key?(:subject)
     assert_not raw.key?(:bounce)
+    assert_not raw.key?(:click)
+    assert_not raw.key?(:failed)
+  end
+
+  test "#raw_data should default tags to empty hash" do
+    raw = ResendWebhookEvent.new({}).raw_data
+
+    assert_equal({}, raw[:tags])
   end
 end


### PR DESCRIPTION
Drops the unused public accessors on `ResendWebhookEvent`. Only `recipient_email` and `raw_data` are called from outside the class — the per-field readers were speculative API with no production callers. Trimming them shrinks the surface to what the controller actually needs.

No behavior change.
