### PR TITLE
Add edit and update actions for LLM credentials

### DIFF
--- a/app/controllers/llm_credentials_controller.rb
+++ b/app/controllers/llm_credentials_controller.rb
@@ -39,11 +39,7 @@ class LlmCredentialsController < ApplicationController
     @llm_credential = find_credential
     authorize @llm_credential
 
-    attrs = { display_name: credential_params[:display_name], state: :pending }
-    new_key = credential_data_from_params["api_key"]
-    attrs[:credential_data] = { "api_key" => new_key } if new_key.present?
-
-    if @llm_credential.update(attrs)
+    if @llm_credential.update(updated_credential_attrs)
       LlmCredentialValidationJob.perform_later(@llm_credential)
       redirect_to llm_credential_path(@llm_credential)
     else
@@ -64,6 +60,13 @@ class LlmCredentialsController < ApplicationController
     return nil if feed_id.blank?
 
     Current.user.feeds.find_by(id: feed_id)
+  end
+
+  def updated_credential_attrs
+    attrs = { display_name: credential_params[:display_name], state: :pending }
+    data = credential_data_from_params
+    attrs[:credential_data] = data if data["api_key"].present?
+    attrs
   end
 
   def build_credential

--- a/app/controllers/llm_credentials_controller.rb
+++ b/app/controllers/llm_credentials_controller.rb
@@ -30,6 +30,27 @@ class LlmCredentialsController < ApplicationController
     end
   end
 
+  def edit
+    @llm_credential = find_credential
+    authorize @llm_credential
+  end
+
+  def update
+    @llm_credential = find_credential
+    authorize @llm_credential
+
+    attrs = { display_name: credential_params[:display_name], state: :pending }
+    new_key = credential_data_from_params["api_key"]
+    attrs[:credential_data] = { "api_key" => new_key } if new_key.present?
+
+    if @llm_credential.update(attrs)
+      LlmCredentialValidationJob.perform_later(@llm_credential)
+      redirect_to llm_credential_path(@llm_credential)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   def destroy
     credential = find_credential
     authorize credential

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -57,6 +57,10 @@
                     method: :patch,
                     class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
     <% end %>
+    <%= link_to "Edit",
+                edit_llm_credential_path(llm_credential),
+                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50",
+                data: { key: "llm_credential.edit" } %>
     <%= button_to "Delete",
                   llm_credential_path(llm_credential),
                   method: :delete,

--- a/app/views/llm_credentials/edit.html.erb
+++ b/app/views/llm_credentials/edit.html.erb
@@ -1,0 +1,55 @@
+<% content_for :title, "Edit AI Credential" %>
+
+<div class="space-y-8" data-key="llm_credentials.edit">
+  <%= render PageHeaderComponent.new(title: "Edit credential") do |header| %>
+    <% header.with_context_paragraph("Update the name or replace the API key. The key will be re-checked after saving.") %>
+  <% end %>
+
+  <div class="max-w-2xl">
+    <%= form_with model: @llm_credential do |f| %>
+      <% if @llm_credential.errors.any? %>
+        <%= render AlertComponent.new(variant: :warning, class: "space-y-2") do %>
+          <ul class="list-disc list-inside text-sm">
+            <% @llm_credential.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+
+      <div class="space-y-6">
+        <div class="space-y-2">
+          <p class="block font-semibold text-slate-800">AI Provider</p>
+          <p class="text-slate-700"><%= LlmProvider.find(@llm_credential.provider)&.display_name %></p>
+        </div>
+
+        <div class="space-y-2">
+          <%= f.label :display_name, "Name", class: "block font-semibold text-slate-800" %>
+          <%= f.text_field :display_name,
+                           placeholder: "Personal Anthropic key",
+                           class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
+                           required: true,
+                           data: { key: "llm_credentials.display-name" } %>
+        </div>
+
+        <div class="space-y-2">
+          <%= label_tag "llm_credential_credential_data_api_key", "API key", class: "block font-semibold text-slate-800" %>
+          <%= password_field_tag "llm_credential[credential_data][api_key]",
+                                 nil,
+                                 id: "llm_credential_credential_data_api_key",
+                                 class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
+                                 autocomplete: "off",
+                                 data: { key: "llm_credentials.credential-data.api_key" } %>
+          <p class="text-slate-500">Leave blank to keep the current key.</p>
+        </div>
+      </div>
+
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4">
+        <%= f.submit "Update Credential",
+                     class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
+                     data: { turbo_submits_with: "Saving..." } %>
+        <%= link_to "Cancel", llm_credential_path(@llm_credential), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :llm_credentials, except: [:edit, :update] do
+  resources :llm_credentials do
     scope module: :llm_credentials do
       resource :validation, only: :show
       resource :default, only: :update

