### PR TITLE
Tidy up status and admin events page layouts

### DIFF
--- a/app/components/stats_bar_component/stat_item_component.rb
+++ b/app/components/stats_bar_component/stat_item_component.rb
@@ -1,6 +1,6 @@
 class StatsBarComponent::StatItemComponent < ViewComponent::Base
   DEFAULT_CELL_CLASSES = "flex-1 flex flex-col items-center justify-center p-4 min-w-0"
-  VALUE_CLASSES = "text-3xl font-semibold text-slate-900 whitespace-nowrap"
+  VALUE_CLASSES = "text-2xl font-semibold text-slate-900 whitespace-nowrap"
   LABEL_CLASSES = "text-sm text-slate-600 whitespace-nowrap mt-1"
 
   def initialize(label:, value:, key: nil)

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -67,9 +67,7 @@
             <% end %>
           </ul>
         <% else %>
-          <%= render EmptyStateComponent.new do %>
-            <p class="text-slate-500">No groups available for posting.</p>
-          <% end %>
+          <%= render EmptyStateComponent.new("No groups available for posting") %>
         <% end %>
       <% end %>
     </div>
@@ -80,9 +78,7 @@
     <% if access_token.feeds.any? %>
       <%= render FeedsListComponent.new(feeds: access_token.feeds) %>
     <% else %>
-      <%= render EmptyStateComponent.new do %>
-        <p class="text-slate-500">No associated feeds yet.</p>
-      <% end %>
+      <%= render EmptyStateComponent.new("No associated feeds yet") %>
     <% end %>
   </div>
 <% elsif access_token.inactive? %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -114,6 +114,6 @@
       <%= render_pagination { |pagination, params| admin_events_path(pagination.merge(@filter.present? ? { filter: @filter.to_h } : {})) } %>
     </div>
   <% else %>
-    <%= render EmptyStateComponent.new("No events to show yet.") %>
+    <%= render EmptyStateComponent.new("No events to show yet") %>
   <% end %>
 </div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -114,11 +114,6 @@
       <%= render_pagination { |pagination, params| admin_events_path(pagination.merge(@filter.present? ? { filter: @filter.to_h } : {})) } %>
     </div>
   <% else %>
-    <%= render CardComponent.new do %>
-      <div class="space-y-6 text-center py-12">
-        <h2 class="text-2xl font-semibold mb-3 text-slate-900">No events found</h2>
-        <p class="text-slate-600">Events will appear here as they are created.</p>
-      </div>
-    <% end %>
+    <%= render EmptyStateComponent.new("No events to show yet.") %>
   <% end %>
 </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -53,8 +53,6 @@
 
     <%= render_pagination { |pagination| admin_users_path(pagination) } %>
   <% else %>
-    <div class="flex flex-col items-center justify-center py-12">
-      <p class="text-slate-500">No users found</p>
-    </div>
+    <%= render EmptyStateComponent.new("No users found") %>
   <% end %>
 </div>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -36,7 +36,7 @@
   <%# Empty State Component %>
   <section class="space-y-4">
     <h2 class="text-xl font-semibold text-slate-900">Empty State Component</h2>
-    <%= render EmptyStateComponent.new("No items found. Try adding some content") %>
+    <%= render EmptyStateComponent.new("No items to show yet") %>
   </section>
 
   <%# Spinner Component %>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -36,7 +36,7 @@
   <%# Empty State Component %>
   <section class="space-y-4">
     <h2 class="text-xl font-semibold text-slate-900">Empty State Component</h2>
-    <%= render EmptyStateComponent.new("No items found. Try adding some content.") %>
+    <%= render EmptyStateComponent.new("No items found. Try adding some content") %>
   </section>
 
   <%# Spinner Component %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -49,10 +49,12 @@
     <% end %>
   <% end %>
 
-  <section class="space-y-4">
-    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Stats</h2>
-    <%= render FeedStatsComponent.new(feed: @feed) %>
-  </section>
+  <% if @recent_posts.any? %>
+    <section class="space-y-4">
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Stats</h2>
+      <%= render FeedStatsComponent.new(feed: @feed) %>
+    </section>
+  <% end %>
 
   <section class="space-y-4">
     <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -65,7 +65,7 @@
     <% if @recent_posts.any? %>
       <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false) %>
     <% else %>
