### PR TITLE
Add option to hide refresh button in EventLogComponent

### DIFF
--- a/app/components/event_log_component.rb
+++ b/app/components/event_log_component.rb
@@ -7,17 +7,16 @@ class EventLogComponent < ViewComponent::Base
 
   # `endpoint` enables polling (first page only). `older_url`/`newer_url` enable
   # cursor pagination links; omit them for an unpaginated log.
-  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil, show_refresh: true)
+  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil)
     @events = events
     @endpoint = endpoint
     @older_url = older_url
     @newer_url = newer_url
-    @show_refresh = show_refresh
   end
 
   def call
     content_tag(:div, class: "space-y-3", id: DOM_ID, data: host_data) do
-      safe_join([refresh_button, events_body, pagination_nav].compact)
+      safe_join([events_body, pagination_nav].compact)
     end
   end
 
@@ -44,20 +43,6 @@ class EventLogComponent < ViewComponent::Base
       polling_indicate_busy_value: false,
       last_event_id: last_event_id
     )
-  end
-
-  def refresh_button
-    return unless polling? && @show_refresh
-
-    content_tag(:div, class: "flex justify-end") do
-      button_tag(
-        helpers.icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh"),
-        type: "button",
-        title: "Refresh",
-        class: "inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-2 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
-        data: { action: "polling#refresh", key: "events.refresh" }
-      )
-    end
   end
 
   def events_body

--- a/app/components/event_log_component.rb
+++ b/app/components/event_log_component.rb
@@ -7,11 +7,12 @@ class EventLogComponent < ViewComponent::Base
 
   # `endpoint` enables polling (first page only). `older_url`/`newer_url` enable
   # cursor pagination links; omit them for an unpaginated log.
-  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil)
+  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil, show_refresh: true)
     @events = events
     @endpoint = endpoint
     @older_url = older_url
     @newer_url = newer_url
+    @show_refresh = show_refresh
   end
 
   def call
@@ -46,7 +47,7 @@ class EventLogComponent < ViewComponent::Base
   end
 
   def refresh_button
