### PR TITLE
Observability improvements and query-feed fix

### DIFF
--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -14,7 +14,7 @@ module FeedHelper
 
   def feed_missing_enablement_parts(feed)
     missing_parts = []
-    missing_parts << "URL" unless feed.url.present?
+    missing_parts << "source" unless feed.source_input.present?
     missing_parts << "feed profile" unless feed.feed_profile_present?
     missing_parts << "active access token" unless feed.access_token&.active?
     missing_parts << "target group" unless feed.target_group.present?

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -19,6 +19,7 @@ class LlmClient
   end
 
   ProviderResponse = Data.define(:payload, :input_tokens, :output_tokens, :cache_write_tokens, :cache_read_tokens)
+  CallContext = Data.define(:feed, :profile_key, :stage, :purpose, :model)
 
   class << self
     def for(target, provider = nil)
@@ -57,17 +58,18 @@ class LlmClient
   def call(feed:, profile_key:, stage:, model:, prompt:, output_schema:, tools: [], purpose: :scheduled_run)
     raise DetectionForbidden if Thread.current[:llm_detection_phase]
 
+    ctx = CallContext.new(feed: feed, profile_key: profile_key, stage: stage, purpose: purpose, model: model)
     started_at = Time.current
 
     begin
       response = invoke_provider(model: model, prompt: prompt, output_schema: output_schema, tools: tools)
     rescue RubyLLM::RateLimitError => e
-      record_failure(feed, profile_key, stage, purpose, model, :rate_limited, started_at, error_message: e.message)
+      write_usage(ctx, outcome: :rate_limited, started_at: started_at, error_message: e.message)
       raised = RateLimited.new(e.message)
       raised.retry_after = e.try(:retry_after)
       raise raised
     rescue Net::ReadTimeout, Net::OpenTimeout, Faraday::TimeoutError => e
-      record_failure(feed, profile_key, stage, purpose, model, :timeout, started_at, error_message: e.message)
+      write_usage(ctx, outcome: :timeout, started_at: started_at, error_message: e.message)
       raise Timeout, e.message
     rescue RubyLLM::Error,
            RubyLLM::ConfigurationError,
@@ -76,8 +78,8 @@ class LlmClient
            RubyLLM::InvalidRoleError,
            RubyLLM::InvalidToolChoiceError,
            RubyLLM::UnsupportedAttachmentError => e
-      Rails.error.report(e, context: error_context(feed, profile_key, stage, model, purpose))
-      record_failure(feed, profile_key, stage, purpose, model, :provider_error, started_at, error_message: e.message)
+      Rails.error.report(e, context: error_context(ctx))
+      write_usage(ctx, outcome: :provider_error, started_at: started_at, error_message: e.message)
       raise ProviderError, e.message
     end
 
@@ -86,22 +88,13 @@ class LlmClient
     begin
       validate_payload!(response.payload, output_schema)
     rescue SchemaError => e
-      record_failure(feed, profile_key, stage, purpose, model, :schema_error, started_at,
-                     finished_at: finished_at, response: response, error_message: e.message)
+      write_usage(ctx, outcome: :schema_error, started_at: started_at,
+                  finished_at: finished_at, response: response, error_message: e.message)
       raise
     end
 
-    usage = write_usage(
-      feed: feed,
-      profile_key: profile_key,
-      stage: stage,
-      purpose: purpose,
-      model: model,
-      response: response,
-      outcome: :success,
-      started_at: started_at,
-      finished_at: finished_at
-    )
+    usage = write_usage(ctx, outcome: :success, started_at: started_at,
+                        finished_at: finished_at, response: response)
 
     Result.new(payload: response.payload, usage_id: usage.id)
   end
@@ -167,48 +160,14 @@ class LlmClient
     raise SchemaError, "response did not match schema: #{errors.first['error']}"
   end
 
