### PR TITLE
Extract admin user detail lists into components

### DIFF
--- a/app/components/admin/user_details_component.rb
+++ b/app/components/admin/user_details_component.rb
@@ -1,0 +1,41 @@
+class Admin::UserDetailsComponent < ViewComponent::Base
+  def initialize(user:, stats:)
+    @user = user
+    @stats = stats
+  end
+
+  def call
+    render(DescriptionListComponent.new) do |list|
+      list.with_item(stat_item("Email", @user.email_address))
+      list.with_item(stat_item("Permissions", permissions_value))
+      list.with_item(stat_item("Created", time_value(@user.created_at)))
+      list.with_item(stat_item("Updated", time_value(@user.updated_at)))
+      list.with_item(stat_item("Password Updated", optional_time(@user.password_updated_at)))
+      list.with_item(stat_item("Last Seen", optional_time(@stats.last_session&.updated_at)))
+    end
+  end
+
+  private
+
+  def stat_item(label, value)
+    ListComponent::StatItemComponent.new(label: label, value: value)
+  end
+
+  def permissions_value
+    return helpers.tag.span("None", class: "text-slate-500") if @user.permissions.empty?
+
+    @user.permissions.pluck(:name).join(", ")
+  end
+
+  def optional_time(time)
+    time.present? ? time_value(time) : helpers.tag.span("Never", class: "text-slate-500")
+  end
+
+  def time_value(time)
+    helpers.tag.time(
+      "#{time.to_date.to_fs(:long)} (#{helpers.short_time_ago(time)})",
+      datetime: time.iso8601,
+      title: time.to_fs(:long)
+    )
+  end
+end

--- a/app/components/admin/user_email_status_component.rb
+++ b/app/components/admin/user_email_status_component.rb
@@ -1,0 +1,42 @@
+class Admin::UserEmailStatusComponent < ViewComponent::Base
+  REACTIVATE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
+  VIEW_EVENTS_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def call
+    render(DescriptionListComponent.new) do |list|
+      list.with_item(stat_item("Status", status_badge))
+      list.with_item(stat_item("Deactivated At", time_value(@user.email_deactivated_at)))
+      list.with_item(stat_item("Reason", @user.email_deactivation_reason.humanize))
+      list.with_item(stat_item("Actions", actions_value))
+    end
+  end
+
+  private
+
+  def stat_item(label, value)
+    ListComponent::StatItemComponent.new(label: label, value: value)
+  end
+
+  def status_badge
+    helpers.tag.span("Deactivated", class: "inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20")
+  end
+
+  def time_value(time)
+    helpers.tag.time(
+      "#{time.to_date.to_fs(:long)} (#{helpers.short_time_ago(time)})",
+      datetime: time.iso8601,
+      title: time.to_fs(:long)
+    )
+  end
+
+  def actions_value
+    helpers.safe_join([
+      helpers.button_to("Reactivate Email", helpers.admin_user_email_reactivation_path(@user), method: :post, class: REACTIVATE_CLASSES),
+      helpers.link_to("View Email Events", helpers.admin_events_path(filter: { user_id: @user.id, type: helpers.mail_event_types }), class: VIEW_EVENTS_CLASSES)
+    ], " ")
+  end
+end

--- a/app/components/admin/user_invitations_component.rb
+++ b/app/components/admin/user_invitations_component.rb
@@ -1,0 +1,35 @@
+class Admin::UserInvitationsComponent < ViewComponent::Base
+  EDIT_CLASSES = "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 text-sm".freeze
+
+  def initialize(user:, stats:)
+    @user = user
+    @stats = stats
+  end
+
+  def call
+    render(DescriptionListComponent.new) do |list|
+      list.with_item(ListComponent::StatItemComponent.new(label: "Available Invites", value: available_invites_value, key: "invitations.available_invites"))
+      list.with_item(ListComponent::StatItemComponent.new(label: "Created Invites", value: @stats.created_invites_count))
+      list.with_item(ListComponent::StatItemComponent.new(label: "Invited Users", value: @stats.invited_users_count))
+    end
+  end
+
+  private
+
+  def available_invites_value
+    helpers.tag.span(class: "flex items-center gap-4") do
+      helpers.safe_join([
+        helpers.render(partial: "admin/users/available_invites_value", locals: { user: @user }),
+        helpers.link_to("Edit", "#", class: EDIT_CLASSES, data: edit_modal_data)
+      ])
+    end
+  end
+
+  def edit_modal_data
+    {
+      controller: "modal-trigger",
+      modal_trigger_modal_id_value: "edit-available-invites-modal-#{@user.id}",
+      action: "click->modal-trigger#open"
+    }
+  end
+end

