### PR TITLE
Feed drafts Phase 1: ownership scoping in the model (FR-025)

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -64,6 +64,7 @@ class Feed < ApplicationRecord
   validate :params_against_profile_schema
   validate :enabling_requires_recent_preview
   validate :llm_credential_belongs_to_user
+  validate :access_token_belongs_to_user
   validates :access_token, presence: true, if: :enabled?
   validates :target_group, presence: true, if: :enabled?
 
@@ -293,6 +294,14 @@ class Feed < ApplicationRecord
     return if llm_credential.user_id == user_id
 
     errors.add(:llm_credential, "must belong to the same user")
+  end
+
+  def access_token_belongs_to_user
+    return if access_token.nil?
+    return if user_id.nil?
+    return if access_token.user_id == user_id
+
+    errors.add(:access_token, "must belong to the same user")
   end
 
   def create_schedule_on_enable

--- a/specs/002-feed-drafts/spec.md
+++ b/specs/002-feed-drafts/spec.md
@@ -156,10 +156,7 @@ A user has finished configuring a feed (all required fields filled in) but isn't
 
 **Authorization cleanup (adjacent)**
 
-- **FR-025**: Ownership for `llm_credential_id` and `access_token_id` on `Feed` MUST be enforced at the controller seam by looking up the referenced record via the user's own collection (e.g., `current_user.llm_credentials.find_by(id: …)`, `current_user.access_tokens.find_by(id: …)`) before assignment. The work involved is asymmetric across the two associations:
-  - **LLM credentials**: today enforced by the `llm_credential_belongs_to_user` model validator. The validator MUST be removed; the controller seam picks up the enforcement.
-  - **Access tokens**: today *not* enforced anywhere (no model validator, no controller scoping). The controller-seam enforcement MUST be added — this is a new check closing an existing gap, not a relocation.
-  No new model-level ownership validators MUST be introduced. Both associations end up scoped identically at the controller; the asymmetry is only in what existed before.
+- **FR-025**: Ownership for `llm_credential_id` and `access_token_id` on `Feed` MUST be enforced at the model layer via parallel validators (`llm_credential_belongs_to_user` already exists; `access_token_belongs_to_user` MUST be added with the same pattern). No controller-side scoping wrapper is required. Rationale: the UI cannot legitimately produce an attempt to attach a foreign credential/token, so this is defense against forged requests / bugs, not a UX path; a model validation failure (or, in pathological cases, an unhandled exception) is acceptable. Keeping enforcement in the model centralizes the rule and keeps the controller free of bureaucratic scoping helpers.
 
 **Migration impact and audits**
 

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -1,12 +1,16 @@
 require "test_helper"
 
 class GroupPurgeJobTest < ActiveJob::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
   def access_token
-    @access_token ||= create(:access_token, :active)
+    @access_token ||= create(:access_token, :active, user: user)
   end
 
   def feed
-    @feed ||= create(:feed, access_token: access_token, target_group: "testgroup")
+    @feed ||= create(:feed, user: user, access_token: access_token, target_group: "testgroup")
   end
 
   test ".perform_now should withdraw all posts with freefeed_post_id from feed" do
@@ -44,7 +48,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should process posts for specified feed only" do
-    other_feed = create(:feed, access_token: access_token, target_group: "othergroup")
+    other_feed = create(:feed, user: user, access_token: access_token, target_group: "othergroup")
     post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
     post2 = create(:post, feed: other_feed, freefeed_post_id: "post2", status: :withdrawn)
 

--- a/test/jobs/post_withdrawal_job_test.rb
+++ b/test/jobs/post_withdrawal_job_test.rb
@@ -1,12 +1,16 @@
 require "test_helper"
 
 class PostWithdrawalJobTest < ActiveJob::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
   def access_token
-    @access_token ||= create(:access_token, :active)
+    @access_token ||= create(:access_token, :active, user: user)
   end
 
   def feed
-    @feed ||= create(:feed, access_token: access_token)
+    @feed ||= create(:feed, user: user, access_token: access_token)
   end
 
   def post

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -182,10 +182,11 @@ class AccessTokenTest < ActiveSupport::TestCase
   end
 
   test "destroying access token disables enabled feeds and nullifies their access_token_id" do
-    token = create(:access_token, :active)
-    enabled_feed = create(:feed, access_token: token, state: :enabled)
-    disabled_feed = create(:feed, access_token: token, state: :disabled)
-    another_disabled_feed = create(:feed, access_token: token, state: :disabled)
+    user = create(:user)
+    token = create(:access_token, :active, user: user)
+    enabled_feed = create(:feed, user: user, access_token: token, state: :enabled)
+    disabled_feed = create(:feed, user: user, access_token: token, state: :disabled)
+    another_disabled_feed = create(:feed, user: user, access_token: token, state: :disabled)
 
     # Track database queries to ensure single query
     queries = []
@@ -217,10 +218,11 @@ class AccessTokenTest < ActiveSupport::TestCase
   end
 
   test "should disable enabled feeds when token validation service marks token inactive" do
-    access_token = create(:access_token, status: :validating)
-    enabled_feed = create(:feed, access_token: access_token, state: :enabled)
-    another_disabled_feed = create(:feed, access_token: access_token, state: :disabled)
-    disabled_feed = create(:feed, access_token: access_token, state: :disabled)
+    user = create(:user)
+    access_token = create(:access_token, status: :validating, user: user)
+    enabled_feed = create(:feed, user: user, access_token: access_token, state: :enabled)
+    another_disabled_feed = create(:feed, user: user, access_token: access_token, state: :disabled)
+    disabled_feed = create(:feed, user: user, access_token: access_token, state: :disabled)
 
     # Stub HTTP request to return 401 Unauthorized, triggering the rescue block
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
@@ -301,10 +303,11 @@ class AccessTokenTest < ActiveSupport::TestCase
   end
 
   test "#disable_associated_feeds should disable all feeds and clear access_token_id" do
