### PR TITLE
Drop synthesized title from post preview

### DIFF
--- a/app/components/post_preview_component.html.erb
+++ b/app/components/post_preview_component.html.erb
@@ -1,22 +1,20 @@
 <%= render(CardComponent.new(id: card_id, class: "space-y-4")) do %>
-  <header class="space-y-2">
-    <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-      <h2 class="text-lg font-semibold text-slate-900"><%= title %></h2>
-      <% if source_url %>
-        <%= link_to "View source", source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 text-sm" %>
-      <% end %>
-    </div>
-    <% if metadata_segments.any? %>
-      <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-slate-600">
-        <% metadata_segments.each_with_index do |segment, index| %>
-          <% if index.positive? %>
-            <span aria-hidden="true" class="text-slate-300">•</span>
-          <% end %>
-          <span><%= segment %></span>
+  <% if metadata_segments.any? || source_url %>
+    <header class="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-slate-200 pb-4 text-xs text-slate-600">
+      <% metadata_segments.each_with_index do |segment, index| %>
+        <% if index.positive? %>
+          <span aria-hidden="true" class="text-slate-300">•</span>
         <% end %>
-      </div>
-    <% end %>
-  </header>
+        <span><%= segment %></span>
+      <% end %>
+      <% if source_url %>
+        <% if metadata_segments.any? %>
+          <span aria-hidden="true" class="text-slate-300">•</span>
+        <% end %>
+        <%= link_to "View source", source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
+      <% end %>
+    </header>
+  <% end %>
 
   <% if formatted_content %>
     <%= formatted_content %>

--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -4,14 +4,6 @@ class PostPreviewComponent < ViewComponent::Base
     @index = index
   end
 
-  def title
-    explicit_title = post_data["title"].presence
-    return explicit_title if explicit_title
-
-    preview = helpers.truncate(helpers.strip_tags(content), length: 80, omission: "...")
-    preview.presence || default_title
-  end
-
   def source_url
     post_data["source_url"].presence
   end
@@ -67,10 +59,6 @@ class PostPreviewComponent < ViewComponent::Base
   private
 
   attr_reader :post_data, :index
-
-  def default_title
-    index ? "Post #{index + 1}" : "Feed Preview Post"
-  end
 
   def valid_attachments
     @valid_attachments ||= raw_attachments.filter_map do |attachment|

--- a/test/components/post_preview_component_test.rb
+++ b/test/components/post_preview_component_test.rb
@@ -29,6 +29,15 @@ class PostPreviewComponentTest < ViewComponent::TestCase
     assert_includes card.css("a").map(&:text), "View source"
   end
 
+  test "renders content without a synthesized title heading" do
+    post_data = { "content" => "Lorem ipsum dolor sit amet, the opening line of the post body" }
+
+    result = render_inline(PostPreviewComponent.new(post_data: post_data, index: 0))
+
+    assert_empty result.css("h1, h2, h3")
+    assert_equal 1, result.text.scan("Lorem ipsum").size
+  end
+
   test "handles bad published_at values without crashing" do
     post_data = { "published_at" => "not-a-date" }
 


### PR DESCRIPTION
Changes:

- Remove the synthesized title heading from preview cards. The preview shows normalized data — exactly what we'd post to FreeFeed, which has no title. The heading was just the first 80 chars of the content duplicated above the body, plus a dead `post_data["title"]` override no producer ever sets.
- Render the post metadata (UID, published time, source link) as a header section divided from the body by a horizontal rule, so each card reads like the FreeFeed post it represents.