### PR TITLE
Feed drafts Phase 6+7: list polish + integration test (FR-022..FR-024)

### DIFF
--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -9,9 +9,10 @@ class FeedsListComponent < ViewComponent::Base
     @feeds.each do |feed|
       component.with_item(ListGroupComponent::FeedItemComponent.new(
         icon: helpers.feed_status_icon(feed),
-        title: feed.name,
+        title: display_title_for(feed),
         title_url: helpers.feed_path(feed),
-        metadata_segments: metadata_segments_for(feed)
+        metadata_segments: metadata_segments_for(feed),
+        badge: badge_for(feed)
       ))
     end
 
@@ -19,6 +20,19 @@ class FeedsListComponent < ViewComponent::Base
   end
 
   private
+
+  # FR-022a: drafts may have a blank name (operational fields are optional
+  # until promotion). Fall back to the user's typed input, then to a
+  # generic label, so the row always has a clickable title.
+  def display_title_for(feed)
+    feed.name.presence || feed.source_input.presence || "Untitled draft"
+  end
+
+  def badge_for(feed)
+    return nil unless feed.draft?
+
+    render(BadgeComponent.new(text: "Draft", color: :yellow, key: "feed.#{feed.id}.draft_badge"))
+  end
 
   def metadata_segments_for(feed)
     [

--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -3,6 +3,10 @@ class FeedsListComponent < ViewComponent::Base
     @feeds = feeds
   end
 
+  CONTINUE_SETUP_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
+  DISCARD_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
+  DISCARD_CONFIRM = "Discard this draft? No data will be lost since it hasn't been activated.".freeze
+
   def call
     component = ListGroupComponent.new
 
@@ -12,7 +16,8 @@ class FeedsListComponent < ViewComponent::Base
         title: display_title_for(feed),
         title_url: helpers.feed_path(feed),
         metadata_segments: metadata_segments_for(feed),
-        badge: badge_for(feed)
+        badge: badge_for(feed),
+        actions: actions_for(feed)
       ))
     end
 
@@ -32,6 +37,25 @@ class FeedsListComponent < ViewComponent::Base
     return nil unless feed.draft?
 
     render(BadgeComponent.new(text: "Draft", color: :yellow, key: "feed.#{feed.id}.draft_badge"))
+  end
+
+  # FR-023: drafts surface inline "Continue setup" and "Discard" affordances so
+  # users can act on stalled drafts without opening the show page. FR-024: the
+  # discard confirmation copy is softer than the regular feed delete since
+  # nothing has been published yet.
+  def actions_for(feed)
+    return nil unless feed.draft?
+
+    safe_join([
+      helpers.link_to("Continue setup", helpers.edit_feed_path(feed),
+                      class: CONTINUE_SETUP_CLASSES,
+                      data: { key: "feed.#{feed.id}.continue_setup" }),
+      helpers.button_to("Discard", helpers.feed_path(feed),
+                        method: :delete,
+                        class: DISCARD_CLASSES,
+                        data: { key: "feed.#{feed.id}.discard" },
+                        form: { data: { turbo_confirm: DISCARD_CONFIRM } })
+    ])
   end
 
   def metadata_segments_for(feed)

--- a/app/components/list_group_component/feed_item_component.rb
+++ b/app/components/list_group_component/feed_item_component.rb
@@ -6,13 +6,15 @@ class ListGroupComponent::FeedItemComponent < ViewComponent::Base
   TITLE_CLASSES = "inline-flex items-center text-base font-semibold text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
   METADATA_CLASSES = "flex flex-wrap items-center gap-x-2 gap-y-1 text-slate-500"
   BULLET_CLASSES = "text-slate-300"
+  ACTIONS_ROW_CLASSES = "flex flex-wrap items-center gap-2 pt-1"
 
-  def initialize(icon:, title:, title_url:, metadata_segments: [], badge: nil, key: nil)
+  def initialize(icon:, title:, title_url:, metadata_segments: [], badge: nil, actions: nil, key: nil)
     @icon = icon
     @title = title
     @title_url = title_url
     @metadata_segments = metadata_segments
     @badge = badge
+    @actions = actions
     @key = key
   end
 
