### PR TITLE
Purge expired events in batches

### DIFF
--- a/app/jobs/purge_expired_events_job.rb
+++ b/app/jobs/purge_expired_events_job.rb
@@ -1,0 +1,21 @@
+# Deletes events whose explicit expiration time has passed.
+#
+# This job intentionally deletes in small batches so a daily cron run does not
+# hold locks on the events table for one long operation.
+class PurgeExpiredEventsJob < ApplicationJob
+  queue_as :default
+
+  BATCH_SIZE = 500
+  BATCH_PAUSE = 0.01.seconds
+
+  def perform
+    deleted_count = 0
+
+    Event.expired.in_batches(of: BATCH_SIZE) do |events|
+      deleted_count += events.delete_all
+      sleep BATCH_PAUSE
+    end
+
+    deleted_count
+  end
+end

--- a/test/jobs/purge_expired_events_job_test.rb
+++ b/test/jobs/purge_expired_events_job_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class PurgeExpiredEventsJobTest < ActiveJob::TestCase
+  test "#perform should delete expired events" do
+    expired = create(:event, expires_at: 1.hour.ago)
+    active = create(:event, expires_at: 1.hour.from_now)
+    permanent = create(:event)
+
+    deleted_count = PurgeExpiredEventsJob.perform_now
+
+    assert_equal 1, deleted_count
+    assert_not Event.exists?(expired.id)
+    assert Event.exists?(active.id)
+    assert Event.exists?(permanent.id)
+  end
+end


### PR DESCRIPTION
Changes:

- Add a daily-cron-friendly job for purging expired events.
- Delete expired rows in small batches with short pauses to avoid long table locks.
- Cover active, permanent, and expired event behavior with a job test.

Verified:

- bin/rails test test/jobs/purge_expired_events_job_test.rb
- bin/rubocop -f github app/jobs/purge_expired_events_job.rb test/jobs/purge_expired_events_job_test.rb