### PR TITLE
Add UI elements reference page for dev tools

### DIFF
--- a/app/views/access_tokens/edit.html.erb
+++ b/app/views/access_tokens/edit.html.erb
@@ -29,7 +29,7 @@
                               class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                               placeholder: "Paste a new token here to replace the current one",
                               autocomplete: "off" %>
-          <p class="text-slate-500">Leave blank to keep the existing token. Entering a new value will trigger re-validation.</p>
+          <p class="text-sm text-slate-500">Leave blank to keep the existing token. Entering a new value will trigger re-validation.</p>
           <% if @access_token.errors[:token].any? %>
             <p class="mt-2 text-sm text-red-600"><%= @access_token.errors[:token].first %></p>
           <% end %>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -60,7 +60,7 @@
                               class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                               placeholder: "e.g., My FreeFeed Token",
                               autocomplete: "off" %>
-          <p class="text-slate-500">
+          <p class="text-sm text-slate-500">
             Give this token a memorable name. If left blank, a default name will be used.
           </p>
           <% if @access_token.errors[:name].any? %>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -44,7 +44,7 @@
       </div>
     <% end %>
 
-    <% if Rails.env.development? %>
+    <% if Rails.configuration.x.dev_tools.enabled %>
       <%= render CardComponent.new(href: development_sent_emails_path, target: "_blank", rel: "noopener noreferrer") do %>
         <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -34,11 +34,11 @@
 <div class="grid grid-cols-1 gap-10 lg:grid-cols-[12rem_1fr]">
   <%# Table of contents %>
   <nav class="hidden lg:block" aria-label="On this page" data-key="toc">
-    <div class="sticky top-6 space-y-5 text-sm">
+    <div class="sticky top-6 space-y-8 text-sm">
       <% toc_groups.each do |group, items| %>
-        <div class="space-y-2">
+        <div class="space-y-4">
           <p class="text-xs font-semibold uppercase tracking-wide text-slate-400"><%= group %></p>
-          <ul class="space-y-1">
+          <ul class="space-y-2">
             <% items.each do |anchor, label| %>
               <li>
                 <a href="#<%= anchor %>" class="text-slate-600 transition hover:text-sky-600" data-key="toc.<%= anchor %>"><%= label %></a>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -1,18 +1,8 @@
 <% content_for :title, "UI Elements" %>
 
 <%
