### PR TITLE
Add prev/next navigation to the user event page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,12 +11,24 @@ class EventsController < ApplicationController
 
   def show
     @event = owned_events.find(params[:id])
+    @previous_event = adjacent_event(:newer)
+    @next_event = adjacent_event(:older)
   end
 
   private
 
   def owned_events
     Event.where(user: Current.user).user_relevant
+  end
+
+  # Navigates the user's own log in the same chronological order as the list:
+  # "previous" is the next-newer event, "next" is the next-older one.
+  def adjacent_event(direction)
+    if direction == :newer
+      owned_events.where(cursor_condition(">", @event.id)).order(created_at: :asc, id: :asc).first
+    else
+      owned_events.where(cursor_condition("<", @event.id)).order(created_at: :desc, id: :desc).first
+    end
   end
 
   def events_scope

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,6 +2,24 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Event ##{@event.id}") do |header| %>
+    <% if @previous_event %>
+      <% header.with_action_button do %>
+        <%= link_to "← Previous", event_path(@previous_event), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+      <% end %>
+    <% else %>
+      <% header.with_action_button do %>
+        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-300 shadow-sm cursor-not-allowed">← Previous</span>
+      <% end %>
+    <% end %>
+    <% if @next_event %>
+      <% header.with_action_button do %>
+        <%= link_to "Next →", event_path(@next_event), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+      <% end %>
+    <% else %>
+      <% header.with_action_button do %>
+        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-300 shadow-sm cursor-not-allowed">Next →</span>
+      <% end %>
+    <% end %>
     <% header.with_action_button do %>
       <%= link_to "Back to Status", status_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -238,6 +238,45 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "#show should link to the chronologically adjacent events" do
+    sign_in_as user
+    older = create(:event, type: "older", user: user, created_at: 2.hours.ago)
+    current = create(:event, type: "current", user: user, created_at: 1.hour.ago)
+    newer = create(:event, type: "newer", user: user, created_at: 10.minutes.ago)
+
+    get event_path(current)
+
+    assert_response :success
+    assert_select "a[href='#{event_path(newer)}']", text: "← Previous"
+    assert_select "a[href='#{event_path(older)}']", text: "Next →"
+  end
+
+  test "#show should disable navigation at the ends of the log" do
+    sign_in_as user
+    only = create(:event, type: "only", user: user)
+
+    get event_path(only)
+
+    assert_response :success
+    assert_select "a", text: "← Previous", count: 0
+    assert_select "a", text: "Next →", count: 0
+    assert_select "span.cursor-not-allowed", text: "← Previous"
+    assert_select "span.cursor-not-allowed", text: "Next →"
+  end
+
+  test "#show navigation should ignore another user's events" do
+    sign_in_as user
+    mine = create(:event, type: "mine", user: user, created_at: 1.hour.ago)
+    create(:event, type: "theirs_newer", user: other_user, created_at: 1.minute.ago)
+    create(:event, type: "theirs_older", user: other_user, created_at: 2.hours.ago)
+
+    get event_path(mine)
+
+    assert_response :success
+    assert_select "span.cursor-not-allowed", text: "← Previous"
+    assert_select "span.cursor-not-allowed", text: "Next →"
+  end
+
   private
 
   def with_page_size(size)


### PR DESCRIPTION
Adds Previous/Next navigation to `/events/:id`, mirroring the admin event page.

- "Previous" links to the next-newer event, "Next" to the next-older one, following the same chronological `(created_at, id)` order as the events log.
- Navigation is scoped to the current user's own events and reuses the existing cursor comparison.
- Buttons render disabled (greyed) at the ends of the log.

References:

- Stacks on #522