### PR TITLE
Improve AI credentials UI and messaging

### DIFF
--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -25,7 +25,7 @@ class LlmProvider
       credential_schema: {
         "type" => "object",
         "properties" => {
-          "api_key" => { "type" => "string", "minLength" => 10 }
+          "api_key" => { "type" => "string", "minLength" => 10, "title" => "API key" }
         },
         "required" => ["api_key"],
         "additionalProperties" => false

--- a/app/views/feed_previews/_credential_gate.html.erb
+++ b/app/views/feed_previews/_credential_gate.html.erb
@@ -1,16 +1,11 @@
 <%# locals: (profile_key:) %>
 <div class="rounded-lg border border-sky-200 bg-sky-50 p-4 space-y-3"
      data-key="credentials.gate">
-  <div class="flex gap-3">
-    <div class="flex-shrink-0 pt-0.5">
-      <%= icon("key", css_class: "h-5 w-5 text-sky-500", aria_hidden: true) %>
-    </div>
-    <div class="space-y-1">
-      <p class="font-semibold text-sky-900">AI extraction needs your API key</p>
-      <p class="text-sky-800 text-sm">
-        To let AI fetch posts on your behalf, add an API key from your AI provider. We'll come back to this feed once you're set up.
-      </p>
-    </div>
+  <div class="space-y-1">
+    <p class="font-semibold text-sky-900">AI extraction needs your API key</p>
+    <p class="text-sky-800 text-sm">
+      To let AI fetch posts on your behalf, add an API key from your AI provider. We'll come back to this feed once you're set up.
+    </p>
   </div>
 
   <div class="space-y-2">

--- a/app/views/feed_previews/_credential_gate.html.erb
+++ b/app/views/feed_previews/_credential_gate.html.erb
@@ -3,21 +3,16 @@
      data-key="credentials.gate">
   <div class="space-y-1">
     <p class="font-semibold text-sky-900">AI extraction needs your API key</p>
-    <p class="text-sky-800 text-sm">
-      To let AI fetch posts on your behalf, add an API key from your AI provider. We'll come back to this feed once you're set up.
+    <p class="text-sky-800 text-sm" data-key="credentials.gate.help">
+      To let AI fetch posts on your behalf, add an API key from your AI provider. We'll come back to this feed once you're set up. We'll save your feed as a draft so you can pick up where you left off.
     </p>
   </div>
 
-  <div class="space-y-2">
-    <button type="submit"
-            name="commit"
-            value="save_as_draft_and_add_credentials"
-            data-key="credentials.gate.add"
-            class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500">
-      Add AI credentials
-    </button>
-    <p class="text-sky-800 text-sm" data-key="credentials.gate.help">
-      We'll save your feed as a draft so you can pick up where you left off.
-    </p>
-  </div>
+  <button type="submit"
+          name="commit"
+          value="save_as_draft_and_add_credentials"
+          data-key="credentials.gate.add"
+          class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500">
+    Add AI credentials
+  </button>
 </div>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -87,7 +87,7 @@
                 data-preview-button-target="button"
                 data-action="click->preview-button#open"
                 data-key="preview.open">
-          See what we'd post
+          Preview feed contents
         </button>
 
         <%= render ModalComponent.new(title: "Feed preview", modal_id: "feed-preview-modal") do %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -24,6 +24,9 @@
               <%= link_to "Tokens", access_tokens_path, class: "block px-4 py-2 text-sm text-slate-700 hover:bg-slate-100" %>
             </li>
             <li>
+              <%= link_to "AI Credentials", llm_credentials_path, class: "block px-4 py-2 text-sm text-slate-700 hover:bg-slate-100" %>
+            </li>
+            <li>
               <%= link_to "Invites", invites_path, class: "block px-4 py-2 text-sm text-slate-700 hover:bg-slate-100" %>
             </li>
           </ul>
@@ -106,6 +109,15 @@
                 }
               ),
               aria: (current_page?(access_tokens_path) ? { current: "page" } : nil) %>
