### PR TITLE
Replace feeds list items with card-based layout

### DIFF
--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -7,9 +7,22 @@
         <%= render BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge") %>
       <% end %>
     </div>
+
+    <% if draft? %>
+      <div class="flex shrink-0 items-center gap-2">
+        <%= link_to "Continue setup", helpers.edit_feed_path(feed),
+              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
+              data: { key: "feed.#{feed.id}.continue_setup" } %>
+        <%= button_to "Discard", helpers.feed_path(feed),
+              method: :delete,
+              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
+              data: { key: "feed.#{feed.id}.discard" },
+              form: { data: { turbo_confirm: DISCARD_CONFIRM } } %>
+      </div>
+    <% end %>
   </div>
 
-  <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-3">
+  <div class="flex items-center gap-4 border-t border-slate-200 px-5 py-3">
     <div class="flex items-center gap-3 text-sm text-slate-400">
       <% if target_group_label %>
         <% if target_group_url %>
@@ -28,18 +41,5 @@
         <%= most_recent_post_tag %>
       </span>
     </div>
-
-    <% if draft? %>
-      <div class="flex items-center gap-2">
-        <%= link_to "Continue setup", helpers.edit_feed_path(feed),
-              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
-              data: { key: "feed.#{feed.id}.continue_setup" } %>
-        <%= button_to "Discard", helpers.feed_path(feed),
-              method: :delete,
-              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
-              data: { key: "feed.#{feed.id}.discard" },
-              form: { data: { turbo_confirm: DISCARD_CONFIRM } } %>
-      </div>
-    <% end %>
   </div>
 </div>

--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -32,11 +32,11 @@
     <% if draft? %>
       <div class="flex items-center gap-2">
         <%= link_to "Continue setup", helpers.edit_feed_path(feed),
-              class: CONTINUE_SETUP_CLASSES,
+              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
               data: { key: "feed.#{feed.id}.continue_setup" } %>
         <%= button_to "Discard", helpers.feed_path(feed),
               method: :delete,
-              class: DISCARD_CLASSES,
+              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
               data: { key: "feed.#{feed.id}.discard" },
               form: { data: { turbo_confirm: DISCARD_CONFIRM } } %>
       </div>

--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -1,0 +1,45 @@
+<div id="<%= helpers.dom_id(feed) %>" class="w-full rounded-lg border border-slate-200 bg-white shadow-xs">
+  <div class="flex items-start justify-between gap-4 px-5 py-4">
+    <div class="flex min-w-0 items-center gap-2">
+      <%= link_to title, feed_url,
+            class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
+      <% if draft? %>
+        <%= render BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge") %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-3">
+    <div class="flex items-center gap-3 text-sm text-slate-400">
+      <% if target_group_label %>
+        <% if target_group_url %>
+          <%= link_to target_group_label, target_group_url, target: "_blank", rel: "noopener",
+                class: "transition hover:text-slate-600" %>
+        <% else %>
+          <span><%= target_group_label %></span>
+        <% end %>
+      <% end %>
+      <span class="flex items-center gap-1">
+        <%= helpers.icon("refresh-ccw", css_class: "size-3.5") %>
+        <%= last_refreshed_tag %>
+      </span>
+      <span class="flex items-center gap-1">
+        <%= helpers.icon("layers", css_class: "size-3.5") %>
+        <%= most_recent_post_tag %>
+      </span>
+    </div>
+
+    <% if draft? %>
+      <div class="flex items-center gap-2">
+        <%= link_to "Continue setup", helpers.edit_feed_path(feed),
+              class: CONTINUE_SETUP_CLASSES,
+              data: { key: "feed.#{feed.id}.continue_setup" } %>
+        <%= button_to "Discard", helpers.feed_path(feed),
+              method: :delete,
+              class: DISCARD_CLASSES,
+              data: { key: "feed.#{feed.id}.discard" },
+              form: { data: { turbo_confirm: DISCARD_CONFIRM } } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/components/feed_card_component.rb
+++ b/app/components/feed_card_component.rb
@@ -1,0 +1,51 @@
+class FeedCardComponent < ViewComponent::Base
+  CONTINUE_SETUP_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
+  DISCARD_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
+  DISCARD_CONFIRM = "Discard this draft? No data will be lost since it hasn't been activated.".freeze
+
+  def initialize(feed:)
+    @feed = feed
+  end
+
+  private
+
+  attr_reader :feed
+
+  def title
+    feed.display_name
+  end
+
+  def feed_url
+    helpers.feed_path(feed)
+  end
+
+  def draft?
+    feed.draft?
+  end
+
+  def target_group_label
+    "@#{feed.target_group}" if feed.target_group.present?
+  end
+
+  def target_group_url
+    return unless feed.access_token && feed.target_group.present?
+
+    "#{feed.access_token.host}/#{feed.target_group}"
+  end
+
+  def last_refreshed_tag
+    return "Never" unless feed.last_refreshed_at
+
+    helpers.content_tag(:time, "#{helpers.short_time_ago(feed.last_refreshed_at)} ago",
+                        datetime: feed.last_refreshed_at.rfc3339,
+                        title: helpers.long_time_format(feed.last_refreshed_at))
+  end
+
+  def most_recent_post_tag
+    return "None" unless feed.most_recent_post_date
+
+    helpers.content_tag(:time, "#{helpers.short_time_ago(feed.most_recent_post_date)} ago",
+                        datetime: feed.most_recent_post_date.rfc3339,
+                        title: helpers.long_time_format(feed.most_recent_post_date))
+  end
+end

