### PR TITLE
Disabled button hover fix and feed list item restyle

### DIFF
--- a/app/components/list_group_component/feed_item_component.rb
+++ b/app/components/list_group_component/feed_item_component.rb
@@ -1,7 +1,7 @@
 class ListGroupComponent::FeedItemComponent < ViewComponent::Base
-  DEFAULT_ITEM_CLASS = "flex flex-1 flex-col gap-2"
+  DEFAULT_ITEM_CLASS = "flex items-baseline gap-3 p-4"
   ICON_CLASSES = "inline-flex shrink-0 text-slate-500"
-  CONTENT_WRAPPER_CLASSES = "flex flex-1 flex-col gap-1"
+  CONTENT_WRAPPER_CLASSES = "flex flex-1 flex-col gap-2"
   TITLE_ROW_CLASSES = "flex flex-wrap items-center gap-2"
   TITLE_CLASSES = "inline-flex items-center text-base font-semibold text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
   METADATA_CLASSES = "flex flex-wrap items-center gap-x-2 gap-y-1 text-slate-500"

--- a/app/components/list_group_component/feed_item_component.rb
+++ b/app/components/list_group_component/feed_item_component.rb
@@ -1,5 +1,5 @@
 class ListGroupComponent::FeedItemComponent < ViewComponent::Base
-  DEFAULT_ITEM_CLASS = "flex items-baseline gap-3 p-4"
+  DEFAULT_ITEM_CLASS = "flex flex-1 flex-col gap-2"
   ICON_CLASSES = "inline-flex shrink-0 text-slate-500"
   CONTENT_WRAPPER_CLASSES = "flex flex-1 flex-col gap-1"
   TITLE_ROW_CLASSES = "flex flex-wrap items-center gap-2"

--- a/app/views/feed_entries/show.html.erb
+++ b/app/views/feed_entries/show.html.erb
@@ -13,7 +13,7 @@
       <% if @feed_entry.posts.any? %>
         <%= link_to "Back to Post", post_path(@feed_entry.posts.first), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
       <% else %>
-        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 opacity-50 cursor-not-allowed">
+        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 opacity-50 cursor-not-allowed">
           Back to Post
         </span>
       <% end %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -29,7 +29,7 @@
       <% end %>
     <% else %>
       <% header.with_action_button do %>
-        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-not-allowed opacity-60" title="Complete setup to enable this feed">Enable</span>
+        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-not-allowed opacity-60" title="Complete setup to enable this feed">Enable</span>
       <% end %>
     <% end %>
     <% if @feed.can_be_previewed? %>
@@ -44,7 +44,7 @@
       <% end %>
     <% else %>
       <% header.with_action_button do %>
-        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-not-allowed opacity-60" title="Preview requires feed URL and source type">Preview</span>
+        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-not-allowed opacity-60" title="Preview requires feed URL and source type">Preview</span>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/invites/_create_button.html.erb
+++ b/app/views/invites/_create_button.html.erb
@@ -2,6 +2,6 @@
 <%= button_to "Invite a user",
               invites_path,
               method: :post,
-              class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", "opacity-60 cursor-not-allowed": !can_create),
+              class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", "hover:bg-sky-500": can_create, "opacity-60 cursor-not-allowed": !can_create),
               disabled: !can_create,
               form: { data: { turbo_frame: "_top" } } %>

--- a/test/controllers/invites_controller_test.rb
+++ b/test/controllers/invites_controller_test.rb
@@ -60,6 +60,20 @@ class InvitesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "should render enabled invite button with hover when invites available" do
+    sign_in_as user
+    get invites_url
+    assert_select "form[data-turbo-frame='_top'] button:not([disabled])[class*='hover:bg-sky-500']"
+  end
+
+  test "should render disabled invite button without hover when no invites available" do
+    u = create(:user, available_invites: 0)
+    sign_in_as u
+    get invites_url
+    assert_select "button[disabled]"
+    assert_select "button[disabled][class*='hover:bg-sky-500']", count: 0
+  end
+
   test "should destroy own unused invite" do
     inv = invite # Create invite before signing in
     sign_in_as user


### PR DESCRIPTION
A couple of small UI tweaks.

Changes:

- Stop disabled buttons from reacting on hover. The always-disabled Enable/Preview spans (feed page) and the disabled "Back to Post" span (feed entry page) no longer carry a hover style; the invite button's hover is now gated on whether the user can actually create an invite.
- Restyle feed list items to a vertical flex layout (`flex flex-1 flex-col gap-2`).