### PR TITLE
Add `FeedPreview` retention sweeper

### DIFF
--- a/app/jobs/prune_feed_previews_job.rb
+++ b/app/jobs/prune_feed_previews_job.rb
@@ -1,0 +1,11 @@
+# Removes stale preview rows. The enable gate only honors previews newer than
+# Feed::ENABLE_PREVIEW_WINDOW, so anything older than RETENTION is safe to drop.
+class PruneFeedPreviewsJob < ApplicationJob
+  queue_as :default
+
+  RETENTION = 7.days
+
+  def perform
+    FeedPreview.where(created_at: ..RETENTION.ago).in_batches(of: 500).delete_all
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -15,12 +15,22 @@ development:
     queue: default
     schedule: every minute
 
+  prune_feed_previews:
+    class: PruneFeedPreviewsJob
+    queue: default
+    schedule: every day at 4am
+
 production:
   feed_scheduler:
     class: FeedSchedulerJob
     queue: default
     schedule: every minute
-  
+
+  prune_feed_previews:
+    class: PruneFeedPreviewsJob
+    queue: default
+    schedule: every day at 4am
+
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12

--- a/specs/003-unify-feed-preview-stack/HANDOFF.md
+++ b/specs/003-unify-feed-preview-stack/HANDOFF.md
@@ -8,9 +8,10 @@ Last updated: 2026-05-25. Read this first when resuming the preview work.
 |----|------|--------|
 | #440 | Drop `llm_handle_search` profile + `:handle` shape; render LLM prompts via a single `{{input}}` placeholder | **Merged** |
 | #441 | Clean up leftover `:handle` references (strong params, test validator, comments) | **Merged** |
-| #442 | **The backend consolidation** (branch `preview-consolidation`) | **Open — awaiting review/merge** |
+| #442 | **The backend consolidation** (branch `preview-consolidation`) | **Merged** |
+| PR3 | `PruneFeedPreviewsJob` retention sweeper (branch `prune-feed-previews`) | **Open — awaiting review/merge** |
 
-After #442 merges, two pieces remain: **PR3 (retention job)** and the **manual-preview follow-up**. Details below.
+After PR3 merges, one piece remains: the **manual-preview follow-up**. Details below.
 
 ## What #442 delivers (the "initial refactoring")
 
@@ -43,8 +44,8 @@ are independent (no shared files of note), so this is a priority choice, not a
 dependency. PR3 is the quick win and goes first; the manual-preview follow-up —
 which also closes #442's interim multi-candidate/refresh gaps — comes after.
 
-### PR3 — `FeedPreview` retention/prune job (small, independent)
-Spec: `plan.md` Phase H. Add `PruneFeedPreviewsJob` deleting rows older than a window comfortably larger than `Feed::ENABLE_PREVIEW_WINDOW` (e.g. `created_at < 7.days.ago`), schedule it in `config/recurring.yml` (dev + prod), with a test. Branch from `main` after #442 merges. The unique key bounds row growth to (user × profile × source), but the cache TTL is gone, so this still ships.
+### PR3 — `FeedPreview` retention/prune job (small, independent) — DONE, awaiting merge
+Spec: `plan.md` Phase H. `PruneFeedPreviewsJob` (`RETENTION = 7.days`) deletes rows with `created_at < 7.days.ago` in batches via `delete_all`; scheduled in `config/recurring.yml` (dev + prod) as `prune_feed_previews`, every day at 4am. Test in `test/jobs/prune_feed_previews_job_test.rb`. Branch `prune-feed-previews` off `main`. The unique key bounds row growth to (user × profile × source), but the cache TTL is gone, so this still ships.
 
 ### Follow-up PR — Manual preview (the bigger one)
 Replaces auto-preview. Recommend running it through brainstorming → spec → plan (likely `specs/004-manual-feed-preview/`).

--- a/test/jobs/prune_feed_previews_job_test.rb
+++ b/test/jobs/prune_feed_previews_job_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class PruneFeedPreviewsJobTest < ActiveJob::TestCase
+  test "#perform should delete previews older than the retention window" do
+    old = create(:feed_preview, created_at: 8.days.ago)
+    recent = create(:feed_preview, created_at: 1.hour.ago)
+
+    PruneFeedPreviewsJob.perform_now
+
+    assert_not FeedPreview.exists?(old.id)
+    assert FeedPreview.exists?(recent.id)
+  end
+end


### PR DESCRIPTION
Changes:

- Add `PruneFeedPreviewsJob` that deletes `FeedPreview` rows older than 7 days (`RETENTION`), batched via `delete_all`.
- Schedule it daily at 4am in `config/recurring.yml` for both development and production.

The unified preview stack dropped the old cache TTL, so persisted preview rows now need a retention sweep. The enable gate only honors previews newer than `Feed::ENABLE_PREVIEW_WINDOW` (60 min), so a 7-day window is comfortably safe to prune against.