--- a/app/components/admin/user_statistics_component.rb
+++ b/app/components/admin/user_statistics_component.rb
@@ -1,0 +1,46 @@
+class Admin::UserStatisticsComponent < ViewComponent::Base
+  def initialize(stats:)
+    @stats = stats
+  end
+
+  def call
+    render(DescriptionListComponent.new) do |list|
+      list.with_item(ListComponent::StatItemComponent.new(label: "Feeds", value: feeds_value, key: "stats.feeds"))
+      list.with_item(ListComponent::StatItemComponent.new(label: "Access Tokens", value: tokens_value, key: "stats.access_tokens"))
+      list.with_item(ListComponent::StatItemComponent.new(label: "Posts", value: @stats.posts_count))
+      list.with_item(ListComponent::StatItemComponent.new(label: "Most Recent Post", value: most_recent_post_value))
+    end
+  end
+
+  private
+
+  def feeds_value
+    parts = ["#{@stats.feeds_count} total"]
+    parts << "#{@stats.feeds_enabled_count} enabled" if @stats.feeds_enabled_count > 0
+    parts << "#{@stats.feeds_disabled_count} disabled" if @stats.feeds_disabled_count > 0
+    summarize(parts)
+  end
+
+  def tokens_value
+    parts = ["#{@stats.access_tokens_count} total"]
+    parts << "#{@stats.active_access_tokens_count} active" if @stats.active_access_tokens_count > 0
+    parts << "#{@stats.inactive_access_tokens_count} not active" if @stats.inactive_access_tokens_count > 0
+    summarize(parts)
+  end
+
+  def summarize(parts)
+    parts.size > 1 ? "#{parts.first} (#{parts[1..].join(', ')})" : parts.first
+  end
+
+  def most_recent_post_value
+    post = @stats.most_recent_post
+    return helpers.tag.span("No posts yet", class: "text-slate-500") unless post
+
+    time = post.published_at
+    helpers.tag.time(
+      "#{time.to_date.to_fs(:long)} (#{helpers.short_time_ago(time)})",
+      datetime: time.iso8601,
+      title: time.to_fs(:long)
+    )
+  end
+end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -7,167 +7,23 @@
     <% end %>
   <% end %>
 
-  <%= render(DescriptionListComponent.new) do |list| %>
-    <% list.with_item(ListComponent::StatItemComponent.new(
-      label: "Email",
-      value: @user.email_address
-    )) %>
-
-    <% permissions_value = @user.permissions.any? ? @user.permissions.pluck(:name).join(", ") : tag.span("None", class: "text-slate-500") %>
-    <% list.with_item(ListComponent::StatItemComponent.new(
-      label: "Permissions",
-      value: permissions_value
-    )) %>
-
-    <% list.with_item(ListComponent::StatItemComponent.new(
-      label: "Created",
-      value: tag.time(
-        "#{@user.created_at.to_date.to_fs(:long)} (#{short_time_ago(@user.created_at)})",
-        datetime: @user.created_at.iso8601,
-        title: @user.created_at.to_fs(:long)
-      )
-    )) %>
-
-    <% list.with_item(ListComponent::StatItemComponent.new(
-      label: "Updated",
-      value: tag.time(
-        "#{@user.updated_at.to_date.to_fs(:long)} (#{short_time_ago(@user.updated_at)})",
-        datetime: @user.updated_at.iso8601,
-        title: @user.updated_at.to_fs(:long)
-      )
-    )) %>
-
-    <% password_updated_value = if @user.password_updated_at.present?
-      tag.time(
-        "#{@user.password_updated_at.to_date.to_fs(:long)} (#{short_time_ago(@user.password_updated_at)})",
-        datetime: @user.password_updated_at.iso8601,
-        title: @user.password_updated_at.to_fs(:long)
-      )
-    else
-      tag.span("Never", class: "text-slate-500")
-    end %>
-    <% list.with_item(ListComponent::StatItemComponent.new(
-      label: "Password Updated",
-      value: password_updated_value
-    )) %>
-
-    <% last_seen_value = if @stats.last_session
-      tag.time(
-        "#{@stats.last_session.updated_at.to_date.to_fs(:long)} (#{short_time_ago(@stats.last_session.updated_at)})",
-        datetime: @stats.last_session.updated_at.iso8601,
-        title: @stats.last_session.updated_at.to_fs(:long)
-      )
-    else
-      tag.span("Never", class: "text-slate-500")
-    end %>
-    <% list.with_item(ListComponent::StatItemComponent.new(
-      label: "Last Seen",
-      value: last_seen_value
-    )) %>
-  <% end %>
+  <%= render Admin::UserDetailsComponent.new(user: @user, stats: @stats) %>
 
   <% if @user.email_deactivated? %>
     <section class="space-y-4">
       <h2 class="text-2xl font-semibold mb-3 text-slate-900">Email Status</h2>