--- a/app/components/feed_card_component.rb
+++ b/app/components/feed_card_component.rb
@@ -1,6 +1,4 @@
 class FeedCardComponent < ViewComponent::Base
-  CONTINUE_SETUP_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
-  DISCARD_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
   DISCARD_CONFIRM = "Discard this draft? No data will be lost since it hasn't been activated.".freeze
 
   def initialize(feed:)

--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -4,7 +4,7 @@ class FeedsListComponent < ViewComponent::Base
   end
 
   def call
-    content_tag(:div, class: "space-y-3") do
+    content_tag(:div, class: "space-y-4") do
       safe_join(@feeds.map { |feed| render(FeedCardComponent.new(feed: feed)) })
     end
   end

--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -3,69 +3,9 @@ class FeedsListComponent < ViewComponent::Base
     @feeds = feeds
   end
 
-  CONTINUE_SETUP_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1".freeze
-  DISCARD_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
-  DISCARD_CONFIRM = "Discard this draft? No data will be lost since it hasn't been activated.".freeze
-
   def call
-    render(ListComponent.new) do |list|
-      @feeds.each do |feed|
-        list.with_item(ListComponent::ItemComponent.new(
-          title: display_title_for(feed),
-          title_url: helpers.feed_path(feed),
-          metadata_segments: metadata_segments_for(feed),
-          badge: badge_for(feed),
-          actions: actions_for(feed)
-        ))
-      end
+    content_tag(:div, class: "space-y-3") do
+      safe_join(@feeds.map { |feed| render(FeedCardComponent.new(feed: feed)) })
     end
