### PR TITLE
Add border-to-border sections to CardComponent

### DIFF
--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,6 +1,10 @@
 class CardComponent < ViewComponent::Base
-  BASE_CLASSES = "w-full rounded-lg border border-slate-200 bg-white p-6 shadow-xs"
+  BASE_CLASSES = "w-full rounded-lg border border-slate-200 bg-white shadow-xs"
+  PADDED_CLASSES = "p-6"
+  SECTIONED_CLASSES = "overflow-hidden divide-y divide-slate-200"
   LINKED_CLASSES = "block no-underline hover:bg-slate-50 hover:shadow-md transition duration-75"
+
+  renders_many :sections, CardComponent::SectionComponent
 
   def initialize(href: nil, **html_options)
     @href = href
@@ -9,16 +13,27 @@ class CardComponent < ViewComponent::Base
 
   def call
     if @href
-      link_to(@href, **merged_options) { content }
+      link_to(@href, **merged_options) { body }
     else
-      content_tag(:div, content, merged_options)
+      content_tag(:div, body, merged_options)
     end
   end
 
   private
 
+  # Sections render as border-to-border regions; a plain card renders its block
+  # content in a single padded box.
+  def body
+    sections.any? ? safe_join(sections) : content
+  end
+
   def merged_options
-    classes = helpers.class_names(BASE_CLASSES, (@href && LINKED_CLASSES), @html_options[:class])
+    classes = helpers.class_names(
+      BASE_CLASSES,
+      sections.any? ? SECTIONED_CLASSES : PADDED_CLASSES,
+      (@href && LINKED_CLASSES),
+      @html_options[:class]
+    )
     @html_options.merge(class: classes)
   end
 end

--- a/app/components/card_component/section_component.rb
+++ b/app/components/card_component/section_component.rb
@@ -1,0 +1,18 @@
+class CardComponent::SectionComponent < ViewComponent::Base
+  BASE_CLASSES = "p-6"
+
+  def initialize(**html_options)
+    @html_options = html_options
+  end
+
+  def call
+    content_tag(:div, content, merged_options)
+  end
+
+  private
+
+  def merged_options
+    classes = helpers.class_names(BASE_CLASSES, @html_options[:class])
+    @html_options.merge(class: classes)
+  end
+end

--- a/app/components/card_component/section_component.rb
+++ b/app/components/card_component/section_component.rb
@@ -1,5 +1,5 @@
 class CardComponent::SectionComponent < ViewComponent::Base
-  BASE_CLASSES = "p-6"
+  DEFAULT_CLASSES = "p-6"
 
   def initialize(**html_options)
     @html_options = html_options
@@ -11,8 +11,9 @@ class CardComponent::SectionComponent < ViewComponent::Base
 
   private
 
+  # An explicit class replaces the default padding rather than merging with it,
+  # so callers stay in full control of a section's spacing.
   def merged_options
-    classes = helpers.class_names(BASE_CLASSES, @html_options[:class])
-    @html_options.merge(class: classes)
+    @html_options.merge(class: @html_options[:class].presence || DEFAULT_CLASSES)
   end
 end

--- a/app/components/post_preview_component.html.erb
+++ b/app/components/post_preview_component.html.erb
@@ -1,6 +1,6 @@
 <%= render(CardComponent.new(id: card_id)) do |card| %>
   <% if metadata_segments.any? || source_url %>
-    <% card.with_section do %>
+    <% card.with_section(class: "px-6 py-4") do %>
       <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-slate-600">
         <% metadata_segments.each_with_index do |segment, index| %>
           <% if index.positive? %>

--- a/app/components/post_preview_component.html.erb
+++ b/app/components/post_preview_component.html.erb
@@ -1,29 +1,37 @@
-<%= render(CardComponent.new(id: card_id, class: "space-y-4")) do %>
+<%= render(CardComponent.new(id: card_id)) do |card| %>
   <% if metadata_segments.any? || source_url %>
-    <header class="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-slate-200 pb-4 text-xs text-slate-600">
-      <% metadata_segments.each_with_index do |segment, index| %>
-        <% if index.positive? %>
-          <span aria-hidden="true" class="text-slate-300">•</span>
+    <% card.with_section do %>
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-slate-600">
+        <% metadata_segments.each_with_index do |segment, index| %>
+          <% if index.positive? %>
+            <span aria-hidden="true" class="text-slate-300">•</span>
+          <% end %>
+          <span><%= segment %></span>
         <% end %>
-        <span><%= segment %></span>
-      <% end %>
-      <% if source_url %>
-        <% if metadata_segments.any? %>
-          <span aria-hidden="true" class="text-slate-300">•</span>
+        <% if source_url %>
+          <% if metadata_segments.any? %>
+            <span aria-hidden="true" class="text-slate-300">•</span>
+          <% end %>
+          <%= link_to "View source", source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
         <% end %>
