### PR TITLE
Split admin event log entry presentation

### DIFF
--- a/app/components/admin/event_log_entry_component.html.erb
+++ b/app/components/admin/event_log_entry_component.html.erb
@@ -8,9 +8,7 @@
       <div class="truncate text-sm text-slate-600">
         <%= render EventDescriptionComponent.new(event: event) %>
       </div>
-      <% if (label = subject_label) %>
-        <div class="text-xs text-slate-500"><%= label %></div>
-      <% end %>
+      <div class="text-xs text-slate-500"><%= safe_join([user_label, subject_label].compact, " • ") %></div>
     </div>
     <%= link_to helpers.short_time_ago(event.created_at), href,
                 class: "shrink-0 text-xs font-medium text-slate-500 hover:text-slate-700",

--- a/app/components/admin/event_log_entry_component.rb
+++ b/app/components/admin/event_log_entry_component.rb
@@ -1,19 +1,23 @@
-class Admin::EventLogEntryComponent < EventLogEntryComponent
-  private
+class Admin::EventLogEntryComponent < ViewComponent::Base
+  include EventLogEntryPresentation
 
-  # Admins always see who an event belongs to, including system events.
-  def show_user_label?
-    true
+  def initialize(event:, href:)
+    @event = event
+    @href = href
   end
 
-  # The user becomes a link that filters the admin events log.
+  private
+
+  attr_reader :event, :href
+
+  # Admins see who an event belongs to; the user links to a filtered log.
   def user_label
-    return super if event.user_id.blank?
+    return helpers.tag.em("System", data: { key: "events.user" }) if event.user_id.blank?
 
     helpers.link_to(
       "User ##{event.user_id}",
       helpers.admin_events_path(filter: { user_id: event.user_id }),
-      class: "underline decoration-dotted underline-offset-2 hover:text-slate-700",
+      class: "underline underline-offset-2 hover:text-slate-700",
       data: { key: "events.user" }
     )
   end

--- a/app/components/event_log_entry_component.rb
+++ b/app/components/event_log_entry_component.rb
@@ -1,4 +1,6 @@
 class EventLogEntryComponent < ViewComponent::Base
+  include EventLogEntryPresentation
+
   def initialize(event:, href:)
     @event = event
     @href = href
@@ -7,42 +9,4 @@ class EventLogEntryComponent < ViewComponent::Base
   private
 
   attr_reader :event, :href
-
-  def event_context
-    parts = []
-    parts << user_label if show_user_label?
-    parts << subject_label
-
-    content_tag(:div, helpers.safe_join(parts.compact, " • "), class: "text-xs text-slate-500") if parts.any?
-  end
-
-  # Hooks overridden by the admin presentation.
-  def show_user_label?
-    event.user_id.present?
-  end
-
-  def user_label
-    if event.user_id.present?
-      helpers.tag.span("User ##{event.user_id}", data: { key: "events.user" })
-    else
-      helpers.tag.em("System", data: { key: "events.user" })
-    end
-  end
-
-  def subject_label
-    return if event.subject_type.blank?
-
-    value = event.subject_id.present? ? "#{event.subject_type} ##{event.subject_id}" : event.subject_type
-    helpers.tag.span(value, data: { key: "events.subject" })
-  end
-
-  def badge_color(level)
-    case level
-    when "debug" then :gray
-    when "info" then :blue
-    when "warning" then :yellow
-    when "error" then :red
-    else :blue
-    end
-  end
 end

--- a/app/components/event_log_entry_presentation.rb
+++ b/app/components/event_log_entry_presentation.rb
@@ -1,0 +1,23 @@
+# Shared rendering helpers for the user-facing and admin event log entries.
+# The two components keep separate templates because they present different
+# information (the admin log also shows which user an event belongs to).
+module EventLogEntryPresentation
+  private
+
+  def badge_color(level)
+    case level
+    when "debug" then :gray
+    when "info" then :blue
+    when "warning" then :yellow
+    when "error" then :red
+    else :blue
+    end
+  end
+
+  def subject_label
+    return if event.subject_type.blank?
+
+    value = event.subject_id.present? ? "#{event.subject_type} ##{event.subject_id}" : event.subject_type
+    helpers.tag.span(value, data: { key: "events.subject" })
+  end
+end

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "Events" %>
+<% content_for :title, "System Events" %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Events") do |header| %>
+  <%= render PageHeaderComponent.new(title: "System Events") do |header| %>
     <% if @filter.present? %>
       <% header.with_context_paragraph do %>
         <span class="text-sm text-slate-500" data-key="admin.events.filter-summary">

--- a/test/components/admin/event_log_entry_component_test.rb
+++ b/test/components/admin/event_log_entry_component_test.rb
@@ -14,6 +14,8 @@ class Admin::EventLogEntryComponentTest < ViewComponent::TestCase
     assert_not_nil link
     assert_equal "User ##{user.id}", link.text
     assert_includes link["href"], "filter%5Buser_id%5D=#{user.id}"
+    assert_includes link["class"], "underline"
+    assert_not_includes link["class"], "decoration-dotted"
   end
 
   test "#call should show System for events without a user" do

--- a/test/components/event_log_entry_component_test.rb
+++ b/test/components/event_log_entry_component_test.rb
@@ -38,17 +38,8 @@ class EventLogEntryComponentTest < ViewComponent::TestCase
     assert_equal "Feed ##{feed.id}", result.css("[data-key='events.subject']").first.text
   end
 
-  test "#call should render the user as plain text" do
+  test "#call should never show an owner (entries belong to the current user)" do
     event = create(:event, user: user)
-
-    result = render_inline(EventLogEntryComponent.new(event: event, href: "/events/#{event.id}"))
-
-    assert_not_nil result.css("span[data-key='events.user']").first
-    assert_empty result.css("a[data-key='events.user']")
-  end
-
-  test "#call should omit the user label for system events" do
-    event = create(:event, user: nil)
 
     result = render_inline(EventLogEntryComponent.new(event: event, href: "/events/#{event.id}"))
 

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -36,7 +36,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     get admin_events_path
 
     assert_response :success
-    assert_select "h1", "Events"
+    assert_select "h1", "System Events"
     assert_select '[data-key="events.type"]', "TestEvent"
     assert_select 'a[data-key="events.user"]', "User ##{user.id}"
   end
@@ -85,7 +85,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     get admin_events_path
 
     assert_response :success
-    assert_select "h1", "Events"
+    assert_select "h1", "System Events"
     assert_select '[data-key="empty-state"]'
     assert_select "p", "No events to show yet"
   end


### PR DESCRIPTION
Splits user-facing and admin event log entry rendering so the user log no longer shows an owner reference while the admin log still shows the owning user/system context.

- User event log entries now show only event details and subject context.
- Admin event log entries use a separate template and component class, sharing common presentation helpers.
- Renames the admin events index heading to "System Events".
- Removes `decoration-dotted` from the admin user filter link styling.