-      <%= render EmptyStateComponent.new("No posts imported yet from this feed.") %>
+      <%= render EmptyStateComponent.new("No posts imported yet from this feed") %>
     <% end %>
   </section>
 

--- a/app/views/invites/_table.html.erb
+++ b/app/views/invites/_table.html.erb
@@ -55,9 +55,5 @@
     </table>
   </div>
 <% else %>
-  <%= render CardComponent.new do %>
-    <div class="space-y-6 text-center">
-      <p class="text-slate-600">No invites yet</p>
-    </div>
-  <% end %>
+  <%= render EmptyStateComponent.new("No invites yet") %>
 <% end %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -30,7 +30,7 @@
   <% elsif suggest_adding_feeds %>
     <%= render "feeds/empty_state" %>
   <% else %>
-    <h1 class="text-4xl font-semibold mb-0 text-slate-900">Status</h1>
+    <%= render PageHeaderComponent.new(title: "Status") %>
     <%= render UserStatsComponent.new(user: @user) %>
 
     <% if @recent_events.any? %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -19,14 +19,13 @@
   <% end %>
 
   <% if suggest_to_add_tokens %>
-    <section class="space-y-4">
-      <h1 class="text-4xl font-semibold mb-0 text-slate-900">Welcome to Feeder</h1>
-      <p class="text-slate-600">Feeder helps you automatically share content from your favorite sources to FreeFeed.</p>
-      <p class="text-slate-600">To get started, add a FreeFeed access token so Feeder can post on your behalf.</p>
-      <div class="mt-8">
-        <%= link_to "Add FreeFeed token", new_access_token_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
-      </div>
-    </section>
+    <%= render PageHeaderComponent.new(title: "Welcome to Feeder") do |header| %>
+      <% header.with_context_paragraph "Feeder helps you automatically share content from your favorite sources to FreeFeed." %>
+      <% header.with_context_paragraph "To get started, add a FreeFeed access token so Feeder can post on your behalf." %>
+    <% end %>
+    <div>
+      <%= link_to "Add FreeFeed token", new_access_token_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+    </div>
   <% elsif suggest_adding_feeds %>
     <%= render "feeds/empty_state" %>
   <% else %>

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -89,8 +89,8 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Events"
     assert_select '[data-key="admin.events.table"]', count: 0 # No table should be rendered
-    assert_select "h2", "No events found"
-    assert_select "p", "Events will appear here as they are created."
+    assert_select '[data-key="empty-state"]'
+    assert_select "p", "No events to show yet."
   end
 
   test "should show recorded subject when subject missing" do

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -90,7 +90,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Events"
     assert_select '[data-key="admin.events.table"]', count: 0 # No table should be rendered
     assert_select '[data-key="empty-state"]'
-    assert_select "p", "No events to show yet."
+    assert_select "p", "No events to show yet"
   end
 
   test "should show recorded subject when subject missing" do

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -339,6 +339,21 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{edit_feed_path(feed)}']", text: "Edit"
   end
 
+  test "#show should hide stats section when feed has no posts" do
+    sign_in_as(user)
+    get feed_url(feed)
+    assert_response :success
+    assert_select "h2", text: "Stats", count: 0
+  end
+
+  test "#show should show stats section when feed has posts" do
+    create(:post, feed: feed)
+    sign_in_as(user)
+    get feed_url(feed)
+    assert_response :success
+    assert_select "h2", text: "Stats", count: 1
+  end
+
   test "#show should return not found for other user's feed" do
     sign_in_as(user)
     get feed_url(other_feed)


### PR DESCRIPTION
Aligns two admin/status views with the shared layout components used elsewhere in the app.

Changes:

- Render the status page header through `PageHeaderComponent`, so the "Status" heading uses the same header layout and spacing as the Feeds page.
- Render the admin events empty state through `EmptyStateComponent` with a single plain line, replacing the ad-hoc card with heading and two paragraphs.