### PR TITLE
Rename FeedDetail to FeedIdentification and url to input

### DIFF
--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -5,7 +5,7 @@ class FeedIdentificationsController < ApplicationController
     render turbo_stream: turbo_stream.replace(
       "feed-form",
       partial: "feeds/identification_error",
-      locals: { url: params[:url], error: "Too many identification attempts. Please wait before trying again." }
+      locals: { input: params[:input], error: "Too many identification attempts. Please wait before trying again." }
     ), status: :too_many_requests
   }
 
@@ -57,7 +57,7 @@ class FeedIdentificationsController < ApplicationController
     render turbo_stream: turbo_stream.replace(
       "feed-form",
       partial: "feeds/form_collapsed",
-      locals: { url: original_input }
+      locals: { input: original_input }
     )
   end
 
@@ -106,7 +106,7 @@ class FeedIdentificationsController < ApplicationController
       turbo_stream: turbo_stream.replace(
         "feed-form",
         partial: "feeds/identification_error",
-        locals: { url: feed_input, error: error }
+        locals: { input: feed_input, error: error }
       )
     }
   end
@@ -116,7 +116,7 @@ class FeedIdentificationsController < ApplicationController
       turbo_stream: turbo_stream.replace(
         "feed-form",
         partial: "feeds/identification_loading",
-        locals: { url: feed_input }
+        locals: { input: feed_input }
       )
     }
   end
@@ -132,6 +132,6 @@ class FeedIdentificationsController < ApplicationController
   end
 
   def feed_input
-    @feed_input ||= params[:url]
+    @feed_input ||= params[:input]
   end
 end

--- a/app/controllers/feeds/previews_controller.rb
+++ b/app/controllers/feeds/previews_controller.rb
@@ -15,7 +15,7 @@ class Feeds::PreviewsController < ApplicationController
         [:credential_gate, {
           profile_key: profile_key,
           new_credential_path: new_llm_credential_path,
-          return_to: draft? && preview_params["url"].present? ? feed_identifications_path(url: preview_params["url"]) : nil
+          return_to: draft? && preview_params["url"].present? ? feed_identifications_path(input: preview_params["url"]) : nil
         }]
       else
         case cached_preview
@@ -136,7 +136,7 @@ class Feeds::PreviewsController < ApplicationController
     return nil unless draft?
 
     source = preview_params["url"].presence
-    source ? feed_identifications_path(url: source) : nil
+    source ? feed_identifications_path(input: source) : nil
   end
 
   def needs_credential_gate?

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -1,11 +1,11 @@
-<%# locals: (url: nil) %>
+<%# locals: (input: nil) %>
 <div id="feed-form">
   <%= form_with url: feed_identifications_path, method: :post do |f| %>
     <div class="space-y-6">
       <div class="space-y-2">
-        <%= f.label :url, "What do you want to follow?", class: "block font-semibold text-slate-800" %>
-        <%= f.text_field :url,
-                         value: url,
+        <%= f.label :input, "What do you want to follow?", class: "block font-semibold text-slate-800" %>
+        <%= f.text_field :input,
+                         value: input,
                          placeholder: "Paste a link, handle, or a few words",
                          class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                          required: true,

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -78,7 +78,7 @@
                          params: { url: feed.url },
                          format: :turbo_stream
                        ),
-                       cancel_url: feed_identifications_path(url: feed.url) %>
+                       cancel_url: feed_identifications_path(input: feed.url) %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -17,8 +17,8 @@
 
   <%= form_with url: feed_identifications_path, method: :post, class: "space-y-6" do |f| %>
     <div class="space-y-2">
-      <%= f.label :url, "Feed URL", class: "block font-semibold text-slate-800" %>
-      <%= f.text_field :url, value: url, placeholder: "https://example.com/feed.xml", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
+      <%= f.label :input, "Feed URL", class: "block font-semibold text-slate-800" %>
+      <%= f.text_field :input, value: input, placeholder: "https://example.com/feed.xml", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
     </div>
 
     <div>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -2,7 +2,7 @@
      class="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 shadow-xs"
      role="status"
      data-controller="polling"