-        <%= link_to "View source", source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
-      <% end %>
-    </header>
+      </div>
+    <% end %>
   <% end %>
 
-  <% if formatted_content %>
-    <%= formatted_content %>
-  <% end %>
+  <% if formatted_content || attachments? %>
+    <% card.with_section do %>
+      <div class="space-y-4">
+        <% if formatted_content %>
+          <%= formatted_content %>
+        <% end %>
 
-  <% if attachments? %>
-    <section class="space-y-2">
-      <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Attachments</p>
-      <%= attachments_list %>
-    </section>
+        <% if attachments? %>
+          <section class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Attachments</p>
+            <%= attachments_list %>
+          </section>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -283,6 +283,19 @@
           <p class="text-slate-700">Last refreshed 5 minutes ago · 142 posts published. Everything is running smoothly.</p>
         </div>
       <% end %>
+
+      <p class="text-slate-600">Add sections to split a card into regions divided edge to edge.</p>
+      <%= render CardComponent.new do |card| %>
+        <% card.with_section do %>
+          <p class="text-sm font-medium text-slate-700">Tech News Daily</p>
+        <% end %>
+        <% card.with_section do %>
+          <p class="text-slate-700">Last refreshed 5 minutes ago · 142 posts published. Everything is running smoothly.</p>
+        <% end %>
+        <% card.with_section do %>
+          <p class="text-sm text-slate-500">Next refresh in about an hour.</p>
+        <% end %>
+      <% end %>
     </section>
 
     <%# Alert %>

--- a/test/components/card_component/section_component_test.rb
+++ b/test/components/card_component/section_component_test.rb
@@ -11,14 +11,13 @@ class CardComponent::SectionComponentTest < ViewComponent::TestCase
     assert_includes section["class"], "p-6"
   end
 
-  test "#call should merge classes and forward html attributes" do
+  test "#call should let an explicit class override the default padding" do
     result = render_inline(
-      CardComponent::SectionComponent.new(class: "extra", data: { key: "stats" })
+      CardComponent::SectionComponent.new(class: "px-6 py-4", data: { key: "stats" })
     ) { "Body" }
 
     section = result.at_css("div")
-    assert_includes section["class"], "extra"
-    assert_includes section["class"], "p-6"
+    assert_equal "px-6 py-4", section["class"]
     assert_equal "stats", section["data-key"]
   end
 end

--- a/test/components/card_component/section_component_test.rb
+++ b/test/components/card_component/section_component_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+require "view_component/test_case"
+
+class CardComponent::SectionComponentTest < ViewComponent::TestCase
+  test "#call should render a padded div with content" do
+    result = render_inline(CardComponent::SectionComponent.new) { "Section body" }
+
+    section = result.at_css("div")
+    assert_not_nil section
+    assert_equal "Section body", section.text.strip
+    assert_includes section["class"], "p-6"
+  end
+
+  test "#call should merge classes and forward html attributes" do
+    result = render_inline(
+      CardComponent::SectionComponent.new(class: "extra", data: { key: "stats" })
+    ) { "Body" }
+
+    section = result.at_css("div")
+    assert_includes section["class"], "extra"
+    assert_includes section["class"], "p-6"
+    assert_equal "stats", section["data-key"]
+  end
+end

--- a/test/components/card_component_test.rb
+++ b/test/components/card_component_test.rb
@@ -10,6 +10,22 @@ class CardComponentTest < ViewComponent::TestCase
     assert_equal "Card body", card.text.strip
     assert_includes card["class"], "bg-white"
     assert_includes card["class"], "rounded-lg"
+    assert_includes card["class"], "p-6"
+  end
+
+  test "#call should render sections divided border-to-border" do
+    result = render_inline(CardComponent.new) do |card|
+      card.with_section { "Header" }
+      card.with_section { "Footer" }
+    end
+
+    card = result.at_css("div")
+    assert_includes card["class"], "divide-y"
+    assert_includes card["class"], "overflow-hidden"
+    refute_includes card["class"], "p-6"
+
+    sections = card.css("> div")
+    assert_equal ["Header", "Footer"], sections.map { |section| section.text.strip }
   end
 
   test "#call should merge classes and forward html attributes" do


### PR DESCRIPTION
Changes:

- Add optional sections to `CardComponent`. A sectioned card renders each section as its own padded region with edge-to-edge dividers between them (container drops its padding and uses `divide-y`). Cards with no sections render exactly as before, so all existing consumers are untouched.
- Add `CardComponent::SectionComponent` — a small padded region that forwards html options for per-section styling (e.g. `class: "bg-slate-50"` for an emphasized header/footer).
- Migrate the feed post preview to use two card sections (metadata header + body), replacing the hand-rolled bottom-border divider so the line now spans the full card width.
- Document sectioned cards on the dev components reference page.