-  def write_usage(feed:, profile_key:, stage:, purpose:, model:, response:, outcome:, started_at:, finished_at:)
-    cost = LlmClient::RateTable.cost_for(
-      provider: credential.provider,
-      model: model,
-      usage: LlmClient::RateTable::Usage.new(
-        input_tokens: response.input_tokens,
-        output_tokens: response.output_tokens,
-        cache_write_tokens: response.cache_write_tokens,
-        cache_read_tokens: response.cache_read_tokens
-      )
-    )
-
-    LlmUsage.create!(
-      user: credential.user,
-      feed: feed,
-      llm_credential: credential,
-      profile_key: profile_key,
-      stage: stage,
-      purpose: purpose,
-      provider: credential.provider,
-      model: model,
-      input_tokens: response.input_tokens,
-      output_tokens: response.output_tokens,
-      cache_write_tokens: response.cache_write_tokens,
-      cache_read_tokens: response.cache_read_tokens,
-      cost_estimate_cents: cost,
-      outcome: outcome,
-      started_at: started_at,
-      finished_at: finished_at,
-      duration_ms: ((finished_at - started_at) * 1000).round
-    )
-  end
-
-  def record_failure(feed, profile_key, stage, purpose, model, outcome, started_at,
-                     finished_at: nil, response: nil, error_message: nil)
+  def write_usage(ctx, outcome:, started_at:, finished_at: nil, response: nil, error_message: nil)
     finished_at ||= Time.current
     tokens = response || ProviderResponse.new(
       payload: nil, input_tokens: 0, output_tokens: 0, cache_write_tokens: 0, cache_read_tokens: 0
     )
     cost = LlmClient::RateTable.cost_for(
       provider: credential.provider,
-      model: model,
+      model: ctx.model,
       usage: LlmClient::RateTable::Usage.new(
         input_tokens: tokens.input_tokens,
         output_tokens: tokens.output_tokens,
@@ -219,13 +178,13 @@ class LlmClient
 
     LlmUsage.create!(
       user: credential.user,
-      feed: feed,
+      feed: ctx.feed,
       llm_credential: credential,
-      profile_key: profile_key,
-      stage: stage,
-      purpose: purpose,
+      profile_key: ctx.profile_key,
+      stage: ctx.stage,
+      purpose: ctx.purpose,
       provider: credential.provider,
-      model: model,
+      model: ctx.model,
       input_tokens: tokens.input_tokens,
       output_tokens: tokens.output_tokens,
       cache_write_tokens: tokens.cache_write_tokens,
@@ -246,14 +205,14 @@ class LlmClient
     end
   end
 
-  def error_context(feed, profile_key, stage, model, purpose)
+  def error_context(ctx)
     {
-      feed_id: feed&.id,
-      profile_key: profile_key,
+      feed_id: ctx.feed&.id,
+      profile_key: ctx.profile_key,
       provider: credential.provider,
-      model: model,
-      stage: stage,
-      purpose: purpose
+      model: ctx.model,
+      stage: ctx.stage,
+      purpose: ctx.purpose
     }
   end
 end

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -19,7 +19,18 @@ class LlmClient
   end
 
   ProviderResponse = Data.define(:payload, :input_tokens, :output_tokens, :cache_write_tokens, :cache_read_tokens)
-  CallContext = Data.define(:feed, :profile_key, :stage, :purpose, :model)
+
+  class CallContext
+    attr_reader :feed, :profile_key, :stage, :model, :purpose
+
+    def initialize(feed:, profile_key:, stage:, model:, purpose: :scheduled_run)
+      @feed = feed
+      @profile_key = profile_key
+      @stage = stage
+      @model = model
+      @purpose = purpose
+    end
+  end
 
   class << self
     def for(target, provider = nil)
@@ -55,14 +66,13 @@ class LlmClient
 
   attr_reader :credential
 
-  def call(feed:, profile_key:, stage:, model:, prompt:, output_schema:, tools: [], purpose: :scheduled_run)
+  def call(ctx, prompt:, output_schema:, tools: [])
     raise DetectionForbidden if Thread.current[:llm_detection_phase]
 
-    ctx = CallContext.new(feed: feed, profile_key: profile_key, stage: stage, purpose: purpose, model: model)
     started_at = Time.current
 
     begin
-      response = invoke_provider(model: model, prompt: prompt, output_schema: output_schema, tools: tools)
+      response = invoke_provider(model: ctx.model, prompt: prompt, output_schema: output_schema, tools: tools)
     rescue RubyLLM::RateLimitError => e
       write_usage(ctx, outcome: :rate_limited, started_at: started_at, error_message: e.message)
       raised = RateLimited.new(e.message)
@@ -102,19 +112,16 @@ class LlmClient
   # Cheap "credentials usable?" call used by LlmCredentialValidationJob.
   # Returns true on success, raises a known error class otherwise.
   def health_check
-    call(
-      feed: nil,
-      profile_key: nil,
-      stage: nil,
-      purpose: :credential_validation,
-      model: default_model_for(credential.provider),
-      prompt: "Reply with the single word: ok",
-      output_schema: {
-        "type" => "object",
-        "properties" => { "reply" => { "type" => "string" } },
-        "required" => ["reply"]
-      }
-    )
+    ctx = CallContext.new(feed: nil, profile_key: nil, stage: nil,
+                          model: default_model_for(credential.provider),
+                          purpose: :credential_validation)
+    call(ctx,
+         prompt: "Reply with the single word: ok",
+         output_schema: {
+           "type" => "object",
+           "properties" => { "reply" => { "type" => "string" } },
+           "required" => ["reply"]
+         })
     true
   end
 

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -20,18 +20,6 @@ class LlmClient
 
   ProviderResponse = Data.define(:payload, :input_tokens, :output_tokens, :cache_write_tokens, :cache_read_tokens)
 
-  class CallContext
-    attr_reader :feed, :profile_key, :stage, :model, :purpose
-
-    def initialize(feed:, profile_key:, stage:, model:, purpose: :scheduled_run)
-      @feed = feed
-      @profile_key = profile_key
-      @stage = stage
-      @model = model
-      @purpose = purpose
-    end
-  end
-
   class << self
     def for(target, provider = nil)
       credential = resolve_credential(target, provider)

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -62,12 +62,12 @@ class LlmClient
     begin
       response = invoke_provider(model: model, prompt: prompt, output_schema: output_schema, tools: tools)
     rescue RubyLLM::RateLimitError => e
-      record_failure(feed, profile_key, stage, purpose, model, :rate_limited, started_at)
+      record_failure(feed, profile_key, stage, purpose, model, :rate_limited, started_at, error_message: e.message)
       raised = RateLimited.new(e.message)
       raised.retry_after = e.try(:retry_after)
       raise raised
     rescue Net::ReadTimeout, Net::OpenTimeout, Faraday::TimeoutError => e
-      record_failure(feed, profile_key, stage, purpose, model, :timeout, started_at)
+      record_failure(feed, profile_key, stage, purpose, model, :timeout, started_at, error_message: e.message)
       raise Timeout, e.message
     rescue RubyLLM::Error,
            RubyLLM::ConfigurationError,
@@ -77,7 +77,7 @@ class LlmClient
            RubyLLM::InvalidToolChoiceError,
            RubyLLM::UnsupportedAttachmentError => e
       Rails.error.report(e, context: error_context(feed, profile_key, stage, model, purpose))
-      record_failure(feed, profile_key, stage, purpose, model, :provider_error, started_at)
+      record_failure(feed, profile_key, stage, purpose, model, :provider_error, started_at, error_message: e.message)
       raise ProviderError, e.message
     end
 
@@ -85,8 +85,9 @@ class LlmClient
 
     begin
       validate_payload!(response.payload, output_schema)
-    rescue SchemaError
-      record_failure(feed, profile_key, stage, purpose, model, :schema_error, started_at, finished_at)
+    rescue SchemaError => e
+      record_failure(feed, profile_key, stage, purpose, model, :schema_error, started_at,
+                     finished_at: finished_at, response: response, error_message: e.message)
       raise
     end
 
@@ -194,11 +195,28 @@ class LlmClient
       cost_estimate_cents: cost,
       outcome: outcome,
       started_at: started_at,
-      finished_at: finished_at
+      finished_at: finished_at,
+      duration_ms: ((finished_at - started_at) * 1000).round
     )
   end
 
-  def record_failure(feed, profile_key, stage, purpose, model, outcome, started_at, finished_at = nil)
+  def record_failure(feed, profile_key, stage, purpose, model, outcome, started_at,
+                     finished_at: nil, response: nil, error_message: nil)
+    finished_at ||= Time.current
+    tokens = response || ProviderResponse.new(
+      payload: nil, input_tokens: 0, output_tokens: 0, cache_write_tokens: 0, cache_read_tokens: 0
+    )
+    cost = LlmClient::RateTable.cost_for(
+      provider: credential.provider,
+      model: model,
+      usage: LlmClient::RateTable::Usage.new(
+        input_tokens: tokens.input_tokens,
+        output_tokens: tokens.output_tokens,
+        cache_write_tokens: tokens.cache_write_tokens,
+        cache_read_tokens: tokens.cache_read_tokens
+      )
+    )
+
     LlmUsage.create!(
       user: credential.user,
       feed: feed,
@@ -208,14 +226,16 @@ class LlmClient
       purpose: purpose,
       provider: credential.provider,
       model: model,
-      input_tokens: 0,
-      output_tokens: 0,
-      cache_write_tokens: 0,
-      cache_read_tokens: 0,
-      cost_estimate_cents: 0,
+      input_tokens: tokens.input_tokens,
+      output_tokens: tokens.output_tokens,
+      cache_write_tokens: tokens.cache_write_tokens,
+      cache_read_tokens: tokens.cache_read_tokens,
+      cost_estimate_cents: cost,
       outcome: outcome,
       started_at: started_at,
-      finished_at: finished_at || Time.current
+      finished_at: finished_at,
+      duration_ms: ((finished_at - started_at) * 1000).round,
+      error_message: error_message
     )
   end
 

--- a/app/services/llm_client/call_context.rb
+++ b/app/services/llm_client/call_context.rb
@@ -1,0 +1,13 @@
+class LlmClient
+  class CallContext
+    attr_reader :feed, :profile_key, :stage, :model, :purpose
+
+    def initialize(feed:, profile_key:, stage:, model:, purpose: :scheduled_run)
+      @feed = feed
+      @profile_key = profile_key
+      @stage = stage
+      @model = model
+      @purpose = purpose
+    end
+  end
+end

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -10,16 +10,17 @@ module Loader
   class LlmLoader < Base
     def load
       llm_client = options.fetch(:llm_client) { LlmClient.for(feed) }
-      result = llm_client.call(
+      ctx = LlmClient::CallContext.new(
         feed: feed.persisted? ? feed : nil,
         profile_key: feed.feed_profile_key,
         stage: :loader,
-        purpose: options.fetch(:purpose, :scheduled_run),
         model: config.fetch(:model),
-        prompt: rendered_prompt,
-        output_schema: config.fetch(:output_schema),
-        tools: config.fetch(:tools, [])
+        purpose: options.fetch(:purpose, :scheduled_run)
       )
+      result = llm_client.call(ctx,
+                               prompt: rendered_prompt,
+                               output_schema: config.fetch(:output_schema),
+                               tools: config.fetch(:tools, []))
 
       payload = result.payload
       raise StandardError, "LlmLoader payload missing 'items' array" unless payload.is_a?(Hash) && payload["items"].is_a?(Array)

--- a/db/migrate/20260526213333_add_observability_columns_to_llm_usages.rb
+++ b/db/migrate/20260526213333_add_observability_columns_to_llm_usages.rb
@@ -1,0 +1,6 @@
+class AddObservabilityColumnsToLlmUsages < ActiveRecord::Migration[8.2]
+  def change
+    add_column :llm_usages, :duration_ms, :integer
+    add_column :llm_usages, :error_message, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_25_000000) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_26_213333) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -191,6 +191,8 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_25_000000) do
     t.datetime "finished_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "duration_ms"
