### PR TITLE
Drop leftover :handle references after profile removal

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -176,7 +176,7 @@ class FeedsController < ApplicationController
       :llm_credential_id,
       :cron_expression,
       :schedule_interval,
-      # Only the three known input-shape keys are accepted. Anything
+      # Only the known input-shape keys are accepted. Anything
       # else inside the params hash would otherwise persist into
       # `feeds.params` jsonb undetected. See the profile schemas.
       params: [:url, :query]
@@ -194,7 +194,7 @@ class FeedsController < ApplicationController
   # pause/resume. Strong params silently drops them for non-drafts.
   def update_feed_params
     always_permitted = %i[name description target_group access_token_id llm_credential_id schedule_interval]
-    draft_only_permitted = [:url, :feed_profile_key, { params: %i[url handle query] }]
+    draft_only_permitted = [:url, :feed_profile_key, { params: %i[url query] }]
 
     permitted_keys = @feed&.draft? ? always_permitted + draft_only_permitted : always_permitted
     params.require(:feed).permit(*permitted_keys)

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -1,6 +1,6 @@
 module FeedHelper
   # Plain-language label for a detection candidate. URL-based candidates
-  # use the profile's display_name; handle / query candidates inject the
+  # use the profile's display_name; query candidates inject the
   # user's input into a short sentence so the chooser feels natural for
   # non-URL inputs.
   def candidate_summary(profile_key, input)

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -27,7 +27,7 @@ class FeedIdentificationFetcher
   private
 
   # Fetch the URL body for inspection by URL matchers; skip the fetch
-  # entirely for handle / query inputs since structured URL detection
+  # entirely for query inputs since structured URL detection
   # doesn't apply.
   def fetch_body_for_input
     return nil if InputClassifier.classify(@input) != :url

--- a/app/services/profile_matcher/base.rb
+++ b/app/services/profile_matcher/base.rb
@@ -55,7 +55,7 @@ module ProfileMatcher
 
     attr_reader :input, :fetched_body
 
-    # @param input [String] the user's raw input (URL, handle, or query)
+    # @param input [String] the user's raw input (URL or query)
     # @param fetched_body [String, nil] the body of the URL when input_shape is :url
     #   and FeedIdentificationFetcher already fetched it; nil otherwise
     def initialize(input, fetched_body = nil)

--- a/test/support/feed_profile_validator.rb
+++ b/test/support/feed_profile_validator.rb
@@ -22,7 +22,7 @@ module FeedProfileValidator
     "properties" => {
       "display_name" => { "type" => "string", "minLength" => 1, "maxLength" => 80 },
       "description" => { "type" => "string", "minLength" => 1, "maxLength" => 200 },
-      "input_shape" => { "type" => "string", "enum" => %w[url handle query any] },
+      "input_shape" => { "type" => "string", "enum" => %w[url query any] },
       "depends_on_ai" => { "type" => "boolean" },
       "matcher" => { "type" => "string", "minLength" => 1 },
       "parameter_schema" => { "type" => "object" },


### PR DESCRIPTION
Follow-up to #440. That PR removed the `llm_handle_search` profile and the `:handle` input shape, but a few stale references slipped through (caught in review):

Changes:

- `FeedsController#update_feed_params`: drop `handle` from the draft-permitted `params` keys (the create path was already fixed in #440).
- Test profile-registry validator: drop `handle` from the allowed `input_shape` enum.
- Remove `handle` mentions from three now-outdated comments.