-  # Standardized utility strings, mirrored from the app's forms and buttons.
-  btn_primary   = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
-  btn_secondary = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
-  btn_danger    = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
-  input_classes       = "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-500"
-  input_error_classes = "w-full rounded-md border border-red-400 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-red-500 transition focus:border-red-500 focus:outline-none focus:ring-2"
-  label_classes       = "block font-semibold text-slate-800"
-  help_classes        = "mt-1 text-sm text-slate-500"
-  error_classes       = "mt-2 text-sm text-red-600"
-  checkbox_classes    = "mt-1 h-4 w-4 rounded border-slate-300 text-cyan-600 focus:ring-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
-  radio_classes       = "mt-1 h-4 w-4 border-slate-300 text-cyan-600 focus:ring-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
-  caption_classes     = "text-xs font-medium uppercase tracking-wide text-slate-400"
+  # Reference-page scaffolding only (not part of the copy-pastable specimens below).
+  caption_classes = "text-xs font-medium uppercase tracking-wide text-slate-400"
 
   toc_groups = {
     "Foundations" => [
@@ -60,12 +50,14 @@
     </div>
   </nav>
 
-  <%# Sections %>
+  <%# Sections. Each specimen below is written exactly as a production view would be,
+      so the markup can be copied straight into a new view. %>
   <div class="min-w-0 space-y-12">
     <%= render PageHeaderComponent.new(title: "UI Elements") do |header| %>
       <% header.with_context_paragraph do %>
         A living reference of the building blocks used across Feeder — buttons, form
-        controls, and components — shown in every state with realistic content.
+        controls, and components — shown in every state with realistic content. Each
+        example mirrors production view code so you can copy it into a new view.
       <% end %>
     <% end %>
 
@@ -77,27 +69,27 @@
       <div class="flex flex-wrap items-start gap-6">
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Primary</p>
-          <button type="button" class="<%= btn_primary %>">Save changes</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50">Save changes</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Secondary</p>
-          <button type="button" class="<%= btn_secondary %>">Cancel</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50">Cancel</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Danger</p>
-          <button type="button" class="<%= btn_danger %>">Delete feed</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50">Delete feed</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Primary disabled</p>
-          <button type="button" class="<%= btn_primary %>" disabled>Save changes</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50" disabled>Save changes</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Secondary disabled</p>
-          <button type="button" class="<%= btn_secondary %>" disabled>Cancel</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50" disabled>Cancel</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Danger disabled</p>
-          <button type="button" class="<%= btn_danger %>" disabled>Delete feed</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50" disabled>Delete feed</button>
         </div>
       </div>
     </section>
@@ -110,20 +102,20 @@
       <div class="grid gap-6 sm:grid-cols-2">
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Empty (with placeholder)</p>
-          <input type="text" class="<%= input_classes %>" placeholder="e.g. Ruby Weekly">
+          <%= text_field_tag :feed_name, nil, placeholder: "e.g. Ruby Weekly", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Filled</p>
-          <input type="text" class="<%= input_classes %>" value="Ruby Weekly">
+          <%= text_field_tag :feed_name_filled, "Ruby Weekly", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Disabled</p>
-          <input type="text" class="<%= input_classes %>" value="Locked while syncing" disabled>
+          <%= text_field_tag :feed_name_disabled, "Locked while syncing", disabled: true, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Error</p>
-          <input type="text" class="<%= input_error_classes %>" value="not-a-valid-url">
-          <p class="<%= error_classes %>">Enter a valid feed URL.</p>
+          <%= text_field_tag :feed_name_error, "not-a-valid-url", class: "w-full rounded-md border border-red-400 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-red-500 transition focus:border-red-500 focus:outline-none focus:ring-2" %>
+          <p class="mt-2 text-sm text-red-600">Enter a valid feed URL.</p>
         </div>
       </div>
     </section>
@@ -136,27 +128,15 @@
       <div class="grid gap-6 sm:grid-cols-2">
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Default</p>
-          <select class="<%= input_classes %>">
-            <option>Every 30 minutes</option>
-            <option>Every hour</option>
-            <option>Every 6 hours</option>
-            <option>Daily at midnight</option>
-          </select>
+          <%= select_tag :frequency, options_for_select(["Every 30 minutes", "Every hour", "Every 6 hours", "Daily at midnight"]), class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">With selection</p>
-          <select class="<%= input_classes %>">
-            <option>Every 30 minutes</option>
-            <option selected>Every hour</option>
-            <option>Every 6 hours</option>
-            <option>Daily at midnight</option>
-          </select>
+          <%= select_tag :frequency_selected, options_for_select(["Every 30 minutes", "Every hour", "Every 6 hours", "Daily at midnight"], "Every hour"), class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Disabled</p>
-          <select class="<%= input_classes %>" disabled>
-            <option>Every hour</option>
-          </select>
+          <%= select_tag :frequency_disabled, options_for_select(["Every hour"]), disabled: true, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
         </div>
       </div>
     </section>
@@ -164,20 +144,20 @@
     <%# Checkbox %>
     <section id="checkbox" class="scroll-mt-6 space-y-4" data-key="section.checkbox">
       <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Checkbox</h2>
-      <p class="text-slate-600">A labeled checkbox for a single on/off choice. The whole label is clickable.</p>
+      <p class="text-slate-600">A labeled checkbox for a single on/off choice. The <code>label_tag</code> targets the checkbox id, so clicking the label toggles it.</p>
 
       <div class="space-y-4">
         <div class="flex items-start gap-3">
-          <input type="checkbox" class="<%= checkbox_classes %>">
-          <label class="text-base text-slate-700">Enable this feed once it's set up</label>
+          <%= check_box_tag :enable_feed, "1", false, class: "mt-1 h-4 w-4 rounded border-slate-300 text-cyan-600 focus:ring-cyan-500" %>
+          <%= label_tag :enable_feed, "Enable this feed once it's set up", class: "text-base text-slate-700" %>
         </div>
         <div class="flex items-start gap-3">
-          <input type="checkbox" class="<%= checkbox_classes %>" checked>
-          <label class="text-base text-slate-700">Notify me when a refresh fails</label>
+          <%= check_box_tag :notify_failures, "1", true, class: "mt-1 h-4 w-4 rounded border-slate-300 text-cyan-600 focus:ring-cyan-500" %>
+          <%= label_tag :notify_failures, "Notify me when a refresh fails", class: "text-base text-slate-700" %>
         </div>
         <div class="flex items-start gap-3">
-          <input type="checkbox" class="<%= checkbox_classes %>" disabled>
-          <label class="text-base text-slate-400">Cross-post to FreeFeed (connect a token first)</label>
+          <%= check_box_tag :cross_post, "1", false, disabled: true, class: "mt-1 h-4 w-4 rounded border-slate-300 text-cyan-600 focus:ring-cyan-500" %>
+          <%= label_tag :cross_post, "Cross-post to FreeFeed (connect a token first)", class: "text-base text-slate-400" %>
         </div>
       </div>
     </section>
@@ -185,25 +165,25 @@
     <%# Radio group %>
     <section id="radio-group" class="scroll-mt-6 space-y-4" data-key="section.radio-group">
       <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Radio group</h2>
-      <p class="text-slate-600">A set of mutually exclusive options. One is selected by default; unavailable options are disabled.</p>
+      <p class="text-slate-600">A set of mutually exclusive options sharing one name. One is selected by default; unavailable options are disabled. Each label targets its radio's id.</p>
 
       <fieldset class="space-y-3">
-        <legend class="<%= label_classes %>">Refresh frequency</legend>
+        <legend class="block font-semibold text-slate-800">Refresh frequency</legend>
         <div class="flex items-start gap-3">
-          <input type="radio" name="refresh-frequency" class="<%= radio_classes %>" checked>
-          <label class="text-base text-slate-700">Every 30 minutes</label>
+          <%= radio_button_tag :refresh_frequency, "30m", true, class: "mt-1 h-4 w-4 border-slate-300 text-cyan-600 focus:ring-cyan-500" %>
+          <%= label_tag :refresh_frequency_30m, "Every 30 minutes", class: "text-base text-slate-700" %>
         </div>
         <div class="flex items-start gap-3">
-          <input type="radio" name="refresh-frequency" class="<%= radio_classes %>">
-          <label class="text-base text-slate-700">Every hour</label>
+          <%= radio_button_tag :refresh_frequency, "1h", false, class: "mt-1 h-4 w-4 border-slate-300 text-cyan-600 focus:ring-cyan-500" %>
+          <%= label_tag :refresh_frequency_1h, "Every hour", class: "text-base text-slate-700" %>
         </div>
         <div class="flex items-start gap-3">
-          <input type="radio" name="refresh-frequency" class="<%= radio_classes %>">
-          <label class="text-base text-slate-700">Daily at midnight</label>
+          <%= radio_button_tag :refresh_frequency, "daily", false, class: "mt-1 h-4 w-4 border-slate-300 text-cyan-600 focus:ring-cyan-500" %>
+          <%= label_tag :refresh_frequency_daily, "Daily at midnight", class: "text-base text-slate-700" %>
         </div>
         <div class="flex items-start gap-3">
-          <input type="radio" name="refresh-frequency" class="<%= radio_classes %>" disabled>
-          <label class="text-base text-slate-400">Real-time (Pro plan only)</label>
+          <%= radio_button_tag :refresh_frequency, "realtime", false, disabled: true, class: "mt-1 h-4 w-4 border-slate-300 text-cyan-600 focus:ring-cyan-500" %>
+          <%= label_tag :refresh_frequency_realtime, "Real-time (Pro plan only)", class: "text-base text-slate-400" %>
         </div>
       </fieldset>
     </section>
@@ -211,29 +191,25 @@
     <%# Form group %>
     <section id="form-group" class="scroll-mt-6 space-y-4" data-key="section.form-group">
       <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Form group</h2>
-      <p class="text-slate-600">The standard composition: a label, a control, and optional help or error text, stacked with consistent spacing.</p>
+      <p class="text-slate-600">The standard composition: a label bound to its control, plus optional help or error text, stacked with consistent spacing.</p>
 
       <div class="max-w-xl space-y-8">
         <div class="space-y-2">
-          <label class="<%= label_classes %>">Feed name</label>
-          <input type="text" class="<%= input_classes %>" placeholder="e.g. Ruby Weekly">
-          <p class="<%= help_classes %>">Shown in your feed list and on FreeFeed posts.</p>
+          <%= label_tag :group_feed_name, "Feed name", class: "block font-semibold text-slate-800" %>
+          <%= text_field_tag :group_feed_name, nil, placeholder: "e.g. Ruby Weekly", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
+          <p class="mt-2 text-sm text-slate-500">Shown in your feed list and on FreeFeed posts.</p>
         </div>
 
         <div class="space-y-2">
-          <label class="<%= label_classes %>">Refresh frequency</label>
-          <select class="<%= input_classes %>">
-            <option>Every 30 minutes</option>
-            <option selected>Every hour</option>
-            <option>Daily at midnight</option>
-          </select>
-          <p class="<%= help_classes %>">How often Feeder checks the source for new posts.</p>
+          <%= label_tag :group_frequency, "Refresh frequency", class: "block font-semibold text-slate-800" %>
+          <%= select_tag :group_frequency, options_for_select(["Every 30 minutes", "Every hour", "Daily at midnight"], "Every hour"), class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
+          <p class="mt-2 text-sm text-slate-500">How often Feeder checks the source for new posts.</p>
         </div>
 
         <div class="space-y-2">
-          <label class="<%= label_classes %>">Source URL</label>
-          <input type="text" class="<%= input_error_classes %>" value="not-a-valid-url">
-          <p class="<%= error_classes %>">Enter a valid feed URL, like https://example.com/feed.xml.</p>
+          <%= label_tag :group_source_url, "Source URL", class: "block font-semibold text-slate-800" %>
+          <%= text_field_tag :group_source_url, "not-a-valid-url", class: "w-full rounded-md border border-red-400 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-red-500 transition focus:border-red-500 focus:outline-none focus:ring-2" %>
+          <p class="mt-2 text-sm text-red-600">Enter a valid feed URL, like https://example.com/feed.xml.</p>
         </div>
       </div>
     </section>
@@ -252,10 +228,10 @@
                 Manage the sources Feeder reposts to FreeFeed.
               <% end %>
               <% header.with_action_button do %>
-                <button type="button" class="<%= btn_secondary %>">Import</button>
+                <%= link_to "Import", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
               <% end %>
               <% header.with_action_button do %>
-                <button type="button" class="<%= btn_primary %>">New feed</button>
+                <%= link_to "New feed", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
               <% end %>
             <% end %>
 

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -197,13 +197,13 @@
         <div class="space-y-2">
           <%= label_tag :group_feed_name, "Feed name", class: "block font-semibold text-slate-800" %>
           <%= text_field_tag :group_feed_name, nil, placeholder: "e.g. Ruby Weekly", class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
-          <p class="mt-2 text-sm text-slate-500">Shown in your feed list and on FreeFeed posts.</p>
+          <p class="text-sm text-slate-500">Shown in your feed list and on FreeFeed posts.</p>
         </div>
 
         <div class="space-y-2">
           <%= label_tag :group_frequency, "Refresh frequency", class: "block font-semibold text-slate-800" %>
           <%= select_tag :group_frequency, options_for_select(["Every 30 minutes", "Every hour", "Daily at midnight"], "Every hour"), class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
-          <p class="mt-2 text-sm text-slate-500">How often Feeder checks the source for new posts.</p>
+          <p class="text-sm text-slate-500">How often Feeder checks the source for new posts.</p>
         </div>
 
         <div class="space-y-2">

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -1,267 +1,422 @@
-<% content_for :title, "Component Reference" %>
+<% content_for :title, "UI Elements" %>
 
-<div class="space-y-12">
-  <%= render PageHeaderComponent.new(title: "Component Reference") do |header| %>
-    <% header.with_context_paragraph do %>
-      Visual reference of all UI components in the application.
+<%
+  # Standardized utility strings, mirrored from the app's forms and buttons.
+  btn_primary   = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
+  btn_secondary = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
+  btn_danger    = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
+  input_classes       = "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-500"
+  input_error_classes = "w-full rounded-md border border-red-400 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-red-500 transition focus:border-red-500 focus:outline-none focus:ring-2"
+  label_classes       = "block font-semibold text-slate-800"
+  help_classes        = "mt-1 text-sm text-slate-500"
+  error_classes       = "mt-2 text-sm text-red-600"
+  checkbox_classes    = "mt-1 h-4 w-4 rounded border-slate-300 text-cyan-600 focus:ring-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+  radio_classes       = "mt-1 h-4 w-4 border-slate-300 text-cyan-600 focus:ring-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+  caption_classes     = "text-xs font-medium uppercase tracking-wide text-slate-400"
+
+  toc_groups = {
+    "Foundations" => [
+      ["buttons", "Buttons"],
+      ["text-input", "Text input"],
+      ["select", "Select"],
+      ["checkbox", "Checkbox"],
+      ["radio-group", "Radio group"],
+      ["form-group", "Form group"]
+    ],
+    "Page structure" => [
+      ["page-header", "Page header"]
+    ],
+    "Components" => [
+      ["badge", "Badge"],
+      ["card", "Card"],
+      ["alert", "Alert"],
+      ["empty-state", "Empty state"],
+      ["spinner", "Spinner"],
+      ["stats-bar", "Stats bar"],
+      ["list", "List"],
+      ["pagination", "Pagination"],
+      ["confirmation-modal", "Confirmation modal"],
+      ["event-description", "Event description"]
+    ]
+  }
+%>
+
+<div class="grid grid-cols-1 gap-10 lg:grid-cols-[12rem_1fr]">
+  <%# Table of contents %>
+  <nav class="hidden lg:block" aria-label="On this page" data-key="toc">
+    <div class="sticky top-6 space-y-5 text-sm">
+      <% toc_groups.each do |group, items| %>
+        <div class="space-y-2">
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-400"><%= group %></p>
+          <ul class="space-y-1">
+            <% items.each do |anchor, label| %>
+              <li>
+                <a href="#<%= anchor %>" class="text-slate-600 transition hover:text-sky-600" data-key="toc.<%= anchor %>"><%= label %></a>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    </div>
+  </nav>
+
+  <%# Sections %>
+  <div class="min-w-0 space-y-12">
+    <%= render PageHeaderComponent.new(title: "UI Elements") do |header| %>
+      <% header.with_context_paragraph do %>
+        A living reference of the building blocks used across Feeder — buttons, form
+        controls, and components — shown in every state with realistic content.
+      <% end %>
     <% end %>
-  <% end %>
 
-  <%# Badge Component %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">Badge Component</h2>
-    <div class="space-y-2">
+    <%# Buttons %>
+    <section id="buttons" class="scroll-mt-6 space-y-4" data-key="section.buttons">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Buttons</h2>
+      <p class="text-slate-600">Used for primary actions, secondary choices, and destructive operations. Disabled buttons keep their shape but drop their emphasis.</p>
+
+      <div class="flex flex-wrap items-start gap-6">
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Primary</p>
+          <button type="button" class="<%= btn_primary %>">Save changes</button>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Secondary</p>
+          <button type="button" class="<%= btn_secondary %>">Cancel</button>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Danger</p>
+          <button type="button" class="<%= btn_danger %>">Delete feed</button>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Primary disabled</p>
+          <button type="button" class="<%= btn_primary %>" disabled>Save changes</button>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Secondary disabled</p>
+          <button type="button" class="<%= btn_secondary %>" disabled>Cancel</button>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Danger disabled</p>
+          <button type="button" class="<%= btn_danger %>" disabled>Delete feed</button>
+        </div>
+      </div>
+    </section>
+
+    <%# Text input %>
+    <section id="text-input" class="scroll-mt-6 space-y-4" data-key="section.text-input">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Text input</h2>
+      <p class="text-slate-600">The standard single-line field. Shown empty, filled, disabled, and in an error state.</p>
+
+      <div class="grid gap-6 sm:grid-cols-2">
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Empty (with placeholder)</p>
+          <input type="text" class="<%= input_classes %>" placeholder="e.g. Ruby Weekly">
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Filled</p>
+          <input type="text" class="<%= input_classes %>" value="Ruby Weekly">
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Disabled</p>
+          <input type="text" class="<%= input_classes %>" value="Locked while syncing" disabled>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Error</p>
+          <input type="text" class="<%= input_error_classes %>" value="not-a-valid-url">
+          <p class="<%= error_classes %>">Enter a valid feed URL.</p>
+        </div>
+      </div>
+    </section>
+
+    <%# Select %>
+    <section id="select" class="scroll-mt-6 space-y-4" data-key="section.select">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Select</h2>
+      <p class="text-slate-600">A dropdown for choosing one option from a known set.</p>
+
+      <div class="grid gap-6 sm:grid-cols-2">
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Default</p>
+          <select class="<%= input_classes %>">
+            <option>Every 30 minutes</option>
+            <option>Every hour</option>
+            <option>Every 6 hours</option>
+            <option>Daily at midnight</option>
+          </select>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">With selection</p>
+          <select class="<%= input_classes %>">
+            <option>Every 30 minutes</option>
+            <option selected>Every hour</option>
+            <option>Every 6 hours</option>
+            <option>Daily at midnight</option>
+          </select>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Disabled</p>
+          <select class="<%= input_classes %>" disabled>
+            <option>Every hour</option>
+          </select>
+        </div>
+      </div>
+    </section>
+
+    <%# Checkbox %>
+    <section id="checkbox" class="scroll-mt-6 space-y-4" data-key="section.checkbox">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Checkbox</h2>
+      <p class="text-slate-600">A labeled checkbox for a single on/off choice. The whole label is clickable.</p>
+
+      <div class="space-y-4">
+        <div class="flex items-start gap-3">
+          <input type="checkbox" class="<%= checkbox_classes %>">
+          <label class="text-base text-slate-700">Enable this feed once it's set up</label>
+        </div>
+        <div class="flex items-start gap-3">
+          <input type="checkbox" class="<%= checkbox_classes %>" checked>
+          <label class="text-base text-slate-700">Notify me when a refresh fails</label>
+        </div>
+        <div class="flex items-start gap-3">
+          <input type="checkbox" class="<%= checkbox_classes %>" disabled>
+          <label class="text-base text-slate-400">Cross-post to FreeFeed (connect a token first)</label>
+        </div>
+      </div>
+    </section>
+
+    <%# Radio group %>
+    <section id="radio-group" class="scroll-mt-6 space-y-4" data-key="section.radio-group">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Radio group</h2>
+      <p class="text-slate-600">A set of mutually exclusive options. One is selected by default; unavailable options are disabled.</p>
+
+      <fieldset class="space-y-3">
+        <legend class="<%= label_classes %>">Refresh frequency</legend>
+        <div class="flex items-start gap-3">
+          <input type="radio" name="refresh-frequency" class="<%= radio_classes %>" checked>
+          <label class="text-base text-slate-700">Every 30 minutes</label>
+        </div>
+        <div class="flex items-start gap-3">
+          <input type="radio" name="refresh-frequency" class="<%= radio_classes %>">
+          <label class="text-base text-slate-700">Every hour</label>
+        </div>
+        <div class="flex items-start gap-3">
+          <input type="radio" name="refresh-frequency" class="<%= radio_classes %>">
+          <label class="text-base text-slate-700">Daily at midnight</label>
+        </div>
+        <div class="flex items-start gap-3">
+          <input type="radio" name="refresh-frequency" class="<%= radio_classes %>" disabled>
+          <label class="text-base text-slate-400">Real-time (Pro plan only)</label>
+        </div>
+      </fieldset>
+    </section>
+
+    <%# Form group %>
+    <section id="form-group" class="scroll-mt-6 space-y-4" data-key="section.form-group">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Form group</h2>
+      <p class="text-slate-600">The standard composition: a label, a control, and optional help or error text, stacked with consistent spacing.</p>
+
+      <div class="max-w-xl space-y-8">
+        <div class="space-y-2">
+          <label class="<%= label_classes %>">Feed name</label>
+          <input type="text" class="<%= input_classes %>" placeholder="e.g. Ruby Weekly">
+          <p class="<%= help_classes %>">Shown in your feed list and on FreeFeed posts.</p>
+        </div>
+
+        <div class="space-y-2">
+          <label class="<%= label_classes %>">Refresh frequency</label>
+          <select class="<%= input_classes %>">
+            <option>Every 30 minutes</option>
+            <option selected>Every hour</option>
+            <option>Daily at midnight</option>
+          </select>
+          <p class="<%= help_classes %>">How often Feeder checks the source for new posts.</p>
+        </div>
+
+        <div class="space-y-2">
+          <label class="<%= label_classes %>">Source URL</label>
+          <input type="text" class="<%= input_error_classes %>" value="not-a-valid-url">
+          <p class="<%= error_classes %>">Enter a valid feed URL, like https://example.com/feed.xml.</p>
+        </div>
+      </div>
+    </section>
+
+    <%# Page header %>
+    <section id="page-header" class="scroll-mt-6 space-y-4" data-key="section.page-header">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Page header</h2>
+      <p class="text-slate-600">Opens a page with a title and optional context and actions. Pair it with <code>space-y-8</code> to keep a steady gap before the page content.</p>
+
+      <div class="space-y-2">
+        <p class="<%= caption_classes %>">With context and actions</p>
+        <div class="rounded-lg border border-slate-200 p-6">
+          <div class="space-y-8">
+            <%= render PageHeaderComponent.new(title: "Your feeds") do |header| %>
+              <% header.with_context_paragraph do %>
+                Manage the sources Feeder reposts to FreeFeed.
+              <% end %>
+              <% header.with_action_button do %>
+                <button type="button" class="<%= btn_secondary %>">Import</button>
+              <% end %>
+              <% header.with_action_button do %>
+                <button type="button" class="<%= btn_primary %>">New feed</button>
+              <% end %>
+            <% end %>
+
+            <%= render CardComponent.new do %>
+              <p class="text-slate-700">Page content sits here. The header keeps a consistent gap above it, so pages feel aligned no matter what's inside.</p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <p class="<%= caption_classes %>">Title only (no actions)</p>
+        <div class="rounded-lg border border-slate-200 p-6">
+          <div class="space-y-8">
+            <%= render PageHeaderComponent.new(title: "Settings") %>
+
+            <%= render CardComponent.new do %>
+              <p class="text-slate-700">Without actions, the title stretches full width and the same spacing applies before the content below.</p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <%# Badge %>
+    <section id="badge" class="scroll-mt-6 space-y-4" data-key="section.badge">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Badge</h2>
+      <p class="text-slate-600">Small status labels. Color carries meaning — green for healthy, red for problems, gray for neutral.</p>
       <div class="flex flex-wrap gap-2">
-        <%= render BadgeComponent.new(text: "Blue", color: :blue) %>
-        <%= render BadgeComponent.new(text: "Gray", color: :gray) %>
-        <%= render BadgeComponent.new(text: "Red", color: :red) %>
-        <%= render BadgeComponent.new(text: "Green", color: :green) %>
-        <%= render BadgeComponent.new(text: "Yellow", color: :yellow) %>
-        <%= render BadgeComponent.new(text: "Orange", color: :orange) %>
+        <%= render BadgeComponent.new(text: "Active", color: :green) %>
+        <%= render BadgeComponent.new(text: "Paused", color: :gray) %>
+        <%= render BadgeComponent.new(text: "Error", color: :red) %>
+        <%= render BadgeComponent.new(text: "Syncing", color: :blue) %>
+        <%= render BadgeComponent.new(text: "Pending", color: :yellow) %>
+        <%= render BadgeComponent.new(text: "Beta", color: :orange) %>
         <%= render BadgeComponent.new(text: "Indigo", color: :indigo) %>
         <%= render BadgeComponent.new(text: "Purple", color: :purple) %>
         <%= render BadgeComponent.new(text: "Pink", color: :pink) %>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <%# Card Component %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">Card Component</h2>
-    <%= render CardComponent.new do %>
-      <p class="text-slate-700">This is a card component with default styling. It provides a clean container for content.</p>
-    <% end %>
-  </section>
-
-  <%# Empty State Component %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">Empty State Component</h2>
-    <%= render EmptyStateComponent.new("No items to show yet") %>
-  </section>
-
-  <%# Spinner Component %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">Spinner Component</h2>
-    <%= render SpinnerComponent.new %>
-  </section>
-
-  <%# Stats Bar Component %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">Stats Bar Component</h2>
-    <% stats_bar = StatsBarComponent.new %>
-    <% stats_bar.with_item(StatsBarComponent::StatItemComponent.new(label: "Total Feeds", value: "42")) %>
-    <% stats_bar.with_item(StatsBarComponent::StatItemComponent.new(label: "Active", value: "38")) %>
-    <% stats_bar.with_item(StatsBarComponent::StatItemComponent.new(label: "Posts", value: "1,234")) %>
-    <% stats_bar.with_item(StatsBarComponent::StatItemComponent.new(label: "Last Updated", value: "2h ago")) %>
-    <%= render stats_bar %>
-  </section>
-
-  <%# List Group Component with Feed Items %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">List Group Component (Feed Items)</h2>
-    <% list = ListComponent.new %>
-    <% list.with_item(
-         ListComponent::ItemComponent.new(
-           title: "Tech News Daily",
-           title_url: "#",
-           metadata_segments: ["Updated 5 min ago", "142 posts", "Active"]
-         )
-       ) %>
-    <% list.with_item(
-         ListComponent::ItemComponent.new(
-           title: "Design Inspiration",
-           title_url: "#",
-           metadata_segments: ["Updated 1 hour ago", "89 posts", "Active"]
-         )
-       ) %>
-    <% list.with_item(
-         ListComponent::ItemComponent.new(
-           title: "Ruby Weekly",
-           title_url: "#",
-           metadata_segments: ["Updated 2 days ago", "23 posts", "Paused"]
-         )
-       ) %>
-    <%= render list %>
-  </section>
-
-  <%# List Group Component with Stat Items %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">List Group Component (Stat Items)</h2>
-    <% stat_list = ListComponent.new %>
-    <% stat_list.with_item(
-         ListComponent::StatItemComponent.new(
-           label: "Total Feeds",
-           value: "42"
-         )
-       ) %>
-    <% stat_list.with_item(
-         ListComponent::StatItemComponent.new(
-           label: "Total Posts",
-           value: "1,234"
-         )
-       ) %>
-    <% stat_list.with_item(
-         ListComponent::StatItemComponent.new(
-           label: "Active Feeds",
-           value: "38"
-         )
-       ) %>
-    <%= render stat_list %>
-  </section>
-
-  <%# Pagination Component %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">Pagination Component</h2>
-    <%= render PaginationComponent.new(
-         collection_name: "posts",
-         path_helper: ->(page) { "#page-#{page}" },
-         current_page: 3,
-         total_pages: 10
-       ) %>
-  </section>
-
-  <%# Page Header Component %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">Page Header Component</h2>
-    <%= render PageHeaderComponent.new(title: "Example Page Title") do |header| %>
-      <% header.with_context_paragraph do %>
-        This is a context paragraph that provides additional information about the page.
+    <%# Card %>
+    <section id="card" class="scroll-mt-6 space-y-4" data-key="section.card">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Card</h2>
+      <p class="text-slate-600">A padded container that groups related content on a clean surface.</p>
+      <%= render CardComponent.new do %>
+        <div class="space-y-2">
+          <h3 class="text-lg font-semibold text-slate-900">Tech News Daily</h3>
+          <p class="text-slate-700">Last refreshed 5 minutes ago · 142 posts published. Everything is running smoothly.</p>
+        </div>
       <% end %>
-      <% header.with_action_button do %>
-        <a href="#" class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">Primary Action</a>
-      <% end %>
-      <% header.with_action_button do %>
-        <a href="#" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">Secondary Action</a>
-      <% end %>
-    <% end %>
-  </section>
+    </section>
 
-  <%# Confirmation Modal Component %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">Confirmation Modal Component</h2>
-    <p class="text-sm text-slate-600">Modal is hidden by default. Add trigger button to show it.</p>
-    <%= render ConfirmationModalComponent.new(
-         title: "Delete Item",
-         action: "Delete",
-         url: "#",
-         method: :delete
-       ) do %>
-      Are you sure you want to delete this item? This action cannot be undone.
-    <% end %>
-  </section>
+    <%# Alert %>
+    <section id="alert" class="scroll-mt-6 space-y-4" data-key="section.alert">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Alert</h2>
+      <p class="text-slate-600">Inline messages that call out information, success, warnings, or errors.</p>
+      <div class="space-y-3">
+        <%= render AlertComponent.new(variant: :info) do %>
+          <p>Your feed will start publishing within the next few minutes.</p>
+        <% end %>
+        <%= render AlertComponent.new(variant: :success) do %>
+          <p>Feed created. We'll keep it in sync from here on.</p>
+        <% end %>
+        <%= render AlertComponent.new(variant: :warning) do %>
+          <p>This source hasn't updated in over a month. It may be inactive.</p>
+        <% end %>
+        <%= render AlertComponent.new(variant: :error) do %>
+          <p>We couldn't reach the source. Check the URL and try again.</p>
+        <% end %>
+        <%= render AlertComponent.new(variant: :secondary) do %>
+          <p>Tip: connect a FreeFeed token to start cross-posting automatically.</p>
+        <% end %>
+      </div>
+    </section>
 
-  <%# Event Description Component %>
-  <section class="space-y-4">
-    <h2 class="text-xl font-semibold text-slate-900">Event Description Component</h2>
-    <div class="space-y-2">
+    <%# Empty state %>
+    <section id="empty-state" class="scroll-mt-6 space-y-4" data-key="section.empty-state">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Empty state</h2>
+      <p class="text-slate-600">Shown when there's nothing to display yet.</p>
+      <%= render EmptyStateComponent.new("No feeds yet — add your first source to get started") %>
+    </section>
+
+    <%# Spinner %>
+    <section id="spinner" class="scroll-mt-6 space-y-4" data-key="section.spinner">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Spinner</h2>
+      <p class="text-slate-600">Indicates a short, indeterminate wait.</p>
+      <%= render SpinnerComponent.new %>
+    </section>
+
+    <%# Stats bar %>
+    <section id="stats-bar" class="scroll-mt-6 space-y-4" data-key="section.stats-bar">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Stats bar</h2>
+      <p class="text-slate-600">A compact row of headline numbers.</p>
+      <% stats_bar = StatsBarComponent.new %>
+      <% stats_bar.with_item(StatsBarComponent::StatItemComponent.new(label: "Total feeds", value: "42")) %>
+      <% stats_bar.with_item(StatsBarComponent::StatItemComponent.new(label: "Active", value: "38")) %>
+      <% stats_bar.with_item(StatsBarComponent::StatItemComponent.new(label: "Posts", value: "1,234")) %>
+      <% stats_bar.with_item(StatsBarComponent::StatItemComponent.new(label: "Last updated", value: "2h ago")) %>
+      <%= render stats_bar %>
+    </section>
+
+    <%# List %>
+    <section id="list" class="scroll-mt-6 space-y-4" data-key="section.list">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">List</h2>
+      <p class="text-slate-600">A grouped list for collections of items, with linked titles and metadata, or simple label/value rows.</p>
+
+      <div class="space-y-2">
+        <p class="<%= caption_classes %>">With feed items</p>
+        <% list = ListComponent.new %>
+        <% list.with_item(ListComponent::ItemComponent.new(title: "Tech News Daily", title_url: "#", metadata_segments: ["Updated 5 min ago", "142 posts", "Active"])) %>
+        <% list.with_item(ListComponent::ItemComponent.new(title: "Design Inspiration", title_url: "#", metadata_segments: ["Updated 1 hour ago", "89 posts", "Active"])) %>
+        <% list.with_item(ListComponent::ItemComponent.new(title: "Ruby Weekly", title_url: "#", metadata_segments: ["Updated 2 days ago", "23 posts", "Paused"])) %>
+        <%= render list %>
+      </div>
+
+      <div class="space-y-2">
+        <p class="<%= caption_classes %>">With stat items</p>
+        <% stat_list = ListComponent.new %>
+        <% stat_list.with_item(ListComponent::StatItemComponent.new(label: "Total feeds", value: "42")) %>
+        <% stat_list.with_item(ListComponent::StatItemComponent.new(label: "Total posts", value: "1,234")) %>
+        <% stat_list.with_item(ListComponent::StatItemComponent.new(label: "Active feeds", value: "38")) %>
+        <%= render stat_list %>
+      </div>
+    </section>
+
+    <%# Pagination %>
+    <section id="pagination" class="scroll-mt-6 space-y-4" data-key="section.pagination">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Pagination</h2>
+      <p class="text-slate-600">Moves between pages of a long collection.</p>
+      <%= render PaginationComponent.new(collection_name: "posts", path_helper: ->(page) { "#page-#{page}" }, current_page: 3, total_pages: 10) %>
+    </section>
+
+    <%# Confirmation modal %>
+    <section id="confirmation-modal" class="scroll-mt-6 space-y-4" data-key="section.confirmation-modal">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Confirmation modal</h2>
+      <p class="text-slate-600">Asks the user to confirm a destructive action. It stays hidden until a trigger opens it, so nothing shows here by default.</p>
+      <%= render ConfirmationModalComponent.new(title: "Delete feed", action: "Delete", url: "#", method: :delete) do %>
+        Are you sure you want to delete this feed? This can't be undone.
+      <% end %>
+    </section>
+
+    <%# Event description %>
+    <section id="event-description" class="scroll-mt-6 space-y-4" data-key="section.event-description">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Event description</h2>
+      <p class="text-slate-600">Renders a human-readable summary of a system event, usually inside an alert that matches its severity.</p>
+
       <% sample_feed = Feed.first || Feed.new(id: 1, name: "Sample Feed") %>
       <% sample_token = AccessToken.first || AccessToken.new(id: 1, name: "Sample Token") %>
-      <% sample_post = Post.first || Post.new(id: 1) %>
 
-      <%# Feed refresh success %>
-      <%= render AlertComponent.new(variant: :info) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "feed_refresh",
-            level: :info,
-            subject: sample_feed
-          )
-        ) %>
-      <% end %>
-
-      <%# Feed refresh error %>
-      <%= render AlertComponent.new(variant: :error) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "feed_refresh_error",
-            level: :error,
-            subject: sample_feed,
-            message: "Connection timeout",
-            metadata: { error: { stage: "load_feed_contents" } }
-          )
-        ) %>
-      <% end %>
-
-      <%# Access token validation failed with multiple feeds %>
-      <%= render AlertComponent.new(variant: :warning) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "access_token_validation_failed",
-            level: :warning,
-            subject: sample_token,
-            metadata: { disabled_feed_ids: Feed.limit(3).pluck(:id) }
-          )
-        ) %>
-      <% end %>
-
-      <%# Group purge started %>
-      <%= render AlertComponent.new(variant: :info) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "group_purge_started",
-            level: :info,
-            subject: sample_feed
-          )
-        ) %>
-      <% end %>
-
-      <%# Post withdrawn %>
-      <%= render AlertComponent.new(variant: :info) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "post_withdrawn",
-            level: :info,
-            subject: sample_post
-          )
-        ) %>
-      <% end %>
-
-      <%# Email events %>
-      <%= render AlertComponent.new(variant: :info) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "resend.email.email_sent",
-            level: :info
-          )
-        ) %>
-      <% end %>
-
-      <%= render AlertComponent.new(variant: :info) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "resend.email.email_delivered",
-            level: :info
-          )
-        ) %>
-      <% end %>
-
-      <%= render AlertComponent.new(variant: :error) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "resend.email.email_bounced",
-            level: :error
-          )
-        ) %>
-      <% end %>
-
-      <%# User events %>
-      <%= render AlertComponent.new(variant: :info) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "email_changed",
-            level: :info
-          )
-        ) %>
-      <% end %>
-
-      <%= render AlertComponent.new(variant: :warning) do %>
-        <%= render EventDescriptionComponent.new(
-          event: Event.new(
-            type: "user_suspended",
-            level: :warning
-          )
-        ) %>
-      <% end %>
-    </div>
-  </section>
+      <div class="space-y-3">
+        <%= render AlertComponent.new(variant: :info) do %>
+          <%= render EventDescriptionComponent.new(event: Event.new(type: "feed_refresh", level: :info, subject: sample_feed)) %>
+        <% end %>
+        <%= render AlertComponent.new(variant: :error) do %>
+          <%= render EventDescriptionComponent.new(event: Event.new(type: "feed_refresh_error", level: :error, subject: sample_feed, message: "Connection timeout", metadata: { error: { stage: "load_feed_contents" } })) %>
+        <% end %>
+        <%= render AlertComponent.new(variant: :warning) do %>
+          <%= render EventDescriptionComponent.new(event: Event.new(type: "access_token_validation_failed", level: :warning, subject: sample_token, metadata: { disabled_feed_ids: Feed.limit(3).pluck(:id) })) %>
+        <% end %>
+      </div>
+    </section>
+  </div>
 </div>

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -11,7 +11,7 @@
                          required: true,
                          autofocus: true,
                          data: { key: "form.entry-input" } %>