--- a/test/controllers/llm_credentials_controller_test.rb
+++ b/test/controllers/llm_credentials_controller_test.rb
@@ -240,6 +240,102 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Continue setting up your feed", count: 0
   end
 
+  test "#edit should render the form" do
+    sign_in_as(user)
+    get edit_llm_credential_url(credential)
+    assert_response :success
+    assert_select "[data-key='llm_credentials.edit']"
+    assert_select "[data-key='llm_credentials.display-name']"
+    assert_select "[data-key='llm_credentials.credential-data.api_key']"
+  end
+
+  test "#edit should 404 for another user's credential" do
+    sign_in_as(user)
+    other = create(:llm_credential, user: other_user)
+    get edit_llm_credential_url(other)
+    assert_response :not_found
+  end
+
+  test "#update should update display_name, reset to pending, and re-enqueue validation" do
+    sign_in_as(user)
+    active = create(:llm_credential, :active, user: user)
+
+    assert_enqueued_with(job: LlmCredentialValidationJob) do
+      patch llm_credential_url(active), params: {
+        llm_credential: {
+          display_name: "Renamed Key",
+          credential_data: { api_key: "" }
+        }
+      }
+    end
+
+    active.reload
+    assert_redirected_to llm_credential_path(active)
+    assert_equal "Renamed Key", active.display_name
+    assert_equal "pending", active.state
+  end
+
+  test "#update should replace credential_data when a new api_key is provided" do
+    sign_in_as(user)
+    active = create(:llm_credential, :active, user: user)
+    new_key = "sk-ant-#{SecureRandom.hex(16)}"
+
+    patch llm_credential_url(active), params: {
+      llm_credential: {
+        display_name: active.display_name,
+        credential_data: { api_key: new_key }
+      }
+    }
+
+    active.reload
+    assert_equal new_key, active.credential_data["api_key"]
+  end
+
+  test "#update should keep existing credential_data when api_key is blank" do
+    sign_in_as(user)
+    active = create(:llm_credential, :active, user: user)
+    original_key = active.credential_data["api_key"]
+
+    patch llm_credential_url(active), params: {
+      llm_credential: {
+        display_name: active.display_name,
+        credential_data: { api_key: "" }
+      }
+    }
+
+    active.reload
+    assert_equal original_key, active.credential_data["api_key"]
+  end
+
+  test "#update should render :edit with errors on invalid input" do
+    sign_in_as(user)
+    get edit_llm_credential_url(credential)
+
+    patch llm_credential_url(credential), params: {
+      llm_credential: {
+        display_name: "",
+        credential_data: { api_key: "" }
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "[data-key='llm_credentials.edit']"
+  end
+
+  test "#update should 404 for another user's credential" do
+    sign_in_as(user)
+    other = create(:llm_credential, user: other_user)
+
+    patch llm_credential_url(other), params: {
+      llm_credential: {
+        display_name: "Hacked",
+        credential_data: { api_key: "" }
+      }
+    }
+
+    assert_response :not_found
+  end
+
   test "#destroy should delete own credential" do
     sign_in_as(user)
     credential


### PR DESCRIPTION
Changes:

- Add `edit` and `update` actions to `LlmCredentialsController` to allow users to modify credential display names and API keys
- Update credential state to `pending` and re-enqueue validation job when credentials are updated
- Preserve existing API key when the key field is left blank during update
- Add "Edit" button to credential detail view
