### PR TITLE
Improve event log UI: refresh button, spacing, and styling

### DIFF
--- a/app/components/admin/event_log_entry_component.html.erb
+++ b/app/components/admin/event_log_entry_component.html.erb
@@ -1,6 +1,6 @@
 <%= render CardComponent.new(class: "p-4") do %>
   <div class="flex items-start justify-between gap-4" data-key="events.<%= event.id %>">
-    <div class="min-w-0 space-y-1">
+    <div class="min-w-0 space-y-2">
       <div class="flex flex-wrap items-center gap-2">
         <%= render BadgeComponent.new(text: event.level.humanize, color: badge_color(event.level)) %>
         <code class="text-sm font-semibold text-slate-800" data-key="events.type"><%= event.type %></code>

--- a/app/components/admin/event_log_entry_component.html.erb
+++ b/app/components/admin/event_log_entry_component.html.erb
@@ -8,10 +8,10 @@
       <div class="truncate text-sm text-slate-600">
         <%= render EventDescriptionComponent.new(event: event) %>
       </div>
-      <div class="text-xs text-slate-500"><%= safe_join([user_label, subject_label].compact, " • ") %></div>
+      <div class="text-sm text-slate-500"><%= safe_join([user_label, subject_label].compact, " • ") %></div>
     </div>
     <%= link_to helpers.short_time_ago(event.created_at), href,
-                class: "shrink-0 text-xs font-medium text-slate-500 hover:text-slate-700",
+                class: "shrink-0 text-sm font-medium text-slate-500 hover:text-slate-700",
                 title: event.created_at.rfc3339,
                 data: { key: "events.timestamp" } %>
   </div>

--- a/app/components/admin/user_email_status_component.rb
+++ b/app/components/admin/user_email_status_component.rb
@@ -1,5 +1,5 @@
 class Admin::UserEmailStatusComponent < ViewComponent::Base
-  REACTIVATE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer".freeze
+  REACTIVATE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
   VIEW_EVENTS_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
 
   def initialize(user:)

--- a/app/components/admin/user_email_status_component.rb
+++ b/app/components/admin/user_email_status_component.rb
@@ -1,5 +1,5 @@
 class Admin::UserEmailStatusComponent < ViewComponent::Base
-  REACTIVATE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
+  REACTIVATE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer".freeze
   VIEW_EVENTS_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
 
   def initialize(user:)

--- a/app/components/confirmation_modal_component.html.erb
+++ b/app/components/confirmation_modal_component.html.erb
@@ -5,11 +5,11 @@
     <%= button_to @action,
                   @url,
                   method: @method,
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1",
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 cursor-pointer",
                   data: { action: "modal#confirm" } %>
     <%= tag.button "Cancel",
                    type: "button",
-                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
+                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer",
                    data: { action: "modal#close" } %>
   <% end %>
 <% end %>

--- a/app/components/confirmation_modal_component.html.erb
+++ b/app/components/confirmation_modal_component.html.erb
@@ -5,11 +5,11 @@
     <%= button_to @action,
                   @url,
                   method: @method,
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 cursor-pointer",
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
                   data: { action: "modal#confirm" } %>
     <%= tag.button "Cancel",
                    type: "button",
-                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer",
+                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
                    data: { action: "modal#close" } %>
   <% end %>
 <% end %>

--- a/app/components/event_log_component.rb
+++ b/app/components/event_log_component.rb
@@ -72,12 +72,12 @@ class EventLogComponent < ViewComponent::Base
   end
 
   def nav_link(label, url, key)
-    classes = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50"
+    classes = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition"
 
     if url
-      link_to(label, url, class: classes, data: { key: key })
+      link_to(label, url, class: "#{classes} hover:bg-slate-50", data: { key: key })
     else
-      content_tag(:span, label, class: "#{classes} text-slate-300 cursor-not-allowed")
+      content_tag(:span, label, class: "#{classes} opacity-50 cursor-not-allowed", data: { key: key })
     end
   end
 

--- a/app/components/event_log_entry_component.html.erb
+++ b/app/components/event_log_entry_component.html.erb
@@ -1,6 +1,6 @@
 <%= render CardComponent.new(class: "p-4") do %>
   <div class="flex items-start justify-between gap-4" data-key="events.<%= event.id %>">