-  end
-
-  private
-
-  def display_title_for(feed)
-    feed.display_name
-  end
-
-  def badge_for(feed)
-    return nil unless feed.draft?
-
-    render(BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge"))
-  end
-
-  # FR-023: drafts surface inline "Continue setup" and "Discard" affordances so
-  # users can act on stalled drafts without opening the show page. FR-024: the
-  # discard confirmation copy is softer than the regular feed delete since
-  # nothing has been published yet.
-  def actions_for(feed)
-    return nil unless feed.draft?
-
-    safe_join([
-      helpers.link_to("Continue setup", helpers.edit_feed_path(feed),
-                      class: CONTINUE_SETUP_CLASSES,
-                      data: { key: "feed.#{feed.id}.continue_setup" }),
-      helpers.button_to("Discard", helpers.feed_path(feed),
-                        method: :delete,
-                        class: DISCARD_CLASSES,
-                        data: { key: "feed.#{feed.id}.discard" },
-                        form: { data: { turbo_confirm: DISCARD_CONFIRM } })
-    ])
-  end
-
-  def metadata_segments_for(feed)
-    [
-      target_segment(feed),
-      safe_join(["Refreshed:", feed.last_refreshed_at ? content_tag(:span, "#{helpers.short_time_ago(feed.last_refreshed_at)} ago", title: helpers.long_time_format(feed.last_refreshed_at)) : "Never"], " "),
-      safe_join(["Publication:", feed.most_recent_post_date ? content_tag(:span, "#{helpers.short_time_ago(feed.most_recent_post_date)} ago", title: helpers.long_time_format(feed.most_recent_post_date)) : "None"], " ")
-    ]
-  end
-
-  def target_segment(feed)
-    target = feed.target_group.presence || "None"
-    return "Target: #{target}" if target == "None" || !feed.access_token
-
-    url = "#{feed.access_token.host}/#{feed.target_group}"
-    link_content = safe_join([target, " ".html_safe, helpers.icon("external-link", css_class: "size-3.5 inline align-text-bottom")])
-    safe_join(["Target:", helpers.link_to(link_content, url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")], " ")
   end
 end

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -9,7 +9,7 @@ class PostCardComponent < ViewComponent::Base
   attr_reader :post, :show_feed
 
   def title
-    helpers.post_content_preview(post.content, 80)
+    helpers.post_content_preview(post.content, 160)
   end
 
   def post_url

--- a/app/components/posts_list_component.rb
+++ b/app/components/posts_list_component.rb
@@ -5,7 +5,7 @@ class PostsListComponent < ViewComponent::Base
   end
 
   def call
-    content_tag(:div, class: "space-y-3") do
+    content_tag(:div, class: "space-y-4") do
       safe_join(@posts.map { |post| render(PostCardComponent.new(post: post, show_feed: @show_feed)) })
     end
   end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,7 +4,9 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: page_title) do |header| %>
     <% if @feed %>
-      <% header.with_context_paragraph("Showing posts from #{@feed.display_name}.") %>
+      <% group = @feed.target_group.presence %>
+      <% label = @feed.display_name + (group ? " (@#{group})" : "") %>
+      <% header.with_context_paragraph("Showing posts from #{label}.") %>
     <% else %>
       <% header.with_context_paragraph("All posts from your feeds") %>
     <% end %>

--- a/test/components/feed_card_component_test.rb
+++ b/test/components/feed_card_component_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+require "view_component/test_case"
+
+class FeedCardComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed
+    @feed ||= create(:feed, :disabled, user: user, name: "My Feed")
+  end
+
+  test "#render should use dom_id as element id" do
+    result = render_inline FeedCardComponent.new(feed: feed)
+
+    assert_not_empty result.css("##{ActionView::RecordIdentifier.dom_id(feed)}")
+  end
+
+  test "#render should link title to feed detail page" do
+    result = render_inline FeedCardComponent.new(feed: feed)
+
+    link = result.at_css("a[href*='/feeds/']")
+    assert_not_nil link
+    assert_includes link.text, "My Feed"
+  end
+
+  test "#render should show Draft badge for draft feeds" do
+    draft_feed = create(:feed, :draft, user: user)
+    result = render_inline FeedCardComponent.new(feed: draft_feed)
+
+    badge = result.css("[data-key='feed.#{draft_feed.id}.draft_badge']").first
+    assert_not_nil badge
+    assert_equal "Draft", badge.text.strip
+  end
+
+  test "#render should not show Draft badge for non-draft feeds" do
+    result = render_inline FeedCardComponent.new(feed: feed)
+
+    assert_empty result.css("[data-key='feed.#{feed.id}.draft_badge']")
+  end
+
+  test "#render should show @group label when target_group present" do
+    result = render_inline FeedCardComponent.new(feed: feed)
+
+    assert_includes result.text, "@testgroup"
+  end
+
+  test "#render should show Continue setup and Discard for draft feeds" do
+    draft_feed = create(:feed, :draft, user: user)
+
+    with_request_url("/feeds") do
+      result = render_inline FeedCardComponent.new(feed: draft_feed)
+
+      assert_not_empty result.css("[data-key='feed.#{draft_feed.id}.continue_setup']")
+      assert_not_empty result.css("[data-key='feed.#{draft_feed.id}.discard']")
+    end
+  end
+
+  test "#render should not show draft actions for non-draft feeds" do
+    with_request_url("/feeds") do
+      result = render_inline FeedCardComponent.new(feed: feed)
+
+      assert_empty result.css("[data-key='feed.#{feed.id}.continue_setup']")
+      assert_empty result.css("[data-key='feed.#{feed.id}.discard']")
+    end
+  end
+
+  test "#render should show refresh and post time placeholders when never refreshed" do
+    result = render_inline FeedCardComponent.new(feed: feed)
+
+    assert_includes result.text, "Never"
+    assert_includes result.text, "None"
+  end
+end

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -29,7 +29,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "button[data-dropdown-toggle='feed-sort-menu']", 1
     assert_select "#feed-sort-menu a", 5
-    assert_select "ul.divide-y li", minimum: 1
+    assert_select "a[href='#{feed_path(feed)}']", minimum: 1
     assert_select "p", text: "You have 1 inactive feed"
   end
 


### PR DESCRIPTION
Applies the same card-based presentation introduced for posts (#546) to the feeds index page.