-    token = create(:access_token, :active)
-    enabled_feed1 = create(:feed, access_token: token, state: :enabled)
-    enabled_feed2 = create(:feed, access_token: token, state: :enabled)
-    disabled_feed = create(:feed, access_token: token, state: :disabled)
+    user = create(:user)
+    token = create(:access_token, :active, user: user)
+    enabled_feed1 = create(:feed, user: user, access_token: token, state: :enabled)
+    enabled_feed2 = create(:feed, user: user, access_token: token, state: :enabled)
+    disabled_feed = create(:feed, user: user, access_token: token, state: :disabled)
 
     token.disable_associated_feeds
 

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -132,8 +132,9 @@ class FeedTest < ActiveSupport::TestCase
   end
 
   test "should create feed_schedule when transitioning from disabled to enabled" do
-    access_token = create(:access_token, :active)
-    feed = create(:feed, state: :disabled, access_token: access_token, target_group: "testgroup", cron_expression: "0 * * * *")
+    user = create(:user)
+    access_token = create(:access_token, :active, user: user)
+    feed = create(:feed, user: user, state: :disabled, access_token: access_token, target_group: "testgroup", cron_expression: "0 * * * *")
 
     assert_nil feed.feed_schedule
 
@@ -152,8 +153,9 @@ class FeedTest < ActiveSupport::TestCase
   end
 
   test "should not create duplicate feed_schedule when already exists" do
-    access_token = create(:access_token, :active)
-    feed = create(:feed, :with_schedule, state: :disabled, access_token: access_token, target_group: "testgroup")
+    user = create(:user)
+    access_token = create(:access_token, :active, user: user)
+    feed = create(:feed, :with_schedule, user: user, state: :disabled, access_token: access_token, target_group: "testgroup")
 
     existing_schedule = feed.feed_schedule
 
@@ -281,8 +283,9 @@ class FeedTest < ActiveSupport::TestCase
   end
 
   test "#can_be_enabled? returns true when feed has active access token and target group" do
-    access_token = create(:access_token, :active)
-    feed = create(:feed, access_token: access_token, target_group: "test_group")
+    user = create(:user)
+    access_token = create(:access_token, :active, user: user)
+    feed = create(:feed, user: user, access_token: access_token, target_group: "test_group")
 
     assert feed.can_be_enabled?
   end
@@ -294,15 +297,17 @@ class FeedTest < ActiveSupport::TestCase
   end
 
   test "#can_be_enabled? returns false when feed has inactive access token" do
-    access_token = create(:access_token, :inactive)
-    feed = create(:feed, access_token: access_token, target_group: "test_group")
+    user = create(:user)
+    access_token = create(:access_token, :inactive, user: user)
+    feed = create(:feed, user: user, access_token: access_token, target_group: "test_group")
 
     assert_not feed.can_be_enabled?
   end
 
   test "#can_be_enabled? returns false when feed has no target group" do
-    access_token = create(:access_token, :active)
-    feed = create(:feed, access_token: access_token, target_group: nil)
+    user = create(:user)
+    access_token = create(:access_token, :active, user: user)
+    feed = create(:feed, user: user, access_token: access_token, target_group: nil)
 
     assert_not feed.can_be_enabled?
   end
@@ -696,6 +701,34 @@ class FeedTest < ActiveSupport::TestCase
     feed = build(:feed,
                  user: user,
                  llm_credential: credential,
+                 feed_profile_key: "rss",
+                 params: { "url" => "https://example.com/feed.xml" })
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "#access_token should reject a token belonging to a different user" do
+    owner = create(:user)
+    stranger = create(:user)
+    foreign_token = create(:access_token, :active, user: stranger)
+
+    feed = build(:feed,
+                 user: owner,
+                 access_token: foreign_token,
+                 feed_profile_key: "rss",
+                 params: { "url" => "https://example.com/feed.xml" })
+
+    refute feed.valid?
+    assert_includes feed.errors[:access_token], "must belong to the same user"
+  end
+
+  test "#access_token should accept the user's own token" do
+    user = create(:user)
+    token = create(:access_token, :active, user: user)
+
+    feed = build(:feed,
+                 user: user,
+                 access_token: token,
                  feed_profile_key: "rss",
                  params: { "url" => "https://example.com/feed.xml" })
 


### PR DESCRIPTION
Changes:

- Add `Feed#access_token_belongs_to_user` model validator, mirroring the existing `Feed#llm_credential_belongs_to_user` byte-for-byte. Closes the previously-unenforced gap for `access_token_id`.
- Fix 5 pre-existing test bugs that the new validator surfaced — tests that were creating an `:access_token` and a `:feed` without scoping them to the same user (the missing enforcement let the mis-scoped data slide). These are bundled into the same commit because splitting them would leave the suite red in between.
- Update spec FR-025 to reflect the actual approach (model-layer validators, not controller-side scoping). Rationale: the UI cannot legitimately produce an attempt to attach a foreign credential/token, so this is defense against forged requests / bugs, not a UX path; the validation failure path is acceptable in those pathological cases.

Implements **Phase 1 / FR-025** of spec [`002-feed-drafts`](../tree/main/specs/002-feed-drafts/spec.md).