### PR TITLE
Schedule recurring jobs on staging

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -20,6 +20,21 @@ development:
     queue: default
     schedule: every day at 4am
 
+staging:
+  feed_scheduler:
+    class: FeedSchedulerJob
+    queue: default
+    schedule: every minute
+
+  prune_feed_previews:
+    class: PruneFeedPreviewsJob
+    queue: default
+    schedule: every day at 4am
+
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12
+
 production:
   feed_scheduler:
     class: FeedSchedulerJob


### PR DESCRIPTION
Changes:

- Add a staging recurring job schedule matching production.
- Enable feed refresh scheduling, preview pruning, and Solid Queue finished job cleanup on staging.