+    t.text "error_message"
     t.index ["feed_id", "started_at"], name: "index_llm_usages_on_feed_id_and_started_at"
     t.index ["feed_id"], name: "index_llm_usages_on_feed_id"
     t.index ["llm_credential_id"], name: "index_llm_usages_on_llm_credential_id"

--- a/test/factories/llm_usages.rb
+++ b/test/factories/llm_usages.rb
@@ -17,6 +17,5 @@ FactoryBot.define do
     started_at { 2.seconds.ago }
     finished_at { 1.second.ago }
     duration_ms { 1_000 }
-    error_message { nil }
   end
 end

--- a/test/factories/llm_usages.rb
+++ b/test/factories/llm_usages.rb
@@ -16,5 +16,7 @@ FactoryBot.define do
     outcome { :success }
     started_at { 2.seconds.ago }
     finished_at { 1.second.ago }
+    duration_ms { 1_000 }
+    error_message { nil }
   end
 end

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -143,6 +143,25 @@ class FeedHelperTest < ActionView::TestCase
     end
   end
 
+  test "#feed_missing_enablement_parts should not report source missing for query-type feed with query" do
+    access_token = create(:access_token, :active)
+    feed = build(:feed, access_token: access_token, target_group: "testgroup",
+                        feed_profile_key: "llm_web_search",
+                        params: { "query" => "climate change news" })
+    result = feed_missing_enablement_parts(feed)
+
+    assert_not_includes result, "source"
+  end
+
+  test "#feed_missing_enablement_parts should report source missing when neither url nor query present" do
+    access_token = create(:access_token, :active)
+    feed = build(:feed, access_token: access_token, target_group: "testgroup",
+                        params: {})
+    result = feed_missing_enablement_parts(feed)
+
+    assert_includes result, "source"
+  end
+
   test "#candidate_summary should fall back to the profile display name for URL profiles" do
     assert_equal "RSS Feed", candidate_summary("rss", "https://example.com/feed.xml")
     assert_equal "AI page reader", candidate_summary("llm_website_extractor", "https://example.com")