@@ -30,8 +32,14 @@ class ListGroupComponent::FeedItemComponent < ViewComponent::Base
 
   def content_wrapper
     content_tag(:div, class: CONTENT_WRAPPER_CLASSES) do
-      safe_join([title_row, metadata_div].compact)
+      safe_join([title_row, metadata_div, actions_row].compact)
     end
+  end
+
+  def actions_row
+    return nil if @actions.blank?
+
+    content_tag(:div, @actions, class: ACTIONS_ROW_CLASSES)
   end
 
   def title_row

--- a/app/components/list_group_component/feed_item_component.rb
+++ b/app/components/list_group_component/feed_item_component.rb
@@ -2,15 +2,17 @@ class ListGroupComponent::FeedItemComponent < ViewComponent::Base
   DEFAULT_ITEM_CLASS = "flex items-baseline gap-3 p-4"
   ICON_CLASSES = "inline-flex shrink-0 text-slate-500"
   CONTENT_WRAPPER_CLASSES = "flex flex-1 flex-col gap-1"
+  TITLE_ROW_CLASSES = "flex flex-wrap items-center gap-2"
   TITLE_CLASSES = "inline-flex items-center text-base font-semibold text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
   METADATA_CLASSES = "flex flex-wrap items-center gap-x-2 gap-y-1 text-slate-500"
   BULLET_CLASSES = "text-slate-300"
 
-  def initialize(icon:, title:, title_url:, metadata_segments: [], key: nil)
+  def initialize(icon:, title:, title_url:, metadata_segments: [], badge: nil, key: nil)
     @icon = icon
     @title = title
     @title_url = title_url
     @metadata_segments = metadata_segments
+    @badge = badge
     @key = key
   end
 
@@ -28,7 +30,13 @@ class ListGroupComponent::FeedItemComponent < ViewComponent::Base
 
   def content_wrapper
     content_tag(:div, class: CONTENT_WRAPPER_CLASSES) do
-      safe_join([title_link, metadata_div])
+      safe_join([title_row, metadata_div].compact)
+    end
+  end
+
+  def title_row
+    content_tag(:div, class: TITLE_ROW_CLASSES) do
+      safe_join([title_link, @badge].compact)
     end
   end
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -43,6 +43,7 @@ class FeedsController < ApplicationController
     scope = policy_scope(Feed)
     @active_feed_count = scope.enabled.count
     @inactive_feed_count = scope.disabled.count
+    @draft_feed_count = scope.draft.count
     @sortable_presenter = sortable_presenter
     @feeds = paginate_scope
   end

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -57,18 +57,15 @@ module FeedHelper
     end
   end
 
-  def feed_summary_line(active_count:, inactive_count:)
+  def feed_summary_line(active_count:, inactive_count:, draft_count:)
     active_part = pluralize_count(active_count, "active feed")
     inactive_part = pluralize_count(inactive_count, "inactive feed")
+    draft_part = pluralize_count(draft_count, "draft feed")
 
-    parts = [active_part, inactive_part].compact
+    parts = [active_part, inactive_part, draft_part].compact
     return nil if parts.empty?
 
-    if parts.size == 1
-      "You have #{parts.first}"
-    else
-      "You have #{parts.first} and #{parts.last}"
-    end
+    "You have #{parts.to_sentence}"
   end
 
   private

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -30,6 +30,11 @@ module FeedHelper
            css_class: "text-emerald-500 text-base leading-5",
            title: "Enabled",
            aria_label: "Enabled")
