### PR TITLE
Rename PostPreviewComponent#content to post_content

### DIFF
--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -30,14 +30,14 @@ class PostPreviewComponent < ViewComponent::Base
     end
   end
 
-  def content
+  def post_content
     post_data["content"].to_s
   end
 
   def formatted_content
-    return if content.blank?
+    return if post_content.blank?
 
-    helpers.content_tag(:div, helpers.format_post_content(content), class: "rounded-lg text-slate-900")
+    helpers.content_tag(:div, helpers.format_post_content(post_content), class: "rounded-lg text-slate-900")
   end
 
   def attachments?


### PR DESCRIPTION
Changes:

- Rename `PostPreviewComponent#content` to `post_content` so it no longer shadows ViewComponent's built-in `content` slot.

The method returned the post body but overrode the framework's `content` method. It works today since the component is never rendered with a block, but the shadowing is a latent footgun — rendering it with a block would silently win over the post body. Only internal callers referenced it (`formatted_content`); the template and tests use `formatted_content` / the `post_data["content"]` input, so this is a self-contained rename.
