### PR TITLE
Move empty state out of PostsListComponent

### DIFF
--- a/app/components/empty_state_component.rb
+++ b/app/components/empty_state_component.rb
@@ -1,9 +1,19 @@
 class EmptyStateComponent < ViewComponent::Base
+  def initialize(text = nil)
+    @text = text
+  end
+
   def call
     content_tag :div, class: "w-full rounded-none border-0 bg-white p-0 shadow-none sm:rounded-lg sm:border sm:border-dashed sm:border-slate-300 sm:bg-white sm:p-6", data: { key: "empty-state" } do
       content_tag :div, class: "space-y-6 text-center py-12", data: { key: "empty-state.body" } do
-        content
+        body
       end
     end
+  end
+
+  private
+
+  def body
+    content.presence || content_tag(:p, @text, class: "text-slate-500")
   end
 end

--- a/app/components/posts_list_component.html.erb
+++ b/app/components/posts_list_component.html.erb
@@ -1,5 +1,1 @@
-<% if @posts.any? %>
-  <%= render render_list %>
-<% else %>
-  <%= render_empty_state %>
-<% end %>
+<%= render render_list %>

--- a/app/components/posts_list_component.html.erb
+++ b/app/components/posts_list_component.html.erb
@@ -1,1 +1,0 @@
-<%= render render_list %>

--- a/app/components/posts_list_component.rb
+++ b/app/components/posts_list_component.rb
@@ -4,6 +4,10 @@ class PostsListComponent < ViewComponent::Base
     @show_feed = show_feed
   end
 
+  def call
+    render render_list
+  end
+
   def render_list
     component = ListGroupComponent.new
 

--- a/app/components/posts_list_component.rb
+++ b/app/components/posts_list_component.rb
@@ -1,8 +1,7 @@
 class PostsListComponent < ViewComponent::Base
-  def initialize(posts:, show_feed: false, empty_text: "No posts yet.")
+  def initialize(posts:, show_feed: false)
     @posts = posts
     @show_feed = show_feed
-    @empty_text = empty_text
   end
 
   def render_list
@@ -13,12 +12,6 @@ class PostsListComponent < ViewComponent::Base
     end
 
     component
-  end
-
-  def render_empty_state
-    content_tag(:div, class: "rounded-lg border border-dashed border-slate-300 bg-slate-50 px-6 py-12 text-center text-slate-600") do
-      content_tag(:h2, @empty_text, class: "text-2xl font-semibold text-slate-900")
-    end
   end
 
   def self.item_component(post:, helpers:, show_feed: false)

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -36,9 +36,7 @@
   <%# Empty State Component %>
   <section class="space-y-4">
     <h2 class="text-xl font-semibold text-slate-900">Empty State Component</h2>
-    <%= render EmptyStateComponent.new do %>
-      <p class="text-slate-500">No items found. Try adding some content.</p>
-    <% end %>
+    <%= render EmptyStateComponent.new("No items found. Try adding some content.") %>
   </section>
 
   <%# Spinner Component %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -65,9 +65,7 @@
     <% if @recent_posts.any? %>
       <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false) %>
     <% else %>
-      <%= render EmptyStateComponent.new do %>
-        <h2 class="text-2xl font-semibold text-slate-500">No posts imported yet from this feed.</h2>
-      <% end %>
+      <%= render EmptyStateComponent.new("No posts imported yet from this feed.") %>
     <% end %>
   </section>
 

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -62,7 +62,13 @@
       <% end %>
     </div>
 
-    <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false, empty_text: "No posts imported yet from this feed.") %>
+    <% if @recent_posts.any? %>
+      <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false) %>
+    <% else %>
+      <%= render EmptyStateComponent.new do %>
+        <h2 class="text-2xl font-semibold text-slate-500">No posts imported yet from this feed.</h2>
+      <% end %>
+    <% end %>
   </section>
 
   <section class="space-y-4">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,10 +15,15 @@
     <% end %>
   <% end %>
 
-  <%= render PostsListComponent.new(
-             posts: @posts,
-             show_feed: @feed.blank?,
-             empty_text: @feed ? "No posts imported yet from this feed." : "No posts yet.") %>
+  <% if @posts.any? %>
+    <%= render PostsListComponent.new(posts: @posts, show_feed: @feed.blank?) %>
+  <% else %>
+    <%= render EmptyStateComponent.new do %>
+      <h2 class="text-2xl font-semibold text-slate-500">
+        <%= @feed ? "No posts imported yet from this feed." : "No posts yet." %>
+      </h2>
+    <% end %>
+  <% end %>
 
   <% if pagination_total_pages > 1 %>
     <div class="text-center text-sm text-slate-600">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -18,11 +18,7 @@
   <% if @posts.any? %>
     <%= render PostsListComponent.new(posts: @posts, show_feed: @feed.blank?) %>
   <% else %>
-    <%= render EmptyStateComponent.new do %>
-      <h2 class="text-2xl font-semibold text-slate-500">
-        <%= @feed ? "No posts imported yet from this feed." : "No posts yet." %>
-      </h2>
-    <% end %>
+    <%= render EmptyStateComponent.new(@feed ? "No posts imported yet from this feed." : "No posts yet.") %>
   <% end %>
 
   <% if pagination_total_pages > 1 %>

--- a/test/components/empty_state_component_test.rb
+++ b/test/components/empty_state_component_test.rb
@@ -12,4 +12,24 @@ class EmptyStateComponentTest < ViewComponent::TestCase
     assert_not_nil body
     assert_includes body.text, "Test content"
   end
+
+  test "#render should render text argument as a paragraph" do
+    result = render_inline EmptyStateComponent.new("Nothing here yet")
+
+    paragraph = result.css("p.text-slate-500").first
+
+    assert_not_nil paragraph
+    assert_equal "Nothing here yet", paragraph.text.strip
+  end
+
+  test "#render should prefer block content over text argument" do
+    result = render_inline EmptyStateComponent.new("Ignored text") do
+      "Block content"
+    end
+
+    body = result.css('[data-key="empty-state.body"]').first
+
+    assert_includes body.text, "Block content"
+    assert_not_includes body.text, "Ignored text"
+  end
 end

--- a/test/components/posts_list_component_test.rb
+++ b/test/components/posts_list_component_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+require "view_component/test_case"
+
+class PostsListComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed
+    @feed ||= create(:feed, user: user)
+  end
+
+  test "#render should render an item for each post" do
+    post = create(:post, feed: feed)
+    result = render_inline PostsListComponent.new(posts: [post])
+
+    assert_not_empty result.css(%([data-key="#{ActionView::RecordIdentifier.dom_id(post)}"]))
+  end
+
+  test "#render should not render an empty state when there are no posts" do
+    result = render_inline PostsListComponent.new(posts: [])
+
+    assert_empty result.css('[data-key="empty-state"]')
+    assert_empty result.css(".border-dashed")
+    assert_not_includes result.text, "No posts"
+  end
+end


### PR DESCRIPTION
Changes:

- `PostsListComponent` no longer renders an empty state — it just renders the list of posts. The `empty_text` parameter and `render_empty_state` method are gone.
- Consumers (`posts/index`, `feeds/show`) now render `EmptyStateComponent` themselves when there are no posts, keeping empty-state presentation consistent with the rest of the app.
- Added component tests covering item rendering and the absence of any empty-state markup when the list is empty.