-    return unless polling?
+    return unless polling? && @show_refresh
 
     content_tag(:div, class: "flex justify-end") do
       button_tag(

--- a/app/components/recent_events_entry_component.rb
+++ b/app/components/recent_events_entry_component.rb
@@ -1,0 +1,36 @@
+class RecentEventsEntryComponent < ViewComponent::Base
+  include EventLogEntryPresentation
+
+  def initialize(event:, href:)
+    @event = event
+    @href = href
+  end
+
+  def call
+    content_tag(:li, class: "flex items-center gap-3 px-4 py-2.5",
+                     data: { key: "recent_events.#{event.id}" }) do
+      safe_join([badge_tag, description_tag, time_tag])
+    end
+  end
+
+  private
+
+  attr_reader :event, :href
+
+  def badge_tag
+    render(BadgeComponent.new(text: event.level.humanize, color: badge_color(event.level)))
+  end
+
+  def description_tag
+    content_tag(:span, render(EventDescriptionComponent.new(event: event)),
+                class: "flex-1 truncate text-sm text-slate-700",
+                data: { key: "recent_events.description" })
+  end
+
+  def time_tag
+    link_to(helpers.short_time_ago(event.created_at), href,
+            class: "shrink-0 text-xs font-medium text-slate-500 hover:text-slate-700",
+            title: event.created_at.rfc3339,
+            data: { key: "recent_events.timestamp" })
+  end
+end

--- a/app/components/recent_events_list_component.rb
+++ b/app/components/recent_events_list_component.rb
@@ -1,0 +1,42 @@
+class RecentEventsListComponent < ViewComponent::Base
+  DOM_ID = "recent_events_list".freeze
+
+  def initialize(events:, endpoint: nil)
+    @events = events
+    @endpoint = endpoint
+  end
+
+  def call
+    content_tag(:div, id: DOM_ID, data: host_data) do
+      if @events.any?
+        list = ListComponent.new
+        @events.each do |event|
+          list.with_item(RecentEventsEntryComponent.new(event: event, href: helpers.event_path(event)))
+        end
+        render(list)
+      else
+        render(EmptyStateComponent.new("No events to show yet"))
+      end
+    end
+  end
+
+  private
+
+  def host_data
+    return {} unless @endpoint.present?
+
+    {
+      controller: "polling",
+      polling_endpoint_value: @endpoint,
+      polling_interval_value: 10_000,
+      polling_initial_delay_value: 10_000,
+      polling_max_polls_value: 0,
+      polling_indicate_busy_value: false,
+      last_event_id: last_event_id
+    }
+  end
+
+  def last_event_id
+    @events.map(&:id).max || 0
+  end
+end

--- a/app/controllers/concerns/event_streaming.rb
+++ b/app/controllers/concerns/event_streaming.rb
@@ -3,6 +3,7 @@ module EventStreaming
 
   included do
     class_attribute :events_page_size, default: 25
+    class_attribute :brief_events_limit, default: 5
   end
 
   private
@@ -24,10 +25,28 @@ module EventStreaming
   def render_events_stream
     return head :ok unless params[:force].present? || new_events?
 
+    brief_display? ? render_brief_events_stream : render_full_events_stream
+  end
+
+  def render_full_events_stream
     load_stream_page
     body = helpers.render(event_log_component) do |log|
       @events.each { |event| log.with_entry { helpers.render(entry_component(event)) } }
     end
     render turbo_stream: turbo_stream.replace(EventLogComponent::DOM_ID, body)
+  end
+
+  def render_brief_events_stream
+    @events = events_scope.includes(:user, :subject).order(created_at: :desc, id: :desc).limit(brief_events_limit)
+    body = helpers.render(RecentEventsListComponent.new(events: @events, endpoint: brief_polling_endpoint))
+    render turbo_stream: turbo_stream.replace(RecentEventsListComponent::DOM_ID, body)
+  end
+
+  def brief_display?
+    params[:display] == "brief"
+  end
+
+  def brief_polling_endpoint
+    events_log_path(format: :turbo_stream, display: :brief)
   end
 end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,7 +1,7 @@
 class StatusesController < ApplicationController
   include EventFiltering
 
-  class_attribute :initial_events_limit, default: 25
+  class_attribute :initial_events_limit, default: 5
 
   def show
     @user = Current.user

--- a/app/javascript/controllers/refresh_trigger_controller.js
+++ b/app/javascript/controllers/refresh_trigger_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { targetId: String }
+
+  trigger() {
+    const el = document.getElementById(this.targetIdValue)
+    this.application.getControllerForElementAndIdentifier(el, "polling")?.refresh()
+  }
+}

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -19,6 +19,18 @@
     <% header.with_action_button do %>
       <%= link_to "Back to Admin", admin_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>
