### PR TITLE
Skip feed preview when source input is blank

### DIFF
--- a/app/controllers/feeds/previews_controller.rb
+++ b/app/controllers/feeds/previews_controller.rb
@@ -11,7 +11,9 @@ class Feeds::PreviewsController < ApplicationController
 
   def show
     @partial, @partial_locals =
-      if needs_credential_gate?
+      if source_input_blank?
+        [nil, {}]
+      elsif needs_credential_gate?
         [:credential_gate, {
           profile_key: profile_key,
           feed_id: draft? ? nil : feed.id
@@ -56,13 +58,24 @@ class Feeds::PreviewsController < ApplicationController
     respond_to do |format|
       format.html { render "feeds/previews/show" }
       format.turbo_stream do
-        render turbo_stream: turbo_stream.update(
-          "feed-preview",
-          partial: "feeds/#{@partial}",
-          locals: @partial_locals
-        )
+        stream =
+          if @partial
+            turbo_stream.update("feed-preview", partial: "feeds/#{@partial}", locals: @partial_locals)
+          else
+            turbo_stream.update("feed-preview", "")
+          end
+        render turbo_stream: stream
       end
     end
+  end
+
+  # The profile's required source input (url/handle/query). When it's blank
+  # there's nothing to preview yet, so we skip the job and clear the pane
+  # instead of running the pipeline against an empty source.
+  def source_input_blank?
+    shape = FeedProfile[profile_key]&.dig(:input_shape)
+    param_key = shape ? shape.to_s : "url"
+    preview_params[param_key].to_s.strip.blank?
   end
 
   def cached_preview

--- a/app/views/feeds/previews/show.html.erb
+++ b/app/views/feeds/previews/show.html.erb
@@ -1,3 +1,3 @@
 <%= turbo_frame_tag "feed-preview" do %>
-  <%= render partial: "feeds/#{@partial}", locals: @partial_locals %>
+  <%= render partial: "feeds/#{@partial}", locals: @partial_locals if @partial %>
 <% end %>

--- a/test/controllers/feeds/previews_controller_test.rb
+++ b/test/controllers/feeds/previews_controller_test.rb
@@ -158,6 +158,33 @@ class Feeds::PreviewsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "#show should not enqueue a preview when the source input is blank" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      assert_no_enqueued_jobs do
+        get feed_live_preview_path("draft"), params: { profile_key: "xkcd", params: { url: "" } }
+      end
+
+      assert_response :success
+      assert_select "turbo-frame#feed-preview"
+      assert_select "[data-key='preview.loading']", false
+    end
+  end
+
+  test "#show should not enqueue a preview when the source input is missing" do
+    sign_in_as(user)
+
+    with_memory_cache do
+      assert_no_enqueued_jobs do
+        get feed_live_preview_path("draft"), params: { profile_key: "xkcd" }
+      end
+
+      assert_response :success
+      assert_select "turbo-frame#feed-preview"
+    end
+  end
+
   test "#show should render the credential gate when an AI profile is selected but the user has no credentials" do
     sign_in_as(user)
 


### PR DESCRIPTION
Changes:

- Guard `Feeds::PreviewsController#show` so it no longer enqueues a preview job when the selected profile’s required source input (url/handle/query) is blank, clearing the preview pane instead.

Fixes a pair of Honeybadger faults on staging: when the live preview pane fired for a profile without a URL entered yet (e.g. XKCD), the pipeline ran against a feed with a nil URL. Faraday then choked on the nil path with a cryptic `NoMethodError: undefined method 'index' for nil`, which `FeedPreviewService` re-reported as `SourceUnreachable`. There is nothing to preview until the user supplies input, so we skip the doomed job entirely — mirroring the existing credential-gate precondition guard.