-     data-polling-endpoint-value="<%= feed_identifications_path(url: url) %>"
+     data-polling-endpoint-value="<%= feed_identifications_path(input: input) %>"
      data-polling-interval-value="<%= Feed::IDENTIFICATION_POLLING_INTERVAL_MS %>"
      data-polling-max-polls-value="<%= FeedIdentification::IDENTIFICATION_TIMEOUT_SECONDS / 2 %>"
      data-polling-stop-condition-value="[data-identification-state='complete'], [data-identification-state='error']">
@@ -14,7 +14,7 @@
     <p class="text-slate-600">This usually takes a few seconds.</p>
   </div>
   <%= button_to "Cancel",
-                feed_identifications_path(url: url),
+                feed_identifications_path(input: input),
                 method: :delete,
                 form: { data: { turbo_frame: "_top" } },
                 class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-50",

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -12,7 +12,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#create should require authentication" do
-    post feed_identifications_path, params: { url: "http://example.com/feed.xml" }
+    post feed_identifications_path, params: { input: "http://example.com/feed.xml" }
     assert_redirected_to new_session_path
   end
 
@@ -21,7 +21,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     url = "http://example.com/feed.xml"
 
     assert_enqueued_with(job: FeedIdentificationJob, args: [user.id, url]) do
-      post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
@@ -39,11 +39,11 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     url = "http://example.com/feed.xml"
 
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     assert_response :success
 
     assert_no_enqueued_jobs do
-      post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
       assert_response :success
     end
   end
@@ -53,10 +53,10 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     url = "http://example.com/feed.xml"
 
     sign_in_as(user)
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     sign_in_as(user2)
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     # Both users should have separate feed detail records
     user1_feed_identification = FeedIdentification.find_by(user: user, input: url)
@@ -91,11 +91,11 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     stub_request(:get, url)
       .to_return(status: 200, body: rss_content, headers: { "Content-Type" => "application/xml" })
 
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
     assert_no_enqueued_jobs do
-      post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
     assert_response :success
@@ -111,12 +111,12 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       .to_return(status: 404, body: "Not Found")
 
     # First attempt - creates failed feed detail
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
     # Second attempt - should restart identification
     assert_enqueued_with(job: FeedIdentificationJob, args: [user.id, url]) do
-      post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
     assert_response :success
@@ -126,7 +126,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
   test "#create should reject empty or malformed input" do
     sign_in_as(user)
 
-    post feed_identifications_path, params: { url: "" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: "" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     assert_includes response.body, "Please enter a link, handle, or a few words"
@@ -136,7 +136,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
 
     assert_enqueued_with(job: FeedIdentificationJob) do
-      post feed_identifications_path, params: { url: "ai safety news" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      post feed_identifications_path, params: { input: "ai safety news" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
     assert_response :success
@@ -146,14 +146,14 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
 
     assert_enqueued_with(job: FeedIdentificationJob) do
-      post feed_identifications_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      post feed_identifications_path, params: { input: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
     assert_response :success
   end
 
   test "#show should require authentication" do
-    get feed_identifications_path, params: { url: "http://example.com/feed.xml" }
+    get feed_identifications_path, params: { input: "http://example.com/feed.xml" }
     assert_redirected_to new_session_path
   end
 
@@ -162,10 +162,10 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     url = "http://example.com/feed.xml"
 
     # Create processing feed detail via controller
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     # Check status while still processing (don't perform jobs)
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     assert_includes response.body, "Checking this feed"
@@ -176,13 +176,13 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     url = "http://example.com/feed.xml"
 
     # Create processing feed detail via controller
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     # Manipulate record to remove started_at (invalid state)
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     feed_identification.update_column(:started_at, nil)
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     assert_includes response.body, "Identification session is invalid"
@@ -194,13 +194,13 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     url = "http://example.com/feed.xml"
 
     # Create processing feed detail via controller
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     # Manipulate record to simulate long-running job
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     feed_identification.update_column(:started_at, 31.seconds.ago)
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     assert_includes response.body, "taking longer than expected"
@@ -226,10 +226,10 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       .to_return(status: 200, body: rss_content, headers: { "Content-Type" => "application/xml" })
 
     # Create successful feed detail via controller and job
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     assert_includes response.body, 'action="replace"'
@@ -244,10 +244,10 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       .to_return(status: 200, body: "Not a valid feed", headers: { "Content-Type" => "text/plain" })
 
     # Create failed feed detail via controller and job
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     # When no structured profile matches, the AI fallback now fires and the
@@ -260,7 +260,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     url = "http://example.com/feed.xml"
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     assert_includes response.body, "Identification session expired"
@@ -272,10 +272,10 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     rss_body = "<?xml version=\"1.0\"?><rss><channel><title>Example</title></channel></rss>"
     stub_request(:get, url).to_return(status: 200, body: rss_body)
 
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     payload = extract_candidates_payload(response.body)
     # RSS plus the AI fallback. RSS ranks first.
@@ -290,10 +290,10 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     rss_body = "<?xml version=\"1.0\"?><rss><channel><title>xkcd.com</title></channel></rss>"
     stub_request(:get, url).to_return(status: 200, body: rss_body)
 
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     payload = extract_candidates_payload(response.body)
     assert_equal %w[xkcd rss llm_website_extractor], payload.map { |c| c["profile_key"] }
@@ -319,7 +319,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       ]
     )
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     payload = extract_candidates_payload(response.body)
     assert_equal 1, payload.size
@@ -344,7 +344,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       ]
     )
 
