### PR TITLE
Drop top margin from field error text

### DIFF
--- a/app/views/access_tokens/edit.html.erb
+++ b/app/views/access_tokens/edit.html.erb
@@ -14,7 +14,7 @@
                               autocomplete: "off",
                               autofocus: true %>
           <% if @access_token.errors[:name].any? %>
-            <p class="mt-2 text-sm text-red-600"><%= @access_token.errors[:name].first %></p>
+            <p class="text-sm text-red-600"><%= @access_token.errors[:name].first %></p>
           <% end %>
         </div>
 
@@ -31,7 +31,7 @@
                               autocomplete: "off" %>
           <p class="text-sm text-slate-500">Leave blank to keep the existing token. Entering a new value will trigger re-validation.</p>
           <% if @access_token.errors[:token].any? %>
-            <p class="mt-2 text-sm text-red-600"><%= @access_token.errors[:token].first %></p>
+            <p class="text-sm text-red-600"><%= @access_token.errors[:token].first %></p>
           <% end %>
         </div>
       </div>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -50,7 +50,7 @@
                               required: true,
                               autocomplete: "off" %>
           <% if @access_token.errors[:token].any? %>
-            <p class="mt-2 text-sm text-red-600"><%= @access_token.errors[:token].first %></p>
+            <p class="text-sm text-red-600"><%= @access_token.errors[:token].first %></p>
           <% end %>
         </div>
 
@@ -64,7 +64,7 @@
             Give this token a memorable name. If left blank, a default name will be used.
           </p>
           <% if @access_token.errors[:name].any? %>
-            <p class="mt-2 text-sm text-red-600"><%= @access_token.errors[:name].first %></p>
+            <p class="text-sm text-red-600"><%= @access_token.errors[:name].first %></p>
           <% end %>
         </div>
       </div>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -115,7 +115,7 @@
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Error</p>
           <%= text_field_tag :feed_name_error, "not-a-valid-url", class: "w-full rounded-md border border-red-400 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-red-500 transition focus:border-red-500 focus:outline-none focus:ring-2" %>
-          <p class="mt-2 text-sm text-red-600">Enter a valid feed URL.</p>
+          <p class="text-sm text-red-600">Enter a valid feed URL.</p>
         </div>
       </div>
     </section>
@@ -209,7 +209,7 @@
         <div class="space-y-2">
           <%= label_tag :group_source_url, "Source URL", class: "block font-semibold text-slate-800" %>
           <%= text_field_tag :group_source_url, "not-a-valid-url", class: "w-full rounded-md border border-red-400 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-red-500 transition focus:border-red-500 focus:outline-none focus:ring-2" %>
-          <p class="mt-2 text-sm text-red-600">Enter a valid feed URL, like https://example.com/feed.xml.</p>
+          <p class="text-sm text-red-600">Enter a valid feed URL, like https://example.com/feed.xml.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Follow-up to the help-text spacing change. Field validation messages still carried a `mt-2` top margin while help text (and some error messages) had none, so the gap under inputs was inconsistent depending on whether help or error text showed.

This removes the top margin from field error messages so they sit directly under the input, matching the help-text spacing — in both the UI elements reference page and production forms.

Changes:

- Normalize field error text to `text-sm text-red-600` (no top margin) in `access_tokens` new/edit and the reference page
- Error messages in `feeds/*` already had no top margin and are unchanged