-      <%= render(DescriptionListComponent.new) do |list| %>
-        <% list.with_item(ListComponent::StatItemComponent.new(
-          label: "Status",
-          value: tag.span("Deactivated", class: "inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20")
-        )) %>
-
-        <% list.with_item(ListComponent::StatItemComponent.new(
-          label: "Deactivated At",
-          value: tag.time(
-            "#{@user.email_deactivated_at.to_date.to_fs(:long)} (#{short_time_ago(@user.email_deactivated_at)})",
-            datetime: @user.email_deactivated_at.iso8601,
-            title: @user.email_deactivated_at.to_fs(:long)
-          )
-        )) %>
-
-        <% list.with_item(ListComponent::StatItemComponent.new(
-          label: "Reason",
-          value: @user.email_deactivation_reason.humanize
-        )) %>
-
-        <% list.with_item(ListComponent::StatItemComponent.new(
-          label: "Actions",
-          value: safe_join([
-            button_to("Reactivate Email", admin_user_email_reactivation_path(@user), method: :post, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
-            link_to("View Email Events", admin_events_path(filter: { user_id: @user.id, type: mail_event_types }), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1")
-          ], " ")
-        )) %>
-      <% end %>
+      <%= render Admin::UserEmailStatusComponent.new(user: @user) %>
     </section>
   <% end %>
 
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Statistics</h2>
-    <%= render(DescriptionListComponent.new) do |list| %>
-      <% feeds_parts = ["#{@stats.feeds_count} total"] %>
-      <% feeds_parts << "#{@stats.feeds_enabled_count} enabled" if @stats.feeds_enabled_count > 0 %>
-      <% feeds_parts << "#{@stats.feeds_disabled_count} disabled" if @stats.feeds_disabled_count > 0 %>
-      <% feeds_value = feeds_parts.size > 1 ? "#{feeds_parts.first} (#{feeds_parts[1..].join(', ')})" : feeds_parts.first %>
-      <% list.with_item(ListComponent::StatItemComponent.new(
-        label: "Feeds",
-        value: feeds_value,
-        key: "stats.feeds"
-      )) %>
-
-      <% tokens_parts = ["#{@stats.access_tokens_count} total"] %>
-      <% tokens_parts << "#{@stats.active_access_tokens_count} active" if @stats.active_access_tokens_count > 0 %>
-      <% tokens_parts << "#{@stats.inactive_access_tokens_count} not active" if @stats.inactive_access_tokens_count > 0 %>
-      <% tokens_value = tokens_parts.size > 1 ? "#{tokens_parts.first} (#{tokens_parts[1..].join(', ')})" : tokens_parts.first %>
-      <% list.with_item(ListComponent::StatItemComponent.new(
-        label: "Access Tokens",
-        value: tokens_value,
-        key: "stats.access_tokens"
-      )) %>
-
-      <% list.with_item(ListComponent::StatItemComponent.new(
-        label: "Posts",
-        value: @stats.posts_count
-      )) %>
-
-      <% most_recent_post_value = if @stats.most_recent_post
-        tag.time(
-          "#{@stats.most_recent_post.published_at.to_date.to_fs(:long)} (#{short_time_ago(@stats.most_recent_post.published_at)})",
-          datetime: @stats.most_recent_post.published_at.iso8601,
-          title: @stats.most_recent_post.published_at.to_fs(:long)
-        )
-      else
-        tag.span("No posts yet", class: "text-slate-500")
-      end %>
-      <% list.with_item(ListComponent::StatItemComponent.new(
-        label: "Most Recent Post",
-        value: most_recent_post_value
-      )) %>
-    <% end %>
+    <%= render Admin::UserStatisticsComponent.new(stats: @stats) %>
   </section>
 
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Invitations</h2>
-    <%= render(DescriptionListComponent.new) do |list| %>
-      <% list.with_item(ListComponent::StatItemComponent.new(
-        label: "Available Invites",
-        value: tag.span(class: "flex items-center gap-4") {
-          safe_join([
-            render(partial: "available_invites_value", locals: { user: @user }),
-            link_to("Edit", "#", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 text-sm", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "edit-available-invites-modal-#{@user.id}", action: "click->modal-trigger#open" })
-          ])
-        },
-        key: "invitations.available_invites"
-      )) %>
-
-      <% list.with_item(ListComponent::StatItemComponent.new(
-        label: "Created Invites",
-        value: @stats.created_invites_count
-      )) %>
-
-      <% list.with_item(ListComponent::StatItemComponent.new(
-        label: "Invited Users",
-        value: @stats.invited_users_count
-      )) %>
-    <% end %>
+    <%= render Admin::UserInvitationsComponent.new(user: @user, stats: @stats) %>
   </section>
 
   <% if @stats.invited_users.any? %>

--- a/test/components/admin/user_details_component_test.rb
+++ b/test/components/admin/user_details_component_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+require "view_component/test_case"
+
+class Admin::UserDetailsComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def stats
+    @stats ||= UserStats.new(user)
+  end
+
+  def render_component
+    render_inline(Admin::UserDetailsComponent.new(user: user, stats: stats))
+  end
+
+  test "#call should render core user fields" do
+    result = render_component
+
+    assert_includes result.text, "Email"
+    assert_includes result.text, user.email_address
+    assert_includes result.text, "Created"
+    assert_includes result.text, "Last Seen"
+  end
+
+  test "#call should show None when the user has no permissions" do
+    result = render_component
+
+    assert_includes result.text, "None"
+  end
+
+  test "#call should list permission names when present" do
+    create(:permission, user: user, name: "admin")
+    result = render_component
+
+    assert_includes result.text, "admin"
+  end
+
+  test "#call should show Never when the user has never been seen" do
+    result = render_component
+
+    assert_includes result.text, "Never"
+  end
+end

--- a/test/components/admin/user_email_status_component_test.rb
+++ b/test/components/admin/user_email_status_component_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+require "view_component/test_case"
+
+class Admin::UserEmailStatusComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user).tap { |u| u.deactivate_email!(reason: "bounced") }
+  end
+
+  def render_component
+    render_inline(Admin::UserEmailStatusComponent.new(user: user))
+  end
+
+  test "#call should show the deactivated status and reason" do
+    result = render_component
+
+    assert_includes result.text, "Deactivated"
+    assert_includes result.text, "Bounced"
+  end
+
+  test "#call should offer reactivate and view-events actions" do
+    result = render_component
+
+    assert_includes result.text, "Reactivate Email"
+    assert_includes result.text, "View Email Events"
+  end
+end

--- a/test/components/admin/user_invitations_component_test.rb
+++ b/test/components/admin/user_invitations_component_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require "view_component/test_case"
+
+class Admin::UserInvitationsComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def stats
+    @stats ||= UserStats.new(user)
+  end
+
+  def render_component
+    render_inline(Admin::UserInvitationsComponent.new(user: user, stats: stats))
+  end
+
+  test "#call should render the invitation rows" do
+    result = render_component
+
+    assert_not_nil result.css('[data-key="invitations.available_invites"]').first
+    assert_includes result.text, "Created Invites"
+    assert_includes result.text, "Invited Users"
+  end
+
+  test "#call should render the available invites value and edit trigger" do
+    result = render_component
+
+    assert_not_nil result.css("#available-invites-value").first
+    edit = result.css("a", text: "Edit").first
+    assert_not_nil edit
+    assert_equal "modal-trigger", edit["data-controller"]
+  end
+end

--- a/test/components/admin/user_statistics_component_test.rb
+++ b/test/components/admin/user_statistics_component_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+require "view_component/test_case"
+
+class Admin::UserStatisticsComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def stats
+    @stats ||= UserStats.new(user)
+  end
+
+  def render_component
+    render_inline(Admin::UserStatisticsComponent.new(stats: stats))
+  end
+
+  test "#call should render the stat rows with keys" do
+    result = render_component
+
+    assert_not_nil result.css('[data-key="stats.feeds"]').first
+    assert_not_nil result.css('[data-key="stats.access_tokens"]').first
+    assert_includes result.text, "Posts"
+    assert_includes result.text, "Most Recent Post"
+  end
+
+  test "#call should summarize feed counts with a breakdown" do
+    create(:feed, :enabled, user: user)
+    result = render_component
+
+    feeds = result.css('[data-key="stats.feeds.value"]').first
+    assert_not_nil feeds
+    assert_includes feeds.text, "total"
+    assert_includes feeds.text, "enabled"
+  end
+
+  test "#call should show No posts yet when there are none" do
+    result = render_component
+
+    assert_includes result.text, "No posts yet"
+  end
+end


### PR DESCRIPTION
Changes:

- Extract the four inline `DescriptionList`s on the admin user show page into focused `Admin::` components: `UserDetailsComponent`, `UserEmailStatusComponent`, `UserStatisticsComponent`, and `UserInvitationsComponent`.
- Move the per-row presentation logic (time formatting, permission/feed/token summaries, the "Never"/"None"/"No posts yet" fallbacks) out of the template and into the components.
- Add unit tests for each new component.

Follow-up to the slots refactor (#529). That PR inlined these lists at their render sites, which pushed branch-heavy logic into the template (the page still carried a "TBD: Extract higher-level components" marker). This moves that logic into components, matching the existing `*DetailsComponent` pattern, so the view just composes sections. Behavior is unchanged — the available-invites partial and its modal trigger are preserved, and the existing controller test still passes.
