### PR TITLE
Handle missing AI credential in admin preview job

### DIFF
--- a/app/jobs/admin_feed_preview_job.rb
+++ b/app/jobs/admin_feed_preview_job.rb
@@ -7,6 +7,13 @@ class AdminFeedPreviewJob < ApplicationJob
     return unless feed_preview
 
     FeedPreviewWorkflow.new(feed_preview).execute
+  rescue LlmClient::CredentialMissing => e
+    # Expected when an AI profile is previewed without the user having an
+    # active AI credential. The workflow already marked the preview failed;
+    # this is a user-state condition, not an alert-worthy crash, so swallow
+    # it instead of re-raising (no retries, no error reporting).
+    Rails.logger.info "AdminFeedPreviewJob: no AI credential for preview #{feed_preview_id}: #{e.message}"
+    feed_preview.update!(status: :failed)
   rescue => e
     Rails.logger.error "AdminFeedPreviewJob failed for preview #{feed_preview_id}: #{e.message}"
 

--- a/test/jobs/admin_feed_preview_job_test.rb
+++ b/test/jobs/admin_feed_preview_job_test.rb
@@ -104,6 +104,23 @@ class AdminFeedPreviewJobTest < ActiveJob::TestCase
     end
   end
 
+  test "should fail gracefully when an AI profile has no credential" do
+    preview = create(:feed_preview,
+                     user: user,
+                     feed_profile_key: "llm_website_extractor",
+                     url: "https://example.com",
+                     status: :pending)
+
+    # User has no AI credentials, so LlmClient.for raises CredentialMissing.
+    # This is an expected user-state condition, not an alert-worthy crash:
+    # the job should mark the preview failed without re-raising.
+    assert_nothing_raised do
+      AdminFeedPreviewJob.perform_now(preview.id)
+    end
+
+    assert preview.reload.failed?
+  end
+
   test "should log error when workflow execution fails" do
     # Create a preview that will cause the workflow to fail
     failing_preview = create(:feed_preview,


### PR DESCRIPTION
Changes:

- `AdminFeedPreviewJob` now treats `LlmClient::CredentialMissing` as a graceful terminal failure: it marks the preview failed and stops, instead of re-raising.

Fixes a Honeybadger fault on staging. When an AI profile (e.g. AI page reader) is previewed through the admin preview path and the user has no active AI credential, `LlmClient.for` raises `CredentialMissing` deep in the workflow. The workflow already marks the preview failed, but the job then re-raised, turning an expected user-state condition into an unhandled job crash (error reporting + a dead job in the queue). Genuine processing errors still propagate as before.