### PR TITLE
Fix feed preview rendering

### DIFF
--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -98,7 +98,7 @@ class FeedPreviewsController < ApplicationController
       # Swap only the inner body so the polling host (rendered by `show`) stays
       # mounted across polls; ready/failed bodies carry `data-preview-done`,
       # which trips the poller's stop-condition.
-      format.turbo_stream { render turbo_stream: turbo_stream.update("feed-preview-body", state_partial(preview)) }
+      format.turbo_stream { render turbo_stream: turbo_stream.update("feed-preview-body", **state_partial(preview)) }
     end
   end
 


### PR DESCRIPTION
Changes:

- Fix argument unpacking in `turbo_stream.update()` call to properly pass the partial rendering result as keyword arguments