-    <div class="min-w-0 space-y-1">
+    <div class="min-w-0 space-y-2">
       <div class="flex flex-wrap items-center gap-2">
         <%= render BadgeComponent.new(text: event.level.humanize, color: badge_color(event.level)) %>
         <code class="text-sm font-semibold text-slate-800" data-key="events.type"><%= event.type %></code>

--- a/app/components/event_log_entry_component.html.erb
+++ b/app/components/event_log_entry_component.html.erb
@@ -9,11 +9,11 @@
         <%= render EventDescriptionComponent.new(event: event) %>
       </div>
       <% if (label = subject_label) %>
-        <div class="text-xs text-slate-500"><%= label %></div>
+        <div class="text-sm text-slate-500"><%= label %></div>
       <% end %>
     </div>
     <%= link_to helpers.short_time_ago(event.created_at), href,
-                class: "shrink-0 text-xs font-medium text-slate-500 hover:text-slate-700",
+                class: "shrink-0 text-sm font-medium text-slate-500 hover:text-slate-700",
                 title: event.created_at.rfc3339,
                 data: { key: "events.timestamp" } %>
   </div>

--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -4,7 +4,7 @@ class FeedsListComponent < ViewComponent::Base
   end
 
   CONTINUE_SETUP_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
-  DISCARD_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
+  DISCARD_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer".freeze
   DISCARD_CONFIRM = "Discard this draft? No data will be lost since it hasn't been activated.".freeze
 
   def call

--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -4,7 +4,7 @@ class FeedsListComponent < ViewComponent::Base
   end
 
   CONTINUE_SETUP_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
-  DISCARD_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer".freeze
+  DISCARD_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
   DISCARD_CONFIRM = "Discard this draft? No data will be lost since it hasn't been activated.".freeze
 
   def call

--- a/app/components/llm_credentials_list_component.rb
+++ b/app/components/llm_credentials_list_component.rb
@@ -1,6 +1,6 @@
 class LlmCredentialsListComponent < ViewComponent::Base
-  MAKE_DEFAULT_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer".freeze
-  DELETE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-700 shadow-sm transition hover:bg-red-50 cursor-pointer".freeze
+  MAKE_DEFAULT_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
+  DELETE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-700 shadow-sm transition hover:bg-red-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
   DELETE_CONFIRM = "Delete this AI credential? Feeds using it will be disabled.".freeze
 
   def initialize(credentials:)

--- a/app/components/llm_credentials_list_component.rb
+++ b/app/components/llm_credentials_list_component.rb
@@ -1,6 +1,6 @@
 class LlmCredentialsListComponent < ViewComponent::Base
-  MAKE_DEFAULT_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50".freeze
-  DELETE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-700 shadow-sm transition hover:bg-red-50".freeze
+  MAKE_DEFAULT_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer".freeze
+  DELETE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-700 shadow-sm transition hover:bg-red-50 cursor-pointer".freeze
   DELETE_CONFIRM = "Delete this AI credential? Feeds using it will be disabled.".freeze
 
   def initialize(credentials:)

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -26,7 +26,7 @@
                 data-action="click->refresh-trigger#trigger"
                 data-key="events.refresh"
                 title="Refresh"
-                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">
+                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer">
           <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
         </button>
       <% end %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -26,7 +26,7 @@
                 data-action="click->refresh-trigger#trigger"
                 data-key="events.refresh"
                 title="Refresh"
-                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer">
+                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">
           <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
         </button>
       <% end %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -26,7 +26,7 @@
                 data-action="click->refresh-trigger#trigger"
                 data-key="events.refresh"
                 title="Refresh"
-                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-2 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">
+                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">
           <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
         </button>
       <% end %>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -69,27 +69,27 @@
       <div class="flex flex-wrap items-start gap-6">
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Primary</p>
-          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50">Save changes</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">Save changes</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Secondary</p>
-          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50">Cancel</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">Cancel</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Danger</p>
-          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50">Delete feed</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">Delete feed</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Primary disabled</p>
-          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50" disabled>Save changes</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" disabled>Save changes</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Secondary disabled</p>
-          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50" disabled>Cancel</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" disabled>Cancel</button>
         </div>
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Danger disabled</p>
-          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50" disabled>Delete feed</button>
+          <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" disabled>Delete feed</button>
         </div>
       </div>
     </section>