-        <p class="text-slate-500">We'll figure out the best way to fetch posts from it.</p>
+        <p class="text-sm text-slate-500">We'll figure out the best way to fetch posts from it.</p>
       </div>
     </div>
 

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -57,7 +57,7 @@
           <%= hidden_field_tag "feed[params][#{key}]", value %>
         <% end %>
         <% unless multi_candidate %>
-          <p class="text-slate-500"><%= edit_mode ? "Source and type can't be changed after creation. Start a new feed to follow a different source." : FeedProfile.display_name_for(feed.feed_profile_key).to_s %></p>
+          <p class="text-sm text-slate-500"><%= edit_mode ? "Source and type can't be changed after creation. Start a new feed to follow a different source." : FeedProfile.display_name_for(feed.feed_profile_key).to_s %></p>
         <% end %>
       </div>
 
@@ -69,9 +69,9 @@
                          class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
                          data: { key: "form.name" } %>
         <% if feed.name.present? %>
-          <p class="text-slate-500">You can edit this name if you'd like.</p>
+          <p class="text-sm text-slate-500">You can edit this name if you'd like.</p>
         <% else %>
-          <p class="text-slate-500">We couldn't automatically detect a name. Please enter one.</p>
+          <p class="text-sm text-slate-500">We couldn't automatically detect a name. Please enter one.</p>
         <% end %>
         <% if f.object.errors[:name].any? %>
           <p class="text-sm text-red-600"><%= f.object.errors[:name].first %></p>
