### PR TITLE
Add Atom feed support to RSS title extractor

### DIFF
--- a/app/services/title_extractor/rss_title_extractor.rb
+++ b/app/services/title_extractor/rss_title_extractor.rb
@@ -14,14 +14,21 @@ module TitleExtractor
 
     private
 
+    RDF_NS = { "rdf" => "http://www.w3.org/1999/02/22-rdf-syntax-ns#" }.freeze
+    ATOM_NS = { "atom" => "http://www.w3.org/2005/Atom" }.freeze
+
     def extract_title(doc)
       # Try RSS 2.0 format
       rss_title = doc.at_xpath("//channel/title")&.text
       return rss_title.strip if rss_title.present?
 
       # Try RSS 1.0 (RDF) format
-      rdf_title = doc.at_xpath("//rdf:RDF/channel/title")&.text
-      rdf_title&.strip
+      rdf_title = doc.at_xpath("//rdf:RDF/channel/title", RDF_NS)&.text
+      return rdf_title.strip if rdf_title.present?
+
+      # Try Atom format (e.g. YouTube)
+      atom_title = doc.at_xpath("//atom:feed/atom:title", ATOM_NS)&.text
+      atom_title&.strip
     end
   end
 end

--- a/test/services/title_extractor/rss_title_extractor_test.rb
+++ b/test/services/title_extractor/rss_title_extractor_test.rb
@@ -74,15 +74,7 @@ class TitleExtractor::RssTitleExtractorTest < ActiveSupport::TestCase
   end
 
   test "#title should extract title from YouTube Atom feed" do
-    body = <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
-            xmlns:media="http://search.yahoo.com/mrss/"
-            xmlns="http://www.w3.org/2005/Atom">
-        <title>Some YouTube Channel</title>
-        <id>yt:channel:UC1234</id>
-      </feed>
-    XML
-    assert_equal "Some YouTube Channel", extractor(body).title
+    body = file_fixture("feeds/youtube/feed.xml").read
+    assert_equal "Sample Tech Channel", extractor(body).title
   end
 end

--- a/test/services/title_extractor/rss_title_extractor_test.rb
+++ b/test/services/title_extractor/rss_title_extractor_test.rb
@@ -62,4 +62,27 @@ class TitleExtractor::RssTitleExtractorTest < ActiveSupport::TestCase
     XML
     assert_nil extractor(body).title
   end
+
+  test "#title should extract title from Atom feed" do
+    body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>My Atom Feed</title>
+      </feed>
+    XML
+    assert_equal "My Atom Feed", extractor(body).title
+  end
+
+  test "#title should extract title from YouTube Atom feed" do
+    body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+            xmlns:media="http://search.yahoo.com/mrss/"
+            xmlns="http://www.w3.org/2005/Atom">
+        <title>Some YouTube Channel</title>
+        <id>yt:channel:UC1234</id>
+      </feed>
+    XML
+    assert_equal "Some YouTube Channel", extractor(body).title
+  end
 end


### PR DESCRIPTION
Changes:

- Add support for extracting titles from Atom feeds (including YouTube channel feeds) in `RssTitleExtractor`
- Define namespace constants (`RDF_NS`, `ATOM_NS`) for XPath queries to properly handle namespaced XML elements
- Fix RSS 1.0 (RDF) title extraction to use proper namespace handling
- Add test cases for Atom feed and YouTube Atom feed title extraction

The extractor now attempts to extract titles in this order: RSS 2.0 → RSS 1.0 (RDF) → Atom, making it compatible with a wider range of feed formats.
