### PR TITLE
Replace admin panel heading with PageHeaderComponent

### DIFF
--- a/app/components/page_header_component.html.erb
+++ b/app/components/page_header_component.html.erb
@@ -1,6 +1,9 @@
 <header class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
   <div class="flex flex-col gap-5">
-    <h1 class="text-4xl font-semibold mb-0 text-slate-900"><%= @title %></h1>
+    <h1 class="<%= class_names("text-4xl font-semibold mb-0 text-slate-900", "flex items-center gap-3" => title_icon?) %>">
+      <%= title_icon if title_icon? %>
+      <%= @title %>
+    </h1>
     <% if context_paragraphs? %>
       <% context_paragraphs.each do |paragraph| %>
         <p class="text-slate-600"><%= paragraph %></p>

--- a/app/components/page_header_component.rb
+++ b/app/components/page_header_component.rb
@@ -1,4 +1,6 @@
 class PageHeaderComponent < ViewComponent::Base
+  renders_one :title_icon
+
   renders_many :context_paragraphs, ->(content = nil, &block) do
     content || block.call
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,30 @@ module ApplicationHelper
     truncate(content.strip, length: length)
   end
 
+  LUCIDE_ICONS = {
+    "play"  => '<polygon points="6 3 20 12 6 21 6 3"/>',
+    "pause" => '<rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>'
+  }.freeze
+
+  def lucide_icon(name, css_class: nil)
+    path_data = LUCIDE_ICONS[name]
+    return "".html_safe unless path_data
+
+    content_tag(
+      :svg,
+      path_data.html_safe,
+      xmlns: "http://www.w3.org/2000/svg",
+      viewBox: "0 0 24 24",
+      fill: "none",
+      stroke: "currentColor",
+      "stroke-width": "2",
+      "stroke-linecap": "round",
+      "stroke-linejoin": "round",
+      "aria-hidden": "true",
+      class: class_names("size-9 shrink-0", css_class)
+    )
+  end
+
   def icon(name, css_class: nil, title: nil, aria_hidden: nil, aria_label: nil)
     options = {
       class: class_names("bi", "bi-#{name}", "inline-block", css_class)

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Admin Panel" %>
 
 <div class="space-y-8">
-  <h1 class="text-4xl font-semibold mb-0 text-slate-900">Admin Panel</h1>
+  <%= render PageHeaderComponent.new(title: "Admin Panel") %>
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
     <%= render CardComponent.new(href: admin_users_path) do %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -2,6 +2,11 @@
 
 <div class="space-y-10">
   <%= render PageHeaderComponent.new(title: @feed.name) do |header| %>
+    <% if @feed.enabled? %>
+      <% header.with_title_icon { lucide_icon("play", css_class: "text-green-600") } %>
+    <% else %>
+      <% header.with_title_icon { lucide_icon("pause", css_class: "text-slate-400") } %>
+    <% end %>
     <% if (status_summary = feed_status_summary(@feed)).present? %>
       <% header.with_context_paragraph(status_summary) %>
     <% end %>
@@ -24,6 +29,7 @@
                       feed_status_path(@feed),
                       method: :patch,
                       params: { status: "enabled" },
+                      data: { turbo_confirm: "Enable this feed?" },
                       class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
                       form: { class: "inline-block" } %>
       <% end %>


### PR DESCRIPTION
Changes:

- Replace hardcoded heading markup on admin panel with `PageHeaderComponent` for consistent styling and maintainability