+          <%= link_to "AI Credentials", llm_credentials_path,
+              class: class_names(
+                "block w-full px-4 py-2 cursor-pointer hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-700 focus:text-slate-900 border-b border-slate-200",
+                {
+                  "bg-slate-600 text-white hover:bg-slate-700 hover:text-white focus:text-white" => current_page?(llm_credentials_path),
+                  "text-slate-700" => !current_page?(llm_credentials_path)
+                }
+              ),
+              aria: (current_page?(llm_credentials_path) ? { current: "page" } : nil) %>
           <%= link_to "Invites", invites_path,
               class: class_names(
                 "block w-full px-4 py-2 cursor-pointer hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-700 focus:text-slate-900 rounded-b-lg",

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -37,11 +37,18 @@
   <% end %>
 
   <div class="flex flex-wrap gap-3">
-    <% if llm_credential.active? && feed_id.present? %>
-      <%= link_to "Continue setting up your feed",
-                  edit_feed_path(feed_id),
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500",
-                  data: { key: "llm_credential.return-to" } %>
+    <% if feed_id.present? %>
+      <% if llm_credential.active? %>
+        <%= link_to "Continue setting up your feed",
+                    edit_feed_path(feed_id),
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500",
+                    data: { key: "llm_credential.return-to" } %>
+      <% else %>
+        <%= link_to "Back to your feed",
+                    edit_feed_path(feed_id),
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50",
+                    data: { key: "llm_credential.return-to" } %>
+      <% end %>
     <% end %>
     <%= link_to "Back to credentials",
                 llm_credentials_path,

--- a/app/views/llm_credentials/index.html.erb
+++ b/app/views/llm_credentials/index.html.erb
@@ -50,10 +50,6 @@
       <% end %>
     </ul>
   <% else %>
-    <%= render EmptyStateComponent.new do %>
-      <h2 class="text-2xl font-semibold mb-2 text-slate-500">No AI credentials yet</h2>
-      <p class="mb-6 text-slate-500">Add a provider key to use AI-backed feed extraction.</p>
-      <%= link_to "Add Credential", new_llm_credential_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
-    <% end %>
+    <%= render EmptyStateComponent.new("No AI credentials yet — add one to use AI-backed feed extraction") %>
   <% end %>
 </div>

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -21,9 +21,8 @@
         <%= f.label :provider, "AI Provider", class: "block font-semibold text-slate-800" %>
         <%= f.select :provider,
                      LlmProvider.all.map { |provider| [provider.display_name, provider.name] },
-                     { include_blank: false },
+                     {},
                      class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
-                     required: true,
                      data: { key: "llm_credentials.provider" } %>
       </div>
 

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -55,7 +55,11 @@
       <%= f.submit "Save Credential",
                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
                    data: { turbo_submits_with: "Saving..." } %>
-      <%= link_to "Cancel", llm_credentials_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50" %>
+      <% if @feed %>
+        <%= link_to "Back to your feed", edit_feed_path(@feed), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50", data: { key: "llm_credentials.back-to-feed" } %>
+      <% else %>
+        <%= link_to "Cancel", llm_credentials_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50" %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -21,7 +21,7 @@
         <%= f.label :provider, "AI Provider", class: "block font-semibold text-slate-800" %>
         <%= f.select :provider,
                      LlmProvider.all.map { |provider| [provider.display_name, provider.name] },
-                     {},
+                     { include_blank: false },
                      class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
                      required: true,
                      data: { key: "llm_credentials.provider" } %>

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto space-y-6" data-key="llm_credentials.new">
   <%= render PageHeaderComponent.new(title: "Add an AI Credential") do |header| %>
-    <% header.with_context_paragraph("Connect a provider key so AI feeds can fetch posts on your behalf.") %>
+    <% header.with_context_paragraph("Add an API key so AI-powered feeds can fetch web content.") %>
   <% end %>
 
   <%= form_with model: @llm_credential, url: llm_credentials_path(feed_id: @feed&.id) do |f| %>
@@ -38,9 +38,9 @@
       </div>
 
       <% schema = LlmProvider.find(@llm_credential.provider)&.credential_schema || { "properties" => {} } %>
-      <% schema["properties"].each do |key, _spec| %>
+      <% schema["properties"].each do |key, spec| %>
         <div class="space-y-2">
-          <%= label_tag "llm_credential_credential_data_#{key}", key.humanize, class: "block font-semibold text-slate-800" %>
+          <%= label_tag "llm_credential_credential_data_#{key}", spec["title"] || key.humanize, class: "block font-semibold text-slate-800" %>
           <%= password_field_tag "llm_credential[credential_data][#{key}]",
                                  @llm_credential.credential_data&.dig(key),
                                  id: "llm_credential_credential_data_#{key}",

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -19,11 +19,12 @@
     <div class="space-y-6">
       <div class="space-y-2">
         <%= f.label :provider, "AI Provider", class: "block font-semibold text-slate-800" %>
-        <%= f.select :provider,
-                     LlmProvider.all.map { |provider| [provider.display_name, provider.name] },
-                     {},
-                     class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
-                     data: { key: "llm_credentials.provider" } %>
+        <%= select_tag "llm_credential[provider]",
+                       options_for_select(LlmProvider.all.map { |provider| [provider.display_name, provider.name] }, @llm_credential.provider),
+                       id: "llm_credential_provider",
+                       class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
+                       required: true,
+                       data: { key: "llm_credentials.provider" } %>
       </div>
 
       <div class="space-y-2">

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -19,12 +19,11 @@
     <div class="space-y-6">
       <div class="space-y-2">
         <%= f.label :provider, "AI Provider", class: "block font-semibold text-slate-800" %>
-        <%= select_tag "llm_credential[provider]",
-                       options_for_select(LlmProvider.all.map { |provider| [provider.display_name, provider.name] }, @llm_credential.provider),
-                       id: "llm_credential_provider",
-                       class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
-                       required: true,
-                       data: { key: "llm_credentials.provider" } %>
+        <%= f.select :provider,
+                     LlmProvider.all.map { |provider| [provider.display_name, provider.name] },
+                     {},
+                     class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
+                     data: { key: "llm_credentials.provider" } %>
       </div>
 
       <div class="space-y-2">

--- a/db/migrate/20260525000000_nullify_llm_usages_credential_on_delete.rb
+++ b/db/migrate/20260525000000_nullify_llm_usages_credential_on_delete.rb
@@ -1,0 +1,11 @@
+class NullifyLlmUsagesCredentialOnDelete < ActiveRecord::Migration[8.1]
+  def up
+    remove_foreign_key :llm_usages, :llm_credentials
+    add_foreign_key :llm_usages, :llm_credentials, on_delete: :nullify
+  end
+
+  def down
+    remove_foreign_key :llm_usages, :llm_credentials
+    add_foreign_key :llm_usages, :llm_credentials
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_24_210153) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_25_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -402,7 +402,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_24_210153) do
   add_foreign_key "invites", "users", column: "invited_user_id"
   add_foreign_key "llm_credentials", "users"
   add_foreign_key "llm_usages", "feeds"
