### PR TITLE
Standardize refresh button padding in events views

### DIFF
--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -26,7 +26,7 @@
                 data-action="click->refresh-trigger#trigger"
                 data-key="events.refresh"
                 title="Refresh"
-                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">
+                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">
           <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
         </button>
       <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -13,7 +13,7 @@
                 data-action="click->refresh-trigger#trigger"
                 data-key="events.refresh"
                 title="Refresh"
-                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-2 py-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">
+                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">
           <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
         </button>
       <% end %>


### PR DESCRIPTION
Changes:

- Replace asymmetric padding (`px-2 py-3`) with uniform padding (`p-3`) on refresh buttons in admin and public events index views for consistent spacing