--- a/test/integration/smart_feed_creation_ai_website_test.rb
+++ b/test/integration/smart_feed_creation_ai_website_test.rb
@@ -52,7 +52,7 @@ class SmartFeedCreationAiWebsiteTest < ActionDispatch::IntegrationTest
   def with_llm_client(result, &block)
     fake_client = Class.new do
       def initialize(result) = (@result = result)
-      def call(**_args)
+      def call(_ctx, **_opts)
         case @result
         when Exception then raise @result
         when Hash then LlmClient::Result.new(payload: @result, usage_id: 1)

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -113,18 +113,9 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal 100_000, usage.input_tokens
     assert_equal 5_000, usage.output_tokens
     assert usage.cost_estimate_cents.positive?, "expected non-zero cost for a known model"
-    assert_not_nil usage.duration_ms, "expected duration_ms to be populated"
+    assert_kind_of Integer, usage.duration_ms
+    assert usage.duration_ms >= 0
     assert_nil usage.error_message
-  end
-
-  test "#call should populate duration_ms on success" do
-    client = LlmClient.new(credential)
-    stub_provider_response(client)
-
-    client.call(default_ctx, **call_opts)
-
-    assert_kind_of Integer, LlmUsage.last.duration_ms
-    assert LlmUsage.last.duration_ms >= 0
   end
 
   test "#call should populate error_message on provider error" do
