### PR TITLE
Make event log subjects filterable via links

### DIFF
--- a/app/components/admin/event_log_entry_component.rb
+++ b/app/components/admin/event_log_entry_component.rb
@@ -10,6 +10,10 @@ class Admin::EventLogEntryComponent < ViewComponent::Base
 
   attr_reader :event, :href
 
+  def subject_filter_path(filter_params)
+    helpers.admin_events_path(filter: filter_params)
+  end
+
   # Admins see who an event belongs to; the user links to a filtered log.
   def user_label
     return helpers.tag.em("System", data: { key: "events.user" }) if event.user_id.blank?

--- a/app/components/event_log_entry_presentation.rb
+++ b/app/components/event_log_entry_presentation.rb
@@ -18,6 +18,19 @@ module EventLogEntryPresentation
     return if event.subject_type.blank?
 
     value = event.subject_id.present? ? "#{event.subject_type} ##{event.subject_id}" : event.subject_type
-    helpers.tag.span(value, data: { key: "events.subject" })
+
+    filter_params = { subject_type: event.subject_type }
+    filter_params[:subject_id] = event.subject_id if event.subject_id.present?
+
+    helpers.link_to(
+      value,
+      subject_filter_path(filter_params),
+      class: "underline underline-offset-2 hover:text-slate-700",
+      data: { key: "events.subject" }
+    )
+  end
+
+  def subject_filter_path(filter_params)
+    helpers.events_path(filter: filter_params)
   end
 end

--- a/test/components/admin/event_log_entry_component_test.rb
+++ b/test/components/admin/event_log_entry_component_test.rb
@@ -18,6 +18,20 @@ class Admin::EventLogEntryComponentTest < ViewComponent::TestCase
     assert_not_includes link["class"], "decoration-dotted"
   end
 
+  test "#call should link the subject to the admin filter" do
+    feed = create(:feed, user: user)
+    event = create(:event, type: "feed_refresh", subject: feed, user: user)
+
+    result = render_inline(Admin::EventLogEntryComponent.new(event: event, href: "/admin/events/#{event.id}"))
+
+    link = result.css("a[data-key='events.subject']").first
+    assert_not_nil link
+    assert_equal "Feed ##{feed.id}", link.text
+    assert_includes link["href"], "/admin/events"
+    assert_includes link["href"], "filter%5Bsubject_type%5D=Feed"
+    assert_includes link["href"], "filter%5Bsubject_id%5D=#{feed.id}"
+  end
+
   test "#call should show System for events without a user" do
     event = create(:event, user: nil)
 

--- a/test/components/event_log_entry_component_test.rb
+++ b/test/components/event_log_entry_component_test.rb
@@ -35,7 +35,12 @@ class EventLogEntryComponentTest < ViewComponent::TestCase
 
     result = render_inline(EventLogEntryComponent.new(event: event, href: "/events/#{event.id}"))
 
-    assert_equal "Feed ##{feed.id}", result.css("[data-key='events.subject']").first.text
+    link = result.css("a[data-key='events.subject']").first
+    assert_not_nil link
+    assert_equal "Feed ##{feed.id}", link.text
+    assert_includes link["href"], "filter%5Bsubject_type%5D=Feed"
+    assert_includes link["href"], "filter%5Bsubject_id%5D=#{feed.id}"
+    assert_not_includes link["href"], "/admin/"
   end
 
   test "#call should never show an owner (entries belong to the current user)" do


### PR DESCRIPTION
Changes:

- Convert event log subject labels from plain text to clickable links that filter the event log by subject type and ID
- Add `subject_filter_path` method to `EventLogEntryPresentation` to generate filter URLs for the public event log
- Override `subject_filter_path` in `Admin::EventLogEntryComponent` to generate admin-specific filter URLs
- Add styling to subject links (underline with offset, hover effect)
- Update tests to verify subjects render as links with correct filter parameters

This allows users to quickly filter event logs by clicking on a subject (e.g., "Feed #123") rather than manually entering filter criteria.