+    elsif feed.draft?
+      icon("pencil-square",
+           css_class: "text-amber-500 text-base leading-5",
+           title: "Draft",
+           aria_label: "Draft")
     else
       icon("x-circle",
            css_class: "text-slate-400 text-base leading-5",

--- a/app/views/feeds/_preview_failed.html.erb
+++ b/app/views/feeds/_preview_failed.html.erb
@@ -21,13 +21,5 @@
             data-key="preview.failed.retry">
       Try again
     </button>
-    <button type="submit"
-            form="feed-form-submit"
-            name="enable_feed"
-            value="0"
-            class="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-3 py-1.5 text-sm font-semibold text-amber-800 shadow-sm transition hover:bg-amber-100"
-            data-key="preview.failed.save-disabled">
-      Save as disabled
-    </button>
   </div>
 </div>

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Feeds") do |header| %>
-    <% if (summary_line = feed_summary_line(active_count: @active_feed_count, inactive_count: @inactive_feed_count)) %>
+    <% if (summary_line = feed_summary_line(active_count: @active_feed_count, inactive_count: @inactive_feed_count, draft_count: @draft_feed_count)) %>
       <% header.with_context_paragraph(summary_line) %>
     <% end %>
     <% if @feeds.any? %>

--- a/db/migrate/20260523000000_make_feeds_name_nullable.rb
+++ b/db/migrate/20260523000000_make_feeds_name_nullable.rb
@@ -1,0 +1,9 @@
+class MakeFeedsNameNullable < ActiveRecord::Migration[8.1]
+  def up
+    change_column_null :feeds, :name, true
+  end
+
+  def down
+    change_column_null :feeds, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_21_120100) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_23_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -54,19 +54,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_21_120100) do
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 
-  create_table "feed_identifications", force: :cascade do |t|
-    t.jsonb "candidates", default: [], null: false
-    t.datetime "created_at", null: false
-    t.text "error"
-    t.datetime "started_at"
-    t.integer "status", default: 0, null: false
-    t.datetime "updated_at", null: false
-    t.string "input", null: false
-    t.bigint "user_id", null: false
-    t.index ["user_id", "input"], name: "index_feed_identifications_on_user_id_and_input", unique: true
-    t.index ["user_id"], name: "index_feed_identifications_on_user_id"
-  end
-
   create_table "feed_entries", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "feed_id", null: false
@@ -88,6 +75,19 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_21_120100) do
     t.index ["feed_id", "uid"], name: "index_feed_entry_uids_on_feed_id_and_uid", unique: true
     t.index ["feed_id"], name: "index_feed_entry_uids_on_feed_id"
     t.index ["imported_at"], name: "index_feed_entry_uids_on_imported_at"
+  end
+
+  create_table "feed_identifications", force: :cascade do |t|
+    t.jsonb "candidates", default: [], null: false
+    t.datetime "created_at", null: false
+    t.text "error"
+    t.datetime "started_at"
+    t.integer "status", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.string "input", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id", "input"], name: "index_feed_identifications_on_user_id_and_input", unique: true
+    t.index ["user_id"], name: "index_feed_identifications_on_user_id"
   end
 
   create_table "feed_metrics", force: :cascade do |t|
@@ -130,7 +130,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_21_120100) do
     t.string "description", default: "", null: false
     t.string "feed_profile_key"
     t.datetime "import_after"
-    t.string "name", null: false
+    t.string "name"
     t.jsonb "params", default: {}, null: false
     t.integer "state", default: 0, null: false
     t.string "target_group", limit: 80
@@ -385,9 +385,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_21_120100) do
   add_foreign_key "access_token_details", "access_tokens"
   add_foreign_key "access_tokens", "users"
   add_foreign_key "events", "users"
-  add_foreign_key "feed_identifications", "users"
   add_foreign_key "feed_entries", "feeds"
   add_foreign_key "feed_entry_uids", "feeds", on_delete: :cascade
+  add_foreign_key "feed_identifications", "users"
   add_foreign_key "feed_metrics", "feeds", on_delete: :cascade
   add_foreign_key "feed_previews", "users"
   add_foreign_key "feed_schedules", "feeds"

--- a/test/components/feeds_list_component_test.rb
+++ b/test/components/feeds_list_component_test.rb
@@ -59,4 +59,40 @@ class FeedsListComponentTest < ViewComponent::TestCase
 
     assert_empty result.css(%([data-key="feed.#{feed.id}.draft_badge"]))
   end
