### PR TITLE
Improve invite summary messaging and pluralization

### DIFF
--- a/app/views/invites/_summary.html.erb
+++ b/app/views/invites/_summary.html.erb
@@ -1,6 +1,14 @@
 <%# locals: (remaining_invites_count:, invited_users_count:, unused_invites_count:) %>
 <p class="text-slate-600">
-  You can send <strong><%= remaining_invites_count %></strong> more invites.
-  <% verb = invited_users_count.to_i == 1 ? "has" : "have" %>
-  <%= pluralize(invited_users_count, "user") %> <%= verb %> joined so far.
+  <% if remaining_invites_count.to_i > 0 %>
+    You can send <strong><%= remaining_invites_count %></strong> more <%= "invite".pluralize(remaining_invites_count) %>.
+  <% else %>
+    No invites left to send.
+  <% end %>
+  <% if invited_users_count.to_i > 0 %>
+    <% verb = invited_users_count.to_i == 1 ? "has" : "have" %>
+    <%= pluralize(invited_users_count, "person") %> <%= verb %> joined so far.
+  <% else %>
+    Nobody's joined yet.
+  <% end %>
 </p>


### PR DESCRIPTION
Changes:

- Add conditional messaging for remaining invites count (show "No invites left to send" when zero)
- Fix pluralization of "invite" to match the count dynamically
- Add conditional messaging for joined users count (show "Nobody's joined yet" when zero)