+    <% if @log_endpoint %>
+      <% header.with_action_button do %>
+        <button data-controller="refresh-trigger"
+                data-refresh-trigger-target-id-value="<%= EventLogComponent::DOM_ID %>"
+                data-action="click->refresh-trigger#trigger"
+                data-key="events.refresh"
+                title="Refresh"
+                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-2 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">
+          <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
+        </button>
+      <% end %>
+    <% end %>
   <% end %>
 
   <%= render(EventLogComponent.new(

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -39,7 +39,8 @@
       </div>
       <%= render(EventLogComponent.new(
         events: @recent_events,
-        endpoint: events_path(format: :turbo_stream, filter: @filter.to_h.presence)
+        endpoint: events_path(format: :turbo_stream, filter: @filter.to_h.presence),
+        show_refresh: false
       )) do |log| %>
         <% @recent_events.each do |event| %>
           <% log.with_entry do %>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -37,17 +37,10 @@
         <h2 class="text-2xl font-semibold text-slate-900">Recent Activity</h2>
         <%= link_to "View all", events_path(filter: @filter.to_h.presence), class: "text-sm font-semibold text-sky-600 hover:text-sky-500", data: { key: "recent_events.view_all" } %>
       </div>
-      <%= render(EventLogComponent.new(
+      <%= render(RecentEventsListComponent.new(
         events: @recent_events,
-        endpoint: events_path(format: :turbo_stream, filter: @filter.to_h.presence),
-        show_refresh: false
-      )) do |log| %>
-        <% @recent_events.each do |event| %>
-          <% log.with_entry do %>
-            <%= render EventLogEntryComponent.new(event: event, href: event_path(event)) %>
-          <% end %>
-        <% end %>
-      <% end %>
+        endpoint: events_path(format: :turbo_stream, display: :brief, filter: @filter.to_h.presence)
+      )) %>
     </section>
   <% end %>
 </div>

--- a/test/components/event_log_component_test.rb
+++ b/test/components/event_log_component_test.rb
@@ -35,22 +35,12 @@ class EventLogComponentTest < ViewComponent::TestCase
     assert_equal "false", host["data-polling-indicate-busy-value"]
   end
 
-  test "#call should render a refresh control" do
-    event = create(:event, user: user)
-    result = render_inline(EventLogComponent.new(events: [event], endpoint: "/events")) { |log| log.with_entry { event.type } }
-
-    refresh = result.css("[data-key='events.refresh']").first
-    assert_not_nil refresh
-    assert_equal "polling#refresh", refresh["data-action"]
-  end
-
   test "#call should omit polling chrome when no endpoint is given" do
     event = create(:event, user: user)
 
     result = render_inline(EventLogComponent.new(events: [event])) { |log| log.with_entry { event.type } }
 
     assert_empty result.css("[data-controller='polling']")
-    assert_empty result.css("[data-key='events.refresh']")
   end
 
   test "#call should render cursor pagination links when urls are given" do

--- a/test/components/recent_events_entry_component_test.rb
+++ b/test/components/recent_events_entry_component_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class RecentEventsEntryComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  test "#call should render level badge, description and timestamp link" do
+    event = create(:event, type: "feed_refresh", level: :info, user: user)
+
+    result = render_inline(RecentEventsEntryComponent.new(event: event, href: "/events/#{event.id}"))
+
+    assert_includes result.text, "Info"
+    assert_not_nil result.css("[data-key='recent_events.description']").first
+    assert_not_nil result.css("a[data-key='recent_events.timestamp'][href='/events/#{event.id}']").first
+  end
+
+  test "#call should render the event row with its data key" do
+    event = create(:event, type: "feed_refresh", level: :info, user: user)
+
+    result = render_inline(RecentEventsEntryComponent.new(event: event, href: "/events/#{event.id}"))
+
+    assert_not_nil result.css("li[data-key='recent_events.#{event.id}']").first
+  end
+
+  test "#call should use the correct badge color for each level" do
+    error_event = create(:event, type: "error_event", level: :error, user: user)
+
+    result = render_inline(RecentEventsEntryComponent.new(event: error_event, href: "/events/#{error_event.id}"))
+
+    assert_includes result.text, "Error"
+  end
+end

--- a/test/components/recent_events_list_component_test.rb
+++ b/test/components/recent_events_list_component_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class RecentEventsListComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  test "#call should render each event as a compact list item" do
+    event1 = create(:event, type: "feed_refresh", level: :info, user: user)
+    event2 = create(:event, type: "post_withdrawn", level: :warning, user: user)
+    events = [event1, event2]
+
+    result = render_inline(RecentEventsListComponent.new(events: events))
+
+    assert_not_nil result.css("li[data-key='recent_events.#{event1.id}']").first
+    assert_not_nil result.css("li[data-key='recent_events.#{event2.id}']").first
+  end
+
+  test "#call should wire up the polling controller when endpoint is given" do
+    event = create(:event, user: user)
+
+    result = render_inline(RecentEventsListComponent.new(events: [event], endpoint: "/events?display=brief"))
+
+    host = result.css("##{RecentEventsListComponent::DOM_ID}").first
+    assert_not_nil host
+    assert_equal "polling", host["data-controller"]
+    assert_equal "/events?display=brief", host["data-polling-endpoint-value"]
+    assert_equal event.id.to_s, host["data-last-event-id"]
+    assert_equal "false", host["data-polling-indicate-busy-value"]
+  end
+
+  test "#call should omit polling chrome when no endpoint is given" do
+    event = create(:event, user: user)
+
+    result = render_inline(RecentEventsListComponent.new(events: [event]))
+
+    assert_empty result.css("[data-controller='polling']")
+  end
+
+  test "#call should render the empty state when events array is empty" do
+    result = render_inline(RecentEventsListComponent.new(events: []))
+
+    assert_not_nil result.css("[data-key='empty-state']").first
+    assert_empty result.css("li")
+  end
+end

--- a/test/controllers/statuses_controller_test.rb
+++ b/test/controllers/statuses_controller_test.rb
@@ -146,8 +146,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     get status_path
     assert_response :success
     assert_select "h2", "Recent Activity"
-    assert_not_nil css_select('[data-key="events.%d"]' % event1.id).first
-    assert_not_nil css_select('[data-key="events.%d"]' % event2.id).first
+    assert_not_nil css_select('[data-key="recent_events.%d"]' % event1.id).first
+    assert_not_nil css_select('[data-key="recent_events.%d"]' % event2.id).first
   end
 
   test "#show should display empty recent events section when no events" do
@@ -169,8 +169,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path
     assert_response :success
-    assert_not_nil css_select('[data-key="events.%d"]' % user_event.id).first
-    assert css_select('[data-key="events.%d"]' % other_event.id).empty?
+    assert_not_nil css_select('[data-key="recent_events.%d"]' % user_event.id).first
+    assert css_select('[data-key="recent_events.%d"]' % other_event.id).empty?
   end
 
   test "#show should exclude debug level events" do
@@ -181,8 +181,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path
     assert_response :success
-    assert_not_nil css_select('[data-key="events.%d"]' % info_event.id).first
-    assert css_select('[data-key="events.%d"]' % debug_event.id).empty?
+    assert_not_nil css_select('[data-key="recent_events.%d"]' % info_event.id).first
+    assert css_select('[data-key="recent_events.%d"]' % debug_event.id).empty?
   end
 
   test "#show should exclude expired events" do
@@ -193,8 +193,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path
     assert_response :success
-    assert_not_nil css_select('[data-key="events.%d"]' % active_event.id).first
-    assert css_select('[data-key="events.%d"]' % expired_event.id).empty?
+    assert_not_nil css_select('[data-key="recent_events.%d"]' % active_event.id).first
+    assert css_select('[data-key="recent_events.%d"]' % expired_event.id).empty?
   end
 
   test "#show should limit recent events to the initial limit" do
@@ -207,7 +207,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
       get status_path
       assert_response :success
-      assert_select '[data-key="events.type"]', count: 2
+      assert_select 'li[data-key^="recent_events."]', count: 2
     end
   end
 
@@ -219,8 +219,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path, params: { filter: { type: ["feed_refresh"] } }
     assert_response :success
-    assert_not_nil css_select('[data-key="events.%d"]' % refresh_event.id).first
-    assert css_select('[data-key="events.%d"]' % withdrawn_event.id).empty?
+    assert_not_nil css_select('[data-key="recent_events.%d"]' % refresh_event.id).first
+    assert css_select('[data-key="recent_events.%d"]' % withdrawn_event.id).empty?
   end
 
   test "#show should carry the active filter into the polling endpoint" do
@@ -230,7 +230,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path, params: { filter: { type: ["feed_refresh"] } }
     assert_response :success
-    assert_select "#events_log[data-polling-endpoint-value*='feed_refresh']"
+    assert_select "#recent_events_list[data-polling-endpoint-value*='feed_refresh']"
   end
 
   private


### PR DESCRIPTION
Changes:

- Add `show_refresh` parameter to `EventLogComponent` to control visibility of the refresh button (defaults to `true`)
- Hide refresh button on status show page by passing `show_refresh: false` to the component

This allows the status page to use event log polling without displaying the manual refresh button, since the page already auto-updates via Turbo.
