### PR TITLE
Simplify LLM credential validation to API key only

### DIFF
--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -25,7 +25,7 @@ class LlmCredential < ApplicationRecord
             length: { maximum: DISPLAY_NAME_MAX_LENGTH },
             uniqueness: { scope: [:user_id, :provider] }
 
-  validate :credential_data_matches_provider_schema
+  validate :api_key_present
 
   before_save :clear_other_defaults_if_promoting
   before_destroy :disable_dependent_feeds
@@ -41,18 +41,10 @@ class LlmCredential < ApplicationRecord
 
   private
 
-  def credential_data_matches_provider_schema
+  def api_key_present
     return if provider.blank?
-    return errors.add(:credential_data, "is missing") if credential_data.blank?
 
-    schema = LlmProvider.find(provider)&.credential_schema
-    return if schema.blank?
-
-    JSONSchemer.schema(schema).validate(credential_data).each do |error|
-      pointer = error["data_pointer"].to_s
-      message = pointer.empty? ? error["error"] : "#{pointer} #{error['error']}"
-      errors.add(:credential_data, message)
-    end
+    errors.add(:base, "Enter your API key") if credential_data.blank? || credential_data["api_key"].blank?
   end
 
   def clear_other_defaults_if_promoting

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -1,35 +1,23 @@
 # Code-only registry of AI providers `LlmClient` can talk to. Parallels
-# `FeedProfile`. Drives the credential form generator (per-provider
-# credential schema) and tells `LlmClient` which RubyLLM provider key
-# to use.
+# `FeedProfile`. Tells `LlmClient` which RubyLLM provider key to use.
+# Every provider authenticates with a single API key; if one ever needs
+# more fields, add them for that provider specifically rather than
+# generalizing back to a schema.
 class LlmProvider
-  attr_reader :name, :display_name, :ruby_llm_provider, :credential_schema
+  attr_reader :name, :display_name, :ruby_llm_provider
 
-  def initialize(name:, display_name:, ruby_llm_provider:, credential_schema:)
+  def initialize(name:, display_name:, ruby_llm_provider:)
     @name = name
     @display_name = display_name
     @ruby_llm_provider = ruby_llm_provider
-    @credential_schema = credential_schema
     freeze
-  end
-
-  def validate(client)
-    client.health_check
   end
 
   PROVIDERS = {
     "anthropic" => new(
       name: "anthropic",
       display_name: "Anthropic (Claude)",
-      ruby_llm_provider: :anthropic,
-      credential_schema: {
-        "type" => "object",
-        "properties" => {
-          "api_key" => { "type" => "string", "minLength" => 10, "title" => "API key" }
-        },
-        "required" => ["api_key"],
-        "additionalProperties" => false
-      }
+      ruby_llm_provider: :anthropic
     )
   }.freeze
 

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -29,10 +29,8 @@
     <div class="rounded-lg border border-red-200 bg-red-50 p-4 space-y-2"
          data-credential-state="inactive"
          data-key="llm_credential.inactive">
-      <p class="font-semibold text-red-900">We couldn't use this credential</p>
-      <% if llm_credential.last_error.present? %>
-        <p class="text-sm text-red-800"><%= llm_credential.last_error %></p>
-      <% end %>
+      <p class="font-semibold text-red-900">This key didn't work</p>
+      <p class="text-sm text-red-800">Double-check you copied the whole key from your provider's dashboard, then add it again.</p>
     </div>
   <% end %>
 

--- a/app/views/llm_credentials/index.html.erb
+++ b/app/views/llm_credentials/index.html.erb
@@ -27,8 +27,8 @@
             <p class="text-sm text-slate-500">
               <%= LlmProvider.find(credential.provider)&.display_name %> · status: <%= credential.state %>
             </p>
-            <% if credential.last_error.present? %>
-              <p class="text-sm text-red-600"><%= credential.last_error %></p>
+            <% if credential.inactive? %>
+              <p class="text-sm text-red-600">This key didn't work. Open it to add a new one.</p>
             <% end %>
           </div>
           <div class="flex items-center gap-2">

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -36,19 +36,16 @@
         <p class="text-slate-500">A label so you can tell credentials apart later.</p>
       </div>
 