@@ -167,9 +158,10 @@ class LlmClientTest < ActiveSupport::TestCase
     usage = LlmUsage.last
     assert_equal "rate_limited", usage.outcome
     assert_not_nil usage.error_message
+    assert_not_nil usage.duration_ms
   end
 
-  test "#call should populate error_message on timeout" do
+  test "#call should populate error_message and duration_ms on timeout" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, Net::ReadTimeout.new)
 
@@ -177,6 +169,7 @@ class LlmClientTest < ActiveSupport::TestCase
 
     usage = LlmUsage.last
     assert_equal "timeout", usage.outcome
+    assert_not_nil usage.error_message
     assert_not_nil usage.duration_ms
   end
 

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -107,6 +107,71 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal 100_000, usage.input_tokens
     assert_equal 5_000, usage.output_tokens
     assert usage.cost_estimate_cents.positive?, "expected non-zero cost for a known model"
+    assert_not_nil usage.duration_ms, "expected duration_ms to be populated"
+    assert_nil usage.error_message
+  end
+
+  test "#call should populate duration_ms on success" do
+    client = LlmClient.new(credential)
+    stub_provider_response(client)
+
+    client.call(**call_args)
+
+    assert_kind_of Integer, LlmUsage.last.duration_ms
+    assert LlmUsage.last.duration_ms >= 0
+  end
+
+  test "#call should populate error_message on provider error" do
+    client = LlmClient.new(credential)
+    stub_provider_to_raise(client, RubyLLM::ServerError.new("downstream failure"))
+
+    assert_raises(LlmClient::ProviderError) { client.call(**call_args) }
+
+    usage = LlmUsage.last
+    assert_equal "provider_error", usage.outcome
+    assert_not_nil usage.error_message
+    assert_includes usage.error_message, "downstream failure"
+  end
+
+  test "#call should populate error_message and duration_ms on schema error" do
+    client = LlmClient.new(credential)
+    bad_response = LlmClient::ProviderResponse.new(
+      payload: { "wrong" => "shape" },
+      input_tokens: 10, output_tokens: 5,
+      cache_write_tokens: 0, cache_read_tokens: 0
+    )
+    stub_provider_response(client, bad_response)
+
+    assert_raises(LlmClient::SchemaError) { client.call(**call_args) }
+
+    usage = LlmUsage.last
+    assert_equal "schema_error", usage.outcome
+    assert_not_nil usage.error_message
+    assert_not_nil usage.duration_ms
+    assert_equal 10, usage.input_tokens
+    assert_equal 5, usage.output_tokens
+  end
+
+  test "#call should populate error_message on rate limit" do
+    client = LlmClient.new(credential)
+    stub_provider_to_raise(client, RubyLLM::RateLimitError.new("rate limit exceeded"))
+
+    assert_raises(LlmClient::RateLimited) { client.call(**call_args) }
+
+    usage = LlmUsage.last
+    assert_equal "rate_limited", usage.outcome
+    assert_not_nil usage.error_message
+  end
+
+  test "#call should populate error_message on timeout" do
+    client = LlmClient.new(credential)
+    stub_provider_to_raise(client, Net::ReadTimeout.new)
+
+    assert_raises(LlmClient::Timeout) { client.call(**call_args) }
+
+    usage = LlmUsage.last
+    assert_equal "timeout", usage.outcome
+    assert_not_nil usage.duration_ms
   end
 
   test "#call should raise SchemaError and record a failed usage row when the response violates the schema" do

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -35,19 +35,25 @@ class LlmClientTest < ActiveSupport::TestCase
     client.define_singleton_method(:invoke_provider) { |**_| raise error }
   end
 
