### PR TITLE
Add links to create groups in target group selector

### DIFF
--- a/app/views/feeds/_target_group_selector.html.erb
+++ b/app/views/feeds/_target_group_selector.html.erb
@@ -10,6 +10,13 @@
       <p class="text-sm text-slate-500">
         The FreeFeed group where posts will be published. Groups are like channels or communities.
       </p>
+      <p class="text-sm text-slate-500">
+        Need a new group?
+        <%= link_to "#{token.host}/groups/create", target: "_blank", rel: "noopener noreferrer",
+                    class: "inline-flex items-center gap-1 font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" do %>
+          Create one on FreeFeed <%= icon("external-link", css_class: "size-3") %>
+        <% end %>
+      </p>
     <% else %>
       <%= select_tag "feed[target_group]",
                      options_for_select([[feed.target_group.presence || "Select a group", ""]]),
@@ -24,6 +31,10 @@
           Unable to load groups. Please select a different access token or add a new one.
         <% elsif defined?(token_error) && token_error == :empty %>
           This account doesn't manage any groups yet.
+          <%= link_to "#{token.host}/groups/create", target: "_blank", rel: "noopener noreferrer",
+                      class: "inline-flex items-center gap-1 font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" do %>
+            Create a new group on FreeFeed <%= icon("external-link", css_class: "size-3") %>
+          <% end %>
           <%= link_to "Retry", access_token_groups_path(token, feed_id: feed.id, retry: 1),
                       data: { turbo_stream: true },
                       class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>


### PR DESCRIPTION
Changes:

- Add "Create one on FreeFeed" link in the target group selector help text when a token is connected
- Add "Create a new group on FreeFeed" link in the empty state message when an account has no groups yet
- Both links open FreeFeed's group creation page in a new tab with appropriate styling and external link icon

These additions help users quickly create a new group without leaving the feed configuration interface, improving the onboarding experience when setting up a new feed.
