### PR TITLE
Add edit and update actions for access tokens

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -35,6 +35,27 @@ class AccessTokensController < ApplicationController
     end
   end
 
+  def edit
+    @access_token = find_access_token
+    authorize @access_token
+  end
+
+  def update
+    @access_token = find_access_token
+    authorize @access_token
+
+    new_token = params.dig(:access_token, :token).presence
+    attrs = { name: params.dig(:access_token, :name) }
+    attrs[:encrypted_token] = new_token if new_token
+
+    if @access_token.update(attrs)
+      @access_token.validate_token_async if new_token
+      redirect_to access_token_path(@access_token), notice: "Changes saved."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   def destroy
     access_token = find_access_token
     authorize access_token

--- a/app/policies/access_token_policy.rb
+++ b/app/policies/access_token_policy.rb
@@ -11,6 +11,10 @@ class AccessTokenPolicy < ApplicationPolicy
     authenticated?
   end
 
+  def update?
+    owner_or_admin?
+  end
+
   def destroy?
     owner_or_admin?
   end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -12,6 +12,10 @@
     <% end %>
 
     <% header.with_action_button do %>
+      <%= link_to "Edit", edit_access_token_path(access_token), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
+    <% end %>
+
+    <% header.with_action_button do %>
       <%= link_to "Delete",
                   "#",
                   class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),

--- a/app/views/access_tokens/edit.html.erb
+++ b/app/views/access_tokens/edit.html.erb
@@ -3,9 +3,43 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Edit Access Token") %>
 
-  <%= render CardComponent.new do %>
-    <div class="space-y-6">
-      <p class="text-slate-600">Access token editing form coming soon...</p>
-    </div>
-  <% end %>
+  <div class="max-w-2xl">
+    <%= form_with model: @access_token do |form| %>
+      <div class="space-y-10">
+        <div class="space-y-2">
+          <%= form.label :name, "Token Name", class: "block font-semibold text-slate-800" %>
+          <%= form.text_field :name,
+                              class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                              placeholder: "e.g., My FreeFeed Token",
+                              autocomplete: "off",
+                              autofocus: true %>
+          <% if @access_token.errors[:name].any? %>
+            <p class="mt-2 text-sm text-red-600"><%= @access_token.errors[:name].first %></p>
+          <% end %>
+        </div>
+
+        <div class="space-y-2">
+          <p class="block font-semibold text-slate-800">FreeFeed Instance</p>
+          <p class="text-slate-600"><%= @access_token.host %></p>
+        </div>
+
+        <div class="space-y-2">
+          <%= form.label :token, "New Token Value", class: "block font-semibold text-slate-800" %>
+          <%= form.text_field :token,
+                              class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                              placeholder: "Paste a new token here to replace the current one",
+                              autocomplete: "off" %>
+          <p class="text-slate-500">Leave blank to keep the existing token. Entering a new value will trigger re-validation.</p>
+          <% if @access_token.errors[:token].any? %>
+            <p class="mt-2 text-sm text-red-600"><%= @access_token.errors[:token].first %></p>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">
+        <%= form.submit "Save Changes", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+        <%= link_to "Cancel", access_token_path(@access_token), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
     resources :email_confirmations, only: :show, param: :token
   end
 
-  resources :access_tokens, except: [:edit, :update] do
+  resources :access_tokens do
     scope module: :access_tokens do
       resource :validation, only: :show
       resources :groups, only: :index

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -279,6 +279,76 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
+  test "#edit should require authentication" do
+    get edit_access_token_path(access_token)
+    assert_redirected_to new_session_path
+  end
+
+  test "#edit should render for own token" do
+    sign_in_as user
+    get edit_access_token_path(access_token)
+
+    assert_response :success
+    assert_select "h1", "Edit Access Token"
+  end
+
+  test "#edit should not render for other user's token" do
+    other_token = create(:access_token, user: create(:user))
+    sign_in_as user
+    get edit_access_token_path(other_token)
+
+    assert_response :not_found
+  end
+
+  test "#update should require authentication" do
+    patch access_token_path(access_token), params: { access_token: { name: "New Name" } }
+    assert_redirected_to new_session_path
+  end
+
+  test "#update should update name" do
+    sign_in_as user
+    patch access_token_path(access_token), params: { access_token: { name: "Updated Name" } }
+
+    assert_redirected_to access_token_path(access_token)
+    assert_equal "Updated Name", access_token.reload.name
+    assert_equal "Changes saved.", flash[:notice]
+  end
+
+  test "#update should not re-validate when only name changes" do
+    sign_in_as user
+    assert_no_enqueued_jobs do
+      patch access_token_path(access_token), params: { access_token: { name: "Updated Name" } }
+    end
+  end
+
+  test "#update should update encrypted token and re-validate when new token provided" do
+    sign_in_as user
+    assert_enqueued_jobs 1, only: TokenValidationJob do
+      patch access_token_path(access_token), params: {
+        access_token: { name: access_token.name, token: "new_token_value" }
+      }
+    end
+
+    assert_redirected_to access_token_path(access_token)
+  end
+
+  test "#update should render edit on validation error" do
+    sign_in_as user
+    other = create(:access_token, name: "Taken Name", user: user)
+    patch access_token_path(access_token), params: { access_token: { name: other.name } }
+
+    assert_response :unprocessable_entity
+    assert_select "h1", "Edit Access Token"
+  end
+
+  test "#update should not update other user's token" do
+    other_token = create(:access_token, user: create(:user))
+    sign_in_as user
+    patch access_token_path(other_token), params: { access_token: { name: "Hacked" } }
+
+    assert_response :not_found
+  end
+
   test "requires authentication for destroy" do
     delete access_token_path(access_token)
 

--- a/test/policies/access_token_policy_test.rb
+++ b/test/policies/access_token_policy_test.rb
@@ -64,6 +64,26 @@ class AccessTokenPolicyTest < ActiveSupport::TestCase
     assert_not policy.create?
   end
 
+  test "should allow update access to token owner" do
+    policy = policy_for_user(user, access_token)
+    assert policy.update?
+  end
+
+  test "should deny update access to other users" do
+    policy = policy_for_user(user, other_access_token)
+    assert_not policy.update?
+  end
+
+  test "should allow update access to admin users" do
+    policy = policy_for_user(admin_user, access_token)
+    assert policy.update?
+  end
+
+  test "edit? should delegate to update?" do
+    policy = policy_for_user(user, access_token)
+    assert_equal policy.update?, policy.edit?
+  end
+
   test "should allow destroy access to token owner" do
     policy = policy_for_user(user, access_token)
     assert policy.destroy?


### PR DESCRIPTION
Changes:

- Add `edit` and `update` actions to AccessTokensController with authorization checks
- Implement edit view with form to update token name and optionally replace the token value
- Add `update?` policy method to AccessTokenPolicy (delegates to `owner_or_admin?`)
- Add `edit?` policy method that delegates to `update?`
- Trigger token re-validation job only when a new token value is provided
- Add "Edit" button to access token detail view
- Enable `:edit` and `:update` routes in config/routes.rb