-  def call_args(**overrides)
-    {
+  def default_ctx(**overrides)
+    LlmClient::CallContext.new(
       feed: feed,
       profile_key: "llm_website_extractor",
       stage: :loader,
       model: "claude-sonnet-4-6",
+      **overrides
+    )
+  end
+
+  def call_opts
+    {
       prompt: "Extract posts",
       output_schema: {
         "type" => "object",
         "properties" => { "items" => { "type" => "array" } },
         "required" => ["items"]
       }
-    }.merge(overrides)
+    }
   end
 
   test ".for should resolve a feed to its assigned credential" do
@@ -82,7 +88,7 @@ class LlmClientTest < ActiveSupport::TestCase
     stub_provider_response(client)
 
     Thread.current[:llm_detection_phase] = true
-    assert_raises(LlmClient::DetectionForbidden) { client.call(**call_args) }
+    assert_raises(LlmClient::DetectionForbidden) { client.call(default_ctx, **call_opts) }
   ensure
     Thread.current[:llm_detection_phase] = false
   end
@@ -92,7 +98,7 @@ class LlmClientTest < ActiveSupport::TestCase
     stub_provider_response(client)
 
     assert_difference("LlmUsage.count", 1) do
-      result = client.call(**call_args)
+      result = client.call(default_ctx, **call_opts)
 
       assert_kind_of LlmClient::Result, result
       assert_equal({ "items" => [{ "title" => "Post 1" }] }, result.payload)