-    get feed_identifications_path, params: { url: handle }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: handle }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     assert_includes response.body, 'name="feed[params][handle]"'
@@ -366,7 +366,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       ]
     )
 
-    get feed_identifications_path, params: { url: query }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: query }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     assert_includes response.body, 'name="feed[params][query]"'
@@ -385,7 +385,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_difference("FeedIdentification.count", -1) do
       delete feed_identifications_path,
-             params: { url: url },
+             params: { input: url },
              headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
@@ -401,7 +401,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_no_difference("FeedIdentification.count") do
       delete feed_identifications_path,
-             params: { url: url },
+             params: { input: url },
              headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
@@ -424,7 +424,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       ]
     )
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
     assert_includes response.body, "data-key=\"candidates\""

--- a/test/integration/smart_feed_creation_ai_website_test.rb
+++ b/test/integration/smart_feed_creation_ai_website_test.rb
@@ -66,7 +66,7 @@ class SmartFeedCreationAiWebsiteTest < ActionDispatch::IntegrationTest
 
   def detect(url)
     stub_request(:get, url).to_return(status: 200, body: "<html><body>no rss here</body></html>")
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
   end
 
@@ -79,7 +79,7 @@ class SmartFeedCreationAiWebsiteTest < ActionDispatch::IntegrationTest
       with_memory_cache do
         detect(ai_url)
 
