### PR TITLE
Refactor feed enable logic and status sorting

### DIFF
--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -11,7 +11,7 @@ class FeedPreviewsController < ApplicationController
     "failed" => "failed"
   }.freeze
 
-  # GET /preview?profile_key=…&params[…]=…
+  # GET /feed_preview?profile_key=…&params[…]=…
   # Workhorse for the lazy turbo-frame and polling: find or create the row for
   # (user, profile_key, params_digest), start a run when it has no fresh result,
   # and render the current state.
@@ -21,7 +21,7 @@ class FeedPreviewsController < ApplicationController
     render_state(preview)
   end
 
-  # POST /preview — explicit refresh: always start a fresh run.
+  # POST /feed_preview — explicit refresh: always start a fresh run.
   def create
     render_state(start_run(locate_preview))
   end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -14,7 +14,7 @@ class FeedsController < ApplicationController
     },
     status: {
       title: "Status",
-      order_by: "CASE WHEN feeds.state = #{Feed.states[:enabled]} THEN 0 ELSE 1 END",
+      order_by: "CASE feeds.state WHEN #{Feed.states[:draft]} THEN 0 WHEN #{Feed.states[:enabled]} THEN 1 ELSE 2 END",
       direction: :asc
     },
     target_group: {

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -56,7 +56,7 @@ class FeedsController < ApplicationController
     if @feed.save
       cleanup_feed_identification(@feed.url) if @feed.url
 
-      if gate_commit?
+      if require_llm_credentials?
         redirect_to new_llm_credential_path(feed_id: @feed.id)
       elsif params[:enable_feed] == "1" && !@feed.enable
         flash.now[:alert] = "Couldn't enable. See issues below."
@@ -92,7 +92,7 @@ class FeedsController < ApplicationController
 
     # Unticked Enable on an enabled feed = pause request (gate flow skips this
     # because the gate only appears for drafts without usable credentials).
-    @feed.state = :disabled if @feed.enabled? && params[:enable_feed] != "1" && !gate_commit?
+    @feed.state = :disabled if @feed.enabled? && params[:enable_feed] != "1" && !require_llm_credentials?
 
     if @feed.save
       # Capture interval-change signal from the first save before the
@@ -100,7 +100,7 @@ class FeedsController < ApplicationController
       interval_changed = @feed.saved_change_to_cron_expression?
       cleanup_feed_identification(@feed.url) if @feed.url
 
-      if gate_commit?
+      if require_llm_credentials?
         redirect_to new_llm_credential_path(feed_id: @feed.id)
       elsif params[:enable_feed] == "1" && !@feed.enabled? && !@feed.enable
         flash.now[:alert] = "Couldn't enable. See issues below."
@@ -126,7 +126,7 @@ class FeedsController < ApplicationController
   # The credential gate (rendered in the preview pane when the chosen profile
   # is AI and the user has no usable credentials) submits the feed form with
   # this commit value. See app/views/feeds/_credential_gate.html.erb.
-  def gate_commit?
+  def require_llm_credentials?
     params[:commit] == "save_as_draft_and_add_credentials"
   end
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -58,9 +58,8 @@ class FeedsController < ApplicationController
 
       if require_llm_credentials?
         redirect_to new_llm_credential_path(feed_id: @feed.id)
-      elsif params[:enable_feed] == "1" && !@feed.enable
-        flash.now[:alert] = "Couldn't enable. See issues below."
-        render :new, status: :unprocessable_entity
+      elsif enable_feed?
+        enable_and_respond(@feed)
       else
         redirect_to feed_path(@feed), notice: success_message_for(@feed)
       end
@@ -92,7 +91,7 @@ class FeedsController < ApplicationController
 
     # Unticked Enable on an enabled feed = pause request (gate flow skips this
     # because the gate only appears for drafts without usable credentials).
-    @feed.state = :disabled if @feed.enabled? && params[:enable_feed] != "1" && !require_llm_credentials?
+    @feed.state = :disabled if @feed.enabled? && !enable_feed? && !require_llm_credentials?
 
     if @feed.save
       # Capture interval-change signal from the first save before the
@@ -102,9 +101,8 @@ class FeedsController < ApplicationController
 
       if require_llm_credentials?
         redirect_to new_llm_credential_path(feed_id: @feed.id)
-      elsif params[:enable_feed] == "1" && !@feed.enabled? && !@feed.enable
-        flash.now[:alert] = "Couldn't enable. See issues below."
-        render :edit, status: :unprocessable_entity
+      elsif enable_feed? && !@feed.enabled?
+        promote_and_redirect(@feed, interval_changed)
       else
         @feed.reset_schedule! if interval_changed && @feed.feed_schedule.present?
         redirect_to feed_path(@feed), notice: update_message_for(@feed)
@@ -128,6 +126,34 @@ class FeedsController < ApplicationController
   # this commit value. See app/views/feeds/_credential_gate.html.erb.
   def require_llm_credentials?
     params[:commit] == "save_as_draft_and_add_credentials"
+  end
+
+  def enable_feed?
+    params[:enable_feed] == "1"
+  end
+
+  def enable_and_respond(feed)
+    if feed.enable
+      redirect_to feed_path(feed), notice: success_message_for(feed)
+    else
+      flash.now[:alert] = "Couldn't enable. See issues below."
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def promote_and_redirect(feed, interval_changed)
+    feed.transaction do
+      if feed.enable
+        feed.reset_schedule! if interval_changed && feed.feed_schedule.present?
+      end
+    end
+
+    if feed.enabled?
+      redirect_to feed_path(feed), notice: update_message_for(feed)
+    else
+      flash.now[:alert] = "Couldn't enable. See issues below."
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def active_access_tokens?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
 
   resources :posts, only: [:index, :show, :destroy]
   resources :feed_entries, only: :show
-  resource :feed_preview, only: [:show, :create], path: "preview"
+  resource :feed_preview, only: [:show, :create]
   resource :admin, only: :show
 
   resource :feed_identifications, only: [:create, :show, :destroy]

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -749,36 +749,44 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert pos_a < pos_z, "Expected A Feed to appear before Z Feed"
   end
 
-  test "#index should sort feeds by status with enabled first when ascending" do
+  test "#index should sort feeds by status as draft, enabled, disabled when ascending" do
     sign_in_as(user)
     create(:feed, :enabled, user: user, name: "Enabled Feed")
     create(:feed, user: user, name: "Disabled Feed", state: :disabled)
+    create(:feed, user: user, name: "Draft Feed", state: :draft)
 
     get feeds_url(sort: "status", direction: "asc")
     assert_response :success
 
     response_body = response.body
-    pos_disabled = response_body.index("Disabled Feed")
+    pos_draft = response_body.index("Draft Feed")
     pos_enabled = response_body.index("Enabled Feed")
+    pos_disabled = response_body.index("Disabled Feed")
+    assert_not_nil pos_draft, "Expected draft feed to be rendered"
     assert_not_nil pos_enabled, "Expected enabled feed to be rendered"
     assert_not_nil pos_disabled, "Expected disabled feed to be rendered"
+    assert pos_draft < pos_enabled, "Expected draft feed to appear before enabled feed"
     assert pos_enabled < pos_disabled, "Expected enabled feed to appear before disabled feed"
   end
 
-  test "#index should sort feeds by status with disabled first when descending" do
+  test "#index should sort feeds by status as disabled, enabled, draft when descending" do
     sign_in_as(user)
     create(:feed, :enabled, user: user, name: "Enabled Feed")
     create(:feed, user: user, name: "Disabled Feed", state: :disabled)
+    create(:feed, user: user, name: "Draft Feed", state: :draft)
 
     get feeds_url(sort: "status", direction: "desc")
     assert_response :success
 
     response_body = response.body
-    pos_disabled = response_body.index("Disabled Feed")
+    pos_draft = response_body.index("Draft Feed")
     pos_enabled = response_body.index("Enabled Feed")
+    pos_disabled = response_body.index("Disabled Feed")
+    assert_not_nil pos_draft, "Expected draft feed to be rendered"
     assert_not_nil pos_enabled, "Expected enabled feed to be rendered"
     assert_not_nil pos_disabled, "Expected disabled feed to be rendered"
     assert pos_disabled < pos_enabled, "Expected disabled feed to appear before enabled feed"
+    assert pos_enabled < pos_draft, "Expected enabled feed to appear before draft feed"
   end
 
   test "#pagination should preserve sort parameters" do


### PR DESCRIPTION
Changes:

- Rename `gate_commit?` to `require_llm_credentials?` for clarity about when LLM credential setup is needed
- Extract feed enable logic into `enable_feed?` helper method to reduce parameter checking duplication
- Add `enable_and_respond` and `promote_and_redirect` helper methods to consolidate enable/promotion response handling in create and update actions
- Update feed status sorting to order by draft → enabled → disabled (ascending) instead of just enabled → disabled
- Add draft feed to status sorting tests to verify correct ordering across all three states
- Fix feed_preview route to use standard resourceful path instead of custom "preview" alias
- Update controller documentation comments to reflect correct route paths

The refactoring improves code clarity and maintainability by extracting repeated conditional logic into named helper methods, making the intent of each code path more explicit. The status sorting change provides better UX by grouping feeds by their lifecycle stage.
