### PR TITLE
Fix YouTube loader URL resolution

### DIFF
--- a/app/services/loader/youtube_loader.rb
+++ b/app/services/loader/youtube_loader.rb
@@ -2,6 +2,7 @@ module Loader
   class YoutubeLoader < Base
     FEED_URL_PATH = "/feeds/videos.xml"
     FEED_BASE_URL = "https://www.youtube.com/feeds/videos.xml"
+    YOUTUBE_DOMAINS = %w[youtube.com www.youtube.com].freeze
     DEFAULT_MAX_REDIRECTS = 3
 
     def load
@@ -50,7 +51,7 @@ module Loader
     end
 
     def youtube_domain?(host)
-      %w[youtube.com www.youtube.com].include?(host)
+      YOUTUBE_DOMAINS.include?(host)
     end
 
     def youtube_feed_url?(url)

--- a/app/services/loader/youtube_loader.rb
+++ b/app/services/loader/youtube_loader.rb
@@ -30,7 +30,7 @@ module Loader
       return nil unless youtube_domain?(uri.host)
 
       case uri.path
-      when %r{\A/channel/(UC[\w-]+)\z}
+      when %r{\A/channel/([\w-]+)\z}
         "#{FEED_BASE_URL}?channel_id=#{$1}"
       when %r{\A/user/([\w.-]+)\z}
         "#{FEED_BASE_URL}?user=#{$1}"

--- a/app/services/loader/youtube_loader.rb
+++ b/app/services/loader/youtube_loader.rb
@@ -1,6 +1,7 @@
 module Loader
   class YoutubeLoader < Base
     FEED_URL_PATH = "/feeds/videos.xml"
+    FEED_BASE_URL = "https://www.youtube.com/feeds/videos.xml"
     DEFAULT_MAX_REDIRECTS = 3
 
     def load
@@ -20,10 +21,36 @@ module Loader
     def resolve_feed_url(url)
       return url if youtube_feed_url?(url)
 
+      feed_url_from_url_pattern(url) || fetch_feed_url_from_html(url)
+    end
+
+    def feed_url_from_url_pattern(url)
+      uri = URI.parse(url)
+      return nil unless youtube_domain?(uri.host)
+
+      case uri.path
+      when %r{\A/channel/(UC[\w-]+)\z}
+        "#{FEED_BASE_URL}?channel_id=#{$1}"
+      when %r{\A/user/([\w.-]+)\z}
+        "#{FEED_BASE_URL}?user=#{$1}"
+      when "/playlist"
+        params = URI.decode_www_form(uri.query.to_s).to_h
+        playlist_id = params["list"]
+        "#{FEED_BASE_URL}?playlist_id=#{playlist_id}" if playlist_id.present?
+      end
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def fetch_feed_url_from_html(url)
       response = http_client.get(url)
       raise StandardError, "HTTP #{response.status}" unless response.success?
 
       extract_feed_url(response.body) or raise StandardError, "Could not find YouTube RSS feed link"
+    end
+
+    def youtube_domain?(host)
+      %w[youtube.com www.youtube.com].include?(host)
     end
 
     def youtube_feed_url?(url)

--- a/app/services/processor/rss_processor.rb
+++ b/app/services/processor/rss_processor.rb
@@ -24,17 +24,17 @@ module Processor
 
     def sanitize_feedjira_entry(entry)
       {
-        id: entry.id,
-        title: entry.title,
-        url: entry.url,
-        link: entry.url,
-        summary: entry.summary,
-        content: entry.content,
-        published: entry.published&.rfc3339,
-        updated: entry.updated&.rfc3339,
-        author: entry.author,
-        categories: entry.categories,
-        enclosures: entry.try(:enclosures) || []
+        "id" => entry.id,
+        "title" => entry.title,
+        "url" => entry.url,
+        "link" => entry.url,
+        "summary" => entry.summary,
+        "content" => entry.content,
+        "published" => entry.published&.rfc3339,
+        "updated" => entry.updated&.rfc3339,
+        "author" => entry.author,
+        "categories" => entry.categories,
+        "enclosures" => entry.try(:enclosures) || []
       }
     end
   end

--- a/app/services/processor/youtube_processor.rb
+++ b/app/services/processor/youtube_processor.rb
@@ -3,7 +3,7 @@ module Processor
     private
 
     def sanitize_feedjira_entry(entry)
-      super.merge(thumbnail: entry.try(:media_thumbnail_url))
+      super.merge("thumbnail" => entry.try(:media_thumbnail_url))
     end
   end
 end

--- a/test/services/loader/youtube_loader_test.rb
+++ b/test/services/loader/youtube_loader_test.rb
@@ -98,6 +98,56 @@ class Loader::YoutubeLoaderTest < ActiveSupport::TestCase
     assert_equal "Connection refused", error.message
   end
 
