### PR TITLE
Add disabled state styling to form inputs

### DIFF
--- a/app/views/feeds/_target_group_selector.html.erb
+++ b/app/views/feeds/_target_group_selector.html.erb
@@ -5,7 +5,7 @@
     <% if groups.present? %>
       <%= select_tag "feed[target_group]",
                      options_for_select(groups.sort, feed.target_group),
-                     class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                     class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
                      required: true %>
       <p class="text-slate-500">
         The FreeFeed group where posts will be published. Groups are like channels or communities.
@@ -13,7 +13,7 @@
     <% else %>
       <%= select_tag "feed[target_group]",
                      options_for_select([[feed.target_group.presence || "Select a group", ""]]),
-                     class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                     class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
                      disabled: true %>
       <p class="text-sm text-red-600">
         <% if token.nil? %>

--- a/app/views/settings/email_updates/edit.html.erb
+++ b/app/views/settings/email_updates/edit.html.erb
@@ -19,7 +19,7 @@
       <div class="space-y-10">
         <div class="space-y-2">
           <%= form.label :current_email, "Current email", class: "block font-semibold text-slate-800" %>
-          <%= form.text_field :current_email, value: @user.email_address, disabled: true, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 bg-slate-100" %>
+          <%= form.text_field :current_email, value: @user.email_address, disabled: true, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed" %>
         </div>
 
         <div class="space-y-2">


### PR DESCRIPTION
Changes:

- Add comprehensive disabled state styling (`disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed`) to the target group selector in the feeds view
- Apply the same disabled state styling to the current email field in the email settings form, replacing the hardcoded `bg-slate-100` class with the full disabled state utility classes for consistency

These changes ensure disabled form inputs have a consistent, accessible appearance across the application with proper visual feedback (grayed background, muted text, lighter border, and not-allowed cursor).