@@ -157,7 +157,7 @@
           </div>
           <div class="ml-3">
             <%= label_tag "enable_feed", "Enable feed", class: "block font-semibold text-slate-800 mb-0" %>
-            <p class="text-slate-500 mt-1">Enabled feeds will automatically check for new posts and publish them to FreeFeed.</p>
+            <p class="text-sm text-slate-500">Enabled feeds will automatically check for new posts and publish them to FreeFeed.</p>
           </div>
         </div>
       </div>

--- a/app/views/feeds/_target_group_selector.html.erb
+++ b/app/views/feeds/_target_group_selector.html.erb
@@ -7,7 +7,7 @@
                      options_for_select(groups.sort, feed.target_group),
                      class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
                      required: true %>
-      <p class="text-slate-500">
+      <p class="text-sm text-slate-500">
         The FreeFeed group where posts will be published. Groups are like channels or communities.
       </p>
     <% else %>

--- a/app/views/llm_credentials/edit.html.erb
+++ b/app/views/llm_credentials/edit.html.erb
@@ -40,7 +40,7 @@
                                  class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
                                  autocomplete: "off",
                                  data: { key: "llm_credentials.credential-data.api_key" } %>
-          <p class="text-slate-500">Leave blank to keep the current key.</p>
+          <p class="text-sm text-slate-500">Leave blank to keep the current key.</p>
         </div>
       </div>
 

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -34,7 +34,7 @@
                            class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
                            required: true,
                            data: { key: "llm_credentials.display-name" } %>