-  add_foreign_key "llm_usages", "llm_credentials"
+  add_foreign_key "llm_usages", "llm_credentials", on_delete: :nullify
   add_foreign_key "llm_usages", "users"
   add_foreign_key "permissions", "users"
   add_foreign_key "posts", "feed_entries"

--- a/test/controllers/llm_credentials_controller_test.rb
+++ b/test/controllers/llm_credentials_controller_test.rb
@@ -238,6 +238,19 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to llm_credentials_path
   end
 
+  test "#destroy should keep usage rows and clear their credential reference" do
+    sign_in_as(user)
+    usage = create(:llm_usage, user: user, llm_credential: credential)
+
+    assert_difference("LlmCredential.count", -1) do
+      assert_no_difference("LlmUsage.count") do
+        delete llm_credential_url(credential)
+      end
+    end
+    assert_redirected_to llm_credentials_path
+    assert_nil usage.reload.llm_credential_id
+  end
+
   test "#destroy should 404 for another user's credential" do
     sign_in_as(user)
     other = create(:llm_credential, user: other_user)

--- a/test/controllers/llm_credentials_controller_test.rb
+++ b/test/controllers/llm_credentials_controller_test.rb
@@ -38,7 +38,7 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     get llm_credentials_url
     assert_response :success
-    assert_select "h2", text: /No AI credentials yet/
+    assert_select "[data-key='empty-state']", text: /No AI credentials yet/
   end
 
   test "#new should render the form" do

--- a/test/controllers/llm_credentials_controller_test.rb
+++ b/test/controllers/llm_credentials_controller_test.rb
@@ -218,6 +218,17 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Continue setting up your feed", count: 0
   end
 
+  test "#show should render a back-to-feed link when credential is inactive and feed_id is owned" do
+    sign_in_as(user)
+    inactive = create(:llm_credential, :inactive, user: user)
+    draft = create(:feed, :draft, user: user)
+
+    get llm_credential_url(inactive, feed_id: draft.id)
+
+    assert_response :success
+    assert_select "a[href=?]", edit_feed_path(draft.id), text: "Back to your feed"
+  end
+
   test "#show should not render Continue setting up your feed link when feed_id is missing" do
     sign_in_as(user)
     active = create(:llm_credential, :active, user: user)

--- a/test/controllers/llm_credentials_controller_test.rb
+++ b/test/controllers/llm_credentials_controller_test.rb
@@ -78,6 +78,7 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-key='llm_credentials.new']"
+    assert_select "a[href=?]", edit_feed_path(draft.id), text: "Back to your feed"
   end
 
   test "#new should ignore foreign feed_id" do


### PR DESCRIPTION
Changes:

- Add "AI Credentials" navigation link to both dropdown and sidebar menus in navbar
- Simplify empty state component usage in credentials index view with improved messaging
- Update credential form context text to be more user-friendly ("Add an API key so AI-powered feeds can fetch web content")
- Use schema-defined field titles in credential form labels instead of humanized keys
- Add "title" field to OpenAI provider's API key schema for better UX
- Update test selector to use `data-key` attribute for empty state assertion

These changes improve the discoverability and usability of the AI credentials feature by making it more accessible in navigation and providing clearer, friendlier messaging throughout the interface.
