### PR TITLE
Improve feed URL input placeholder text

### DIFF
--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -6,7 +6,7 @@
         <%= f.label :input, "What do you want to follow?", class: "block font-semibold text-slate-800" %>
         <%= f.text_field :input,
                          value: input,
-                         placeholder: "Paste a link, handle, or a few words",
+                         placeholder: "Paste a URL or describe what to follow",
                          class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                          required: true,
                          autofocus: true,


### PR DESCRIPTION
Changes:

- Updated the placeholder text for the feed URL input field from "Paste a link, handle, or a few words" to "Paste a URL or describe what to follow" for better clarity and alignment with the form's purpose