@@ -115,7 +121,7 @@ class LlmClientTest < ActiveSupport::TestCase
     client = LlmClient.new(credential)
     stub_provider_response(client)
 
-    client.call(**call_args)
+    client.call(default_ctx, **call_opts)
 
     assert_kind_of Integer, LlmUsage.last.duration_ms
     assert LlmUsage.last.duration_ms >= 0
@@ -125,7 +131,7 @@ class LlmClientTest < ActiveSupport::TestCase
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, RubyLLM::ServerError.new("downstream failure"))
 
-    assert_raises(LlmClient::ProviderError) { client.call(**call_args) }
+    assert_raises(LlmClient::ProviderError) { client.call(default_ctx, **call_opts) }
 
     usage = LlmUsage.last
     assert_equal "provider_error", usage.outcome
@@ -142,7 +148,7 @@ class LlmClientTest < ActiveSupport::TestCase
     )
     stub_provider_response(client, bad_response)
 
-    assert_raises(LlmClient::SchemaError) { client.call(**call_args) }
+    assert_raises(LlmClient::SchemaError) { client.call(default_ctx, **call_opts) }
 
     usage = LlmUsage.last
     assert_equal "schema_error", usage.outcome
@@ -156,7 +162,7 @@ class LlmClientTest < ActiveSupport::TestCase
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, RubyLLM::RateLimitError.new("rate limit exceeded"))
 
-    assert_raises(LlmClient::RateLimited) { client.call(**call_args) }
+    assert_raises(LlmClient::RateLimited) { client.call(default_ctx, **call_opts) }
 
     usage = LlmUsage.last
     assert_equal "rate_limited", usage.outcome
@@ -167,7 +173,7 @@ class LlmClientTest < ActiveSupport::TestCase
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, Net::ReadTimeout.new)
 
-    assert_raises(LlmClient::Timeout) { client.call(**call_args) }
+    assert_raises(LlmClient::Timeout) { client.call(default_ctx, **call_opts) }
 
     usage = LlmUsage.last
     assert_equal "timeout", usage.outcome
@@ -184,7 +190,7 @@ class LlmClientTest < ActiveSupport::TestCase
     stub_provider_response(client, bad_response)
 
     assert_difference("LlmUsage.count", 1) do
-      assert_raises(LlmClient::SchemaError) { client.call(**call_args) }
+      assert_raises(LlmClient::SchemaError) { client.call(default_ctx, **call_opts) }
     end
 
     assert_equal "schema_error", LlmUsage.last.outcome
@@ -195,7 +201,7 @@ class LlmClientTest < ActiveSupport::TestCase
     stub_provider_to_raise(client, RubyLLM::RateLimitError.new("429"))
 
     assert_difference("LlmUsage.count", 1) do
-      assert_raises(LlmClient::RateLimited) { client.call(**call_args) }
+      assert_raises(LlmClient::RateLimited) { client.call(default_ctx, **call_opts) }
     end
 
     assert_equal "rate_limited", LlmUsage.last.outcome
