### PR TITLE
Refactor empty state and improve feed target links

### DIFF
--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -70,6 +70,7 @@ class FeedsListComponent < ViewComponent::Base
     return "Target: #{target}" if target == "None" || !feed.access_token
 
     url = "#{feed.access_token.host}/#{feed.target_group}"
-    safe_join(["Target:", helpers.link_to(target, url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")], " ")
+    link_content = safe_join([target, " ".html_safe, helpers.lucide_icon("external-link", size: "size-3.5", css_class: "inline align-text-bottom")])
+    safe_join(["Target:", helpers.link_to(link_content, url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")], " ")
   end
 end

--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -35,7 +35,7 @@ class FeedsListComponent < ViewComponent::Base
   def badge_for(feed)
     return nil unless feed.draft?
 
-    render(BadgeComponent.new(text: "Draft", color: :yellow, key: "feed.#{feed.id}.draft_badge"))
+    render(BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge"))
   end
 
   # FR-023: drafts surface inline "Continue setup" and "Discard" affordances so

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,11 +16,12 @@ module ApplicationHelper
   end
 
   LUCIDE_ICONS = {
-    "play"  => '<polygon points="6 3 20 12 6 21 6 3"/>',
-    "pause" => '<rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>'
+    "play"          => '<polygon points="6 3 20 12 6 21 6 3"/>',
+    "pause"         => '<rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>',
+    "external-link" => '<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>'
   }.freeze
 
-  def lucide_icon(name, css_class: nil)
+  def lucide_icon(name, css_class: nil, size: "size-9")
     path_data = LUCIDE_ICONS[name]
     return "".html_safe unless path_data
 
@@ -35,7 +36,7 @@ module ApplicationHelper
       "stroke-linecap": "round",
       "stroke-linejoin": "round",
       "aria-hidden": "true",
-      class: class_names("size-9 shrink-0", css_class)
+      class: class_names(size, "shrink-0", css_class)
     )
   end
 

--- a/app/views/feeds/_empty_state.html.erb
+++ b/app/views/feeds/_empty_state.html.erb
@@ -1,7 +1,1 @@
-<div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-6 py-12 text-center text-slate-600">
-  <h2 class="text-2xl font-semibold text-slate-900">You don't have any feeds yet</h2>
-  <p class="mt-2 text-sm text-slate-600">Create your first feed to start refreshing posts and sharing them with your audience.</p>
-  <div class="mt-6">
-    <%= link_to "Create your first feed", new_feed_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
-  </div>
-</div>
+<%= render EmptyStateComponent.new("No feeds yet") %>


### PR DESCRIPTION
Changes:

- Replace inline empty state markup in feeds view with reusable `EmptyStateComponent`
- Add `external-link` icon to Lucide icon set for use in external links
- Make `lucide_icon` helper size customizable via new `size` parameter (defaults to "size-9")
- Update feed target links to display with external-link icon indicator
- Change draft badge color from yellow to gray for better visual hierarchy
- Improve code formatting and alignment in icon definitions
