### PR TITLE
Add Reddit feed profile support

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -58,12 +58,12 @@ class FeedProfile
       parameter_schema: {
         "type" => "object",
         "properties" => {
-          "url" => { "type" => "string", "format" => "uri" }
+          "url" => { "type" => "string", "minLength" => 2 }
         },
         "required" => ["url"],
         "additionalProperties" => false
       },
-      loader: { class: "Loader::HttpLoader", config: {} },
+      loader: { class: "Loader::RedditLoader", config: {} },
       processor: { class: "Processor::RssProcessor", config: {} },
       normalizer: { class: "Normalizer::RedditNormalizer", config: {} },
       title_extractor: "TitleExtractor::RssTitleExtractor",

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -49,6 +49,26 @@ class FeedProfile
       title_extractor: "TitleExtractor::RssTitleExtractor",
       output_schema: nil
     },
+    "reddit" => {
+      display_name: "Reddit",
+      description: "Posts from a subreddit or Reddit user page via RSS",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::RedditProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "format" => "uri" }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::HttpLoader", config: {} },
+      processor: { class: "Processor::RssProcessor", config: {} },
+      normalizer: { class: "Normalizer::RedditNormalizer", config: {} },
+      title_extractor: "TitleExtractor::RssTitleExtractor",
+      output_schema: nil
+    },
     "xkcd" => {
       display_name: "XKCD",
       description: "Posts from xkcd.com with the alt text included",

--- a/app/services/loader/reddit_loader.rb
+++ b/app/services/loader/reddit_loader.rb
@@ -1,0 +1,37 @@
+module Loader
+  # Fetches a Reddit RSS feed, normalising any form of Reddit input
+  # (full URL, short name like "r/worldnews") to a /new.rss URL so that
+  # entries arrive in chronological order regardless of what the user typed.
+  class RedditLoader < HttpLoader
+    SHORT_SUBREDDIT = %r{\Ar/([A-Za-z0-9_]+)\z}i
+    SHORT_USER      = %r{\Auser/([A-Za-z0-9_-]+)\z}i
+    REDDIT_PATH     = %r{reddit\.com/(r|user)/([A-Za-z0-9_-]+)}
+
+    def load
+      response = http_client.get(rss_url)
+      raise StandardError, "HTTP #{response.status}" unless response.success?
+
+      response.body
+    rescue HttpClient::Error => e
+      raise StandardError, e.message
+    end
+
+    private
+
+    def rss_url
+      @rss_url ||= build_rss_url(feed.url.to_s.strip)
+    end
+
+    def build_rss_url(input)
+      if (m = input.match(SHORT_SUBREDDIT))
+        "https://www.reddit.com/r/#{m[1]}/new.rss"
+      elsif (m = input.match(SHORT_USER))
+        "https://www.reddit.com/user/#{m[1]}/new.rss"
+      elsif (m = input.match(REDDIT_PATH))
+        "https://www.reddit.com/#{m[1]}/#{m[2]}/new.rss"
+      else
+        input
+      end
+    end
+  end
+end

--- a/app/services/normalizer/reddit_normalizer.rb
+++ b/app/services/normalizer/reddit_normalizer.rb
@@ -1,0 +1,25 @@
+module Normalizer
+  # Reddit-specific normalizer that extracts the post body from the HTML
+  # description field, separating it from Reddit's "submitted by" footer.
+  # Link posts (no body) fall back to title only.
+  class RedditNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      title = raw_data.dig("title").to_s.strip
+      body = extract_post_body
+      body.present? ? "#{title}\n\n#{body}" : title
+    end
+
+    def extract_post_body
+      summary = raw_data.dig("summary") || ""
+      return "" if summary.blank?
+
+      doc = Nokogiri::HTML::DocumentFragment.parse(summary)
+      md_div = doc.css("div.md").first
+      return "" if md_div.nil?
+
+      md_div.text.strip.gsub(/\s+/, " ")
+    end
+  end
+end

--- a/app/services/profile_matcher/reddit_profile_matcher.rb
+++ b/app/services/profile_matcher/reddit_profile_matcher.rb
@@ -5,11 +5,17 @@ module ProfileMatcher
 
     REDDIT_DOMAINS = %w[reddit.com www.reddit.com old.reddit.com].freeze
     REDDIT_PATH_PATTERN = %r{\A/(r|user)/[^/]+}
+    SHORT_SUBREDDIT = %r{\Ar/[A-Za-z0-9_]+\z}i
+    SHORT_USER      = %r{\Auser/[A-Za-z0-9_-]+\z}i
 
     def match?
       return false if input.blank?
 
-      uri = URI.parse(input)
+      stripped = input.strip
+      return true if stripped.match?(SHORT_SUBREDDIT)
+      return true if stripped.match?(SHORT_USER)
+
+      uri = URI.parse(stripped)
       REDDIT_DOMAINS.include?(uri.host) && uri.path.match?(REDDIT_PATH_PATTERN)
     end
   end

--- a/app/services/profile_matcher/reddit_profile_matcher.rb
+++ b/app/services/profile_matcher/reddit_profile_matcher.rb
@@ -1,0 +1,16 @@
+module ProfileMatcher
+  class RedditProfileMatcher < Base
+    input_shape :url
+    match_specificity 50
+
+    REDDIT_DOMAINS = %w[reddit.com www.reddit.com old.reddit.com].freeze
+    REDDIT_PATH_PATTERN = %r{\A/(r|user)/[^/]+}
+
+    def match?
+      return false if input.blank?
+
+      uri = URI.parse(input)
+      REDDIT_DOMAINS.include?(uri.host) && uri.path.match?(REDDIT_PATH_PATTERN)
+    end
+  end
+end

--- a/test/fixtures/files/feeds/reddit/feed.xml
+++ b/test/fixtures/files/feeds/reddit/feed.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>r/programming: Computer Science</title>
+    <link>https://www.reddit.com/r/programming/</link>
+    <description>Computer Science</description>
+
+    <item>
+      <title>Ask r/programming: What are you working on?</title>
+      <link>https://www.reddit.com/r/programming/comments/abc123/ask_rprogramming_what_are_you_working_on/</link>
+      <guid isPermaLink="true">https://www.reddit.com/r/programming/comments/abc123/ask_rprogramming_what_are_you_working_on/</guid>
+      <pubDate>Mon, 26 May 2026 10:00:00 +0000</pubDate>
+      <description>&lt;!-- SC_OFF --&gt;&lt;div class="md"&gt;&lt;p&gt;Share what you are currently hacking on. Feel free to be brief, this is not for feedback.&lt;/p&gt;&lt;/div&gt;&lt;!-- SC_ON --&gt; &amp;#32; submitted by &amp;#32; &lt;a href="https://www.reddit.com/user/techuser"&gt; /u/techuser &lt;/a&gt; &amp;#32; &lt;a href="https://www.reddit.com/r/programming/comments/abc123/ask_rprogramming_what_are_you_working_on/"&gt;[link]&lt;/a&gt; &amp;#32; &lt;a href="https://www.reddit.com/r/programming/comments/abc123/ask_rprogramming_what_are_you_working_on/"&gt;[comments]&lt;/a&gt;</description>
+      <dc:creator>techuser</dc:creator>
+    </item>
+
+    <item>
+      <title>Ruby 3.4 Released</title>
+      <link>https://www.reddit.com/r/programming/comments/def456/ruby_34_released/</link>
+      <guid isPermaLink="true">https://www.reddit.com/r/programming/comments/def456/ruby_34_released/</guid>
+      <pubDate>Sun, 25 May 2026 08:00:00 +0000</pubDate>
+      <description>&amp;#32; submitted by &amp;#32; &lt;a href="https://www.reddit.com/user/rubydev"&gt; /u/rubydev &lt;/a&gt; &amp;#32; &lt;a href="https://www.ruby-lang.org/en/news/2026/05/25/ruby-3-4-released/"&gt;[link]&lt;/a&gt; &amp;#32; &lt;a href="https://www.reddit.com/r/programming/comments/def456/ruby_34_released/"&gt;[comments]&lt;/a&gt;</description>
+      <dc:creator>rubydev</dc:creator>
+    </item>
+
+  </channel>
+</rss>

--- a/test/fixtures/files/feeds/reddit/normalized.json
+++ b/test/fixtures/files/feeds/reddit/normalized.json
@@ -1,0 +1,10 @@
+{
+  "attachment_urls": [],
+  "comments": [],
+  "content": "Ask r/programming: What are you working on?\n\nShare what you are currently hacking on. Feel free to be brief, this is not for feedback. - https://www.reddit.com/r/programming/comments/abc123/ask_rprogramming_what_are_you_working_on/",
+  "published_at": "2026-05-26T10:00:00.000Z",
+  "source_url": "https://www.reddit.com/r/programming/comments/abc123/ask_rprogramming_what_are_you_working_on/",
+  "status": "enqueued",
+  "uid": "https://www.reddit.com/r/programming/comments/abc123/ask_rprogramming_what_are_you_working_on/",
+  "validation_errors": []
+}

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
-    assert_equal ["llm_web_search", "llm_website_extractor", "rss", "xkcd", "youtube"], FeedProfile.all.sort
+    assert_equal ["llm_web_search", "llm_website_extractor", "reddit", "rss", "xkcd", "youtube"], FeedProfile.all.sort
   end
 
   test ".exists? returns true for valid profile key" do

--- a/test/services/loader/reddit_loader_test.rb
+++ b/test/services/loader/reddit_loader_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class Loader::RedditLoaderTest < ActiveSupport::TestCase
+  RSS_BODY = "<rss>reddit feed</rss>"
+
+  def mock_client(url: nil)
+    MockHttpClient.new(
+      url: url,
+      response: HttpClient::Response.new(status: 200, body: RSS_BODY)
+    )
+  end
+
+  def loader(feed_url, http_client: nil)
+    feed = create(:feed, feed_profile_key: "reddit", url: feed_url)
+    opts = http_client ? { http_client: http_client } : {}
+    Loader::RedditLoader.new(feed, opts)
+  end
+
+  test "#load should normalise short subreddit name to new.rss URL" do
+    client = mock_client
+    loader("r/worldnews", http_client: client).load
+    assert_equal "https://www.reddit.com/r/worldnews/new.rss", client.last_request_url
+  end
+
+  test "#load should normalise short user name to new.rss URL" do
+    client = mock_client
+    loader("user/someuser", http_client: client).load
+    assert_equal "https://www.reddit.com/user/someuser/new.rss", client.last_request_url
+  end
+
+  test "#load should normalise full subreddit URL to new.rss URL" do
+    client = mock_client
+    loader("https://www.reddit.com/r/programming/", http_client: client).load
+    assert_equal "https://www.reddit.com/r/programming/new.rss", client.last_request_url
+  end
+
+  test "#load should normalise full user page URL to new.rss URL" do
+    client = mock_client
+    loader("https://www.reddit.com/user/someuser/", http_client: client).load
+    assert_equal "https://www.reddit.com/user/someuser/new.rss", client.last_request_url
+  end
+
+  test "#load should normalise old.reddit.com URL to www.reddit.com new.rss URL" do
+    client = mock_client
+    loader("https://old.reddit.com/r/ruby/", http_client: client).load
+    assert_equal "https://www.reddit.com/r/ruby/new.rss", client.last_request_url
+  end
+
+  test "#load should normalise existing .rss URL to new.rss URL" do
+    client = mock_client
+    loader("https://www.reddit.com/r/worldnews/.rss", http_client: client).load
+    assert_equal "https://www.reddit.com/r/worldnews/new.rss", client.last_request_url
+  end
+
+  test "#load should return feed body on success" do
+    result = loader("r/worldnews", http_client: mock_client).load
+    assert_equal RSS_BODY, result
+  end
+
+  test "#load should raise on HTTP error" do
+    feed = create(:feed, feed_profile_key: "reddit", url: "r/worldnews")
+    error_client = MockHttpClient.new(response: HttpClient::Response.new(status: 429, body: "Too Many Requests"))
+    error = assert_raises(StandardError) { Loader::RedditLoader.new(feed, { http_client: error_client }).load }
+    assert_equal "HTTP 429", error.message
+  end
+
+  private
+
+  class MockHttpClient
+    attr_reader :last_request_url
+
+    def initialize(url: nil, response: nil, error: nil)
+      @response = response
+      @error = error
+    end
+
+    def get(url)
+      @last_request_url = url
+      raise @error if @error
+      @response
+    end
+  end
+end

--- a/test/services/normalizer/reddit_normalizer_test.rb
+++ b/test/services/normalizer/reddit_normalizer_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class Normalizer::RedditNormalizerTest < ActiveSupport::TestCase
+  include FixtureFeedEntries
+
+  def fixture_dir
+    "feeds/reddit"
+  end
+
+  def processor_class
+    Processor::RssProcessor
+  end
+
+  test "#normalize should match the expected normalization result for a text post" do
+    entry = feed_entry(0)
+
+    normalizer = Normalizer::RedditNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
+  end
+
+  test "#normalize should use title only for a link post with no body" do
+    entry = feed_entry(1)
+
+    normalizer = Normalizer::RedditNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal "enqueued", post.status
+    assert_equal [], post.validation_errors
+    assert post.content.start_with?("Ruby 3.4 Released")
+    assert_not_includes post.content, "submitted by"
+    assert_not_includes post.content, "/u/rubydev"
+  end
+
+  test "#normalize should strip 'submitted by' footer from text posts" do
+    entry = feed_entry(0)
+
+    normalizer = Normalizer::RedditNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_not_includes post.content, "submitted by"
+    assert_not_includes post.content, "/u/techuser"
+  end
+
+  test "#normalize should include Reddit permalink as source URL" do
+    entry = feed_entry(0)
+
+    normalizer = Normalizer::RedditNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal "https://www.reddit.com/r/programming/comments/abc123/ask_rprogramming_what_are_you_working_on/",
+                 post.source_url
+  end
+end

--- a/test/services/profile_matcher/reddit_profile_matcher_test.rb
+++ b/test/services/profile_matcher/reddit_profile_matcher_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class ProfileMatcher::RedditProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::RedditProfileMatcher.new(url)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::RedditProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 50" do
+    # Higher than RSS (10) so reddit.com URLs prefer the Reddit profile.
+    assert_equal 50, ProfileMatcher::RedditProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::RedditProfileMatcher.depends_on_ai
+  end
+
+  test "#match? should match subreddit RSS URLs" do
+    assert matcher("https://www.reddit.com/r/programming/.rss").match?
+  end
+
+  test "#match? should match subreddit page URLs" do
+    assert matcher("https://www.reddit.com/r/programming/").match?
+  end
+
+  test "#match? should match user page RSS URLs" do
+    assert matcher("https://www.reddit.com/user/someuser/.rss").match?
+  end
+
+  test "#match? should match reddit.com without www" do
+    assert matcher("https://reddit.com/r/ruby/").match?
+  end
+
+  test "#match? should match old.reddit.com URLs" do
+    assert matcher("https://old.reddit.com/r/ruby/").match?
+  end
+
+  test "#match? should not match reddit.com homepage" do
+    assert_not matcher("https://www.reddit.com/").match?
+  end
+
+  test "#match? should not match non-reddit URLs" do
+    assert_not matcher("https://example.com/feed.xml").match?
+  end
+
+  test "#match? should not match URLs that only mention reddit in path" do
+    assert_not matcher("https://example.com/reddit.com/r/programming/").match?
+  end
+
+  test "#match? should handle blank inputs" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+end

--- a/test/services/profile_matcher/reddit_profile_matcher_test.rb
+++ b/test/services/profile_matcher/reddit_profile_matcher_test.rb
@@ -38,6 +38,14 @@ class ProfileMatcher::RedditProfileMatcherTest < ActiveSupport::TestCase
     assert matcher("https://old.reddit.com/r/ruby/").match?
   end
 
+  test "#match? should match short subreddit names like r/worldnews" do
+    assert matcher("r/worldnews").match?
+  end
+
+  test "#match? should match short user names like user/someuser" do
+    assert matcher("user/someuser").match?
+  end
+
   test "#match? should not match reddit.com homepage" do
     assert_not matcher("https://www.reddit.com/").match?
   end


### PR DESCRIPTION
Changes:

- Add `RedditProfileMatcher` to identify Reddit subreddit and user page URLs (with specificity 50 to prefer Reddit profile over generic RSS)
- Add `RedditNormalizer` to extract post body from Reddit's HTML description field, stripping the "submitted by" footer and handling link posts
- Register "reddit" profile in `FeedProfile` with HTTP loader, RSS processor, and Reddit normalizer

References:

- Closes #502
