### PR TITLE
Improve feed input label and placeholder text

### DIFF
--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -17,8 +17,8 @@
 
   <%= form_with url: feed_identifications_path, method: :post, class: "space-y-6" do |f| %>
     <div class="space-y-2">
-      <%= f.label :input, "Feed URL", class: "block font-semibold text-slate-800" %>
-      <%= f.text_field :input, value: input, placeholder: "https://example.com/feed.xml", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
+      <%= f.label :input, "What do you want to follow?", class: "block font-semibold text-slate-800" %>
+      <%= f.text_field :input, value: input, placeholder: "Paste a URL or describe what to follow", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
     </div>
 
     <div>


### PR DESCRIPTION
Changes:

- Update input label in the feed form to match it's purpose
- Update placeholder text from "https://example.com/feed.xml" to "Paste a URL or describe what to follow" to better guide users on what input is expected
