### PR TITLE
Add YouTube feed support

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -123,6 +123,26 @@ class FeedProfile
       title_extractor: nil,
       output_schema: UNIVERSAL_OUTPUT_SCHEMA
     },
+    "youtube" => {
+      display_name: "YouTube",
+      description: "Videos from a YouTube channel",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::YoutubeProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "format" => "uri" }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::YoutubeLoader", config: {} },
+      processor: { class: "Processor::YoutubeProcessor", config: {} },
+      normalizer: { class: "Normalizer::YoutubeNormalizer", config: {} },
+      title_extractor: "TitleExtractor::RssTitleExtractor",
+      output_schema: nil
+    },
     "llm_web_search" => {
       display_name: "AI search",
       description: "Uses AI to follow an account, handle, or search topic as an evergreen subscription",

--- a/app/services/loader/youtube_loader.rb
+++ b/app/services/loader/youtube_loader.rb
@@ -1,0 +1,49 @@
+module Loader
+  class YoutubeLoader < Base
+    FEED_URL_PATH = "/feeds/videos.xml"
+    DEFAULT_MAX_REDIRECTS = 3
+
+    def load
+      response = http_client.get(feed_url)
+      raise StandardError, "HTTP #{response.status}" unless response.success?
+      response.body
+    rescue HttpClient::Error => e
+      raise StandardError, e.message
+    end
+
+    private
+
+    def feed_url
+      @feed_url ||= resolve_feed_url(feed.url)
+    end
+
+    def resolve_feed_url(url)
+      return url if youtube_feed_url?(url)
+
+      response = http_client.get(url)
+      raise StandardError, "HTTP #{response.status}" unless response.success?
+
+      extract_feed_url(response.body) or raise StandardError, "Could not find YouTube RSS feed link"
+    end
+
+    def youtube_feed_url?(url)
+      URI.parse(url).path.start_with?(FEED_URL_PATH)
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def extract_feed_url(html)
+      doc = Nokogiri::HTML(html)
+      link = doc.at_css('link[type="application/rss+xml"]') ||
+             doc.at_css('link[type="application/atom+xml"]')
+      link&.[]("href")
+    end
+
+    def http_client
+      @http_client ||= options.fetch(:http_client) do
+        max_redirects = options.fetch(:max_redirects, DEFAULT_MAX_REDIRECTS)
+        HttpClient.build(max_redirects: max_redirects)
+      end
+    end
+  end
+end

--- a/app/services/normalizer/youtube_normalizer.rb
+++ b/app/services/normalizer/youtube_normalizer.rb
@@ -1,0 +1,19 @@
+module Normalizer
+  class YoutubeNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      raw_data.dig("title") || ""
+    end
+
+    def normalize_attachment_urls
+      thumbnail = raw_data.dig("thumbnail")
+      thumbnail.present? ? [thumbnail] : []
+    end
+
+    def normalize_comments
+      description = raw_data.dig("content") || ""
+      description.present? ? [strip_html(description)] : []
+    end
+  end
+end

--- a/app/services/processor/youtube_processor.rb
+++ b/app/services/processor/youtube_processor.rb
@@ -1,0 +1,9 @@
+module Processor
+  class YoutubeProcessor < RssProcessor
+    private
+
+    def sanitize_feedjira_entry(entry)
+      super.merge(thumbnail: entry.try(:media_thumbnail_url))
+    end
+  end
+end

--- a/app/services/profile_matcher/youtube_profile_matcher.rb
+++ b/app/services/profile_matcher/youtube_profile_matcher.rb
@@ -3,13 +3,13 @@ module ProfileMatcher
     input_shape :url
     match_specificity 100
 
-    YOUTUBE_DOMAINS = %w[youtube.com youtu.be].freeze
+    YOUTUBE_DOMAINS = %w[youtube.com www.youtube.com youtu.be www.youtu.be].freeze
 
     def match?
       return false if input.blank?
 
       uri = URI.parse(input)
-      YOUTUBE_DOMAINS.any? { |domain| uri.host&.end_with?(domain) }
+      YOUTUBE_DOMAINS.include?(uri.host)
     end
   end
 end

--- a/app/services/profile_matcher/youtube_profile_matcher.rb
+++ b/app/services/profile_matcher/youtube_profile_matcher.rb
@@ -1,0 +1,15 @@
+module ProfileMatcher
+  class YoutubeProfileMatcher < Base
+    input_shape :url
+    match_specificity 100
+
+    YOUTUBE_DOMAINS = %w[youtube.com youtu.be].freeze
+
+    def match?
+      return false if input.blank?
+
+      uri = URI.parse(input)
+      YOUTUBE_DOMAINS.any? { |domain| uri.host&.end_with?(domain) }
+    end
+  end
+end

--- a/test/fixtures/files/feeds/youtube/feed.xml
+++ b/test/fixtures/files/feeds/youtube/feed.xml
@@ -1,49 +1,499 @@
+
 <?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
-      xmlns:media="http://search.yahoo.com/mrss/"
-      xmlns="http://www.w3.org/2005/Atom">
-  <link rel="self" href="https://www.youtube.com/feeds/videos.xml?channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw"/>
-  <id>yt:channel:UC_x5XG1OV2P6uZZ5FSM9Ttw</id>
-  <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
-  <title>Test Channel</title>
-  <entry>
-    <id>yt:video:dQw4w9WgXcQ</id>
-    <yt:videoId>dQw4w9WgXcQ</yt:videoId>
-    <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
-    <title>Sample Video Title</title>
-    <link rel="alternate" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"/>
-    <author>
-      <name>Test Channel</name>
-    </author>
-    <published>2024-09-12T10:00:00+00:00</published>
-    <updated>2024-09-12T10:00:00+00:00</updated>
-    <media:group>
-      <media:title>Sample Video Title</media:title>
-      <media:content url="https://www.youtube.com/v/dQw4w9WgXcQ?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-      <media:thumbnail url="https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg" width="480" height="360"/>
-      <media:description>This is the video description.</media:description>
-      <media:community>
-        <media:starRating count="100" average="5.00" min="1" max="5"/>
-        <media:statistics views="1234"/>
-      </media:community>
-    </media:group>
-  </entry>
-  <entry>
-    <id>yt:video:oHg5SJYRHA0</id>
-    <yt:videoId>oHg5SJYRHA0</yt:videoId>
-    <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
-    <title>Another Video</title>
-    <link rel="alternate" href="https://www.youtube.com/watch?v=oHg5SJYRHA0"/>
-    <author>
-      <name>Test Channel</name>
-    </author>
-    <published>2024-09-10T08:00:00+00:00</published>
-    <updated>2024-09-10T08:00:00+00:00</updated>
-    <media:group>
-      <media:title>Another Video</media:title>
-      <media:content url="https://www.youtube.com/v/oHg5SJYRHA0?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-      <media:thumbnail url="https://i.ytimg.com/vi/oHg5SJYRHA0/hqdefault.jpg" width="480" height="360"/>
-      <media:description>Another video description.</media:description>
-    </media:group>
-  </entry>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/" xmlns="http://www.w3.org/2005/Atom">
+ <link rel="self" href="http://www.youtube.com/feeds/videos.xml?channel_id=UCMCgOm8GZkHp8zJ6l7_hIuA"/>
+ <id>yt:channel:UCMCgOm8GZkHp8zJ6l7_hIuA</id>
+ <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+ <title>вДудь</title>
+ <link rel="alternate" href="https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA"/>
+ <author>
+  <name>вДудь</name>
+  <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+ </author>
+ <published>2014-01-03T06:27:22+00:00</published>
+ <entry>
+  <id>yt:video:CNJL4GsSrcc</id>
+  <yt:videoId>CNJL4GsSrcc</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Серебряков - об эмиграции, детях и законе подлецов / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=CNJL4GsSrcc"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2018-02-20T11:25:57+00:00</published>
+  <updated>2018-02-26T17:49:27+00:00</updated>
+  <media:group>
+   <media:title>Серебряков - об эмиграции, детях и законе подлецов / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/CNJL4GsSrcc?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i4.ytimg.com/vi/CNJL4GsSrcc/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Выбирай свой Acer Spin 5 на Windows 10 http://bit.ly/2EQiKyn
+
+Алексей Серебряков - большой русский актер - новый герой вДудя.
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="212955" average="4.77" min="1" max="5"/>
+    <media:statistics views="4781216"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:SPauxWv1Rnk</id>
+  <yt:videoId>SPauxWv1Rnk</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Поперечный - о цензуре, геях и чувствах верующих / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=SPauxWv1Rnk"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2018-02-13T14:30:05+00:00</published>
+  <updated>2018-02-26T17:44:45+00:00</updated>
+  <media:group>
+   <media:title>Поперечный - о цензуре, геях и чувствах верующих / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/SPauxWv1Rnk?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i4.ytimg.com/vi/SPauxWv1Rnk/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Такого размера скидки мы еще не давали: http://2119.ru/vdud/
+
+Данила Поперечный - главный стендап комик русского интернета https://www.youtube.com/user/Spoontamer
+
+Тот самый нежный редактор (с Ириной Хакамадой) - https://www.youtube.com/watch?v=6R-5esYJR7Q
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="255213" average="4.78" min="1" max="5"/>
+    <media:statistics views="4359805"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:_IPXiNIXuFI</id>
+  <yt:videoId>_IPXiNIXuFI</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Грудинин: Сталин наш лучший лидер за 100 лет / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=_IPXiNIXuFI"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2018-02-06T12:08:20+00:00</published>
+  <updated>2018-02-26T17:48:24+00:00</updated>
+  <media:group>
+   <media:title>Грудинин: Сталин наш лучший лидер за 100 лет / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/_IPXiNIXuFI?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i4.ytimg.com/vi/_IPXiNIXuFI/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Интернет-магаз часов Bestwatch https://www.bestwatch.ru/u/vdud
+Бомбические скидки 30-50-70% + промоскидка по слову VDUD
+
+Павел Грудинин - кандидат в президенты России от партии КПРФ
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="244990" average="3.67" min="1" max="5"/>
+    <media:statistics views="4873706"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:zcjKJ7FHDLM</id>
+  <yt:videoId>zcjKJ7FHDLM</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Невзоров - о Фараоне и ориентации Милонова / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=zcjKJ7FHDLM"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2018-01-30T12:36:45+00:00</published>
+  <updated>2018-02-26T17:48:15+00:00</updated>
+  <media:group>
+   <media:title>Невзоров - о Фараоне и ориентации Милонова / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/zcjKJ7FHDLM?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i3.ytimg.com/vi/zcjKJ7FHDLM/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Аудиокниги для каждого в Storytel https://rr7d3.app.goo.gl/UPkV
+
+Александр Невзоров - легенда русской тележурналистики и просто философ. Его канал: https://www.youtube.com/user/NevzorovTV
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="199233" average="4.73" min="1" max="5"/>
+    <media:statistics views="4537010"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:S9y4R11gzPY</id>
+  <yt:videoId>S9y4R11gzPY</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Ройзман - о предателях и легалайзе / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=S9y4R11gzPY"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2018-01-23T11:53:01+00:00</published>
+  <updated>2018-02-26T17:47:01+00:00</updated>
+  <media:group>
+   <media:title>Ройзман - о предателях и легалайзе / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/S9y4R11gzPY?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i4.ytimg.com/vi/S9y4R11gzPY/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Бронируем отели тут - https://ostrvk.co/vdud
+Промокод ВДУДЬ дает 10% скидку на бронирование с оплатой в мобильном приложении до 15 февраля 2018
+
+Евгений Ройзман - мэр Екатеринбурга и один из главных борцов с наркотиками на Руси. Его благотворительный фонд -
+https://roizmanfond.ru
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="130083" average="4.38" min="1" max="5"/>
+    <media:statistics views="3464655"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:x7Ilf1mAZCk</id>
+  <yt:videoId>x7Ilf1mAZCk</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Новая Россия: The Hatters, Аксенова, Покрас Лампас, Пязок / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=x7Ilf1mAZCk"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2018-01-17T15:14:01+00:00</published>
+  <updated>2018-02-26T17:42:41+00:00</updated>
+  <media:group>
+   <media:title>Новая Россия: The Hatters, Аксенова, Покрас Лампас, Пязок / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/x7Ilf1mAZCk?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i1.ytimg.com/vi/x7Ilf1mAZCk/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Кинокинокинокино: https://okko.tv/?utm_source=vdud&amp;utm_medium=display&amp;utm_campaign=okko.tv_trjan18
+14 дней БЕСПЛАТНО на пакет «Оптимальный + Амедиатека». Промокод 20180116
+14 дней БЕСПЛАТНО на пакет «Оптимальный». Промокод 01162018
+
+* * * * * * * *
+
+У русского народа есть традиция: каждый Новый год включать телевизор и охеревать от того, что там происходит. Старые, несовременные, заставшие не одного генсека люди продираются к экрану и делают какой-то стыд. Зрители злятся, ругаются, но все равно включают телек - чтобы потом снова ругаться, злиться и производить шум. В этом шуме может показаться, что Россия - это страна, где по части развлечений не происходит ничего нового.
+
+Но это - не так.
+
+Глобально Россия остается страной нефтяных вышек и доисторической попсы, но локально - плодит очень много достойной крути. Уже сейчас в России есть музыканты, актеры, режиссеры, клипмейкеры, дизайнеры, художники, которые делают классно здесь, которые или уже востребованы за границей, или имеют на это все шансы в будущем. Про многих из них вы даже не знаете, хотя они живут совсем рядом с каждым из нас.
+
+Некоторые из них - герои сегодняшнего выпуска вДудя. Они молоды, талантливы и напомнят каждому из вас: в России - невиданное количество проблем, но это не повод грустить и забиваться в угол. Это повод фигачить с еще большей силой - и рано или поздно это обязательно вынесет тебя на верх.
+
+Покрас Лампас - https://www.instagram.com/pokraslampas/
+Любовь Аксенова - https://www.instagram.com/aksenovalove
+Юрий Музыченко - https://www.instagram.com/anna_muzichenko/
+Алина Пязок - https://www.instagram.com/alina_pasok/
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="193075" average="4.81" min="1" max="5"/>
+    <media:statistics views="3557875"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:Bjg7WSd8dyQ</id>
+  <yt:videoId>Bjg7WSd8dyQ</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Человек после войны / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=Bjg7WSd8dyQ"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2018-01-09T06:59:23+00:00</published>
+  <updated>2018-02-26T17:24:17+00:00</updated>
+  <media:group>
+   <media:title>Человек после войны / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/Bjg7WSd8dyQ?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i3.ytimg.com/vi/Bjg7WSd8dyQ/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Несколько недель назад вы смотрели выпуск с Юрием Шевчуком - тот самый, который получился совсем не про музыку. В числе прочего там было про исследовательский опыт Шевчука: в 1995 году он приезжал в Чечню, встречался с российскими бойцами, пел им песни и снимал на видео каждый свой шаг. Возможно, самое страшное видео - перекличка бойцов, которую он там проводит:  https://goo.gl/DcByz4
+
+По легенде - важно: по легенде - через несколько дней из этих парней погибли почти все. Мы не знаем, так это или нет, но знаем, что как минимум один человек с этого видео жив. Мы нашли его совершенно случайно - благодаря одному из наших зрителей. Бойца зовут Олег Ситников, он живет в Калининграде очень тихой и очень скромной жизнью. Но перед тем как в этой жизни оказаться, он долгие годы бухал и искал хоть какие-то интересы.
+
+Мы приехали к нему в гости, чтобы показать, как живут люди, вернувшиеся с войны. Чечня была много лет назад, но в самых разных войнах мы участвуем и сейчас.
+
+Здорово, если это не пригодится вам. К сожалению, кому-то это пригодится точно.</media:description>
+   <media:community>
+    <media:starRating count="322650" average="4.95" min="1" max="5"/>
+    <media:statistics views="3472592"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:Rx_1WLpTrdk</id>
+  <yt:videoId>Rx_1WLpTrdk</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Петров - о BadComedian и лучшем русском режиссере / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=Rx_1WLpTrdk"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2017-12-26T07:43:06+00:00</published>
+  <updated>2018-02-26T17:45:55+00:00</updated>
+  <media:group>
+   <media:title>Петров - о BadComedian и лучшем русском режиссере / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/Rx_1WLpTrdk?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i3.ytimg.com/vi/Rx_1WLpTrdk/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Уникальное предложение от Альфа-Банка - бесплатно на год карта с самым выгодным CashBack:
+https://anketa.alfabank.ru/alfaform_dc/step1?cardId=E0&amp;packetId=L01
+
+Актер Александр Петров - звезда &quot;Притяжения&quot;, &quot;Гоголя&quot; и уймы других русских фильмов
+
+инстаграм Петрова - https://www.instagram.com/actorsashapetrov/
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="134964" average="4.42" min="1" max="5"/>
+    <media:statistics views="3672404"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:qc7AZkWPynE</id>
+  <yt:videoId>qc7AZkWPynE</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Feduk - автор главного хита этой осени / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=qc7AZkWPynE"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2017-12-19T11:36:46+00:00</published>
+  <updated>2018-02-26T17:44:36+00:00</updated>
+  <media:group>
+   <media:title>Feduk - автор главного хита этой осени / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/qc7AZkWPynE?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i2.ytimg.com/vi/qc7AZkWPynE/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Выигрывай билеты на Чемпионат мира по футболу FIFA 2018 тут
+https://goo.gl/Jyt5aT
+
+Элджей и Feduk &quot;Розовое вино&quot; - https://www.youtube.com/watch?v=wOBnq0Ewz5k
+
+еще рэпчик во вДуде:
+Face - https://goo.gl/Ah14NC
+Гнойный - https://goo.gl/SSRbDj
+Jah Khalib - https://goo.gl/PXQssK
+Скриптонит - https://goo.gl/qt4imW
+Влади (Каста) - https://goo.gl/LdfpYa
+Гуф - https://goo.gl/CzNjGD
+Noize MC - https://goo.gl/53X9J1
+Ресторатор - https://goo.gl/ST4ruu
+L'One - https://goo.gl/oZuQxh
+Баста - https://goo.gl/yq8XdV
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="167534" average="4.27" min="1" max="5"/>
+    <media:statistics views="4356582"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:yP6VGTtRgMI</id>
+  <yt:videoId>yP6VGTtRgMI</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Слепаков - о &quot;Нашей Russia&quot; и современной России / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=yP6VGTtRgMI"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2017-12-12T08:55:24+00:00</published>
+  <updated>2018-02-26T17:46:42+00:00</updated>
+  <media:group>
+   <media:title>Слепаков - о &quot;Нашей Russia&quot; и современной России / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/yP6VGTtRgMI?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i2.ytimg.com/vi/yP6VGTtRgMI/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Заказываем карту Cash-Back от Альфа-Банка с самым выгодным кэшбэком деньгами: https://alfabank.ru/dud
+
+инстаграм Слепакова - https://www.instagram.com/slepakovsemyon/
+ютуб-канал Слепакова - https://www.youtube.com/channel/UCncuVFZrHKza2d2HXU6axaQ
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="208654" average="4.67" min="1" max="5"/>
+    <media:statistics views="5378566"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:98pE29S5Gb4</id>
+  <yt:videoId>98pE29S5Gb4</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Шевчук - о батле с Путиным и войне в Чечне / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=98pE29S5Gb4"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2017-12-07T09:34:09+00:00</published>
+  <updated>2018-02-26T17:45:09+00:00</updated>
+  <media:group>
+   <media:title>Шевчук - о батле с Путиным и войне в Чечне / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/98pE29S5Gb4?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i2.ytimg.com/vi/98pE29S5Gb4/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Заказываем карту Cash-Back от Альфа-Банка с самым выгодным кэшбэком деньгами: https://alfabank.ru/dud
+
+Старт нового сезона - это особенная штука. Поэтому вместо одного выпуска мы сделали для вас два. Первая серия нового сезона вДудя (герой - Артемий Лебедев) здесь https://goo.gl/siUT7V Велком!
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="224261" average="4.55" min="1" max="5"/>
+    <media:statistics views="3968157"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:b9i0tWSuSac</id>
+  <yt:videoId>b9i0tWSuSac</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Артемий Лебедев - магистр мата и отец 10 детей / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=b9i0tWSuSac"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2017-12-05T06:57:20+00:00</published>
+  <updated>2018-02-26T17:40:57+00:00</updated>
+  <media:group>
+   <media:title>Артемий Лебедев - магистр мата и отец 10 детей / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/b9i0tWSuSac?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i3.ytimg.com/vi/b9i0tWSuSac/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Купи систему VR HTC VIVE на официальном сайте и получи бесплатную копию игры Fallout 4 VR сразу после релиза. Подробности: https://www.vive.com/
+
+Артемий Лебедев - тролль, путешественник, дизайнер. Вторая серия сезона - с Юрием Шевчуком - здесь https://www.goo.gl/nyud3L
+
+Инстаграм Дудя - https://www.instagram.com/yurydud/</media:description>
+   <media:community>
+    <media:starRating count="129002" average="4.53" min="1" max="5"/>
+    <media:statistics views="3810308"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:wpfpey_0G5A</id>
+  <yt:videoId>wpfpey_0G5A</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Собчак - о Навальном, крестном и выборах / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=wpfpey_0G5A"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2017-10-24T16:08:55+00:00</published>
+  <updated>2018-02-26T17:47:49+00:00</updated>
+  <media:group>
+   <media:title>Собчак - о Навальном, крестном и выборах / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/wpfpey_0G5A?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i4.ytimg.com/vi/wpfpey_0G5A/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Подушки, матрасы, МАССАЖЕРЫ ДЛЯ ГЛАЗ и прочая красота - http://www.askona.ru/ Если при заказе введете промокод IR7ZYL11 - получите скидос
+
+Мы завершили второй сезон. Спасибо, что с нами. Все - благодаря вам.
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="249541" average="4.14" min="1" max="5"/>
+    <media:statistics views="8223033"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:wg-TMymYSwE</id>
+  <yt:videoId>wg-TMymYSwE</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Познер - о цензуре, страхе и Путине / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=wg-TMymYSwE"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2017-10-18T07:10:00+00:00</published>
+  <updated>2018-02-26T17:47:09+00:00</updated>
+  <media:group>
+   <media:title>Познер - о цензуре, страхе и Путине / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/wg-TMymYSwE?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i4.ytimg.com/vi/wg-TMymYSwE/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Скидка 2 000 ₽ на колонку JBL Boombox по промокоду ЭЛЬДОВДУДЬ. Заказать можно тут: https://eldorado.ru/~JBL
+
+Порнофильмы - главная панк-команда России прямо сейчас - едет в тур по стране. Лови их в своем городе http://www.pornopunk.ru/concerts/
+
+Нежный редактор Таня запустила свой канал. Я еще не смотрел, но, говорят, там будут ЖЕНЩИНЫ https://goo.gl/yL9Fvo
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="236852" average="4.84" min="1" max="5"/>
+    <media:statistics views="5147079"/>
+   </media:community>
+  </media:group>
+ </entry>
+ <entry>
+  <id>yt:video:mmid_NMUoFg</id>
+  <yt:videoId>mmid_NMUoFg</yt:videoId>
+  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
+  <title>Face - почему от него фанатеет молодежь / вДудь</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=mmid_NMUoFg"/>
+  <author>
+   <name>вДудь</name>
+   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  </author>
+  <published>2017-10-11T21:19:19+00:00</published>
+  <updated>2018-02-26T17:49:12+00:00</updated>
+  <media:group>
+   <media:title>Face - почему от него фанатеет молодежь / вДудь</media:title>
+   <media:content url="https://www.youtube.com/v/mmid_NMUoFg?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i2.ytimg.com/vi/mmid_NMUoFg/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Пельмени и прочую вкуснятину берем здесь - https://goo.gl/wG6YpH
+
+видосы внутри - https://www.youtube.com/watch?v=ctkML3BVaxw
+
+инстаграм Дудя - https://www.instagram.com/yurydud/
+вконтос Дудя - https://vk.com/vdud
+одноклассники Дудя - https://ok.ru/vdud
+твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:community>
+    <media:starRating count="367063" average="3.73" min="1" max="5"/>
+    <media:statistics views="9493950"/>
+   </media:community>
+  </media:group>
+ </entry>
 </feed>

--- a/test/fixtures/files/feeds/youtube/feed.xml
+++ b/test/fixtures/files/feeds/youtube/feed.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+      xmlns:media="http://search.yahoo.com/mrss/"
+      xmlns="http://www.w3.org/2005/Atom">
+  <link rel="self" href="https://www.youtube.com/feeds/videos.xml?channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw"/>
+  <id>yt:channel:UC_x5XG1OV2P6uZZ5FSM9Ttw</id>
+  <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
+  <title>Test Channel</title>
+  <entry>
+    <id>yt:video:dQw4w9WgXcQ</id>
+    <yt:videoId>dQw4w9WgXcQ</yt:videoId>
+    <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
+    <title>Sample Video Title</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"/>
+    <author>
+      <name>Test Channel</name>
+    </author>
+    <published>2024-09-12T10:00:00+00:00</published>
+    <updated>2024-09-12T10:00:00+00:00</updated>
+    <media:group>
+      <media:title>Sample Video Title</media:title>
+      <media:content url="https://www.youtube.com/v/dQw4w9WgXcQ?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+      <media:thumbnail url="https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg" width="480" height="360"/>
+      <media:description>This is the video description.</media:description>
+      <media:community>
+        <media:starRating count="100" average="5.00" min="1" max="5"/>
+        <media:statistics views="1234"/>
+      </media:community>
+    </media:group>
+  </entry>
+  <entry>
+    <id>yt:video:oHg5SJYRHA0</id>
+    <yt:videoId>oHg5SJYRHA0</yt:videoId>
+    <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
+    <title>Another Video</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=oHg5SJYRHA0"/>
+    <author>
+      <name>Test Channel</name>
+    </author>
+    <published>2024-09-10T08:00:00+00:00</published>
+    <updated>2024-09-10T08:00:00+00:00</updated>
+    <media:group>
+      <media:title>Another Video</media:title>
+      <media:content url="https://www.youtube.com/v/oHg5SJYRHA0?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+      <media:thumbnail url="https://i.ytimg.com/vi/oHg5SJYRHA0/hqdefault.jpg" width="480" height="360"/>
+      <media:description>Another video description.</media:description>
+    </media:group>
+  </entry>
+</feed>

--- a/test/fixtures/files/feeds/youtube/feed.xml
+++ b/test/fixtures/files/feeds/youtube/feed.xml
@@ -1,498 +1,367 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/" xmlns="http://www.w3.org/2005/Atom">
- <link rel="self" href="http://www.youtube.com/feeds/videos.xml?channel_id=UCMCgOm8GZkHp8zJ6l7_hIuA"/>
- <id>yt:channel:UCMCgOm8GZkHp8zJ6l7_hIuA</id>
- <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
- <title>вДудь</title>
- <link rel="alternate" href="https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA"/>
+ <link rel="self" href="https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123def456ghi789jkl"/>
+ <id>yt:channel:UCabc123def456ghi789jkl</id>
+ <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+ <title>Sample Tech Channel</title>
+ <link rel="alternate" href="https://www.youtube.com/channel/UCabc123def456ghi789jkl"/>
  <author>
-  <name>вДудь</name>
-  <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+  <name>Sample Tech Channel</name>
+  <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
  </author>
- <published>2014-01-03T06:27:22+00:00</published>
+ <published>2020-01-01T00:00:00+00:00</published>
  <entry>
-  <id>yt:video:CNJL4GsSrcc</id>
-  <yt:videoId>CNJL4GsSrcc</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Серебряков - об эмиграции, детях и законе подлецов / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=CNJL4GsSrcc"/>
+  <id>yt:video:aAbBcCdDeEf</id>
+  <yt:videoId>aAbBcCdDeEf</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Getting Started with Ruby on Rails</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=aAbBcCdDeEf"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2018-02-20T11:25:57+00:00</published>
-  <updated>2018-02-26T17:49:27+00:00</updated>
+  <published>2024-09-15T10:00:00+00:00</published>
+  <updated>2024-09-15T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Серебряков - об эмиграции, детях и законе подлецов / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/CNJL4GsSrcc?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i4.ytimg.com/vi/CNJL4GsSrcc/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Выбирай свой Acer Spin 5 на Windows 10 http://bit.ly/2EQiKyn
+   <media:title>Getting Started with Ruby on Rails</media:title>
+   <media:content url="https://www.youtube.com/v/aAbBcCdDeEf?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/aAbBcCdDeEf/hqdefault.jpg" width="480" height="360"/>
+   <media:description>A beginner-friendly introduction to building web applications with Ruby on Rails.
 
-Алексей Серебряков - большой русский актер - новый герой вДудя.
+In this video we cover:
+- Setting up your development environment
+- Creating your first Rails app
+- Understanding the MVC pattern
 
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+Subscribe for more tutorials: https://www.youtube.com/channel/UCabc123def456ghi789jkl</media:description>
    <media:community>
-    <media:starRating count="212955" average="4.77" min="1" max="5"/>
-    <media:statistics views="4781216"/>
+    <media:starRating count="18420" average="4.91" min="1" max="5"/>
+    <media:statistics views="312540"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:SPauxWv1Rnk</id>
-  <yt:videoId>SPauxWv1Rnk</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Поперечный - о цензуре, геях и чувствах верующих / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=SPauxWv1Rnk"/>
+  <id>yt:video:bBcCdDeEfFg</id>
+  <yt:videoId>bBcCdDeEfFg</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Understanding ActiveRecord Associations</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=bBcCdDeEfFg"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2018-02-13T14:30:05+00:00</published>
-  <updated>2018-02-26T17:44:45+00:00</updated>
+  <published>2024-09-08T10:00:00+00:00</published>
+  <updated>2024-09-08T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Поперечный - о цензуре, геях и чувствах верующих / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/SPauxWv1Rnk?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i4.ytimg.com/vi/SPauxWv1Rnk/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Такого размера скидки мы еще не давали: http://2119.ru/vdud/
+   <media:title>Understanding ActiveRecord Associations</media:title>
+   <media:content url="https://www.youtube.com/v/bBcCdDeEfFg?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/bBcCdDeEfFg/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Deep dive into has_many, belongs_to, and has_many :through associations in Rails.
 
-Данила Поперечный - главный стендап комик русского интернета https://www.youtube.com/user/Spoontamer
-
-Тот самый нежный редактор (с Ириной Хакамадой) - https://www.youtube.com/watch?v=6R-5esYJR7Q
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+Source code: https://github.com/sample/rails-associations</media:description>
    <media:community>
-    <media:starRating count="255213" average="4.78" min="1" max="5"/>
-    <media:statistics views="4359805"/>
+    <media:starRating count="9870" average="4.85" min="1" max="5"/>
+    <media:statistics views="178900"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:_IPXiNIXuFI</id>
-  <yt:videoId>_IPXiNIXuFI</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Грудинин: Сталин наш лучший лидер за 100 лет / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=_IPXiNIXuFI"/>
+  <id>yt:video:cCdDeEfFgGh</id>
+  <yt:videoId>cCdDeEfFgGh</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Testing Rails Apps with Minitest</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=cCdDeEfFgGh"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2018-02-06T12:08:20+00:00</published>
-  <updated>2018-02-26T17:48:24+00:00</updated>
+  <published>2024-09-01T10:00:00+00:00</published>
+  <updated>2024-09-01T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Грудинин: Сталин наш лучший лидер за 100 лет / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/_IPXiNIXuFI?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i4.ytimg.com/vi/_IPXiNIXuFI/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Интернет-магаз часов Bestwatch https://www.bestwatch.ru/u/vdud
-Бомбические скидки 30-50-70% + промоскидка по слову VDUD
-
-Павел Грудинин - кандидат в президенты России от партии КПРФ
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>Testing Rails Apps with Minitest</media:title>
+   <media:content url="https://www.youtube.com/v/cCdDeEfFgGh?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/cCdDeEfFgGh/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Learn how to write reliable tests for your Rails application using Minitest and fixtures.</media:description>
    <media:community>
-    <media:starRating count="244990" average="3.67" min="1" max="5"/>
-    <media:statistics views="4873706"/>
+    <media:starRating count="7340" average="4.80" min="1" max="5"/>
+    <media:statistics views="134200"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:zcjKJ7FHDLM</id>
-  <yt:videoId>zcjKJ7FHDLM</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Невзоров - о Фараоне и ориентации Милонова / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=zcjKJ7FHDLM"/>
+  <id>yt:video:dDeEfFgGhHi</id>
+  <yt:videoId>dDeEfFgGhHi</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Background Jobs with Solid Queue</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=dDeEfFgGhHi"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2018-01-30T12:36:45+00:00</published>
-  <updated>2018-02-26T17:48:15+00:00</updated>
+  <published>2024-08-25T10:00:00+00:00</published>
+  <updated>2024-08-25T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Невзоров - о Фараоне и ориентации Милонова / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/zcjKJ7FHDLM?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i3.ytimg.com/vi/zcjKJ7FHDLM/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Аудиокниги для каждого в Storytel https://rr7d3.app.goo.gl/UPkV
-
-Александр Невзоров - легенда русской тележурналистики и просто философ. Его канал: https://www.youtube.com/user/NevzorovTV
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>Background Jobs with Solid Queue</media:title>
+   <media:content url="https://www.youtube.com/v/dDeEfFgGhHi?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/dDeEfFgGhHi/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Processing background jobs in Rails using Solid Queue — setup, configuration, and monitoring.</media:description>
    <media:community>
-    <media:starRating count="199233" average="4.73" min="1" max="5"/>
-    <media:statistics views="4537010"/>
+    <media:starRating count="5120" average="4.88" min="1" max="5"/>
+    <media:statistics views="98400"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:S9y4R11gzPY</id>
-  <yt:videoId>S9y4R11gzPY</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Ройзман - о предателях и легалайзе / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=S9y4R11gzPY"/>
+  <id>yt:video:eEfFgGhHiIj</id>
+  <yt:videoId>eEfFgGhHiIj</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Deploying Rails with Kamal</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=eEfFgGhHiIj"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2018-01-23T11:53:01+00:00</published>
-  <updated>2018-02-26T17:47:01+00:00</updated>
+  <published>2024-08-18T10:00:00+00:00</published>
+  <updated>2024-08-18T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Ройзман - о предателях и легалайзе / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/S9y4R11gzPY?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i4.ytimg.com/vi/S9y4R11gzPY/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Бронируем отели тут - https://ostrvk.co/vdud
-Промокод ВДУДЬ дает 10% скидку на бронирование с оплатой в мобильном приложении до 15 февраля 2018
-
-Евгений Ройзман - мэр Екатеринбурга и один из главных борцов с наркотиками на Руси. Его благотворительный фонд -
-https://roizmanfond.ru
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>Deploying Rails with Kamal</media:title>
+   <media:content url="https://www.youtube.com/v/eEfFgGhHiIj?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/eEfFgGhHiIj/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Step-by-step guide to deploying a Rails application to a VPS using Kamal 2.</media:description>
    <media:community>
-    <media:starRating count="130083" average="4.38" min="1" max="5"/>
-    <media:statistics views="3464655"/>
+    <media:starRating count="6250" average="4.82" min="1" max="5"/>
+    <media:statistics views="115600"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:x7Ilf1mAZCk</id>
-  <yt:videoId>x7Ilf1mAZCk</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Новая Россия: The Hatters, Аксенова, Покрас Лампас, Пязок / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=x7Ilf1mAZCk"/>
+  <id>yt:video:fFgGhHiIjJk</id>
+  <yt:videoId>fFgGhHiIjJk</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Turbo Frames and Streams Explained</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=fFgGhHiIjJk"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2018-01-17T15:14:01+00:00</published>
-  <updated>2018-02-26T17:42:41+00:00</updated>
+  <published>2024-08-11T10:00:00+00:00</published>
+  <updated>2024-08-11T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Новая Россия: The Hatters, Аксенова, Покрас Лампас, Пязок / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/x7Ilf1mAZCk?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i1.ytimg.com/vi/x7Ilf1mAZCk/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Кинокинокинокино: https://okko.tv/?utm_source=vdud&amp;utm_medium=display&amp;utm_campaign=okko.tv_trjan18
-14 дней БЕСПЛАТНО на пакет «Оптимальный + Амедиатека». Промокод 20180116
-14 дней БЕСПЛАТНО на пакет «Оптимальный». Промокод 01162018
-
-* * * * * * * *
-
-У русского народа есть традиция: каждый Новый год включать телевизор и охеревать от того, что там происходит. Старые, несовременные, заставшие не одного генсека люди продираются к экрану и делают какой-то стыд. Зрители злятся, ругаются, но все равно включают телек - чтобы потом снова ругаться, злиться и производить шум. В этом шуме может показаться, что Россия - это страна, где по части развлечений не происходит ничего нового.
-
-Но это - не так.
-
-Глобально Россия остается страной нефтяных вышек и доисторической попсы, но локально - плодит очень много достойной крути. Уже сейчас в России есть музыканты, актеры, режиссеры, клипмейкеры, дизайнеры, художники, которые делают классно здесь, которые или уже востребованы за границей, или имеют на это все шансы в будущем. Про многих из них вы даже не знаете, хотя они живут совсем рядом с каждым из нас.
-
-Некоторые из них - герои сегодняшнего выпуска вДудя. Они молоды, талантливы и напомнят каждому из вас: в России - невиданное количество проблем, но это не повод грустить и забиваться в угол. Это повод фигачить с еще большей силой - и рано или поздно это обязательно вынесет тебя на верх.
-
-Покрас Лампас - https://www.instagram.com/pokraslampas/
-Любовь Аксенова - https://www.instagram.com/aksenovalove
-Юрий Музыченко - https://www.instagram.com/anna_muzichenko/
-Алина Пязок - https://www.instagram.com/alina_pasok/
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>Turbo Frames and Streams Explained</media:title>
+   <media:content url="https://www.youtube.com/v/fFgGhHiIjJk?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/fFgGhHiIjJk/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Build reactive UIs without JavaScript using Turbo Frames and Turbo Streams in Rails 8.</media:description>
    <media:community>
-    <media:starRating count="193075" average="4.81" min="1" max="5"/>
-    <media:statistics views="3557875"/>
+    <media:starRating count="8910" average="4.76" min="1" max="5"/>
+    <media:statistics views="162300"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:Bjg7WSd8dyQ</id>
-  <yt:videoId>Bjg7WSd8dyQ</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Человек после войны / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=Bjg7WSd8dyQ"/>
+  <id>yt:video:gGhHiIjJkKl</id>
+  <yt:videoId>gGhHiIjJkKl</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>PostgreSQL Full-Text Search in Rails</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=gGhHiIjJkKl"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2018-01-09T06:59:23+00:00</published>
-  <updated>2018-02-26T17:24:17+00:00</updated>
+  <published>2024-08-04T10:00:00+00:00</published>
+  <updated>2024-08-04T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Человек после войны / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/Bjg7WSd8dyQ?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i3.ytimg.com/vi/Bjg7WSd8dyQ/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Несколько недель назад вы смотрели выпуск с Юрием Шевчуком - тот самый, который получился совсем не про музыку. В числе прочего там было про исследовательский опыт Шевчука: в 1995 году он приезжал в Чечню, встречался с российскими бойцами, пел им песни и снимал на видео каждый свой шаг. Возможно, самое страшное видео - перекличка бойцов, которую он там проводит:  https://goo.gl/DcByz4
-
-По легенде - важно: по легенде - через несколько дней из этих парней погибли почти все. Мы не знаем, так это или нет, но знаем, что как минимум один человек с этого видео жив. Мы нашли его совершенно случайно - благодаря одному из наших зрителей. Бойца зовут Олег Ситников, он живет в Калининграде очень тихой и очень скромной жизнью. Но перед тем как в этой жизни оказаться, он долгие годы бухал и искал хоть какие-то интересы.
-
-Мы приехали к нему в гости, чтобы показать, как живут люди, вернувшиеся с войны. Чечня была много лет назад, но в самых разных войнах мы участвуем и сейчас.
-
-Здорово, если это не пригодится вам. К сожалению, кому-то это пригодится точно.</media:description>
+   <media:title>PostgreSQL Full-Text Search in Rails</media:title>
+   <media:content url="https://www.youtube.com/v/gGhHiIjJkKl?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/gGhHiIjJkKl/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Implement fast, scalable full-text search using PostgreSQL tsvectors directly in your Rails app.</media:description>
    <media:community>
-    <media:starRating count="322650" average="4.95" min="1" max="5"/>
-    <media:statistics views="3472592"/>
+    <media:starRating count="4780" average="4.90" min="1" max="5"/>
+    <media:statistics views="88700"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:Rx_1WLpTrdk</id>
-  <yt:videoId>Rx_1WLpTrdk</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Петров - о BadComedian и лучшем русском режиссере / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=Rx_1WLpTrdk"/>
+  <id>yt:video:hHiIjJkKlLm</id>
+  <yt:videoId>hHiIjJkKlLm</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Stimulus JS Controllers from Scratch</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=hHiIjJkKlLm"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2017-12-26T07:43:06+00:00</published>
-  <updated>2018-02-26T17:45:55+00:00</updated>
+  <published>2024-07-28T10:00:00+00:00</published>
+  <updated>2024-07-28T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Петров - о BadComedian и лучшем русском режиссере / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/Rx_1WLpTrdk?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i3.ytimg.com/vi/Rx_1WLpTrdk/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Уникальное предложение от Альфа-Банка - бесплатно на год карта с самым выгодным CashBack:
-https://anketa.alfabank.ru/alfaform_dc/step1?cardId=E0&amp;packetId=L01
-
-Актер Александр Петров - звезда &quot;Притяжения&quot;, &quot;Гоголя&quot; и уймы других русских фильмов
-
-инстаграм Петрова - https://www.instagram.com/actorsashapetrov/
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>Stimulus JS Controllers from Scratch</media:title>
+   <media:content url="https://www.youtube.com/v/hHiIjJkKlLm?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/hHiIjJkKlLm/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Practical guide to writing Stimulus controllers for interactive UI behavior in Hotwire apps.</media:description>
    <media:community>
-    <media:starRating count="134964" average="4.42" min="1" max="5"/>
-    <media:statistics views="3672404"/>
+    <media:starRating count="6630" average="4.83" min="1" max="5"/>
+    <media:statistics views="121000"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:qc7AZkWPynE</id>
-  <yt:videoId>qc7AZkWPynE</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Feduk - автор главного хита этой осени / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=qc7AZkWPynE"/>
+  <id>yt:video:iIjJkKlLmMn</id>
+  <yt:videoId>iIjJkKlLmMn</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Rails Database Migrations Deep Dive</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=iIjJkKlLmMn"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2017-12-19T11:36:46+00:00</published>
-  <updated>2018-02-26T17:44:36+00:00</updated>
+  <published>2024-07-21T10:00:00+00:00</published>
+  <updated>2024-07-21T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Feduk - автор главного хита этой осени / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/qc7AZkWPynE?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i2.ytimg.com/vi/qc7AZkWPynE/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Выигрывай билеты на Чемпионат мира по футболу FIFA 2018 тут
-https://goo.gl/Jyt5aT
-
-Элджей и Feduk &quot;Розовое вино&quot; - https://www.youtube.com/watch?v=wOBnq0Ewz5k
-
-еще рэпчик во вДуде:
-Face - https://goo.gl/Ah14NC
-Гнойный - https://goo.gl/SSRbDj
-Jah Khalib - https://goo.gl/PXQssK
-Скриптонит - https://goo.gl/qt4imW
-Влади (Каста) - https://goo.gl/LdfpYa
-Гуф - https://goo.gl/CzNjGD
-Noize MC - https://goo.gl/53X9J1
-Ресторатор - https://goo.gl/ST4ruu
-L'One - https://goo.gl/oZuQxh
-Баста - https://goo.gl/yq8XdV
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>Rails Database Migrations Deep Dive</media:title>
+   <media:content url="https://www.youtube.com/v/iIjJkKlLmMn?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/iIjJkKlLmMn/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Everything you need to know about writing, running, and rolling back database migrations in Rails.</media:description>
    <media:community>
-    <media:starRating count="167534" average="4.27" min="1" max="5"/>
-    <media:statistics views="4356582"/>
+    <media:starRating count="5440" average="4.87" min="1" max="5"/>
+    <media:statistics views="99800"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:yP6VGTtRgMI</id>
-  <yt:videoId>yP6VGTtRgMI</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Слепаков - о &quot;Нашей Russia&quot; и современной России / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=yP6VGTtRgMI"/>
+  <id>yt:video:jJkKlLmMnNo</id>
+  <yt:videoId>jJkKlLmMnNo</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>API Authentication with Devise</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=jJkKlLmMnNo"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2017-12-12T08:55:24+00:00</published>
-  <updated>2018-02-26T17:46:42+00:00</updated>
+  <published>2024-07-14T10:00:00+00:00</published>
+  <updated>2024-07-14T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Слепаков - о &quot;Нашей Russia&quot; и современной России / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/yP6VGTtRgMI?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i2.ytimg.com/vi/yP6VGTtRgMI/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Заказываем карту Cash-Back от Альфа-Банка с самым выгодным кэшбэком деньгами: https://alfabank.ru/dud
-
-инстаграм Слепакова - https://www.instagram.com/slepakovsemyon/
-ютуб-канал Слепакова - https://www.youtube.com/channel/UCncuVFZrHKza2d2HXU6axaQ
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>API Authentication with Devise</media:title>
+   <media:content url="https://www.youtube.com/v/jJkKlLmMnNo?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/jJkKlLmMnNo/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Add token-based authentication to your Rails API using Devise and JWT.</media:description>
    <media:community>
-    <media:starRating count="208654" average="4.67" min="1" max="5"/>
-    <media:statistics views="5378566"/>
+    <media:starRating count="7120" average="4.79" min="1" max="5"/>
+    <media:statistics views="130500"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:98pE29S5Gb4</id>
-  <yt:videoId>98pE29S5Gb4</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Шевчук - о батле с Путиным и войне в Чечне / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=98pE29S5Gb4"/>
+  <id>yt:video:kKlLmMnNoOp</id>
+  <yt:videoId>kKlLmMnNoOp</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Caching Strategies in Rails</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=kKlLmMnNoOp"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2017-12-07T09:34:09+00:00</published>
-  <updated>2018-02-26T17:45:09+00:00</updated>
+  <published>2024-07-07T10:00:00+00:00</published>
+  <updated>2024-07-07T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Шевчук - о батле с Путиным и войне в Чечне / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/98pE29S5Gb4?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i2.ytimg.com/vi/98pE29S5Gb4/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Заказываем карту Cash-Back от Альфа-Банка с самым выгодным кэшбэком деньгами: https://alfabank.ru/dud
-
-Старт нового сезона - это особенная штука. Поэтому вместо одного выпуска мы сделали для вас два. Первая серия нового сезона вДудя (герой - Артемий Лебедев) здесь https://goo.gl/siUT7V Велком!
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>Caching Strategies in Rails</media:title>
+   <media:content url="https://www.youtube.com/v/kKlLmMnNoOp?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/kKlLmMnNoOp/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Fragment caching, Russian doll caching, and HTTP caching explained with practical examples.</media:description>
    <media:community>
-    <media:starRating count="224261" average="4.55" min="1" max="5"/>
-    <media:statistics views="3968157"/>
+    <media:starRating count="4390" average="4.86" min="1" max="5"/>
+    <media:statistics views="80200"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:b9i0tWSuSac</id>
-  <yt:videoId>b9i0tWSuSac</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Артемий Лебедев - магистр мата и отец 10 детей / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=b9i0tWSuSac"/>
+  <id>yt:video:lLmMnNoOpPq</id>
+  <yt:videoId>lLmMnNoOpPq</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Building a REST API with Rails</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=lLmMnNoOpPq"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2017-12-05T06:57:20+00:00</published>
-  <updated>2018-02-26T17:40:57+00:00</updated>
+  <published>2024-06-30T10:00:00+00:00</published>
+  <updated>2024-06-30T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Артемий Лебедев - магистр мата и отец 10 детей / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/b9i0tWSuSac?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i3.ytimg.com/vi/b9i0tWSuSac/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Купи систему VR HTC VIVE на официальном сайте и получи бесплатную копию игры Fallout 4 VR сразу после релиза. Подробности: https://www.vive.com/
-
-Артемий Лебедев - тролль, путешественник, дизайнер. Вторая серия сезона - с Юрием Шевчуком - здесь https://www.goo.gl/nyud3L
-
-Инстаграм Дудя - https://www.instagram.com/yurydud/</media:description>
+   <media:title>Building a REST API with Rails</media:title>
+   <media:content url="https://www.youtube.com/v/lLmMnNoOpPq?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/lLmMnNoOpPq/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Build a fully-featured JSON API with Rails, including serialization, versioning, and error handling.</media:description>
    <media:community>
-    <media:starRating count="129002" average="4.53" min="1" max="5"/>
-    <media:statistics views="3810308"/>
+    <media:starRating count="9560" average="4.88" min="1" max="5"/>
+    <media:statistics views="175400"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:wpfpey_0G5A</id>
-  <yt:videoId>wpfpey_0G5A</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Собчак - о Навальном, крестном и выборах / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=wpfpey_0G5A"/>
+  <id>yt:video:mMnNoOpPqQr</id>
+  <yt:videoId>mMnNoOpPqQr</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>ActiveJob and Email Queuing</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=mMnNoOpPqQr"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2017-10-24T16:08:55+00:00</published>
-  <updated>2018-02-26T17:47:49+00:00</updated>
+  <published>2024-06-23T10:00:00+00:00</published>
+  <updated>2024-06-23T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Собчак - о Навальном, крестном и выборах / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/wpfpey_0G5A?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i4.ytimg.com/vi/wpfpey_0G5A/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Подушки, матрасы, МАССАЖЕРЫ ДЛЯ ГЛАЗ и прочая красота - http://www.askona.ru/ Если при заказе введете промокод IR7ZYL11 - получите скидос
-
-Мы завершили второй сезон. Спасибо, что с нами. Все - благодаря вам.
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>ActiveJob and Email Queuing</media:title>
+   <media:content url="https://www.youtube.com/v/mMnNoOpPqQr?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/mMnNoOpPqQr/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Send transactional emails asynchronously using ActionMailer and ActiveJob with a persistent queue backend.</media:description>
    <media:community>
-    <media:starRating count="249541" average="4.14" min="1" max="5"/>
-    <media:statistics views="8223033"/>
+    <media:starRating count="3870" average="4.84" min="1" max="5"/>
+    <media:statistics views="71300"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:wg-TMymYSwE</id>
-  <yt:videoId>wg-TMymYSwE</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Познер - о цензуре, страхе и Путине / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=wg-TMymYSwE"/>
+  <id>yt:video:nNoOpPqQrRs</id>
+  <yt:videoId>nNoOpPqQrRs</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Rails Security Best Practices</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=nNoOpPqQrRs"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2017-10-18T07:10:00+00:00</published>
-  <updated>2018-02-26T17:47:09+00:00</updated>
+  <published>2024-06-16T10:00:00+00:00</published>
+  <updated>2024-06-16T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Познер - о цензуре, страхе и Путине / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/wg-TMymYSwE?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i4.ytimg.com/vi/wg-TMymYSwE/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Скидка 2 000 ₽ на колонку JBL Boombox по промокоду ЭЛЬДОВДУДЬ. Заказать можно тут: https://eldorado.ru/~JBL
-
-Порнофильмы - главная панк-команда России прямо сейчас - едет в тур по стране. Лови их в своем городе http://www.pornopunk.ru/concerts/
-
-Нежный редактор Таня запустила свой канал. Я еще не смотрел, но, говорят, там будут ЖЕНЩИНЫ https://goo.gl/yL9Fvo
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>Rails Security Best Practices</media:title>
+   <media:content url="https://www.youtube.com/v/nNoOpPqQrRs?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/nNoOpPqQrRs/hqdefault.jpg" width="480" height="360"/>
+   <media:description>Protect your Rails app from SQL injection, XSS, CSRF, and other common vulnerabilities.</media:description>
    <media:community>
-    <media:starRating count="236852" average="4.84" min="1" max="5"/>
-    <media:statistics views="5147079"/>
+    <media:starRating count="6180" average="4.92" min="1" max="5"/>
+    <media:statistics views="113600"/>
    </media:community>
   </media:group>
  </entry>
  <entry>
-  <id>yt:video:mmid_NMUoFg</id>
-  <yt:videoId>mmid_NMUoFg</yt:videoId>
-  <yt:channelId>UCMCgOm8GZkHp8zJ6l7_hIuA</yt:channelId>
-  <title>Face - почему от него фанатеет молодежь / вДудь</title>
-  <link rel="alternate" href="https://www.youtube.com/watch?v=mmid_NMUoFg"/>
+  <id>yt:video:oOpPqQrRsSt</id>
+  <yt:videoId>oOpPqQrRsSt</yt:videoId>
+  <yt:channelId>UCabc123def456ghi789jkl</yt:channelId>
+  <title>Polymorphic Associations in Rails</title>
+  <link rel="alternate" href="https://www.youtube.com/watch?v=oOpPqQrRsSt"/>
   <author>
-   <name>вДудь</name>
-   <uri>https://www.youtube.com/channel/UCMCgOm8GZkHp8zJ6l7_hIuA</uri>
+   <name>Sample Tech Channel</name>
+   <uri>https://www.youtube.com/channel/UCabc123def456ghi789jkl</uri>
   </author>
-  <published>2017-10-11T21:19:19+00:00</published>
-  <updated>2018-02-26T17:49:12+00:00</updated>
+  <published>2024-06-09T10:00:00+00:00</published>
+  <updated>2024-06-09T10:00:00+00:00</updated>
   <media:group>
-   <media:title>Face - почему от него фанатеет молодежь / вДудь</media:title>
-   <media:content url="https://www.youtube.com/v/mmid_NMUoFg?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
-   <media:thumbnail url="https://i2.ytimg.com/vi/mmid_NMUoFg/hqdefault.jpg" width="480" height="360"/>
-   <media:description>Пельмени и прочую вкуснятину берем здесь - https://goo.gl/wG6YpH
-
-видосы внутри - https://www.youtube.com/watch?v=ctkML3BVaxw
-
-инстаграм Дудя - https://www.instagram.com/yurydud/
-вконтос Дудя - https://vk.com/vdud
-одноклассники Дудя - https://ok.ru/vdud
-твиттер Дудя - https://twitter.com/yurydud</media:description>
+   <media:title>Polymorphic Associations in Rails</media:title>
+   <media:content url="https://www.youtube.com/v/oOpPqQrRsSt?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+   <media:thumbnail url="https://i.ytimg.com/vi/oOpPqQrRsSt/hqdefault.jpg" width="480" height="360"/>
+   <media:description>When and how to use polymorphic associations for flexible, reusable model relationships in Rails.</media:description>
    <media:community>
-    <media:starRating count="367063" average="3.73" min="1" max="5"/>
-    <media:statistics views="9493950"/>
+    <media:starRating count="4950" average="4.89" min="1" max="5"/>
+    <media:statistics views="91100"/>
    </media:community>
   </media:group>
  </entry>

--- a/test/fixtures/files/feeds/youtube/normalized.json
+++ b/test/fixtures/files/feeds/youtube/normalized.json
@@ -1,14 +1,14 @@
 {
   "attachment_urls": [
-    "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+    "https://i4.ytimg.com/vi/CNJL4GsSrcc/hqdefault.jpg"
   ],
   "comments": [
-    "This is the video description."
+    "Выбирай свой Acer Spin 5 на Windows 10 http://bit.ly/2EQiKyn Алексей Серебряков - большой русский актер - новый герой вДудя. инстаграм Дудя - https://www.instagram.com/yurydud/ вконтос Дудя - https://vk.com/vdud одноклассники Дудя - https://ok.ru/vdud твиттер Дудя - https://twitter.com/yurydud"
   ],
-  "content": "Sample Video Title - https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-  "published_at": "2024-09-12T10:00:00.000Z",
-  "source_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  "content": "Серебряков - об эмиграции, детях и законе подлецов / вДудь - https://www.youtube.com/watch?v=CNJL4GsSrcc",
+  "published_at": "2018-02-20T11:25:57.000Z",
+  "source_url": "https://www.youtube.com/watch?v=CNJL4GsSrcc",
   "status": "enqueued",
-  "uid": "yt:video:dQw4w9WgXcQ",
+  "uid": "yt:video:CNJL4GsSrcc",
   "validation_errors": []
 }

--- a/test/fixtures/files/feeds/youtube/normalized.json
+++ b/test/fixtures/files/feeds/youtube/normalized.json
@@ -1,14 +1,14 @@
 {
   "attachment_urls": [
-    "https://i4.ytimg.com/vi/CNJL4GsSrcc/hqdefault.jpg"
+    "https://i.ytimg.com/vi/aAbBcCdDeEf/hqdefault.jpg"
   ],
   "comments": [
-    "Выбирай свой Acer Spin 5 на Windows 10 http://bit.ly/2EQiKyn Алексей Серебряков - большой русский актер - новый герой вДудя. инстаграм Дудя - https://www.instagram.com/yurydud/ вконтос Дудя - https://vk.com/vdud одноклассники Дудя - https://ok.ru/vdud твиттер Дудя - https://twitter.com/yurydud"
+    "A beginner-friendly introduction to building web applications with Ruby on Rails. In this video we cover: - Setting up your development environment - Creating your first Rails app - Understanding the MVC pattern Subscribe for more tutorials: https://www.youtube.com/channel/UCabc123def456ghi789jkl"
   ],
-  "content": "Серебряков - об эмиграции, детях и законе подлецов / вДудь - https://www.youtube.com/watch?v=CNJL4GsSrcc",
-  "published_at": "2018-02-20T11:25:57.000Z",
-  "source_url": "https://www.youtube.com/watch?v=CNJL4GsSrcc",
+  "content": "Getting Started with Ruby on Rails - https://www.youtube.com/watch?v=aAbBcCdDeEf",
+  "published_at": "2024-09-15T10:00:00.000Z",
+  "source_url": "https://www.youtube.com/watch?v=aAbBcCdDeEf",
   "status": "enqueued",
-  "uid": "yt:video:CNJL4GsSrcc",
+  "uid": "yt:video:aAbBcCdDeEf",
   "validation_errors": []
 }

--- a/test/fixtures/files/feeds/youtube/normalized.json
+++ b/test/fixtures/files/feeds/youtube/normalized.json
@@ -1,0 +1,14 @@
+{
+  "attachment_urls": [
+    "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+  ],
+  "comments": [
+    "This is the video description."
+  ],
+  "content": "Sample Video Title - https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  "published_at": "2024-09-12T10:00:00.000Z",
+  "source_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  "status": "enqueued",
+  "uid": "yt:video:dQw4w9WgXcQ",
+  "validation_errors": []
+}

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
-    assert_equal ["llm_web_search", "llm_website_extractor", "rss", "xkcd"], FeedProfile.all.sort
+    assert_equal ["llm_web_search", "llm_website_extractor", "rss", "xkcd", "youtube"], FeedProfile.all.sort
   end
 
   test ".exists? returns true for valid profile key" do

--- a/test/services/loader/youtube_loader_test.rb
+++ b/test/services/loader/youtube_loader_test.rb
@@ -1,0 +1,127 @@
+require "test_helper"
+
+class Loader::YoutubeLoaderTest < ActiveSupport::TestCase
+  FEED_URL = "https://www.youtube.com/feeds/videos.xml?channel_id=UC123"
+  CHANNEL_URL = "https://www.youtube.com/@TestChannel"
+  FEED_BODY = "<feed>...</feed>"
+
+  CHANNEL_PAGE_WITH_RSS = <<~HTML
+    <html><head>
+      <link rel="alternate" type="application/rss+xml" title="RSS" href="#{FEED_URL}">
+    </head><body></body></html>
+  HTML
+
+  CHANNEL_PAGE_WITH_ATOM = <<~HTML
+    <html><head>
+      <link rel="alternate" type="application/atom+xml" title="Atom" href="#{FEED_URL}">
+    </head><body></body></html>
+  HTML
+
+  def feed_with_url(url)
+    create(:feed, url: url)
+  end
+
+  test "#load should fetch feed URL directly when URL is already a feed URL" do
+    feed = feed_with_url(FEED_URL)
+    mock_client = MockHttpClient.new(responses: { FEED_URL => ok(FEED_BODY) })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    assert_equal FEED_BODY, loader.load
+    assert_equal [FEED_URL], mock_client.requested_urls
+  end
+
+  test "#load should resolve channel URL to feed URL via RSS link" do
+    feed = feed_with_url(CHANNEL_URL)
+    mock_client = MockHttpClient.new(responses: {
+      CHANNEL_URL => ok(CHANNEL_PAGE_WITH_RSS),
+      FEED_URL => ok(FEED_BODY)
+    })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    assert_equal FEED_BODY, loader.load
+    assert_equal [CHANNEL_URL, FEED_URL], mock_client.requested_urls
+  end
+
+  test "#load should resolve channel URL to feed URL via Atom link" do
+    feed = feed_with_url(CHANNEL_URL)
+    mock_client = MockHttpClient.new(responses: {
+      CHANNEL_URL => ok(CHANNEL_PAGE_WITH_ATOM),
+      FEED_URL => ok(FEED_BODY)
+    })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    assert_equal FEED_BODY, loader.load
+  end
+
+  test "#load should raise when channel page has no RSS link" do
+    feed = feed_with_url(CHANNEL_URL)
+    mock_client = MockHttpClient.new(responses: {
+      CHANNEL_URL => ok("<html><body>No RSS here</body></html>")
+    })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    error = assert_raises(StandardError) { loader.load }
+    assert_match "Could not find YouTube RSS feed link", error.message
+  end
+
+  test "#load should raise on HTTP error for feed URL" do
+    feed = feed_with_url(FEED_URL)
+    mock_client = MockHttpClient.new(responses: { FEED_URL => error_response(404) })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    error = assert_raises(StandardError) { loader.load }
+    assert_equal "HTTP 404", error.message
+  end
+
+  test "#load should raise on HTTP error for channel page" do
+    feed = feed_with_url(CHANNEL_URL)
+    mock_client = MockHttpClient.new(responses: { CHANNEL_URL => error_response(403) })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    error = assert_raises(StandardError) { loader.load }
+    assert_equal "HTTP 403", error.message
+  end
+
+  test "#load should handle connection errors" do
+    feed = feed_with_url(FEED_URL)
+    mock_client = MockHttpClient.new(error: HttpClient::ConnectionError.new("Connection refused"))
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    error = assert_raises(StandardError) { loader.load }
+    assert_equal "Connection refused", error.message
+  end
+
+  private
+
+  def ok(body)
+    HttpClient::Response.new(status: 200, body: body, headers: {})
+  end
+
+  def error_response(status)
+    HttpClient::Response.new(status: status, body: "Error")
+  end
+
+  class MockHttpClient
+    attr_reader :requested_urls
+
+    def initialize(responses: {}, error: nil)
+      @responses = responses
+      @error = error
+      @requested_urls = []
+    end
+
+    def get(url)
+      @requested_urls << url
+      raise @error if @error
+
+      @responses.fetch(url) { raise KeyError, "Unexpected URL: #{url}" }
+    end
+  end
+end

--- a/test/services/normalizer/youtube_normalizer_test.rb
+++ b/test/services/normalizer/youtube_normalizer_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class Normalizer::YoutubeNormalizerTest < ActiveSupport::TestCase
+  include FixtureFeedEntries
+
+  def fixture_dir
+    "feeds/youtube"
+  end
+
+  def processor_class
+    Processor::YoutubeProcessor
+  end
+
+  test "#normalize should match the expected normalization result" do
+    entry = feed_entry(0)
+
+    normalizer = Normalizer::YoutubeNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
+  end
+
+  test "#normalize should use video title as content" do
+    entry = create(:feed_entry, raw_data: {
+      "title" => "My Video",
+      "link" => "https://www.youtube.com/watch?v=abc123"
+    })
+
+    normalizer = Normalizer::YoutubeNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_includes post.content, "My Video"
+  end
+
+  test "#normalize should include thumbnail as attachment" do
+    entry = create(:feed_entry, raw_data: {
+      "title" => "Video",
+      "link" => "https://www.youtube.com/watch?v=abc123",
+      "thumbnail" => "https://i.ytimg.com/vi/abc123/hqdefault.jpg"
+    })
+
+    normalizer = Normalizer::YoutubeNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal ["https://i.ytimg.com/vi/abc123/hqdefault.jpg"], post.attachment_urls
+  end
+
+  test "#normalize should include description as comment" do
+    entry = create(:feed_entry, raw_data: {
+      "title" => "Video",
+      "link" => "https://www.youtube.com/watch?v=abc123",
+      "content" => "This is a description."
+    })
+
+    normalizer = Normalizer::YoutubeNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal ["This is a description."], post.comments
+  end
+
+  test "#normalize should produce empty comments when description is blank" do
+    entry = create(:feed_entry, raw_data: {
+      "title" => "Video",
+      "link" => "https://www.youtube.com/watch?v=abc123"
+    })
+
+    normalizer = Normalizer::YoutubeNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal [], post.comments
+  end
+
+  test "#normalize should produce empty attachment_urls when no thumbnail" do
+    entry = create(:feed_entry, raw_data: {
+      "title" => "Video",
+      "link" => "https://www.youtube.com/watch?v=abc123"
+    })
+
+    normalizer = Normalizer::YoutubeNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal [], post.attachment_urls
+  end
+end

--- a/test/services/processor/youtube_processor_test.rb
+++ b/test/services/processor/youtube_processor_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
-  CHANNEL_ID = "UCMCgOm8GZkHp8zJ6l7_hIuA"
-  FIRST_VIDEO_ID = "CNJL4GsSrcc"
+  CHANNEL_ID = "UCabc123def456ghi789jkl"
+  FIRST_VIDEO_ID = "aAbBcCdDeEf"
 
   def feed
     @feed ||= create(:feed, url: "https://www.youtube.com/feeds/videos.xml?channel_id=#{CHANNEL_ID}")
@@ -34,7 +34,7 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
     entry = processor.process.first
     entry.save!
 
-    assert_equal "https://i4.ytimg.com/vi/#{FIRST_VIDEO_ID}/hqdefault.jpg", entry.raw_data["thumbnail"]
+    assert_equal "https://i.ytimg.com/vi/#{FIRST_VIDEO_ID}/hqdefault.jpg", entry.raw_data["thumbnail"]
   end
 
   test "#process should include video URL in raw_data" do

--- a/test/services/processor/youtube_processor_test.rb
+++ b/test/services/processor/youtube_processor_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, url: "https://www.youtube.com/feeds/videos.xml?channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw")
+  end
+
+  def sample_feed_xml
+    @sample_feed_xml ||= file_fixture("feeds/youtube/feed.xml").read
+  end
+
+  test "#process should parse YouTube feed and create FeedEntry objects" do
+    processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
+    entries = processor.process
+
+    assert_equal 2, entries.length
+    assert entries.all? { |entry| entry.is_a?(FeedEntry) }
+    assert entries.all? { |entry| entry.feed == feed }
+    assert entries.all? { |entry| entry.status == "pending" }
+  end
+
+  test "#process should set uid from video id" do
+    processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
+    entries = processor.process
+
+    assert_equal "yt:video:dQw4w9WgXcQ", entries.first.uid
+  end
+
+  test "#process should include thumbnail in raw_data" do
+    processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
+    entry = processor.process.first
+    entry.save!
+
+    assert_equal "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg", entry.raw_data["thumbnail"]
+  end
+
+  test "#process should include video URL in raw_data" do
+    processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
+    entry = processor.process.first
+    entry.save!
+
+    assert_equal "https://www.youtube.com/watch?v=dQw4w9WgXcQ", entry.raw_data["url"]
+  end
+end

--- a/test/services/processor/youtube_processor_test.rb
+++ b/test/services/processor/youtube_processor_test.rb
@@ -1,8 +1,11 @@
 require "test_helper"
 
 class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
+  CHANNEL_ID = "UCMCgOm8GZkHp8zJ6l7_hIuA"
+  FIRST_VIDEO_ID = "CNJL4GsSrcc"
+
   def feed
-    @feed ||= create(:feed, url: "https://www.youtube.com/feeds/videos.xml?channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw")
+    @feed ||= create(:feed, url: "https://www.youtube.com/feeds/videos.xml?channel_id=#{CHANNEL_ID}")
   end
 
   def sample_feed_xml
@@ -13,7 +16,7 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
     processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
     entries = processor.process
 
-    assert_equal 2, entries.length
+    assert_equal 15, entries.length
     assert entries.all? { |entry| entry.is_a?(FeedEntry) }
     assert entries.all? { |entry| entry.feed == feed }
     assert entries.all? { |entry| entry.status == "pending" }
@@ -23,7 +26,7 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
     processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
     entries = processor.process
 
-    assert_equal "yt:video:dQw4w9WgXcQ", entries.first.uid
+    assert_equal "yt:video:#{FIRST_VIDEO_ID}", entries.first.uid
   end
 
   test "#process should include thumbnail in raw_data" do
@@ -31,7 +34,7 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
     entry = processor.process.first
     entry.save!
 
-    assert_equal "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg", entry.raw_data["thumbnail"]
+    assert_equal "https://i4.ytimg.com/vi/#{FIRST_VIDEO_ID}/hqdefault.jpg", entry.raw_data["thumbnail"]
   end
 
   test "#process should include video URL in raw_data" do
@@ -39,6 +42,6 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
     entry = processor.process.first
     entry.save!
 
-    assert_equal "https://www.youtube.com/watch?v=dQw4w9WgXcQ", entry.raw_data["url"]
+    assert_equal "https://www.youtube.com/watch?v=#{FIRST_VIDEO_ID}", entry.raw_data["url"]
   end
 end

--- a/test/services/profile_matcher/youtube_profile_matcher_test.rb
+++ b/test/services/profile_matcher/youtube_profile_matcher_test.rb
@@ -17,24 +17,32 @@ class ProfileMatcher::YoutubeProfileMatcherTest < ActiveSupport::TestCase
     assert_equal false, ProfileMatcher::YoutubeProfileMatcher.depends_on_ai
   end
 
-  test "#match? should match youtube.com channel URLs" do
+  test "#match? should match youtube.com with www prefix" do
     assert matcher("https://www.youtube.com/@SomeChannel").match?
     assert matcher("https://www.youtube.com/channel/UC123").match?
     assert matcher("https://www.youtube.com/c/ChannelName").match?
     assert matcher("https://www.youtube.com/user/Username").match?
-  end
-
-  test "#match? should match youtube.com feed URLs" do
     assert matcher("https://www.youtube.com/feeds/videos.xml?channel_id=UC123").match?
   end
 
-  test "#match? should match youtu.be URLs" do
+  test "#match? should match youtube.com without www prefix" do
+    assert matcher("https://youtube.com/@SomeChannel").match?
+    assert matcher("https://youtube.com/feeds/videos.xml?channel_id=UC123").match?
+  end
+
+  test "#match? should match youtu.be with and without www prefix" do
     assert matcher("https://youtu.be/dQw4w9WgXcQ").match?
+    assert matcher("https://www.youtu.be/dQw4w9WgXcQ").match?
   end
 
   test "#match? should not match non-YouTube URLs" do
     assert_not matcher("https://example.com/feed.xml").match?
     assert_not matcher("https://vimeo.com/channel/test").match?
+  end
+
+  test "#match? should not match domains that merely end with youtube.com" do
+    assert_not matcher("https://notyoutube.com/feed").match?
+    assert_not matcher("https://fakeyoutube.com/channel/UC123").match?
   end
 
   test "#match? should not match URLs that contain youtube in the path only" do

--- a/test/services/profile_matcher/youtube_profile_matcher_test.rb
+++ b/test/services/profile_matcher/youtube_profile_matcher_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class ProfileMatcher::YoutubeProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::YoutubeProfileMatcher.new(url)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::YoutubeProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 100" do
+    assert_equal 100, ProfileMatcher::YoutubeProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::YoutubeProfileMatcher.depends_on_ai
+  end
+
+  test "#match? should match youtube.com channel URLs" do
+    assert matcher("https://www.youtube.com/@SomeChannel").match?
+    assert matcher("https://www.youtube.com/channel/UC123").match?
+    assert matcher("https://www.youtube.com/c/ChannelName").match?
+    assert matcher("https://www.youtube.com/user/Username").match?
+  end
+
+  test "#match? should match youtube.com feed URLs" do
+    assert matcher("https://www.youtube.com/feeds/videos.xml?channel_id=UC123").match?
+  end
+
+  test "#match? should match youtu.be URLs" do
+    assert matcher("https://youtu.be/dQw4w9WgXcQ").match?
+  end
+
+  test "#match? should not match non-YouTube URLs" do
+    assert_not matcher("https://example.com/feed.xml").match?
+    assert_not matcher("https://vimeo.com/channel/test").match?
+  end
+
+  test "#match? should not match URLs that contain youtube in the path only" do
+    assert_not matcher("https://example.com/youtube.com/feed").match?
+  end
+
+  test "#match? should handle blank input" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+end


### PR DESCRIPTION
Changes:

- Add `YoutubeProfileMatcher` to detect YouTube channel and feed URLs
- Add `YoutubeLoader` to resolve YouTube channel URLs to feed URLs and fetch feed content
- Add `YoutubeProcessor` to parse YouTube Atom feeds and extract video metadata (thumbnails, descriptions)
- Add `YoutubeNormalizer` to normalize YouTube video entries into posts with content, attachments, and comments
- Register YouTube as a feed profile type in `FeedProfile`
- Add comprehensive test coverage for all YouTube components including feed resolution, parsing, and normalization

The implementation allows users to subscribe to YouTube channels by providing either a channel URL (e.g., `https://www.youtube.com/@ChannelName`) or a direct feed URL. The loader automatically resolves channel pages to their RSS/Atom feeds, the processor extracts video metadata including thumbnails and descriptions, and the normalizer formats videos as posts with the video title as content, thumbnail as attachment, and description as a comment.

References:

- Closes #476
