### PR TITLE
Add AI usage stats component to feed show page

### DIFF
--- a/app/components/feed_llm_stats_component.rb
+++ b/app/components/feed_llm_stats_component.rb
@@ -1,0 +1,76 @@
+class FeedLlmStatsComponent < ViewComponent::Base
+  def initialize(feed:)
+    @feed = feed
+  end
+
+  def call
+    tag.div { safe_join([mobile_layout, desktop_layout]) }
+  end
+
+  private
+
+  def mobile_layout
+    render(mobile_list_component)
+  end
+
+  def desktop_layout
+    render(desktop_bar_component)
+  end
+
+  def layout_items
+    @layout_items ||= [
+      {
+        key: "ai_calls",
+        label: "AI calls",
+        label_short: "AI calls",
+        value: helpers.number_with_delimiter(call_count)
+      },
+      {
+        key: "estimated_spend",
+        label: "Estimated spend",
+        label_short: "Spend",
+        value: formatted_cost
+      }
+    ]
+  end
+
+  def mobile_list_component
+    DescriptionListComponent.new(css_class: class_names("md:hidden", DescriptionListComponent::DEFAULT_CSS_CLASSES)).tap do |list|
+      layout_items.each { |item| list.with_item(mobile_stat_cell(item)) }
+    end
+  end
+
+  def desktop_bar_component
+    StatsBarComponent.new(css_class: class_names("hidden", StatsBarComponent::DEFAULT_CSS_CLASSES)).tap do |bar|
+      layout_items.each { |item| bar.with_item(desktop_stat_cell(item)) }
+    end
+  end
+
+  def mobile_stat_cell(item)
+    ListComponent::StatItemComponent.new(
+      label: item[:label],
+      value: item[:value],
+      key: "llm_stats.#{item[:key]}"
+    )
+  end
+
+  def desktop_stat_cell(item)
+    StatsBarComponent::StatItemComponent.new(
+      label: item[:label_short],
+      value: item[:value],
+      key: "llm_stats.#{item[:key]}"
+    )
+  end
+
+  def call_count
+    @call_count ||= @feed.llm_usages.count
+  end
+
+  def total_cost_cents
+    @total_cost_cents ||= @feed.llm_usages.sum(:cost_estimate_cents)
+  end
+
+  def formatted_cost
+    helpers.number_to_currency(total_cost_cents / 100.0)
+  end
+end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -72,6 +72,7 @@ class FeedsController < ApplicationController
     @feed = load_feed
     authorize @feed
     @recent_posts = recent_posts(@feed)
+    @has_llm_usages = @feed.llm_usages.exists?
   end
 
   def edit

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -39,6 +39,7 @@ class Feed < ApplicationRecord
   has_many :events, as: :subject, dependent: :destroy
   has_many :feed_entries, dependent: :destroy
   has_many :feed_metrics, dependent: :destroy
+  has_many :llm_usages, dependent: :destroy
   has_many :posts, dependent: :destroy
 
   enum :state, { draft: 0, disabled: 1, enabled: 2 }, default: :draft

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -47,6 +47,13 @@
     </section>
   <% end %>
 
+  <% if @has_llm_usages %>
+    <section class="space-y-4">
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">AI usage</h2>
+      <%= render FeedLlmStatsComponent.new(feed: @feed) %>
+    </section>
+  <% end %>
+
   <section class="space-y-4">
     <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
       <h2 class="text-2xl font-semibold mb-0 text-slate-900">Recent posts</h2>

--- a/test/components/feed_llm_stats_component_test.rb
+++ b/test/components/feed_llm_stats_component_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+require "view_component/test_case"
+
+class FeedLlmStatsComponentTest < ViewComponent::TestCase
+  def feed
+    @feed ||= create(:feed)
+  end
+
+  def feed_with_usages
+    @feed_with_usages ||= create(:feed).tap do |f|
+      create(:llm_usage, feed: f, user: f.user, cost_estimate_cents: 25, input_tokens: 10_000, output_tokens: 5_000)
+      create(:llm_usage, feed: f, user: f.user, cost_estimate_cents: 15, input_tokens: 8_000, output_tokens: 2_000)
+    end
+  end
+
+  test "#render should display AI call count" do
+    result = render_inline(FeedLlmStatsComponent.new(feed: feed_with_usages))
+
+    value = result.css('[data-key="llm_stats.ai_calls.value"]').first
+    assert_not_nil value
+    assert_equal "2", value.text.strip
+  end
+
+  test "#render should display estimated spend" do
+    result = render_inline(FeedLlmStatsComponent.new(feed: feed_with_usages))
+
+    value = result.css('[data-key="llm_stats.estimated_spend.value"]').first
+    assert_not_nil value
+    assert_equal "$0.40", value.text.strip
+  end
+
+  test "#render should include mobile layout with full labels" do
+    result = render_inline(FeedLlmStatsComponent.new(feed: feed))
+
+    assert_not_nil result.css(".md\\:hidden").first
+    assert_equal "AI calls", result.css(".md\\:hidden [data-key=\"llm_stats.ai_calls.label\"]").first.text
+    assert_equal "Estimated spend", result.css(".md\\:hidden [data-key=\"llm_stats.estimated_spend.label\"]").first.text
+  end
+
+  test "#render should include desktop layout with short labels" do
+    result = render_inline(FeedLlmStatsComponent.new(feed: feed))
+
+    assert_not_nil result.css(".hidden.md\\:flex").first
+    assert_equal "AI calls", result.css(".hidden.md\\:flex [data-key=\"llm_stats.ai_calls.label\"]").first.text
+    assert_equal "Spend", result.css(".hidden.md\\:flex [data-key=\"llm_stats.estimated_spend.label\"]").first.text
+  end
+
+  test "#render should show zero when no usages" do
+    result = render_inline(FeedLlmStatsComponent.new(feed: feed))
+
+    calls_value = result.css('[data-key="llm_stats.ai_calls.value"]').first.text.strip
+    assert_equal "0", calls_value
+
+    spend_value = result.css('[data-key="llm_stats.estimated_spend.value"]').first.text.strip
+    assert_equal "$0.00", spend_value
+  end
+end


### PR DESCRIPTION
Changes:

- Add `FeedLlmStatsComponent` to display AI call count and estimated spend for a feed
- Component renders responsive layouts: mobile list view with full labels, desktop bar view with abbreviated labels
- Update `feeds#show` to conditionally render the AI usage section when LLM usages exist
- Add `has_many :llm_usages` association to Feed model