+
+  test "#call should render Continue setup and Discard affordances for draft rows" do
+    feed = create(:feed, :draft, user: user, name: "Draft Feed")
+
+    with_request_url("/feeds") do
+      result = render_inline(FeedsListComponent.new(feeds: [feed]))
+
+      continue_link = result.css(%([data-key="feed.#{feed.id}.continue_setup"])).first
+      assert_not_nil continue_link, "Expected Continue setup link"
+      assert_equal "Continue setup", continue_link.text.strip
+      assert_equal Rails.application.routes.url_helpers.edit_feed_path(feed), continue_link["href"]
+
+      discard_button = result.css(%([data-key="feed.#{feed.id}.discard"])).first
+      assert_not_nil discard_button, "Expected Discard button"
+      assert_equal "Discard", discard_button.text.strip
+
+      discard_form = discard_button.ancestors("form").first
+      assert_not_nil discard_form, "Expected Discard button to be inside a form"
+      assert_equal Rails.application.routes.url_helpers.feed_path(feed), discard_form["action"]
+      assert_equal "Discard this draft? No data will be lost since it hasn't been activated.",
+                   discard_form["data-turbo-confirm"]
+      assert_equal "post", discard_form["method"]
+      assert_equal "delete", discard_form.css("input[name='_method']").first&.[]("value")
+    end
+  end
+
+  test "#call should not render those affordances for non-draft rows" do
+    feed = create(:feed, :disabled, user: user, name: "Inactive Feed")
+
+    with_request_url("/feeds") do
+      result = render_inline(FeedsListComponent.new(feeds: [feed]))
+
+      assert_empty result.css(%([data-key="feed.#{feed.id}.continue_setup"]))
+      assert_empty result.css(%([data-key="feed.#{feed.id}.discard"]))
+    end
+  end
 end

--- a/test/components/feeds_list_component_test.rb
+++ b/test/components/feeds_list_component_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+require "view_component/test_case"
+
+class FeedsListComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  test "#call renders feed name as title for a regular feed" do
+    feed = create(:feed, :disabled, user: user, name: "My Feed")
+    result = render_inline(FeedsListComponent.new(feeds: [feed]))
+
+    assert_match "My Feed", result.text
+  end
+
+  test "#call renders draft feed with source_input as title when name is blank" do
+    feed = create(
+      :feed,
+      :draft,
+      user: user,
+      name: "",
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/draft-feed.xml" }
+    )
+
+    result = render_inline(FeedsListComponent.new(feeds: [feed]))
+
+    assert_match "https://example.com/draft-feed.xml", result.text
+  end
+
+  test "#call renders 'Untitled draft' when both name and source_input are blank" do
+    feed = build(
+      :feed,
+      :draft,
+      user: user,
+      name: "",
+      feed_profile_key: "rss",
+      params: {}
+    )
+    feed.save(validate: false)
+
+    result = render_inline(FeedsListComponent.new(feeds: [feed]))
+
+    assert_match "Untitled draft", result.text
+  end
+
+  test "#call renders draft badge for draft feeds" do
+    feed = create(:feed, :draft, user: user, name: "Draft Feed")
+    result = render_inline(FeedsListComponent.new(feeds: [feed]))
+
+    badge = result.css(%([data-key="feed.#{feed.id}.draft_badge"])).first
+    assert_not_nil badge, "Expected to find a draft badge for draft feed"
+    assert_equal "Draft", badge.text.strip
+  end
+
+  test "#call does not render draft badge for non-draft feeds" do
+    feed = create(:feed, :disabled, user: user, name: "Inactive Feed")
+    result = render_inline(FeedsListComponent.new(feeds: [feed]))
+
+    assert_empty result.css(%([data-key="feed.#{feed.id}.draft_badge"]))
+  end
+end

--- a/test/controllers/feeds/previews_controller_test.rb
+++ b/test/controllers/feeds/previews_controller_test.rb
@@ -109,7 +109,6 @@ class Feeds::PreviewsControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_select "[data-key='preview.failed']"
       assert_select "[data-key='preview.failed.retry']"
-      assert_select "[data-key='preview.failed.save-disabled']"
     end
   end
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -33,6 +33,19 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: "You have 1 inactive feed"
   end
 