-      get feed_identifications_path, params: { url: ai_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      get feed_identifications_path, params: { input: ai_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
       assert_response :success
       assert_includes response.body, "AI page reader"
 

--- a/test/integration/smart_feed_creation_handle_query_test.rb
+++ b/test/integration/smart_feed_creation_handle_query_test.rb
@@ -16,10 +16,10 @@ class SmartFeedCreationHandleQueryTest < ActionDispatch::IntegrationTest
   test "#create should detect a handle input and offer the llm_handle_search candidate" do
     sign_in_as(user)
 
-    post feed_identifications_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
-    get feed_identifications_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     assert_response :success
     assert_includes response.body, "llm_handle_search"
   end
@@ -27,10 +27,10 @@ class SmartFeedCreationHandleQueryTest < ActionDispatch::IntegrationTest
   test "#create should detect a free-text query and offer the llm_web_search candidate" do
     sign_in_as(user)
 
-    post feed_identifications_path, params: { url: "climate change" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: "climate change" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
-    get feed_identifications_path, params: { url: "climate change" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: "climate change" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     assert_response :success
     assert_includes response.body, "llm_web_search"
   end
@@ -38,10 +38,10 @@ class SmartFeedCreationHandleQueryTest < ActionDispatch::IntegrationTest
   test "#create should render the personalized candidate summary for a handle input" do
     sign_in_as(user)
 
-    post feed_identifications_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
-    get feed_identifications_path, params: { url: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: "@alice" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     # Multi-candidate would render the chooser; single-candidate renders the
     # source caption. Either way the user's input appears in the form copy.
     assert_includes response.body, "@alice"

--- a/test/integration/smart_feed_creation_reload_test.rb
+++ b/test/integration/smart_feed_creation_reload_test.rb
@@ -46,11 +46,11 @@ class SmartFeedCreationReloadTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     stub_request(:get, feed_url).to_return(status: 200, body: rss_body)
 
-    post feed_identifications_path, params: { url: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
     assert_no_enqueued_jobs do
-      get feed_identifications_path, params: { url: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      get feed_identifications_path, params: { input: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
   end
 

--- a/test/integration/smart_feed_creation_rss_test.rb
+++ b/test/integration/smart_feed_creation_rss_test.rb
@@ -53,12 +53,12 @@ class SmartFeedCreationRssTest < ActionDispatch::IntegrationTest
       .to_return(status: 200, body: rss_body, headers: { "Content-Type" => "application/xml" })
 
     with_memory_cache do
-      post feed_identifications_path, params: { url: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      post feed_identifications_path, params: { input: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
       assert_response :success
 
       perform_enqueued_jobs
 
-      get feed_identifications_path, params: { url: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      get feed_identifications_path, params: { input: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
       assert_response :success
       assert_includes response.body, 'data-identification-state="complete"'
       assert_includes response.body, "RSS Feed"
@@ -106,10 +106,10 @@ class SmartFeedCreationRssTest < ActionDispatch::IntegrationTest
       .to_return(status: 200, body: rss_body, headers: { "Content-Type" => "application/xml" })
 
     with_memory_cache do
-      post feed_identifications_path, params: { url: xkcd_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      post feed_identifications_path, params: { input: xkcd_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
       perform_enqueued_jobs
 
-      get feed_identifications_path, params: { url: xkcd_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      get feed_identifications_path, params: { input: xkcd_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
       assert_response :success
       assert_includes response.body, "XKCD"
     end
@@ -121,7 +121,7 @@ class SmartFeedCreationRssTest < ActionDispatch::IntegrationTest
 
     assert_difference("FeedIdentification.count", -1) do
       delete feed_identifications_path,
-             params: { url: feed_url },
+             params: { input: feed_url },
              headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 

--- a/test/integration/smart_feed_creation_vocabulary_test.rb
+++ b/test/integration/smart_feed_creation_vocabulary_test.rb
@@ -83,10 +83,10 @@ class SmartFeedCreationVocabularyTest < ActionDispatch::IntegrationTest
     XML
     stub_request(:get, url).to_return(status: 200, body: rss_body)
 
-    post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
 
-    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     assert_response :success
     assert_no_banned_vocabulary(response.body, page: "feed_identifications (success / form-expanded)")
   end


### PR DESCRIPTION
Changes:

- Rename the feed-identification HTTP form param from `url` to `input` so the wire-level name matches the model column (`feed_identifications.input`) and the rest of the vocabulary (`InputClassifier`, `FeedProfileDetector.call(input:)`, `Feed#source_input`).
- Form fields `f.text_field :url` / `f.label :url` → `:input` in `_form_collapsed` and `_identification_error` partials.
- Strict-locals docs and internal local-var references in the three identification partials (`_form_collapsed`, `_identification_error`, `_identification_loading`) renamed `url` → `input`.
- Controller `params[:url]` → `params[:input]` (rate-limit lambda + `feed_input` helper) and `locals: { url: … }` → `locals: { input: … }` (5 spots).
- Path-helper kwargs `feed_identifications_path(url: …)` → `(input: …)` in `feeds/previews_controller.rb` and `_form_expanded.html.erb`.
- Tests that POST/GET/DELETE `feed_identifications_path` updated to `params: { input: … }`. `params: { url: … }` keys targeting other endpoints (Feed `params` jsonb, feeds#create, preview#create, edit mass-assign test) are left alone — they're the Feed model's params hash, a separate concern.

Heads-up: any external client/bookmark pointing at `POST /feed_identifications?url=…` would need to switch to `?input=…`. The endpoint is internal/Turbo-driven so this should be a non-issue in practice.