-      <% schema = LlmProvider.find(@llm_credential.provider)&.credential_schema || { "properties" => {} } %>
-      <% schema["properties"].each do |key, spec| %>
-        <div class="space-y-2">
-          <%= label_tag "llm_credential_credential_data_#{key}", spec["title"] || key.humanize, class: "block font-semibold text-slate-800" %>
-          <%= password_field_tag "llm_credential[credential_data][#{key}]",
-                                 @llm_credential.credential_data&.dig(key),
-                                 id: "llm_credential_credential_data_#{key}",
-                                 class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
-                                 required: schema["required"]&.include?(key),
-                                 autocomplete: "off",
-                                 data: { key: "llm_credentials.credential-data.#{key}" } %>
-        </div>
-      <% end %>
+      <div class="space-y-2">
+        <%= label_tag "llm_credential_credential_data_api_key", "API key", class: "block font-semibold text-slate-800" %>
+        <%= password_field_tag "llm_credential[credential_data][api_key]",
+                               @llm_credential.credential_data&.dig("api_key"),
+                               id: "llm_credential_credential_data_api_key",
+                               class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
+                               required: true,
+                               autocomplete: "off",
+                               data: { key: "llm_credentials.credential-data.api_key" } %>
+      </div>
     </div>
 
     <div class="mt-6 flex flex-wrap items-center justify-start gap-4">

--- a/test/models/llm_credential_test.rb
+++ b/test/models/llm_credential_test.rb
@@ -5,7 +5,7 @@ class LlmCredentialTest < ActiveSupport::TestCase
     @user ||= create(:user)
   end
 
-  test "should be valid with a registered provider and a schema-compliant credential_data" do
+  test "should be valid with a registered provider and an api_key" do
     credential = build(:llm_credential, user: user)
     assert credential.valid?, credential.errors.full_messages.inspect
   end
@@ -16,16 +16,16 @@ class LlmCredentialTest < ActiveSupport::TestCase
     assert_includes credential.errors[:provider], "is not included in the list"
   end
 
-  test "should reject credential_data that violates the provider schema" do
-    credential = build(:llm_credential, user: user, credential_data: { "api_key" => "x" })
+  test "should reject a blank api_key" do
+    credential = build(:llm_credential, user: user, credential_data: { "api_key" => "" })
     refute credential.valid?
-    assert credential.errors[:credential_data].any?
+    assert_includes credential.errors[:base], "Enter your API key"
   end
 
   test "should reject missing credential_data" do
     credential = build(:llm_credential, user: user, credential_data: {})
     refute credential.valid?
-    assert credential.errors[:credential_data].any?
+    assert_includes credential.errors[:base], "Enter your API key"
   end
 
   test "should enforce display_name uniqueness per (user, provider)" do

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -37,13 +37,6 @@ class LlmProviderTest < ActiveSupport::TestCase
     assert_nil LlmProvider.find(nil)
   end
 
-  test "#credential_schema should require api_key" do
-    schema = LlmProvider.find("anthropic").credential_schema
-    assert_equal "object", schema["type"]
-    assert_includes schema["required"], "api_key"
-    assert_equal false, schema["additionalProperties"]
-  end
-
   test "instances should be frozen" do
     assert LlmProvider.find("anthropic").frozen?
   end


### PR DESCRIPTION
Changes:

- Remove `credential_schema` from `LlmProvider` and the schema-based validation system. Every provider now authenticates with a single API key; if a provider needs additional fields in the future, they can be added specifically for that provider rather than generalizing back to a schema.
- Replace JSON schema validation in `LlmCredential` with a simple check that `api_key` is present and non-blank.
- Simplify the credential form to a single hardcoded API key field instead of dynamically generating fields from a schema.
- Update error messages to be more user-friendly ("This key didn't work" instead of technical validation errors).
- Remove the `validate` method from `LlmProvider` (it was unused).
- Update tests to reflect the simpler validation logic.
