### PR TITLE
Adjust padding in list item components

### DIFF
--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -12,7 +12,6 @@ class FeedsListComponent < ViewComponent::Base
 
     @feeds.each do |feed|
       component.with_item(ListComponent::FeedItemComponent.new(
-        icon: helpers.feed_status_icon(feed),
         title: display_title_for(feed),
         title_url: helpers.feed_path(feed),
         metadata_segments: metadata_segments_for(feed),

--- a/app/components/list_component/access_token_item_component.html.erb
+++ b/app/components/list_component/access_token_item_component.html.erb
@@ -1,7 +1,4 @@
-<li class="flex items-baseline gap-3 p-4" data-key="<%= @key %>">
-  <span class="inline-flex shrink-0 text-slate-500">
-    <%= status_icon %>
-  </span>
+<li class="flex items-baseline gap-3 px-4 py-3" data-key="<%= @key %>">
   <div class="flex flex-1 flex-col gap-1">
     <div class="inline-flex items-center gap-2 text-base font-semibold text-slate-900">
       <%= link_to @access_token.name, access_token_path(@access_token), class: "transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>

--- a/app/components/list_component/access_token_item_component.rb
+++ b/app/components/list_component/access_token_item_component.rb
@@ -11,19 +11,6 @@ class ListComponent::AccessTokenItemComponent < ViewComponent::Base
 
   private
 
-  def status_icon
-    case @access_token.status
-    when "active"
-      icon("check-circle", css_class: "text-emerald-600", aria_label: "Active")
-    when "inactive"
-      icon("x-circle", css_class: "text-slate-400", aria_label: "Inactive")
-    when "pending", "validating"
-      icon("clock", css_class: "text-slate-400", aria_label: @access_token.status.capitalize)
-    else
-      icon("question-circle", css_class: "text-slate-400", aria_label: "Unknown status")
-    end
-  end
-
   def username_with_host
     raise "AccessToken should be valid at this point" unless @access_token.valid?
 

--- a/app/components/list_component/feed_item_component.rb
+++ b/app/components/list_component/feed_item_component.rb
@@ -1,6 +1,5 @@
 class ListComponent::FeedItemComponent < ViewComponent::Base
   DEFAULT_ITEM_CLASS = "flex items-baseline gap-3 px-4 py-3"
-  ICON_CLASSES = "inline-flex shrink-0 text-slate-500"
   CONTENT_WRAPPER_CLASSES = "flex flex-1 flex-col gap-2"
   TITLE_ROW_CLASSES = "flex flex-wrap items-center gap-2"
   TITLE_CLASSES = "inline-flex items-center text-base font-semibold text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
@@ -8,8 +7,7 @@ class ListComponent::FeedItemComponent < ViewComponent::Base
   BULLET_CLASSES = "text-slate-300"
   ACTIONS_ROW_CLASSES = "flex flex-wrap items-center gap-2 pt-1"
 
-  def initialize(icon:, title:, title_url:, metadata_segments: [], badge: nil, actions: nil, key: nil)
-    @icon = icon
+  def initialize(title:, title_url:, metadata_segments: [], badge: nil, actions: nil, key: nil)
     @title = title
     @title_url = title_url
     @metadata_segments = metadata_segments
@@ -25,10 +23,6 @@ class ListComponent::FeedItemComponent < ViewComponent::Base
   end
 
   private
-
-  def icon_span
-    content_tag(:span, @icon, class: ICON_CLASSES)
-  end
 
   def content_wrapper
     content_tag(:div, class: CONTENT_WRAPPER_CLASSES) do

--- a/app/components/list_component/feed_item_component.rb
+++ b/app/components/list_component/feed_item_component.rb
@@ -1,5 +1,5 @@
 class ListComponent::FeedItemComponent < ViewComponent::Base
-  DEFAULT_ITEM_CLASS = "flex items-baseline gap-3 p-4"
+  DEFAULT_ITEM_CLASS = "flex items-baseline gap-3 px-4 py-3"
   ICON_CLASSES = "inline-flex shrink-0 text-slate-500"
   CONTENT_WRAPPER_CLASSES = "flex flex-1 flex-col gap-2"
   TITLE_ROW_CLASSES = "flex flex-wrap items-center gap-2"
@@ -20,7 +20,7 @@ class ListComponent::FeedItemComponent < ViewComponent::Base
 
   def call
     content_tag :li, class: DEFAULT_ITEM_CLASS, data: { key: @key } do
-      safe_join([icon_span, content_wrapper])
+      content_wrapper
     end
   end
 

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -62,7 +62,6 @@
     <% list = ListComponent.new %>
     <% list.with_item(
          ListComponent::FeedItemComponent.new(
-           icon: icon("rss"),
            title: "Tech News Daily",
            title_url: "#",
            metadata_segments: ["Updated 5 min ago", "142 posts", "Active"]
@@ -70,7 +69,6 @@
        ) %>
     <% list.with_item(
          ListComponent::FeedItemComponent.new(
-           icon: icon("rss"),
            title: "Design Inspiration",
            title_url: "#",
            metadata_segments: ["Updated 1 hour ago", "89 posts", "Active"]
@@ -78,7 +76,6 @@
        ) %>
     <% list.with_item(
          ListComponent::FeedItemComponent.new(
-           icon: icon("rss"),
            title: "Ruby Weekly",
            title_url: "#",
            metadata_segments: ["Updated 2 days ago", "23 posts", "Paused"]

--- a/app/views/development/sent_emails/index.html.erb
+++ b/app/views/development/sent_emails/index.html.erb
@@ -24,7 +24,6 @@
       <% subject = email[:subject].presence || "(no subject)" %>
       <% list.with_item(
            ListComponent::FeedItemComponent.new(
-             icon: icon("envelope"),
              title: subject,
              title_url: development_sent_email_path(id: email[:id]),
              metadata_segments: [

--- a/app/views/llm_credentials/index.html.erb
+++ b/app/views/llm_credentials/index.html.erb
@@ -14,7 +14,7 @@
   <% if @llm_credentials.any? %>
     <ul class="divide-y divide-slate-200 rounded-lg border border-slate-200 bg-white shadow-xs">
       <% @llm_credentials.each do |credential| %>
-        <li class="p-4 flex flex-wrap items-center justify-between gap-3"
+        <li class="px-4 py-3 flex flex-wrap items-center justify-between gap-3"
             data-key="llm_credential.<%= credential.id %>">
           <div class="space-y-1">
             <p class="font-semibold text-slate-800">

--- a/test/components/list_component/access_token_item_component_test.rb
+++ b/test/components/list_component/access_token_item_component_test.rb
@@ -34,33 +34,6 @@ class ListComponent::AccessTokenItemComponentTest < ViewComponent::TestCase
     assert_includes result.text, "Used: 1h"
   end
 
-  test "#render should display active status icon" do
-    access_token = create(:access_token, :active)
-    component = ListComponent::AccessTokenItemComponent.new(access_token: access_token)
-    result = render_inline(component)
-    icon = result.css("i.bi-check-circle").first
-
-    assert_not_nil icon
-  end
-
-  test "#render should display inactive status icon" do
-    access_token = create(:access_token, :inactive)
-    component = ListComponent::AccessTokenItemComponent.new(access_token: access_token)
-    result = render_inline(component)
-    icon = result.css("i.bi-x-circle").first
-
-    assert_not_nil icon
-  end
-
-  test "#render should display pending status icon" do
-    access_token = create(:access_token)
-    component = ListComponent::AccessTokenItemComponent.new(access_token: access_token)
-    result = render_inline(component)
-    icon = result.css("i.bi-clock").first
-
-    assert_not_nil icon
-  end
-
   test "#render should link to access token show page" do
     component = ListComponent::AccessTokenItemComponent.new(access_token: access_token)
     result = render_inline(component)


### PR DESCRIPTION
Changes:

- Changed padding from `p-4` to `px-4 py-3` in `AccessTokenItemComponent` to use separate horizontal and vertical padding values
- Updated `FeedItemComponent` default item class to use `px-4 py-3` instead of `p-4`
- Removed the icon span rendering from `FeedItemComponent#call`, now only rendering the content wrapper
- Applied the same padding adjustment to the LLM credentials list view
