### PR TITLE
Adjust checkbox container height in feed form

### DIFF
--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -152,7 +152,7 @@
 
       <div class="mt-6">
         <div class="flex items-start">
-          <div class="flex items-center h-5">
+          <div class="flex items-center h-6">
             <%= check_box_tag "enable_feed",
                               "1",
                               params[:enable_feed] == "1" || feed.enabled?,


### PR DESCRIPTION
Changes:

- Increase the height of the checkbox container from `h-5` to `h-6` in the feed form's expanded view to improve vertical alignment with the checkbox input
