### PR TITLE
Polish feed preview metadata row

### DIFF
--- a/app/components/post_preview_component.html.erb
+++ b/app/components/post_preview_component.html.erb
@@ -12,7 +12,10 @@
           <% if metadata_segments.any? %>
             <span aria-hidden="true" class="text-slate-300">•</span>
           <% end %>
-          <%= link_to "View source", source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
+          <%= link_to source_url, target: "_blank", rel: "noopener", class: "inline-flex items-center gap-1 font-medium text-sky-600 transition hover:text-sky-500" do %>
+            <span class="underline underline-offset-4">View source</span>
+            <%= helpers.icon("external-link", css_class: "size-3.5", aria_label: "Opens in a new window") %>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -20,7 +20,7 @@ class PostPreviewComponent < ViewComponent::Base
 
   def metadata_segments
     [].tap do |segments|
-      segments << "UID #{post_data["uid"]}" if post_data["uid"].present?
+      segments << "UID: #{post_data["uid"]}" if post_data["uid"].present?
 
       if published_at
         segments << "Published #{helpers.time_ago_in_words(published_at)} ago"

--- a/app/views/feed_previews/_ready.html.erb
+++ b/app/views/feed_previews/_ready.html.erb
@@ -13,7 +13,7 @@
             class="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50"
             data-action="click->preview#refresh"
             data-key="preview.refresh">
-      Refresh preview
+      Refresh
     </button>
   </div>
 

--- a/test/components/post_preview_component_test.rb
+++ b/test/components/post_preview_component_test.rb
@@ -22,11 +22,22 @@ class PostPreviewComponentTest < ViewComponent::TestCase
 
     card = result.at_css("#feed-preview-post-1")
     assert_not_nil card
-    assert_includes card.text, "UID post-123"
+    assert_includes card.text, "UID: post-123"
     assert_includes card.text, "Published about 1 hour ago"
     assert_includes card.text, "Attachments: 1"
     assert_includes card.text, "Hello world"
-    assert_includes card.css("a").map(&:text), "View source"
+
+    source_link = card.css("a").find { |link| link.text.include?("View source") }
+    assert_not_nil source_link
+    assert_not_nil source_link.at_css("svg"), "expected an external-link icon in the source link"
+  end
+
+  test "omits the attachments count when there are none" do
+    post_data = { "content" => "Body", "uid" => "post-1" }
+
+    result = render_inline(PostPreviewComponent.new(post_data: post_data))
+
+    refute_includes result.text, "Attachments"
   end
 
   test "renders content without a synthesized title heading" do


### PR DESCRIPTION
Changes:

- Add an "open in new window" icon (external-link) after the **View source** link, so it's obvious the link leaves the page.
- Prefix the post UID with a colon — `UID: …`.
- Shorten the preview **Refresh preview** button to just **Refresh**.
- Add test coverage confirming the attachments count is hidden when a post has no attachments (already the behavior, now locked in).