### PR TITLE
Feed drafts Phase 5: credential round-trip via feed_id (FR-015..FR-021)

### DIFF
--- a/app/controllers/feeds/previews_controller.rb
+++ b/app/controllers/feeds/previews_controller.rb
@@ -14,8 +14,7 @@ class Feeds::PreviewsController < ApplicationController
       if needs_credential_gate?
         [:credential_gate, {
           profile_key: profile_key,
-          new_credential_path: new_llm_credential_path,
-          input: draft? ? preview_params["url"] : nil
+          feed_id: draft? ? nil : feed.id
         }]
       else
         case cached_preview

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -58,11 +58,14 @@ class FeedsController < ApplicationController
     @feed.preview_token = params[:preview_token]
 
     if @feed.save
-      if params[:enable_feed] == "1" && !@feed.enable
+      cleanup_feed_identification(@feed.url) if @feed.url
+
+      if gate_commit?
+        redirect_to new_llm_credential_path(feed_id: @feed.id)
+      elsif params[:enable_feed] == "1" && !@feed.enable
         flash.now[:alert] = "Couldn't enable. See issues below."
         render :new, status: :unprocessable_entity
       else
-        cleanup_feed_identification(@feed.url) if @feed.url
         redirect_to feed_path(@feed), notice: success_message_for(@feed)
       end
     else
@@ -92,22 +95,23 @@ class FeedsController < ApplicationController
     @feed.preview_token = params[:preview_token]
     @feed.assign_attributes(update_feed_params)
 
-    # Unticked Enable on an enabled feed = pause request. Drafts and disabled
-    # feeds stay at their current state; promotion (if requested) happens via
-    # @feed.enable after the first save.
-    @feed.state = :disabled if @feed.enabled? && params[:enable_feed] != "1"
+    # Unticked Enable on an enabled feed = pause request (gate flow skips this
+    # because the gate only appears for drafts without usable credentials).
+    @feed.state = :disabled if @feed.enabled? && params[:enable_feed] != "1" && !gate_commit?
 
     if @feed.save
       # Capture interval-change signal from the first save before the
       # promotion attempt's save overwrites `saved_changes`.
       interval_changed = @feed.saved_change_to_cron_expression?
+      cleanup_feed_identification(@feed.url) if @feed.url
 
-      if params[:enable_feed] == "1" && !@feed.enabled? && !@feed.enable
+      if gate_commit?
+        redirect_to new_llm_credential_path(feed_id: @feed.id)
+      elsif params[:enable_feed] == "1" && !@feed.enabled? && !@feed.enable
         flash.now[:alert] = "Couldn't enable. See issues below."
         render :edit, status: :unprocessable_entity
       else
         @feed.reset_schedule! if interval_changed && @feed.feed_schedule.present?
-        cleanup_feed_identification(@feed.url) if @feed.url
         redirect_to feed_path(@feed), notice: update_message_for(@feed)
       end
     else
@@ -123,6 +127,13 @@ class FeedsController < ApplicationController
   end
 
   private
+
+  # The credential gate (rendered in the preview pane when the chosen profile
+  # is AI and the user has no usable credentials) submits the feed form with
+  # this commit value. See app/views/feeds/_credential_gate.html.erb.
+  def gate_commit?
+    params[:commit] == "save_as_draft_and_add_credentials"
+  end
 
   def active_access_tokens?
     current_user.access_tokens.active.exists?

--- a/app/controllers/llm_credentials/validations_controller.rb
+++ b/app/controllers/llm_credentials/validations_controller.rb
@@ -6,7 +6,7 @@ class LlmCredentials::ValidationsController < ApplicationController
     render turbo_stream: turbo_stream.update(
       "llm-credential-show",
       partial: "llm_credentials/show_content",
-      locals: { llm_credential: llm_credential, input: params[:input] }
+      locals: { llm_credential: llm_credential, feed_id: params[:feed_id] }
     )
   end
 

--- a/app/controllers/llm_credentials_controller.rb
+++ b/app/controllers/llm_credentials_controller.rb
@@ -6,24 +6,25 @@ class LlmCredentialsController < ApplicationController
 
   def show
     @llm_credential = find_credential
-    @input = params[:input]
+    @feed = scoped_feed(params[:feed_id])
     authorize @llm_credential
   end
 
   def new
     @llm_credential = LlmCredential.new(provider: params[:provider] || LlmProvider.names.first)
