### PR TITLE
Allow creating feeds with blank names as drafts

### DIFF
--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -43,7 +43,7 @@ class EventDescriptionComponent < ViewComponent::Base
   def subject_link
     case event.subject
     when Feed
-      helpers.link_to(event.subject.name, helpers.feed_path(event.subject), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
+      helpers.link_to(event.subject.display_name, helpers.feed_path(event.subject), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     when AccessToken
       helpers.link_to(event.subject.name, helpers.access_tokens_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     when Post
@@ -70,7 +70,7 @@ class EventDescriptionComponent < ViewComponent::Base
     return "" if disabled_feed_ids.blank?
 
     links = disabled_feeds.map do |feed|
-      helpers.link_to(feed.name, helpers.feed_path(feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
+      helpers.link_to(feed.display_name, helpers.feed_path(feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     end
 
     linked_feeds = helpers.safe_join(links, ", ")

--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -25,11 +25,8 @@ class FeedsListComponent < ViewComponent::Base
 
   private
 
-  # FR-022a: drafts may have a blank name (operational fields are optional
-  # until promotion). Fall back to the user's typed input, then to a
-  # generic label, so the row always has a clickable title.
   def display_title_for(feed)
-    feed.name.presence || feed.source_input.presence || "Untitled draft"
+    feed.display_name
   end
 
   def badge_for(feed)

--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -23,7 +23,7 @@ class PostDetailsComponent < ViewComponent::Base
   def add_feed_item(component)
     component.with_item(ListComponent::StatItemComponent.new(
       label: "Feed",
-      value: helpers.link_to(@post.feed.name, @post.feed, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500"),
+      value: helpers.link_to(@post.feed.display_name, @post.feed, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500"),
       key: "post.feed"
     ))
   end

--- a/app/components/posts_list_component.rb
+++ b/app/components/posts_list_component.rb
@@ -50,7 +50,7 @@ class PostsListComponent < ViewComponent::Base
     return unless show_feed
     return unless post.feed.present?
 
-    helpers.link_to(post.feed.name, helpers.feed_path(post.feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
+    helpers.link_to(post.feed.display_name, helpers.feed_path(post.feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
   end
 
   def self.published_segment(post:, helpers:)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -132,7 +132,7 @@ class Feed < ApplicationRecord
   end
 
   def display_name
-    name.presence || source_input.presence || "Untitled feed"
+    name.presence || "Untitled feed"
   end
 
   def feed_profile_present?

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -131,6 +131,10 @@ class Feed < ApplicationRecord
     (FeedProfile[feed_profile_key]&.dig(:input_shape) || :url).to_s
   end
 
+  def display_name
+    name.presence || source_input.presence || "Untitled feed"
+  end
+
   def feed_profile_present?
     feed_profile_key.present? && FeedProfile.exists?(feed_profile_key)
   end

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -67,7 +67,6 @@
                          placeholder: "Enter a name for this feed",
                          maxlength: Feed::NAME_MAX_LENGTH,
                          class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
-                         required: true,
                          data: { key: "form.name" } %>
         <% if feed.name.present? %>
           <p class="text-slate-500">You can edit this name if you'd like.</p>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, @feed.name %>
+<% content_for :title, @feed.display_name %>
 
 <div class="space-y-10">
-  <%= render PageHeaderComponent.new(title: @feed.name) do |header| %>
+  <%= render PageHeaderComponent.new(title: @feed.display_name) do |header| %>
     <% if @feed.enabled? %>
       <% header.with_title_icon { lucide_icon("play", css_class: "text-green-600") } %>
     <% else %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
-<% page_title = @feed ? "#{@feed.name} posts" : "Posts" %>
+<% page_title = @feed ? "#{@feed.display_name} posts" : "Posts" %>
 <% content_for :title, page_title %>
 
 <div class="space-y-8">

--- a/test/components/feeds_list_component_test.rb
+++ b/test/components/feeds_list_component_test.rb
@@ -28,7 +28,7 @@ class FeedsListComponentTest < ViewComponent::TestCase
     assert_match "https://example.com/draft-feed.xml", result.text
   end
 
-  test "#call renders 'Untitled draft' when both name and source_input are blank" do
+  test "#call renders 'Untitled feed' when name is blank" do
     feed = build(
       :feed,
       :draft,
@@ -41,7 +41,7 @@ class FeedsListComponentTest < ViewComponent::TestCase
 
     result = render_inline(FeedsListComponent.new(feeds: [feed]))
 
-    assert_match "Untitled draft", result.text
+    assert_match "Untitled feed", result.text
   end
 
   test "#call renders draft badge for draft feeds" do

--- a/test/components/feeds_list_component_test.rb
+++ b/test/components/feeds_list_component_test.rb
@@ -13,7 +13,7 @@ class FeedsListComponentTest < ViewComponent::TestCase
     assert_match "My Feed", result.text
   end
 
-  test "#call renders draft feed with source_input as title when name is blank" do
+  test "#call renders 'Untitled feed' as title when name is blank" do
     feed = create(
       :feed,
       :draft,
@@ -25,7 +25,7 @@ class FeedsListComponentTest < ViewComponent::TestCase
 
     result = render_inline(FeedsListComponent.new(feeds: [feed]))
 
-    assert_match "https://example.com/draft-feed.xml", result.text
+    assert_match "Untitled feed", result.text
   end
 
   test "#call renders 'Untitled feed' when name is blank" do

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -109,7 +109,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
 
     feed = Feed.last
     assert_predicate feed, :draft?
-    assert_nil feed.name
+    assert_predicate feed.name, :blank?
     assert_redirected_to feed_path(feed)
   end
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -90,6 +90,29 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_match "successfully created and is now active", flash[:notice]
   end
 
+  test "#create should save as draft with blank name" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: { feed: feed_params, enable_feed: "0" }
+    end
+
+    feed = Feed.last
+    assert_predicate feed, :draft?
+    assert_nil feed.name
+    assert_redirected_to feed_path(feed)
+  end
+
   test "#create should save as draft when checkbox unchecked" do
     sign_in_as(user)
     access_token

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -43,13 +43,8 @@ class FeedTest < ActiveSupport::TestCase
     assert_equal "My Feed", feed.display_name
   end
 
-  test "#display_name should fall back to source_input when name is blank" do
-    feed = build(:feed, name: nil, params: { "url" => "https://example.com/feed.xml" })
-    assert_equal "https://example.com/feed.xml", feed.display_name
-  end
-
-  test "#display_name should return placeholder when name and source_input are both blank" do
-    feed = build(:feed, name: nil, params: {})
+  test "#display_name should return placeholder when name is blank" do
+    feed = build(:feed, name: nil)
     assert_equal "Untitled feed", feed.display_name
   end
 

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -38,6 +38,21 @@ class FeedTest < ActiveSupport::TestCase
     assert feed.errors.of_kind?(:name, :taken)
   end
 
+  test "#display_name should return name when present" do
+    feed = build(:feed, name: "My Feed")
+    assert_equal "My Feed", feed.display_name
+  end
+
+  test "#display_name should fall back to source_input when name is blank" do
+    feed = build(:feed, name: nil, params: { "url" => "https://example.com/feed.xml" })
+    assert_equal "https://example.com/feed.xml", feed.display_name
+  end
+
+  test "#display_name should return placeholder when name and source_input are both blank" do
+    feed = build(:feed, name: nil, params: {})
+    assert_equal "Untitled feed", feed.display_name
+  end
+
   test "should default params to empty hash for new records" do
     feed = Feed.new
     assert_equal({}, feed.params)


### PR DESCRIPTION
Changes:

- Remove `required: true` attribute from feed name input field to allow blank names
- Add test case verifying feeds can be created as drafts with blank names

This enables users to create feed drafts without providing a name upfront, allowing them to fill in the name later during editing. The feed is saved with a `nil` name when the name field is left blank and the feed is created as a draft.