@@ -206,7 +212,7 @@ class LlmClientTest < ActiveSupport::TestCase
     stub_provider_to_raise(client, RubyLLM::ServerError.new("500"))
 
     assert_difference("LlmUsage.count", 1) do
-      assert_raises(LlmClient::ProviderError) { client.call(**call_args) }
+      assert_raises(LlmClient::ProviderError) { client.call(default_ctx, **call_opts) }
     end
 
     assert_equal "provider_error", LlmUsage.last.outcome
@@ -217,7 +223,7 @@ class LlmClientTest < ActiveSupport::TestCase
     stub_provider_to_raise(client, Net::ReadTimeout.new)
 
     assert_difference("LlmUsage.count", 1) do
-      assert_raises(LlmClient::Timeout) { client.call(**call_args) }
+      assert_raises(LlmClient::Timeout) { client.call(default_ctx, **call_opts) }
     end
 
     assert_equal "timeout", LlmUsage.last.outcome
@@ -227,7 +233,7 @@ class LlmClientTest < ActiveSupport::TestCase
     client = LlmClient.new(credential)
     stub_provider_response(client)
 
-    client.call(**call_args(feed: nil, purpose: :preview))
+    client.call(default_ctx(feed: nil, purpose: :preview), **call_opts)
 
     usage = LlmUsage.last
     assert_nil usage.feed_id
@@ -260,7 +266,7 @@ class LlmClientTest < ActiveSupport::TestCase
     stub_provider_to_raise(client, RubyLLM::ModelNotFoundError.new("unknown model"))
 
     assert_difference("LlmUsage.count", 1) do
-      assert_raises(LlmClient::ProviderError) { client.call(**call_args) }
+      assert_raises(LlmClient::ProviderError) { client.call(default_ctx, **call_opts) }
     end
 
     assert_equal "provider_error", LlmUsage.last.outcome
@@ -270,7 +276,7 @@ class LlmClientTest < ActiveSupport::TestCase
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, RubyLLM::ConfigurationError.new("misconfigured"))
 
-    assert_raises(LlmClient::ProviderError) { client.call(**call_args) }
+    assert_raises(LlmClient::ProviderError) { client.call(default_ctx, **call_opts) }
     assert_equal "provider_error", LlmUsage.last.outcome
   end
 
@@ -279,7 +285,7 @@ class LlmClientTest < ActiveSupport::TestCase
     bad_credential.save(validate: false)
     client = LlmClient.new(bad_credential)
 
-    assert_raises(LlmClient::ProviderError) { client.call(**call_args(feed: nil)) }
+    assert_raises(LlmClient::ProviderError) { client.call(default_ctx(feed: nil), **call_opts) }
     assert_equal "provider_error", LlmUsage.last.outcome
   end
 end

--- a/test/services/loader/llm_loader_test.rb
+++ b/test/services/loader/llm_loader_test.rb
@@ -20,7 +20,7 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
   def fake_client(payload)
     Class.new do
       def initialize(payload) = (@payload = payload)
-      def call(**_args)
+      def call(_ctx, **_opts)
         LlmClient::Result.new(payload: @payload, usage_id: 42)
       end
     end.new(payload)


### PR DESCRIPTION
Two fixes from the Staging milestone, plus a follow-up refactor.

- Fix false "source missing" alarm for `llm_web_search` feeds — the helper was checking `feed.url`, which is always nil for query-based feeds. Switched to `feed.source_input`.
- Add `duration_ms` and `error_message` columns to `llm_usages` so failed calls record their elapsed time and the provider error message, making post-mortem debugging practical. Schema errors now also capture token counts from the (valid) provider response instead of zeroing them out.
- Simplify `LlmClient` by introducing `CallContext` to bundle the five per-call constants, replacing two near-identical private methods with a single `write_usage`.

## References

- Closes #480
- Closes #454
