### PR TITLE
Extract SlotListComponent base for list components

### DIFF
--- a/app/components/list_component.rb
+++ b/app/components/list_component.rb
@@ -1,21 +1,5 @@
-class ListComponent < ViewComponent::Base
+class ListComponent < SlotListComponent
   DEFAULT_CSS_CLASSES = "overflow-hidden rounded-lg border border-slate-200 bg-white divide-y divide-slate-200"
-
-  # Polymorphic slot: items are pre-built components, so the lambda just
-  # passes them through to be rendered.
-  renders_many :items, ->(item) { item }
-
-  def initialize(css_class: nil)
-    @css_class = css_class
-  end
-
-  def call
-    return unless items?
-
-    content_tag container_tag, class: @css_class || DEFAULT_CSS_CLASSES do
-      safe_join(items)
-    end
-  end
 
   private
 

--- a/app/components/slot_list_component.rb
+++ b/app/components/slot_list_component.rb
@@ -1,0 +1,24 @@
+class SlotListComponent < ViewComponent::Base
+  # Polymorphic slot: items are pre-built components, so the lambda just
+  # passes them through to be rendered. Subclasses define the container tag
+  # and a DEFAULT_CSS_CLASSES constant.
+  renders_many :items, ->(item) { item }
+
+  def initialize(css_class: nil)
+    @css_class = css_class
+  end
+
+  def call
+    return unless items?
+
+    content_tag container_tag, class: @css_class || self.class::DEFAULT_CSS_CLASSES do
+      safe_join(items)
+    end
+  end
+
+  private
+
+  def container_tag
+    raise NotImplementedError, "#{self.class} must define #container_tag"
+  end
+end

--- a/app/components/stats_bar_component.rb
+++ b/app/components/stats_bar_component.rb
@@ -1,19 +1,9 @@
-class StatsBarComponent < ViewComponent::Base
+class StatsBarComponent < SlotListComponent
   DEFAULT_CSS_CLASSES = "overflow-hidden md:flex md:divide-x md:divide-slate-200 rounded-lg border border-slate-200 bg-white"
 
-  # Polymorphic slot: items are pre-built components, so the lambda just
-  # passes them through to be rendered.
-  renders_many :items, ->(item) { item }
+  private
 
-  def initialize(css_class: nil)
-    @css_class = css_class
-  end
-
-  def call
-    return unless items?
-
-    content_tag :dl, class: @css_class || DEFAULT_CSS_CLASSES do
-      safe_join(items)
-    end
+  def container_tag
+    :dl
   end
 end


### PR DESCRIPTION
Changes:

- Add a `SlotListComponent` base that holds the shared slot definition, initializer, and `call` for list-style components.
- Reparent `ListComponent` and `StatsBarComponent` onto it; each now only declares `DEFAULT_CSS_CLASSES` and overrides `container_tag`.
- Resolve the container's CSS classes via `self.class::DEFAULT_CSS_CLASSES` so each subclass renders with its own classes (lexical constant lookup would have used the base's).

Follow-up to the slots refactor (#529): `ListComponent` and `StatsBarComponent` had become near-identical copies. This removes that duplication so future changes to how items render live in one place. `DescriptionListComponent` continues to subclass `ListComponent` unchanged.