-          <p class="text-slate-500">A label so you can tell credentials apart later.</p>
+          <p class="text-sm text-slate-500">A label so you can tell credentials apart later.</p>
         </div>
 
         <div class="space-y-2">

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -72,13 +72,13 @@
             <div class="space-y-2">
               <%= form.label :email_address, "Email", class: "block font-semibold text-slate-800" %>
               <%= form.email_field :email_address, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", required: true, autofocus: true %>
-              <p class="text-slate-500">Only used for password resets—we don't send marketing emails.</p>
+              <p class="text-sm text-slate-500">Only used for password resets—we don't send marketing emails.</p>
             </div>
 
             <div class="space-y-2">
               <%= form.label :password, class: "block font-semibold text-slate-800" %>
               <%= form.password_field :password, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", required: true %>
-              <p class="text-slate-500">Choose at least <%= User::PASSWORD_MIN_LENGTH %> characters to keep things secure.</p>
+              <p class="text-sm text-slate-500">Choose at least <%= User::PASSWORD_MIN_LENGTH %> characters to keep things secure.</p>
             </div>
           </div>
           <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,4 +70,7 @@ Rails.application.configure do
 
   # Use filesystem storage for captured emails in development
   config.email_storage_adapter = :file_system
+
+  # Expose developer-only tools (component reference, captured emails).
+  config.x.dev_tools.enabled = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,4 +66,7 @@ Rails.application.configure do
 
   # See resend initializer for configuration
   config.action_mailer.delivery_method = :resend