+  test "#index should include drafts in summary line" do
+    sign_in_as(user)
+    create(:feed, :enabled, user: user)
+    create(:feed, :disabled, user: user)
+    create(:feed, :draft, user: user)
+    create(:feed, :draft, user: user)
+
+    get feeds_url
+
+    assert_response :success
+    assert_select "p", text: "You have 1 active feed, 1 inactive feed, and 2 draft feeds"
+  end
+
   test "#index should render tailwind pagination controls" do
     sign_in_as(user)
     create_list(:feed, 4, user: user)

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -63,6 +63,17 @@ class FeedHelperTest < ActionView::TestCase
     assert_includes result, 'aria-label="Disabled"'
   end
 
+  test "#feed_status_icon should render draft icon" do
+    feed = build(:feed, :draft)
+
+    result = feed_status_icon(feed)
+
+    assert_includes result, "bi-pencil-square"
+    assert_includes result, "text-amber-500"
+    assert_includes result, 'title="Draft"'
+    assert_includes result, 'aria-label="Draft"'
+  end
+
   test "#feed_summary_line should describe active and inactive counts" do
     result = feed_summary_line(active_count: 2, inactive_count: 1)
     assert_equal "You have 2 active feeds and 1 inactive feed", result

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -74,23 +74,38 @@ class FeedHelperTest < ActionView::TestCase
     assert_includes result, 'aria-label="Draft"'
   end
 
+  test "#feed_summary_line should describe active, inactive, and draft counts" do
+    result = feed_summary_line(active_count: 2, inactive_count: 1, draft_count: 3)
+    assert_equal "You have 2 active feeds, 1 inactive feed, and 3 draft feeds", result
+  end
+
   test "#feed_summary_line should describe active and inactive counts" do
-    result = feed_summary_line(active_count: 2, inactive_count: 1)
+    result = feed_summary_line(active_count: 2, inactive_count: 1, draft_count: 0)
     assert_equal "You have 2 active feeds and 1 inactive feed", result
   end
 
   test "#feed_summary_line should handle single active count" do
-    result = feed_summary_line(active_count: 1, inactive_count: 0)
+    result = feed_summary_line(active_count: 1, inactive_count: 0, draft_count: 0)
     assert_equal "You have 1 active feed", result
   end
 
   test "#feed_summary_line should handle single inactive count" do
-    result = feed_summary_line(active_count: 0, inactive_count: 3)
+    result = feed_summary_line(active_count: 0, inactive_count: 3, draft_count: 0)
     assert_equal "You have 3 inactive feeds", result
   end
 
+  test "#feed_summary_line should handle only draft count" do
+    result = feed_summary_line(active_count: 0, inactive_count: 0, draft_count: 1)
+    assert_equal "You have 1 draft feed", result
+  end
+
+  test "#feed_summary_line should describe active and draft counts" do
+    result = feed_summary_line(active_count: 2, inactive_count: 0, draft_count: 1)
+    assert_equal "You have 2 active feeds and 1 draft feed", result
+  end
+
   test "#feed_summary_line should return nil for zero counts" do
-    assert_nil feed_summary_line(active_count: 0, inactive_count: 0)
+    assert_nil feed_summary_line(active_count: 0, inactive_count: 0, draft_count: 0)
   end
 
   test "#feed_status_summary should describe enabled feed" do