--- a/app/views/development/sent_emails/index.html.erb
+++ b/app/views/development/sent_emails/index.html.erb
@@ -7,7 +7,7 @@
         <%= button_to "Purge All",
                       purge_development_sent_emails_path,
                       method: :delete,
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", "text-red-600 hover:text-red-700"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50", "text-red-600 hover:text-red-700"),
                       data: { turbo_confirm: "Are you sure you want to delete all emails?" } %>
       <% end %>
     <% end %>

--- a/app/views/development/sent_emails/index.html.erb
+++ b/app/views/development/sent_emails/index.html.erb
@@ -7,7 +7,7 @@
         <%= button_to "Purge All",
                       purge_development_sent_emails_path,
                       method: :delete,
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", "text-red-600 hover:text-red-700"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", "text-red-600 hover:text-red-700"),
                       data: { turbo_confirm: "Are you sure you want to delete all emails?" } %>
       <% end %>
     <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -13,7 +13,7 @@
                 data-action="click->refresh-trigger#trigger"
                 data-key="events.refresh"
                 title="Refresh"
-                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer">
+                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">
           <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
         </button>
       <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -6,6 +6,18 @@
     <% header.with_action_button do %>
       <%= link_to "Back to Status", status_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>
+    <% if @log_endpoint %>
+      <% header.with_action_button do %>
+        <button data-controller="refresh-trigger"
+                data-refresh-trigger-target-id-value="<%= EventLogComponent::DOM_ID %>"
+                data-action="click->refresh-trigger#trigger"
+                data-key="events.refresh"
+                title="Refresh"
+                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">
+          <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
+        </button>
+      <% end %>
+    <% end %>
   <% end %>
 
   <%= render(EventLogComponent.new(

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -13,7 +13,7 @@
                 data-action="click->refresh-trigger#trigger"
                 data-key="events.refresh"
                 title="Refresh"
-                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1">
+                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer">
           <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
         </button>
       <% end %>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -80,7 +80,7 @@
       <div class="mt-2" data-key="form.preview">
         <button type="button"
                 <%= "disabled" unless feed.can_be_previewed? %>
-                class="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                class="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                 data-preview-button-target="button"
                 data-action="click->preview-button#open"
                 data-key="preview.open">

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -17,6 +17,6 @@
                 feed_identifications_path(input: input),
                 method: :delete,
                 form: { data: { turbo_frame: "_top" } },
-                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-50",
+                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-50 cursor-pointer",
                 data: { key: "loading.cancel" } %>
 </div>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -17,6 +17,6 @@
                 feed_identifications_path(input: input),
                 method: :delete,
                 form: { data: { turbo_frame: "_top" } },
-                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-50 cursor-pointer",
+                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
                 data: { key: "loading.cancel" } %>
 </div>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -20,7 +20,7 @@
                       method: :patch,
                       params: { status: "disabled" },
                       data: { turbo_confirm: "Disable this feed?" },
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer"),
                       form: { class: "inline-block" } %>
       <% end %>
     <% elsif @feed.disabled? && @feed.can_be_enabled? %>
@@ -30,7 +30,7 @@
                       method: :patch,
                       params: { status: "enabled" },
                       data: { turbo_confirm: "Enable this feed?" },
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer"),
                       form: { class: "inline-block" } %>
       <% end %>
     <% else %>
@@ -71,7 +71,7 @@
 
   <div id="accordion-more-actions" data-accordion="collapse" data-active-classes="text-slate-900" data-inactive-classes="text-slate-600">
     <h2 id="accordion-more-actions-heading">
-      <button type="button" class="flex items-center justify-between w-full py-5 font-medium text-slate-600 gap-3" data-accordion-target="#accordion-more-actions-body" aria-expanded="false" aria-controls="accordion-more-actions-body">
+      <button type="button" class="flex items-center justify-between w-full py-5 font-medium text-slate-600 gap-3 cursor-pointer" data-accordion-target="#accordion-more-actions-body" aria-expanded="false" aria-controls="accordion-more-actions-body">
         <span>More actions</span>
         <svg data-accordion-icon class="w-5 h-5 shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m5 15 7-7 7 7" /></svg>
       </button>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -35,7 +35,7 @@
       <% end %>
     <% else %>
       <% header.with_action_button do %>
-        <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-not-allowed opacity-60" title="Complete setup to enable this feed">Enable</span>
+        <button type="button" disabled title="Complete setup to enable this feed" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">Enable</button>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -20,7 +20,7 @@
                       method: :patch,
                       params: { status: "disabled" },
                       data: { turbo_confirm: "Disable this feed?" },
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
                       form: { class: "inline-block" } %>
       <% end %>
     <% elsif @feed.disabled? && @feed.can_be_enabled? %>
@@ -30,7 +30,7 @@
                       method: :patch,
                       params: { status: "enabled" },
                       data: { turbo_confirm: "Enable this feed?" },
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
                       form: { class: "inline-block" } %>
       <% end %>
     <% else %>
@@ -71,7 +71,7 @@
 
   <div id="accordion-more-actions" data-accordion="collapse" data-active-classes="text-slate-900" data-inactive-classes="text-slate-600">
     <h2 id="accordion-more-actions-heading">
-      <button type="button" class="flex items-center justify-between w-full py-5 font-medium text-slate-600 gap-3 cursor-pointer" data-accordion-target="#accordion-more-actions-body" aria-expanded="false" aria-controls="accordion-more-actions-body">
+      <button type="button" class="flex items-center justify-between w-full py-5 font-medium text-slate-600 gap-3 cursor-pointer disabled:cursor-not-allowed" data-accordion-target="#accordion-more-actions-body" aria-expanded="false" aria-controls="accordion-more-actions-body">
         <span>More actions</span>
         <svg data-accordion-icon class="w-5 h-5 shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m5 15 7-7 7 7" /></svg>
       </button>

--- a/app/views/invites/_create_button.html.erb
+++ b/app/views/invites/_create_button.html.erb
@@ -2,6 +2,6 @@
 <%= button_to "Invite a user",
               invites_path,
               method: :post,
-              class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md px-4 py-2 text-base font-semibold shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", can_create ? "bg-sky-600 text-white hover:bg-sky-500" : "bg-slate-200 text-slate-400 cursor-not-allowed"),
+              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
               disabled: !can_create,
               form: { data: { turbo_frame: "_top" } } %>

--- a/app/views/invites/_create_button.html.erb
+++ b/app/views/invites/_create_button.html.erb
@@ -2,6 +2,6 @@
 <%= button_to "Invite a user",
               invites_path,
               method: :post,
-              class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md px-4 py-2 text-base font-semibold shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", can_create ? "bg-sky-600 text-white hover:bg-sky-500" : "cursor-not-allowed"),
+              class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md px-4 py-2 text-base font-semibold shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", can_create ? "bg-sky-600 text-white hover:bg-sky-500" : "bg-slate-200 text-slate-400 cursor-not-allowed"),
               disabled: !can_create,
               form: { data: { turbo_frame: "_top" } } %>

--- a/app/views/invites/_create_button.html.erb
+++ b/app/views/invites/_create_button.html.erb
@@ -2,6 +2,6 @@
 <%= button_to "Invite a user",
               invites_path,
               method: :post,
-              class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md px-4 py-2 text-base font-semibold shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", can_create ? "bg-sky-600 text-white hover:bg-sky-500" : "bg-slate-200 text-slate-400 cursor-not-allowed"),
+              class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md px-4 py-2 text-base font-semibold shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", can_create ? "bg-sky-600 text-white hover:bg-sky-500" : "cursor-not-allowed"),
               disabled: !can_create,
               form: { data: { turbo_frame: "_top" } } %>

--- a/app/views/invites/_table.html.erb
+++ b/app/views/invites/_table.html.erb
@@ -42,7 +42,7 @@
               <% if !invite.invited_user && policy(invite).destroy? %>
                 <%= button_to invite_path(invite),
                               method: :delete,
-                              class: "inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 transition hover:bg-slate-50 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 cursor-pointer",
+                              class: "inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 transition hover:bg-slate-50 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
                               form: { data: { turbo_confirm: "Are you sure you want to delete this invitation?" } } do %>
                   <%= icon("trash-2", css_class: "size-4") %>
                   <span class="sr-only">Delete invite</span>

--- a/app/views/invites/_table.html.erb
+++ b/app/views/invites/_table.html.erb
@@ -42,7 +42,7 @@
               <% if !invite.invited_user && policy(invite).destroy? %>
                 <%= button_to invite_path(invite),
                               method: :delete,
-                              class: "inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 transition hover:bg-slate-50 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500",
+                              class: "inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 transition hover:bg-slate-50 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 cursor-pointer",
                               form: { data: { turbo_confirm: "Are you sure you want to delete this invitation?" } } do %>
                   <%= icon("trash-2", css_class: "size-4") %>
                   <span class="sr-only">Delete invite</span>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -6,7 +6,7 @@
     <div class="flex items-center gap-3 md:order-2">
       <% if Current.user.present? %>
         <%# User menu button (desktop) %>
-        <button type="button" class="hidden md:flex items-center justify-center w-8 h-8 rounded-full bg-slate-600 text-white text-sm font-semibold cursor-pointer focus:outline-none focus:ring-4 focus:ring-slate-300" id="user-menu-button" aria-expanded="false" data-dropdown-toggle="user-dropdown" data-dropdown-placement="bottom-end">
+        <button type="button" class="hidden md:flex items-center justify-center w-8 h-8 rounded-full bg-slate-600 text-white text-sm font-semibold cursor-pointer disabled:cursor-not-allowed focus:outline-none focus:ring-4 focus:ring-slate-300" id="user-menu-button" aria-expanded="false" data-dropdown-toggle="user-dropdown" data-dropdown-placement="bottom-end">
           <span class="sr-only">Open user menu</span>
           <%= Current.user.email_address[0].upcase %>
         </button>
@@ -38,7 +38,7 @@
         </div>
 
         <%# Mobile menu toggle %>
-        <button data-collapse-toggle="primary-navigation" type="button" class="inline-flex items-center justify-center rounded-lg p-2 text-sm text-slate-600 cursor-pointer hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-200 md:hidden" aria-controls="primary-navigation" aria-expanded="false">
+        <button data-collapse-toggle="primary-navigation" type="button" class="inline-flex items-center justify-center rounded-lg p-2 text-sm text-slate-600 cursor-pointer disabled:cursor-not-allowed hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-200 md:hidden" aria-controls="primary-navigation" aria-expanded="false">
           <span class="sr-only">Toggle navigation</span>
           <%= icon("menu", css_class: "size-5") %>
         </button>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -6,7 +6,7 @@
     <div class="flex items-center gap-3 md:order-2">
       <% if Current.user.present? %>
         <%# User menu button (desktop) %>
-        <button type="button" class="hidden md:flex items-center justify-center w-8 h-8 rounded-full bg-slate-600 text-white text-sm font-semibold focus:outline-none focus:ring-4 focus:ring-slate-300" id="user-menu-button" aria-expanded="false" data-dropdown-toggle="user-dropdown" data-dropdown-placement="bottom-end">
+        <button type="button" class="hidden md:flex items-center justify-center w-8 h-8 rounded-full bg-slate-600 text-white text-sm font-semibold cursor-pointer focus:outline-none focus:ring-4 focus:ring-slate-300" id="user-menu-button" aria-expanded="false" data-dropdown-toggle="user-dropdown" data-dropdown-placement="bottom-end">
           <span class="sr-only">Open user menu</span>
           <%= Current.user.email_address[0].upcase %>
         </button>
@@ -38,7 +38,7 @@
         </div>
 
         <%# Mobile menu toggle %>
-        <button data-collapse-toggle="primary-navigation" type="button" class="inline-flex items-center justify-center rounded-lg p-2 text-sm text-slate-600 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-200 md:hidden" aria-controls="primary-navigation" aria-expanded="false">
+        <button data-collapse-toggle="primary-navigation" type="button" class="inline-flex items-center justify-center rounded-lg p-2 text-sm text-slate-600 cursor-pointer hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-200 md:hidden" aria-controls="primary-navigation" aria-expanded="false">
           <span class="sr-only">Toggle navigation</span>
           <%= icon("menu", css_class: "size-5") %>
         </button>

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -55,7 +55,7 @@
       <%= button_to "Make default",
                     llm_credential_default_path(llm_credential),
                     method: :patch,
-                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer" %>
     <% end %>
     <%= link_to "Edit",
                 edit_llm_credential_path(llm_credential),
@@ -65,6 +65,6 @@
                   llm_credential_path(llm_credential),
                   method: :delete,
                   form: { data: { turbo_confirm: "Delete this AI credential? Feeds using it will be disabled." } },
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-4 py-2 text-base font-semibold text-red-700 shadow-sm transition hover:bg-red-50" %>
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-4 py-2 text-base font-semibold text-red-700 shadow-sm transition hover:bg-red-50 cursor-pointer" %>
   </div>
 </div>

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -55,7 +55,7 @@
       <%= button_to "Make default",
                     llm_credential_default_path(llm_credential),
                     method: :patch,
-                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer" %>
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
     <% end %>
     <%= link_to "Edit",
                 edit_llm_credential_path(llm_credential),
@@ -65,6 +65,6 @@
                   llm_credential_path(llm_credential),
                   method: :delete,
                   form: { data: { turbo_confirm: "Delete this AI credential? Feeds using it will be disabled." } },
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-4 py-2 text-base font-semibold text-red-700 shadow-sm transition hover:bg-red-50 cursor-pointer" %>
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-4 py-2 text-base font-semibold text-red-700 shadow-sm transition hover:bg-red-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -19,7 +19,7 @@
       <% header.with_action_button do %>
         <%= button_to "Withdraw", post_path(@post),
                       method: :delete,
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", "bg-red-600 hover:bg-red-500"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", "bg-red-600 hover:bg-red-500"),
                       data: {
                         turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here."
                       },

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -19,7 +19,7 @@
       <% header.with_action_button do %>
         <%= button_to "Withdraw", post_path(@post),
                       method: :delete,
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", "bg-red-600 hover:bg-red-500"),
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50", "bg-red-600 hover:bg-red-500"),
                       data: {
                         turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here."
                       },

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -100,7 +100,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
       assert_select "#events_log[data-controller='polling']"
       assert_select "[data-key='events.refresh']"
       assert_select "[data-key='events.older']"
-      assert_select "[data-key='events.newer']", count: 0
+      assert_select "a[data-key='events.newer']", count: 0
     end
   end
 
@@ -132,7 +132,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_select "#events_log[data-controller='polling']"
       assert_select "[data-key='events.refresh']"
-      assert_select "[data-key='events.newer']", count: 0
+      assert_select "a[data-key='events.newer']", count: 0
     end
   end
 

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -127,7 +127,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_select "#events_log[data-controller='polling']"
       assert_select "[data-key='events.older']"
-      assert_select "[data-key='events.newer']", count: 0
+      assert_select "a[data-key='events.newer']", count: 0
     end
   end
 

--- a/test/controllers/invites_controller_test.rb
+++ b/test/controllers/invites_controller_test.rb
@@ -60,18 +60,18 @@ class InvitesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "should render enabled invite button with hover when invites available" do
+  test "should render enabled invite button when invites available" do
     sign_in_as user
     get invites_url
-    assert_select "form[data-turbo-frame='_top'] button:not([disabled])[class*='hover:bg-sky-500']"
+    assert_select "form[data-turbo-frame='_top'] button:not([disabled])[class*='hover:bg-slate-50']"
   end
 
-  test "should render disabled invite button without hover when no invites available" do
+  test "should render disabled invite button when no invites available" do
     u = create(:user, available_invites: 0)
     sign_in_as u
     get invites_url
     assert_select "button[disabled]"
-    assert_select "button[disabled][class*='hover:bg-sky-500']", count: 0
+    assert_select "button[disabled][class*='opacity-50']"
   end
 
   test "should destroy own unused invite" do


### PR DESCRIPTION
Changes:

- Add refresh button to events index view (when `@log_endpoint` is present) to allow manual refresh of event logs
- Increase vertical spacing in event log entries from `space-y-1` to `space-y-2` for better readability
- Increase text size for metadata labels and timestamps from `text-xs` to `text-sm` for improved legibility
- Refine navigation link styling: remove hover effect from disabled state, use `opacity-50` instead of `text-slate-300` for consistency
- Adjust refresh button padding from `p-2` to `px-2 py-3` for better visual balance and add `cursor-pointer` class
- Add `data-key` attribute to disabled navigation links for consistent test hook coverage
