### PR TITLE
Document ActionCable Connection as unused during dev stage

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,5 +1,9 @@
+# Currently unused; preserved during the dev stage for future real-time features
+# 
+# TODO: Consider removing the ActionCable dependency if there will be no practical
+#   use upon public release
+# 
 module ApplicationCable
-  # Currently unused; preserved during the dev stage for future real-time features.
   class Connection < ActionCable::Connection::Base
     identified_by :current_user
 

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,8 +1,8 @@
 # Currently unused; preserved during the dev stage for future real-time features
-# 
+#
 # TODO: Consider removing the ActionCable dependency if there will be no practical
 #   use upon public release
-# 
+#
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
     identified_by :current_user

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,5 @@
 module ApplicationCable
+  # Currently unused; preserved during the dev stage for future real-time features.
   class Connection < ActionCable::Connection::Base
     identified_by :current_user
 


### PR DESCRIPTION
Changes:

- Add clarifying comment to `ApplicationCable::Connection` noting it's currently unused and preserved for future real-time features