--- a/test/integration/feed_draft_flow_test.rb
+++ b/test/integration/feed_draft_flow_test.rb
@@ -1,0 +1,155 @@
+require "test_helper"
+
+# End-to-end integration test covering the headline user flow of the
+# feed-drafts feature (User Stories 1 and 2):
+#
+#   1. Start a feed pointing at an AI-requiring URL with no LLM credentials.
+#   2. Submit via the credential-gate commit -> feed persists as draft, user is
+#      sent to credential creation with feed_id pre-attached.
+#   3. Submit the credential form -> credential is created, auto-attached to
+#      the draft, user is redirected to the credential show page with feed_id.
+#   4. Once the credential validates as active, the show page surfaces a
+#      "Continue setting up your feed" affordance pointing at the feed editor.
+#   5. From the editor, tick "Enable feed" and submit -> draft promotes to
+#      enabled state with source-side fields now anchored.
+#   6. Feeds index shows the feed in the enabled bucket of the summary line.
+#
+# Validation of the credential is stubbed by toggling the state directly
+# (the controller flow is the focus, not the LlmCredentialValidationJob).
+class FeedDraftFlowTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def access_token
+    @access_token ||= create(:access_token, :active, user: user)
+  end
+
+  def ai_url
+    "https://no-rss-example.com/blog"
+  end
+
+  test "full flow: save draft via credential gate, create credential, enable feed, see it in index" do
+    sign_in_as(user)
+    access_token # ensure user has a usable access token for enabling later
+
+    # Step 1+2: submit the new-feed form via the credential gate commit. The
+    # user picked an AI profile but has no LLM credentials, so the gate kicks
+    # in and routes the request to credential setup with the freshly-saved
+    # draft pre-attached.
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: {
+        feed: {
+          url: ai_url,
+          name: "No-RSS Blog",
+          feed_profile_key: "llm_website_extractor"
+        },
+        commit: "save_as_draft_and_add_credentials"
+      }
+    end
+
+    draft = Feed.last
+    assert_predicate draft, :draft?, "Feed should be saved as a draft"
+    assert_equal user.id, draft.user_id
+    assert_equal "llm_website_extractor", draft.feed_profile_key
+    assert_equal ai_url, draft.url
+    assert_equal "No-RSS Blog", draft.name
+    assert_nil draft.llm_credential_id, "No credential yet at draft-save time"
+    assert_redirected_to new_llm_credential_path(feed_id: draft.id)
+
+    # Step 3: follow the redirect and submit the credential form. The
+    # controller should create the credential, auto-attach it to the draft,
+    # and redirect to the credential show page carrying feed_id.
+    follow_redirect!
+    assert_response :success
+
+    assert_difference("LlmCredential.count", 1) do
+      post llm_credentials_path, params: {
+        feed_id: draft.id,
+        llm_credential: {
+          provider: "anthropic",
+          display_name: "My Anthropic key",
+          credential_data: { api_key: "sk-ant-#{SecureRandom.hex(16)}" }
+        }
+      }
+    end
+
+    credential = LlmCredential.last
+    assert_equal user.id, credential.user_id
+    assert_equal "pending", credential.state
+    draft.reload
+    assert_equal credential.id, draft.llm_credential_id, "Credential should be auto-attached to the draft"
+    assert_redirected_to llm_credential_path(credential, feed_id: draft.id)
+
+    # Step 4: stub the validation job by flipping the credential state
+    # directly. Re-fetch the show page and confirm the "Continue setting up
+    # your feed" call-to-action is rendered with a link back to the feed
+    # editor.
+    credential.update!(state: :active, last_validated_at: Time.current)
+
+    get llm_credential_path(credential, feed_id: draft.id)
+    assert_response :success
+    assert_select "[data-key='llm_credential.return-to']" do
+      assert_select "[href=?]", edit_feed_path(draft), text: /Continue setting up your feed/
+    end
+
+    # Step 5: visit the edit page, fill in the remaining required fields,
+    # tick "Enable feed", and submit with a fresh preview_token. The feed
+    # should transition into the enabled state.
+    get edit_feed_path(draft)
+    assert_response :success
+
+    preview_token = PreviewToken.sign(
+      user_id: user.id,
+      profile_key: "llm_website_extractor",
+      params: { "url" => ai_url },
+      generated_at: Time.current
+    )
+
+    patch feed_path(draft), params: {
+      feed: {
+        access_token_id: access_token.id,
+        target_group: "testgroup",
+        schedule_interval: "1h",
+        llm_credential_id: credential.id
+      },
+      enable_feed: "1",
+      preview_token: preview_token
+    }
+
+    assert_redirected_to feed_path(draft)
+    draft.reload
+    assert_equal "enabled", draft.state
+    assert_equal "No-RSS Blog", draft.name
+
+    # Source-side fields stay anchored once the feed leaves the draft envelope:
+    # strong params silently drops url, feed_profile_key, and params on
+    # non-drafts (FR-026/027/028). Keep enable_feed=1 so the operational save
+    # leaves the feed in the enabled state.
+    patch feed_path(draft), params: {
+      feed: {
+        url: "https://attacker.example/feed.xml",
+        feed_profile_key: "rss"
+      },
+      enable_feed: "1"
+    }
+    draft.reload
+    assert_equal "enabled", draft.state, "Feed should stay enabled across the operational-only edit"
+    assert_equal ai_url, draft.url, "Source URL should be locked after promotion"
+    assert_equal "llm_website_extractor", draft.feed_profile_key, "Profile key should be locked after promotion"
+
+    # Step 6: feeds index should show the feed in the enabled bucket of the
+    # 3-bucket summary line, and the row itself should not carry the Draft
+    # badge or draft-only inline actions anymore.
+    get feeds_path
+    assert_response :success
+    assert_select "p", text: /1 active feed/
+    assert_select "[data-key=?]", "feed.#{draft.id}.draft_badge", false
+    assert_select "[data-key=?]", "feed.#{draft.id}.continue_setup", false
+    assert_select "a[href=?]", feed_path(draft), text: "No-RSS Blog"
+  end
+end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -17,6 +17,11 @@ class FeedTest < ActiveSupport::TestCase
     assert feed.valid?, feed.errors.full_messages.inspect
   end
 