+  test "#load should resolve /channel/UCxxx URL to feed URL without fetching channel page" do
+    channel_url = "https://www.youtube.com/channel/UCabc123def456ghi789jkl"
+    expected_feed_url = "https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123def456ghi789jkl"
+    feed = feed_with_url(channel_url)
+    mock_client = MockHttpClient.new(responses: { expected_feed_url => ok(FEED_BODY) })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    assert_equal FEED_BODY, loader.load
+    assert_equal [expected_feed_url], mock_client.requested_urls
+  end
+
+  test "#load should resolve /user/Username URL to feed URL without fetching channel page" do
+    user_url = "https://www.youtube.com/user/SampleTechChannel"
+    expected_feed_url = "https://www.youtube.com/feeds/videos.xml?user=SampleTechChannel"
+    feed = feed_with_url(user_url)
+    mock_client = MockHttpClient.new(responses: { expected_feed_url => ok(FEED_BODY) })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    assert_equal FEED_BODY, loader.load
+    assert_equal [expected_feed_url], mock_client.requested_urls
+  end
+
+  test "#load should resolve playlist URL to feed URL without fetching channel page" do
+    playlist_url = "https://www.youtube.com/playlist?list=PLabc123def456"
+    expected_feed_url = "https://www.youtube.com/feeds/videos.xml?playlist_id=PLabc123def456"
+    feed = feed_with_url(playlist_url)
+    mock_client = MockHttpClient.new(responses: { expected_feed_url => ok(FEED_BODY) })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    assert_equal FEED_BODY, loader.load
+    assert_equal [expected_feed_url], mock_client.requested_urls
+  end
+
+  test "#load should fall back to HTML scraping for @handle URLs" do
+    handle_url = "https://www.youtube.com/@SampleChannel"
+    feed = feed_with_url(handle_url)
+    mock_client = MockHttpClient.new(responses: {
+      handle_url => ok(CHANNEL_PAGE_WITH_RSS),
+      FEED_URL => ok(FEED_BODY)
+    })
+
+    loader = Loader::YoutubeLoader.new(feed, { http_client: mock_client })
+
+    assert_equal FEED_BODY, loader.load
+    assert_equal [handle_url, FEED_URL], mock_client.requested_urls
+  end
+
   private
 
   def ok(body)

--- a/test/services/normalizer/youtube_normalizer_test.rb
+++ b/test/services/normalizer/youtube_normalizer_test.rb
@@ -81,4 +81,27 @@ class Normalizer::YoutubeNormalizerTest < ActiveSupport::TestCase
 
     assert_equal [], post.attachment_urls
   end
+
+  test "#normalize should work with raw_data produced directly by YoutubeProcessor" do
+    feed = create(:feed, url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123")
+    sample_feed_xml = file_fixture("feeds/youtube/feed.xml").read
+
+    processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
+    processor_entry = processor.process.first
+
+    temp_entry = FeedEntry.new(
+      uid: processor_entry.uid,
+      published_at: processor_entry.published_at,
+      raw_data: processor_entry.raw_data,
+      feed: feed
+    )
+
+    normalizer = Normalizer::YoutubeNormalizer.new(temp_entry)
+    post = normalizer.normalize
+
+    assert_includes post.content, "Getting Started with Ruby on Rails"
+    assert_equal ["https://i.ytimg.com/vi/aAbBcCdDeEf/hqdefault.jpg"], post.attachment_urls
+    assert_equal 1, post.comments.length
+    assert_includes post.comments.first, "beginner-friendly introduction"
+  end
 end

--- a/test/services/processor/youtube_processor_test.rb
+++ b/test/services/processor/youtube_processor_test.rb
@@ -44,4 +44,13 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
 
     assert_equal "https://www.youtube.com/watch?v=#{FIRST_VIDEO_ID}", entry.raw_data["url"]
   end
+
+  test "#process should store raw_data with string keys accessible without saving" do
+    processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
+    entry = processor.process.first
+
+    assert_equal "Getting Started with Ruby on Rails", entry.raw_data["title"]
+    assert_equal "https://www.youtube.com/watch?v=#{FIRST_VIDEO_ID}", entry.raw_data["url"]
+    assert_equal "https://i.ytimg.com/vi/#{FIRST_VIDEO_ID}/hqdefault.jpg", entry.raw_data["thumbnail"]
+  end
 end


### PR DESCRIPTION
## What changed

**YouTube loader — direct URL pattern matching**

The loader was resolving all non-feed URLs by fetching the channel page HTML and looking for a `<link rel="alternate" type="application/rss+xml">` tag. This fails for URL formats where YouTube doesn't include a discoverable feed link (e.g. `/channel/UCxxx` pages served without standard link tags, or pages blocked by bot detection).

The fix adds direct feed URL construction for known URL patterns before falling back to HTML scraping:

- `/channel/UCxxx` → `feeds/videos.xml?channel_id=UCxxx`
- `/user/Username` → `feeds/videos.xml?user=Username`
- `/playlist?list=PLxxx` → `feeds/videos.xml?playlist_id=PLxxx`

For `@handle` and `/c/name` URLs, HTML scraping is still used as a fallback.

**Processor raw_data key consistency**

Ad-hoc testing through the full loader→processor→normalizer pipeline revealed that `RssProcessor` was building `raw_data` hashes with symbol keys, while all normalizers access them with string keys (`raw_data.dig("title")`, etc.). This works in `FeedRefreshWorkflow` because entries are persisted to the DB (JSONB serialization converts symbols to strings) before normalization. But in `FeedPreviewWorkflow`, entries are normalized before being saved, so normalizers were silently receiving `nil` for all fields.

Fixed by switching the processor to string keys, which is consistent with how the data is always accessed.

## Tests

- Added loader tests for each new URL pattern (verify no channel-page fetch occurs)
- Added loader test confirming `@handle` URLs still use HTML scraping
- Added processor test verifying string keys are accessible on unsaved entries
- Added end-to-end normalizer test: processor output → unsaved `FeedEntry` → `YoutubeNormalizer`, confirming title, thumbnail, and description all round-trip correctly

## References

- Fixes #539
- Honeybadger: https://app.honeybadger.io/projects/134930/faults/131019486
