### PR TITLE
Add feed_details association to User model

### DIFF
--- a/app/controllers/feed_details_controller.rb
+++ b/app/controllers/feed_details_controller.rb
@@ -1,8 +1,6 @@
 class FeedDetailsController < ApplicationController
   before_action :require_authentication
 
-  IDENTIFICATION_TIMEOUT_SECONDS = 30
-
   rate_limit to: 10, within: 1.minute, by: -> { Current.user.id }, only: :create, with: -> {
     render turbo_stream: turbo_stream.replace(
       "feed-form",
@@ -74,14 +72,12 @@ class FeedDetailsController < ApplicationController
   end
 
   def handle_processing_status
-    if feed_detail.started_at.nil?
+    if feed_detail.invalid_processing?
       feed_detail.destroy
       return render(identification_error(error: "Identification session is invalid. Please try again."))
     end
 
-    timeout_threshold = IDENTIFICATION_TIMEOUT_SECONDS.seconds
-
-    if Time.current - feed_detail.started_at > timeout_threshold
+    if feed_detail.timed_out?
       feed_detail.destroy
       return render(identification_error(error: "Feed identification is taking longer than expected. The feed URL may not be responding. Please try again."))
     end

--- a/app/models/feed_detail.rb
+++ b/app/models/feed_detail.rb
@@ -4,6 +4,4 @@ class FeedDetail < ApplicationRecord
   enum :status, { processing: 0, success: 1, failed: 2 }
 
   validates :url, presence: true
-
-  scope :stale, -> { where("created_at < ?", 1.hour.ago) }
 end

--- a/app/models/feed_detail.rb
+++ b/app/models/feed_detail.rb
@@ -1,7 +1,17 @@
 class FeedDetail < ApplicationRecord
+  IDENTIFICATION_TIMEOUT_SECONDS = 30
+
   belongs_to :user
 
   enum :status, { processing: 0, success: 1, failed: 2 }
 
   validates :url, presence: true
+
+  def invalid_processing?
+    processing? && started_at.nil?
+  end
+
+  def timed_out?
+    processing? && started_at.present? && started_at < IDENTIFICATION_TIMEOUT_SECONDS.seconds.ago
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
   has_many :feeds, dependent: :destroy
   has_many :feed_previews, dependent: :destroy
+  has_many :feed_details, dependent: :destroy
   has_many :permissions, dependent: :destroy
   has_many :access_tokens, dependent: :destroy
   has_many :llm_credentials, dependent: :destroy

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -4,7 +4,7 @@
      data-controller="polling"
      data-polling-endpoint-value="<%= feed_details_path(url: url) %>"
      data-polling-interval-value="<%= Feed::IDENTIFICATION_POLLING_INTERVAL_MS %>"
-     data-polling-max-polls-value="<%= FeedDetailsController::IDENTIFICATION_TIMEOUT_SECONDS / 2 %>"
+     data-polling-max-polls-value="<%= FeedDetail::IDENTIFICATION_TIMEOUT_SECONDS / 2 %>"
      data-polling-stop-condition-value="[data-identification-state='complete'], [data-identification-state='error']">
   <div class="flex-shrink-0">
     <%= render SpinnerComponent.new %>

--- a/test/models/feed_detail_test.rb
+++ b/test/models/feed_detail_test.rb
@@ -28,6 +28,56 @@ class FeedDetailTest < ActiveSupport::TestCase
     assert_equal false, detail.candidates.first["depends_on_ai"]
   end
 
+  test "#invalid_processing? should be true when processing without started_at" do
+    detail = FeedDetail.new(user: user, url: "https://example.com/feed.xml", status: :processing, started_at: nil)
+    assert_predicate detail, :invalid_processing?
+  end
+
+  test "#invalid_processing? should be false when started_at is present" do
+    detail = FeedDetail.new(user: user, url: "https://example.com/feed.xml", status: :processing, started_at: Time.current)
+    refute_predicate detail, :invalid_processing?
+  end
+
+  test "#invalid_processing? should be false for non-processing status" do
+    detail = FeedDetail.new(user: user, url: "https://example.com/feed.xml", status: :success, started_at: nil)
+    refute_predicate detail, :invalid_processing?
+  end
+
+  test "#timed_out? should be true when processing exceeds the identification timeout" do
+    detail = FeedDetail.new(
+      user: user,
+      url: "https://example.com/feed.xml",
+      status: :processing,
+      started_at: (FeedDetail::IDENTIFICATION_TIMEOUT_SECONDS + 1).seconds.ago
+    )
+    assert_predicate detail, :timed_out?
+  end
+
+  test "#timed_out? should be false within the identification timeout" do
+    detail = FeedDetail.new(
+      user: user,
+      url: "https://example.com/feed.xml",
+      status: :processing,
+      started_at: 1.second.ago
+    )
+    refute_predicate detail, :timed_out?
+  end
+
+  test "#timed_out? should be false when started_at is missing" do
+    detail = FeedDetail.new(user: user, url: "https://example.com/feed.xml", status: :processing, started_at: nil)
+    refute_predicate detail, :timed_out?
+  end
+
+  test "#timed_out? should be false for non-processing status" do
+    detail = FeedDetail.new(
+      user: user,
+      url: "https://example.com/feed.xml",
+      status: :success,
+      started_at: 1.hour.ago
+    )
+    refute_predicate detail, :timed_out?
+  end
+
   test "should accept multiple ranked candidates" do
     detail = FeedDetail.create!(
       user: user,


### PR DESCRIPTION
Changes:

- Add `has_many :feed_details, dependent: :destroy` association to `User` model.
- Remove unused `stale` scope from `FeedDetail` model.