+
+  # Keep developer-only tools out of production. Staging re-enables them.
+  config.x.dev_tools.enabled = false
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,1 +1,6 @@
 require_relative "production"
+
+Rails.application.configure do
+  # Staging mirrors production but keeps developer-only tools available for QA.
+  config.x.dev_tools.enabled = true
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,4 +54,7 @@ Rails.application.configure do
 
   # Use in-memory storage for captured emails in tests
   config.email_storage_adapter = :in_memory
+
+  # Expose developer-only tools (component reference, captured emails).
+  config.x.dev_tools.enabled = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  if Rails.env.development? || Rails.env.test?
+  if Rails.configuration.x.dev_tools.enabled
     namespace :development do
       resource :components, only: :show
 

--- a/test/controllers/development/components_controller_test.rb
+++ b/test/controllers/development/components_controller_test.rb
@@ -22,4 +22,19 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "#show should associate checkbox and radio labels with their controls" do
+    get development_components_path
+
+    # Clickable labels require a matching id/for pair (the production idiom).
+    assert_select "input[type=checkbox]#enable_feed"
+    assert_select "label[for=enable_feed]"
+
+    assert_select "input[type=radio]#refresh_frequency_30m"
+    assert_select "label[for=refresh_frequency_30m]"
+
+    # Form-group label points at its input.
+    assert_select "input[type=text]#group_feed_name"
+    assert_select "label[for=group_feed_name]"
+  end
 end