+  test "#name should persist as NULL when state is draft" do
+    feed = create(:feed, state: :draft, name: nil)
+    assert_nil feed.reload.name
+  end
+
   test "#name should be required when transitioning to enabled" do
     feed = build(:feed, state: :draft, name: nil)
     feed.state = :enabled


### PR DESCRIPTION
Builds on **Phase 5** (#428). Final phase of the feed-drafts feature. Implements **FR-022..FR-024 + FR-006 schema follow-through** of spec [`002-feed-drafts`](../tree/main/specs/002-feed-drafts/spec.md), plus the end-to-end integration test.

## Changes

### List polish (FR-022, FR-022a, FR-023, FR-023a, FR-024)
- **Draft status icon**: `feed_status_icon` gains a `:draft` branch (pencil icon, amber) — visually distinct from enabled (check, emerald) and disabled (x, slate).
- **Fallback title**: `FeedsListComponent#display_title_for(feed)` returns `name.presence || source_input.presence || "Untitled draft"`. View-layer only — the model isn't coerced. Nameless drafts get the URL or handle they were typed from; ultimate fallback if both are blank.
- **Draft badge**: `FeedItemComponent` extended with an optional `badge:` parameter. Draft rows render a yellow "Draft" badge inline with the title.
- **3-bucket summary**: `FeedsController#index` exposes `@draft_feed_count = scope.draft.count`; `feed_summary_line` now takes a `draft_count:` keyword. The summary reads "You have X active feeds, Y inactive feeds, and Z draft feeds" with sensible degradation for fewer buckets via `Array#to_sentence`.
- **Affordances + softer copy**: Draft rows render `[Continue setup]` (→ `edit_feed_path`) and `[Discard]` (→ `feed_path` with `method: :delete`, softer `turbo_confirm`: *"Discard this draft? No data will be lost since it hasn't been activated."*).

### Integration test
- New `test/integration/feed_draft_flow_test.rb` exercises the full headline flow end to end: paste URL → gate-commit saves as draft → credential creation auto-attaches → activation → "Continue setting up your feed" → enable from edit form → source-side fields locked → enabled feed visible in summary and list.

### Sweep cleanup
- Removed the broken `Save as disabled` button from `_preview_failed.html.erb` (referenced a non-existent `form="feed-form-submit"` id; the same UX is now naturally available via the main "Save feed" button with Enable unchecked). Pre-existing bug, fixed under the sweep.
- **Migration**: `feeds.name` becomes nullable to match the model-level draft envelope from FR-006 (model already allows blank name on drafts; schema now consistent). Reversible; no data backfill needed (pre-production).

## Audit results from sweep

- No obsolete `?input=` / `input:` references in the credential round-trip surface.
- No `feed_form_controller` / `feed-form` Stimulus controller references.
- No `scope_ownership_ids` / `scoped_id` references (Phase 1 was reworked with the model-validator approach).

This PR finalizes the feed-drafts feature across 5 sequential PRs (Phases 1, 2, 3+4, 5, 6+7).