### PR TITLE
Improve Status page stats bar readability

### DIFF
--- a/app/components/user_stats_component.rb
+++ b/app/components/user_stats_component.rb
@@ -40,10 +40,10 @@ class UserStatsComponent < ViewComponent::Base
         value: number_with_delimiter(user.total_published_posts_count)
       },
       {
-        key: "average_posts_per_day",
-        label: "Average posts per day (last week)",
-        label_short: "Daily",
-        value: user.average_posts_per_day_last_week.present? ? number_with_precision(user.average_posts_per_day_last_week.to_f, precision: 1) : "—"
+        key: "posts_last_week",
+        label: "Posts published last week",
+        label_short: "Last week",
+        value: number_with_delimiter(user.posts_published_last_week_count)
       },
       {
         key: "most_recent_post_publication",

--- a/app/components/user_stats_component.rb
+++ b/app/components/user_stats_component.rb
@@ -49,7 +49,7 @@ class UserStatsComponent < ViewComponent::Base
         key: "most_recent_post_publication",
         label: "Most recent post publication",
         label_short: "Recent",
-        value: user.most_recent_post_published_at.present? ? "#{time_ago_in_words(user.most_recent_post_published_at)} ago" : "—"
+        value: user.most_recent_post_published_at.present? ? "#{helpers.short_time_ago(user.most_recent_post_published_at)} ago" : "—"
       }
     ]
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,13 +116,8 @@ class User < ApplicationRecord
     published_posts.maximum(:published_at)
   end
 
-  # Returns the average number of posts per day for the last week across all user's feeds
-  # @return [Float] average posts per day (0.0 if no posts)
-  def average_posts_per_day_last_week
-    start_date = 1.week.ago.beginning_of_day
-    end_date = Time.current.end_of_day
-    count = imported_posts.where(published_at: start_date..end_date).count
-    (count / 7.0).round(1)
+  def posts_published_last_week_count
+    imported_posts.where(published_at: 1.week.ago.beginning_of_day..Time.current.end_of_day).count
   end
 
   def update_password!(new_password)

--- a/test/components/user_stats_component_test.rb
+++ b/test/components/user_stats_component_test.rb
@@ -22,7 +22,7 @@ class UserStatsComponentTest < ViewComponent::TestCase
     recent = result.css('[data-key="stats.most_recent_post_publication"]').first
     assert_not_nil recent
 
-    average = result.css('[data-key="stats.average_posts_per_day"]').first
+    average = result.css('[data-key="stats.posts_last_week"]').first
     assert_not_nil average
   end
 

--- a/test/controllers/statuses_controller_test.rb
+++ b/test/controllers/statuses_controller_test.rb
@@ -75,7 +75,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     get status_path
     assert_response :success
     assert_not_nil css_select('[data-key="stats.most_recent_post_publication"]').first
-    assert_match(/1 day ago/, css_select('[data-key="stats.most_recent_post_publication.value"]').first.text)
+    assert_match(/1d ago/, css_select('[data-key="stats.most_recent_post_publication.value"]').first.text)
   end
 
   test "#show should hide most recent post publication when no published posts" do

--- a/test/controllers/statuses_controller_test.rb
+++ b/test/controllers/statuses_controller_test.rb
@@ -86,7 +86,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     assert css_select('[data-key="stats.most_recent_post_publication"]').empty?
   end
 
-  test "#show should display average posts per day for last week" do
+  test "#show should display posts published last week" do
     sign_in_as user
     feed = create(:feed, user: user)
     entry1 = create(:feed_entry, feed: feed)
@@ -96,16 +96,16 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path
     assert_response :success
-    assert_not_nil css_select('[data-key="stats.average_posts_per_day"]').first
-    assert_equal "0.3", css_select('[data-key="stats.average_posts_per_day.value"]').first.text.strip
+    assert_not_nil css_select('[data-key="stats.posts_last_week"]').first
+    assert_equal "2", css_select('[data-key="stats.posts_last_week.value"]').first.text.strip
   end
 
-  test "#show should hide average posts per day when no posts" do
+  test "#show should hide posts last week when no posts" do
     sign_in_as user
 
     get status_path
     assert_response :success
-    assert css_select('[data-key="stats.average_posts_per_day"]').empty?
+    assert css_select('[data-key="stats.posts_last_week"]').empty?
   end
 
   test "#show should hide post statistics when no posts" do
@@ -116,7 +116,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     assert css_select('[data-key="stats.total_imported_posts"]').empty?
     assert css_select('[data-key="stats.total_published_posts"]').empty?
     assert css_select('[data-key="stats.most_recent_post_publication"]').empty?
-    assert css_select('[data-key="stats.average_posts_per_day"]').empty?
+    assert css_select('[data-key="stats.posts_last_week"]').empty?
   end
 
   test "#show should render empty state when no feeds" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -204,7 +204,7 @@ class UserTest < ActiveSupport::TestCase
     assert_nil user.most_recent_post_published_at
   end
 
-  test "#average_posts_per_day_last_week calculates average correctly" do
+  test "#posts_published_last_week_count should return count of posts from the last 7 days" do
     user = create(:user)
     feed = create(:feed, user: user)
     entry1 = create(:feed_entry, feed: feed)
@@ -215,13 +215,13 @@ class UserTest < ActiveSupport::TestCase
     create(:post, feed: feed, feed_entry: entry2, published_at: 1.day.ago)
     create(:post, feed: feed, feed_entry: entry3, published_at: 10.days.ago)
 
-    assert_equal 0.3, user.average_posts_per_day_last_week
+    assert_equal 2, user.posts_published_last_week_count
   end
 
-  test "#average_posts_per_day_last_week returns 0.0 when no posts" do
+  test "#posts_published_last_week_count should return 0 when no posts" do
     user = create(:user)
 
-    assert_equal 0.0, user.average_posts_per_day_last_week
+    assert_equal 0, user.posts_published_last_week_count
   end
 
   test "#deactivate_email! should set email_deactivated_at and reason" do


### PR DESCRIPTION
Two small UX improvements to the stats bar on the Status page:

- **Recent:** time format changed from verbose ("about 13 hours ago") to compact ("13h ago"), consistent with how feed-level stats already display time.
- **Last week:** replaced the "Daily" average (which showed awkward decimals like `0.6`) with a plain post count for the last 7 days — a whole number that's easier to read at a glance.