-    @input = params[:input]
+    @feed = scoped_feed(params[:feed_id])
     authorize @llm_credential
   end
 
   def create
     @llm_credential = build_credential
-    @input = params[:input]
+    @feed = scoped_feed(params[:feed_id])
     authorize @llm_credential
 
     if @llm_credential.save
+      @feed&.update_column(:llm_credential_id, @llm_credential.id)
       LlmCredentialValidationJob.perform_later(@llm_credential)
-      redirect_to llm_credential_path(@llm_credential, input: @input)
+      redirect_to llm_credential_path(@llm_credential, feed_id: @feed&.id)
     else
       render :new, status: :unprocessable_entity
     end
@@ -37,6 +38,12 @@ class LlmCredentialsController < ApplicationController
   end
 
   private
+
+  def scoped_feed(feed_id)
+    return nil if feed_id.blank?
+
+    Current.user.feeds.find_by(id: feed_id)
+  end
 
   def build_credential
     Current.user.llm_credentials.build(

--- a/app/views/feeds/_credential_gate.html.erb
+++ b/app/views/feeds/_credential_gate.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (profile_key:, new_credential_path:, input: nil) %>
+<%# locals: (profile_key:, feed_id: nil) %>
 <div class="rounded-lg border border-sky-200 bg-sky-50 p-4 space-y-3"
      data-key="credentials.gate">
   <div class="flex gap-3">
@@ -13,10 +13,16 @@
     </div>
   </div>
 
-  <div>
-    <%= link_to "Add AI credentials",
-                input.present? ? "#{new_credential_path}?input=#{CGI.escape(input)}" : new_credential_path,
-                data: { turbo_frame: "_top", key: "credentials.gate.add" },
-                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500" %>
+  <div class="space-y-2">
+    <button type="submit"
+            name="commit"
+            value="save_as_draft_and_add_credentials"
+            data-key="credentials.gate.add"
+            class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500">
+      Add AI credentials
+    </button>
+    <p class="text-sky-800 text-sm" data-key="credentials.gate.help">
+      We'll save your feed as a draft so you can pick up where you left off.
+    </p>
   </div>
 </div>

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (llm_credential:, input: nil) %>
+<%# locals: (llm_credential:, feed_id: nil) %>
 <div class="space-y-6" data-key="llm_credential.show">
   <%= render PageHeaderComponent.new(title: llm_credential.display_name) do |header| %>
     <% header.with_context_paragraph(LlmProvider.find(llm_credential.provider)&.display_name.to_s) %>
@@ -37,9 +37,9 @@
   <% end %>
 
   <div class="flex flex-wrap gap-3">
-    <% if llm_credential.active? && input.present? %>
+    <% if llm_credential.active? && feed_id.present? %>
       <%= link_to "Continue setting up your feed",
-                  feed_identifications_path(input: input),
+                  edit_feed_path(feed_id),
                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500",
                   data: { key: "llm_credential.return-to" } %>
     <% end %>

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -5,7 +5,7 @@
     <% header.with_context_paragraph("Connect a provider key so AI feeds can fetch posts on your behalf.") %>
   <% end %>
 
-  <%= form_with model: @llm_credential, url: llm_credentials_path(input: @input) do |f| %>
+  <%= form_with model: @llm_credential, url: llm_credentials_path(feed_id: @feed&.id) do |f| %>
     <% if @llm_credential.errors.any? %>
       <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
         <ul class="list-disc list-inside text-sm">

--- a/app/views/llm_credentials/show.html.erb
+++ b/app/views/llm_credentials/show.html.erb
@@ -3,16 +3,16 @@
 <% if @llm_credential.pending? || @llm_credential.validating? %>
   <div
     data-controller="polling"
-    data-polling-endpoint-value="<%= llm_credential_validation_path(@llm_credential, input: @input) %>"
+    data-polling-endpoint-value="<%= llm_credential_validation_path(@llm_credential, feed_id: @feed&.id) %>"
     data-polling-interval-value="2000"
     data-polling-stop-condition-value="[data-credential-state]"
     aria-busy="true">
     <div id="llm-credential-show" class="space-y-8">
-      <%= render "llm_credentials/show_content", llm_credential: @llm_credential, input: @input %>
+      <%= render "llm_credentials/show_content", llm_credential: @llm_credential, feed_id: @feed&.id %>
     </div>
   </div>
 <% else %>
   <div id="llm-credential-show" class="space-y-8">
-    <%= render "llm_credentials/show_content", llm_credential: @llm_credential, input: @input %>
+    <%= render "llm_credentials/show_content", llm_credential: @llm_credential, feed_id: @feed&.id %>
   </div>
 <% end %>

--- a/test/controllers/feeds/previews_controller_test.rb
+++ b/test/controllers/feeds/previews_controller_test.rb
@@ -168,7 +168,25 @@ class Feeds::PreviewsControllerTest < ActionDispatch::IntegrationTest
 
       assert_response :success
       assert_select "[data-key='credentials.gate']"
-      assert_select "[data-key='credentials.gate.add']"
+      assert_select "button[data-key='credentials.gate.add'][type='submit'][name='commit'][value='save_as_draft_and_add_credentials']",
+                    text: /Add AI credentials/
+      assert_select "[data-key='credentials.gate.help']",
+                    text: /We'll save your feed as a draft/
+    end
+  end
+
+  test "#show should render the credential gate for a saved draft feed without an AI credential" do
+    sign_in_as(user)
+    draft_feed = create(:feed, :draft, user: user, feed_profile_key: "llm_website_extractor",
+                                       params: { "url" => "https://example.com" })
+
+    with_memory_cache do
+      get feed_live_preview_path(draft_feed),
+          params: { profile_key: "llm_website_extractor", params: { url: "https://example.com" } }
+
+      assert_response :success
+      assert_select "[data-key='credentials.gate']"
+      assert_select "button[data-key='credentials.gate.add'][name='commit'][value='save_as_draft_and_add_credentials']"
     end
   end
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -223,6 +223,57 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_predicate feed, :draft?, "State should be draft despite state param"
   end
 
+  test "#create should save as draft and redirect to credential setup when commit signals gate" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "Test Feed",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: {
+        feed: feed_params,
+        commit: "save_as_draft_and_add_credentials"
+      }
+    end
+
+    feed = Feed.last
+    assert_predicate feed, :draft?
+    assert_redirected_to new_llm_credential_path(feed_id: feed.id)
+  end
+
+  test "#create gate-commit should ignore enable_feed=1" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "Test Feed",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: {
+        feed: feed_params,
+        enable_feed: "1",
+        commit: "save_as_draft_and_add_credentials"
+      }
+    end
+
+    feed = Feed.last
+    assert_predicate feed, :draft?, "Gate commit must force draft regardless of enable_feed"
+    assert_redirected_to new_llm_credential_path(feed_id: feed.id)
+  end
+
   test "#create should render form with errors on validation failure" do
     sign_in_as(user)
 
@@ -540,6 +591,21 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     enabled_feed.reload
     assert_predicate enabled_feed, :disabled?
     assert_equal "Paused Feed", enabled_feed.name
+  end
+
+  test "#update should save and redirect to credential setup when commit signals gate" do
+    sign_in_as(user)
+    draft = create(:feed, :draft, user: user)
+
+    patch feed_url(draft), params: {
+      feed: { name: "Updated Draft Name" },
+      commit: "save_as_draft_and_add_credentials"
+    }
+
+    assert_redirected_to new_llm_credential_path(feed_id: draft.id)
+    draft.reload
+    assert_predicate draft, :draft?
+    assert_equal "Updated Draft Name", draft.name
   end
 
   test "#update should save changes to a draft without enabling" do

--- a/test/controllers/llm_credentials/validations_controller_test.rb
+++ b/test/controllers/llm_credentials/validations_controller_test.rb
@@ -38,4 +38,17 @@ class LlmCredentials::ValidationsControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :not_found
   end
+
+  test "#show should render the partial with feed_id when feed_id is provided" do
+    sign_in_as(user)
+    active = create(:llm_credential, :active, user: user)
+    draft = create(:feed, :draft, user: user)
+
+    get llm_credential_validation_url(active, feed_id: draft.id),
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_includes response.body, "llm-credential-show"
+    assert_includes response.body, edit_feed_path(draft.id)
+  end
 end

--- a/test/controllers/llm_credentials_controller_test.rb
+++ b/test/controllers/llm_credentials_controller_test.rb
@@ -70,12 +70,32 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "pending", saved.state
   end
 
-  test "#create should preserve input through to the show redirect" do
+  test "#new should accept and remember a feed_id owned by current_user" do
     sign_in_as(user)
-    input = "https://example.com"
+    draft = create(:feed, :draft, user: user)
+
+    get new_llm_credential_url, params: { feed_id: draft.id }
+
+    assert_response :success
+    assert_select "[data-key='llm_credentials.new']"
+  end
+
+  test "#new should ignore foreign feed_id" do
+    sign_in_as(user)
+    other_draft = create(:feed, :draft, user: other_user)
+
+    get new_llm_credential_url, params: { feed_id: other_draft.id }
+
+    assert_response :success
+    assert_select "[data-key='llm_credentials.new']"
+  end
+
+  test "#create should auto-attach the credential to the owned feed" do
+    sign_in_as(user)
+    draft = create(:feed, :draft, user: user)
 
     post llm_credentials_url, params: {
-      input: input,
+      feed_id: draft.id,
       llm_credential: {
         provider: "anthropic",
         display_name: "My Key",
@@ -84,29 +104,43 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
     }
 
     saved = LlmCredential.last
-    assert_redirected_to llm_credential_path(saved, input: input)
+    draft.reload
+    assert_equal saved.id, draft.llm_credential_id
   end
 
-  test "#new should embed input in the form action" do
+  test "#create should not attach when feed_id is foreign" do
     sign_in_as(user)
-    input = "https://example.com"
+    other_draft = create(:feed, :draft, user: other_user)
+    original_credential_id = other_draft.llm_credential_id
 
-    get new_llm_credential_url, params: { input: input }
+    post llm_credentials_url, params: {
+      feed_id: other_draft.id,
+      llm_credential: {
+        provider: "anthropic",
+        display_name: "My Key",
+        credential_data: { api_key: "sk-ant-#{SecureRandom.hex(16)}" }
+      }
+    }
 
-    assert_response :success
-    assert_select "form[action=?]", llm_credentials_path(input: input)
+    other_draft.reload
+    assert_equal original_credential_id, other_draft.llm_credential_id
   end
 
-  test "#show should carry input into the validation polling endpoint" do
+  test "#create should redirect with feed_id in the show path" do
     sign_in_as(user)
-    pending = create(:llm_credential, user: user, state: :pending)
-    input = "https://example.com"
+    draft = create(:feed, :draft, user: user)
 
-    get llm_credential_url(pending, input: input)
+    post llm_credentials_url, params: {
+      feed_id: draft.id,
+      llm_credential: {
+        provider: "anthropic",
+        display_name: "My Key",
+        credential_data: { api_key: "sk-ant-#{SecureRandom.hex(16)}" }
+      }
+    }
 
-    assert_response :success
-    assert_select "[data-polling-endpoint-value=?]",
-                  llm_credential_validation_path(pending, input: input)
+    saved = LlmCredential.last
+    assert_redirected_to llm_credential_path(saved, feed_id: draft.id)
   end
 
   test "#create should render :new with errors on invalid input" do

--- a/test/controllers/llm_credentials_controller_test.rb
+++ b/test/controllers/llm_credentials_controller_test.rb
@@ -196,6 +196,38 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "#show should render Continue setting up your feed link when credential is active and feed_id is owned" do
+    sign_in_as(user)
+    active = create(:llm_credential, :active, user: user)
+    draft = create(:feed, :draft, user: user)
+
+    get llm_credential_url(active, feed_id: draft.id)
+
+    assert_response :success
+    assert_select "a[href=?]", edit_feed_path(draft.id), text: "Continue setting up your feed"
+  end
+
+  test "#show should not render Continue setting up your feed link when credential is pending" do
+    sign_in_as(user)
+    pending = create(:llm_credential, user: user, state: :pending)
+    draft = create(:feed, :draft, user: user)
+
+    get llm_credential_url(pending, feed_id: draft.id)
+
+    assert_response :success
+    assert_select "a", text: "Continue setting up your feed", count: 0
+  end
+
+  test "#show should not render Continue setting up your feed link when feed_id is missing" do
+    sign_in_as(user)
+    active = create(:llm_credential, :active, user: user)
+
+    get llm_credential_url(active)
+
+    assert_response :success
+    assert_select "a", text: "Continue setting up your feed", count: 0
+  end
+
   test "#destroy should delete own credential" do
     sign_in_as(user)
     credential

--- a/test/integration/credential_gate_test.rb
+++ b/test/integration/credential_gate_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+# Integration test for the credential gate as a form-submit button.
+# Renders the gate from the feed-preview turbo-frame (inside the feed
+# form) and asserts the button and help-text shape that the
+# FeedsController#create handler keys off in T506.
+class CredentialGateTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def with_memory_cache
+    previous = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = previous
+  end
+
+  test "credential gate renders as form-submit button with help text when AI profile lacks credentials" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      get feed_live_preview_path("draft"),
+          params: { profile_key: "llm_website_extractor", params: { url: "https://example.com" } }
+
+      assert_response :success
+      assert_select "[data-key='credentials.gate']" do
+        assert_select "button[type='submit'][name='commit'][value='save_as_draft_and_add_credentials']",
+                      text: /Add AI credentials/
+        assert_select "[data-key='credentials.gate.help']",
+                      text: /We'll save your feed as a draft so you can pick up where you left off\./
+      end
+    end
+  end
+
+  test "credential gate does not include a stray link to new_llm_credential_path" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      get feed_live_preview_path("draft"),
+          params: { profile_key: "llm_website_extractor", params: { url: "https://example.com" } }
+
+      assert_response :success
+      assert_select "[data-key='credentials.gate'] a[href*='/llm_credentials/new']", false
+    end
+  end
+end


### PR DESCRIPTION
Builds on **Phase 3+4** (#427). Implements **FR-015..FR-021** of spec [`002-feed-drafts`](../tree/main/specs/002-feed-drafts/spec.md).

## Changes

Replaces the temporary `?input=<URL>` plumbing (from PR #422) with the structured `?feed_id=<id>` round-trip. The credential gate transitions from a navigation link to a form-submit button that saves the in-progress feed as a draft before redirecting to credential setup.

### `LlmCredentialsController` (FR-017, FR-018, FR-019)
- Replaced `@input = params[:input]` with `@feed = scoped_feed(params[:feed_id])` in `#new`, `#create`, `#show`. Scoped via `current_user.feeds.find_by` so foreign / missing ids are silently ignored (the credential flow still works without a return target).
- On `#create`, the created credential is auto-attached to the originating draft via `update_column` (skips validations — the feed is a draft, no envelope cares about the credential yet).
- Redirect after create carries `feed_id` through to `#show`.

### `LlmCredentials::ValidationsController` + LLM credential views (FR-017, FR-020, FR-021)
- Polling endpoint and view partials switched from `input:` locals to `feed_id:`.
- "Continue setting up your feed" link in `_show_content` only renders when `llm_credential.active? && feed_id.present?`, pointing at `edit_feed_path(feed_id)`. Pending / validating credentials don't show the link (user benefits from seeing validation succeed first).

### `Feeds::PreviewsController` (FR-016)
- Passes `feed_id: draft? ? nil : feed.id` to the gate locals instead of `input:`.

### Credential gate template (FR-016)
- New strict locals `(profile_key:, feed_id: nil)`. Dropped the obsolete `new_credential_path:` local.
- Replaced the `link_to` with a `<button type="submit" name="commit" value="save_as_draft_and_add_credentials">Add AI credentials</button>` inside the surrounding feed form.
- Help text under the button: "We'll save your feed as a draft so you can pick up where you left off." — makes the side-effect explicit (you don't end up with a mystery draft in your list).

### `FeedsController` (FR-016)
- Both `#create` and `#update` recognize `commit=save_as_draft_and_add_credentials`: force state to `:draft`, save under the draft envelope, and on success redirect to `new_llm_credential_path(feed_id: @feed.id)` instead of the usual feed-show redirect. Ignores `enable_feed` checkbox state for this commit value.

### Sweep (FR-021)
- Confirmed no obsolete `?input=` / `input:` references remain in the credential round-trip surface (LlmCredentialsController, ValidationsController, gate template, previews controller). The single remaining `feed_identifications_path(input: …)` in the previews controller is the legitimate FeedIdentification path (not the credential plumbing).

## Note

The implementer of T504+T505 flagged that `app/views/feeds/_preview_failed.html.erb:25` references `form="feed-form-submit"` but no element in the codebase has that id — a pre-existing broken submit button (introduced in PR #396, unrelated to feed-drafts). Left untouched here; deserves its own follow-up.

Phase 6 (feed list polish — Draft badge, fallback label, summary count, discard copy) and Phase 7 (integration test + final sweep) are separate PRs.