### PR TITLE
Tighten feed status toggle handling

### DIFF
--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -5,19 +5,14 @@ class FeedStatusesController < ApplicationController
     feed = load_feed
 
     if feed.draft?
-      redirect_to edit_feed_path(feed),
-                  alert: "Drafts must be promoted via the feed form, not the status toggle."
+      redirect_to edit_feed_path(feed), alert: "Drafts must be promoted via the feed form, not the status toggle."
       return
     end
 
-    case status
-    when "enabled"
-      enable(feed)
-    when "disabled"
-      disable(feed)
-    else
-      redirect_to feed, alert: "Invalid status parameter."
-    end
+    return enable(feed) if feed.enabled?
+    return disable(feed) if feed.disabled?
+
+    redirect_to feed_path(feed.id), alert: "Invalid status parameter."
   rescue ActiveRecord::RecordNotFound
     redirect_to feeds_path, alert: "Feed not found."
   rescue ActiveRecord::StaleObjectError

--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -5,7 +5,7 @@ class FeedStatusesController < ApplicationController
     feed = load_feed
 
     if feed.draft?
-      redirect_to edit_feed_path(feed), alert: "Drafts must be promoted via the feed form, not the status toggle."
+      redirect_to edit_feed_path(feed), alert: "This feed is still a draft. Finish setting it up here before you can enable or disable it."
       return
     end
 

--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -4,15 +4,11 @@ class FeedStatusesController < ApplicationController
   def update
     feed = load_feed
 
-    if feed.draft?
-      redirect_to edit_feed_path(feed), alert: "This feed is still a draft. Finish setting it up here before you can enable or disable it."
-      return
+    case status
+    when "enabled" then enable(feed)
+    when "disabled" then disable(feed)
+    else raise "Unsupported status: #{status.inspect}"
     end
-
-    return enable(feed) if feed.enabled?
-    return disable(feed) if feed.disabled?
-
-    raise "Unexpected feed state: #{feed.state.inspect}"
   rescue ActiveRecord::RecordNotFound
     redirect_to feeds_path, alert: "Feed not found."
   rescue ActiveRecord::StaleObjectError

--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -12,7 +12,7 @@ class FeedStatusesController < ApplicationController
     return enable(feed) if feed.enabled?
     return disable(feed) if feed.disabled?
 
-    redirect_to feed_path(feed.id), alert: "Invalid status parameter."
+    raise "Unexpected feed state: #{feed.state.inspect}"
   rescue ActiveRecord::RecordNotFound
     redirect_to feeds_path, alert: "Feed not found."
   rescue ActiveRecord::StaleObjectError

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -18,7 +18,7 @@
                       class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
                       form: { class: "inline-block" } %>
       <% end %>
-    <% elsif @feed.can_be_enabled? %>
+    <% elsif @feed.disabled? && @feed.can_be_enabled? %>
       <% header.with_action_button do %>
         <%= button_to "Enable",
                       feed_status_path(@feed),

--- a/test/controllers/feed_statuses_controller_test.rb
+++ b/test/controllers/feed_statuses_controller_test.rb
@@ -36,6 +36,14 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "disabled", feed.state
   end
 
+  test "#update should reject an unsupported status" do
+    sign_in_as(user)
+
+    assert_raises(RuntimeError) do
+      patch feed_status_path(feed), params: { status: "bogus" }
+    end
+  end
+
   test "#update should pause an enabled feed when status=disabled" do
     sign_in_as(user)
     enabled_feed = create(:feed, :enabled, user: user)
@@ -62,36 +70,6 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
 
     disabled_feed.reload
     assert_equal "enabled", disabled_feed.state
-  end
-
-  test "#update should reject toggling a draft and redirect with an alert" do
-    sign_in_as(user)
-    draft_feed = create(:feed, :draft, user: user)
-
-    patch feed_status_path(draft_feed), params: { status: "enabled" }
-
-    assert_redirected_to edit_feed_path(draft_feed)
-    follow_redirect!
-    assert_includes response.body,
-                    "Drafts must be promoted via the feed form, not the status toggle."
-
-    draft_feed.reload
-    assert_equal "draft", draft_feed.state
-  end
-
-  test "#update should reject disabling a draft and redirect with an alert" do
-    sign_in_as(user)
-    draft_feed = create(:feed, :draft, user: user)
-
-    patch feed_status_path(draft_feed), params: { status: "disabled" }
-
-    assert_redirected_to edit_feed_path(draft_feed)
-    follow_redirect!
-    assert_includes response.body,
-                    "Drafts must be promoted via the feed form, not the status toggle."
-
-    draft_feed.reload
-    assert_equal "draft", draft_feed.state
   end
 
   test "#update should not enable feed when access token is missing" do

--- a/test/controllers/feed_statuses_controller_test.rb
+++ b/test/controllers/feed_statuses_controller_test.rb
@@ -123,16 +123,6 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "disabled", feed_with_inactive_token.state
   end
 
-  test "#update should handle invalid status parameter" do
-    sign_in_as(user)
-
-    patch feed_status_path(feed), params: { status: "invalid" }
-
-    assert_redirected_to feed
-    follow_redirect!
-    assert_includes response.body, "Invalid status parameter"
-  end
-
   test "#update should redirect to login when not authenticated" do
     patch feed_status_path(feed), params: { status: "enabled" }
     assert_redirected_to new_session_url

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -339,6 +339,16 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{edit_feed_path(feed)}']", text: "Edit"
   end
 
+  test "#show should not offer a status toggle for a draft feed" do
+    sign_in_as(user)
+    draft = create(:feed, :draft, user: user)
+
+    get feed_url(draft)
+
+    assert_response :success
+    assert_select "form[action='#{feed_status_path(draft)}']", count: 0
+  end
+
   test "#show should hide stats section when feed has no posts" do
     sign_in_as(user)
     get feed_url(feed)


### PR DESCRIPTION
Cleans up `FeedStatusesController#update` and the feed show page so the status toggle only deals with states it actually supports.

Changes:

- Drop the user-facing "Invalid status parameter" message — an unknown status isn't a real user scenario, so it now raises instead of rendering a friendly alert.
- Stop offering the Enable toggle for drafts on the feed page; drafts are promoted through the feed form, and the show page now only shows a live toggle for non-draft feeds.
- Remove the controller's draft special-case redirect, since drafts can no longer reach the toggle through the UI.
- Update tests to match.