--- a/test/controllers/development/components_controller_test.rb
+++ b/test/controllers/development/components_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
+  test "dev tools should be enabled in the test environment" do
+    assert Rails.configuration.x.dev_tools.enabled,
+           "dev tools must be enabled so the component reference route is drawn"
+  end
+
+  test "#show should render the UI elements reference" do
+    get development_components_path
+
+    assert_response :success
+    assert_select '[data-key="toc"]'
+    assert_select '[data-key="section.buttons"]'
+    assert_select '[data-key="section.form-group"]'
+    assert_select '[data-key="section.page-header"]'
+    assert_select '[data-key="section.event-description"]'
+  end
+
+  test "#show should not require authentication" do
+    get development_components_path
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Adds a developer-only UI elements reference — a single page that shows every reusable button, form control, and component in all of its states with realistic, in-context content. It doubles as a living style guide while building features.

The dev-tools route is no longer gated on `Rails.env`. A `config.x.dev_tools.enabled` flag (on in development/staging/test, off in production) decides whether the routes are drawn at all, so the page genuinely doesn't exist in production and is available on staging for QA.

Changes:

- Gate the `development` namespace (and admin links to it) on a `dev_tools.enabled` config flag instead of `Rails.env`
- Rebuild the reference page with a sticky table of contents and one section per UI element
- Show each element in all states (e.g. button primary/secondary/danger, default + disabled) with in-context content and standard whitespace; no hover state in the static view
- Cover form controls (input, select, checkbox, radio group, form group) plus all existing view components
- Add an integration test for the page and the config gate