### PR TITLE
Handle LLM authentication errors and disable invalid credentials

### DIFF
--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -48,6 +48,8 @@ class EventDescriptionComponent < ViewComponent::Base
       helpers.link_to(event.subject.name, helpers.access_tokens_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     when Post
       helpers.link_to("Post", helpers.post_path(event.subject), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
+    when LlmCredential
+      helpers.link_to(event.subject.display_name, helpers.llm_credential_path(event.subject), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     else
       ""
     end

--- a/app/jobs/llm_credential_validation_job.rb
+++ b/app/jobs/llm_credential_validation_job.rb
@@ -11,7 +11,6 @@ class LlmCredentialValidationJob < ApplicationJob
     LlmClient.for(credential).health_check
     credential.update!(state: :active, last_validated_at: Time.current, last_error: nil)
   rescue LlmClient::Error => e
-    Rails.error.report(e, context: { credential_id: credential.id, provider: credential.provider })
     credential.update!(state: :inactive, last_validated_at: Time.current, last_error: e.message)
   end
 end

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -204,7 +204,15 @@ class FeedRefreshWorkflow
     return unless error.is_a?(LlmClient::AuthError)
     return unless feed.llm_credential
 
-    feed.llm_credential.update!(state: :inactive, last_validated_at: Time.current, last_error: error.message)
+    credential = feed.llm_credential
+    credential.update!(state: :inactive, last_validated_at: Time.current, last_error: error.message)
+    Event.create!(
+      type: "llm_credential_deactivated",
+      level: :warning,
+      subject: credential,
+      user: feed.user,
+      message: error.message
+    )
   end
 
   def create_feed_refresh_error_event(error)

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -26,6 +26,7 @@ class FeedRefreshWorkflow
 
   def on_error(error)
     record_error_stats(error, current_step: current_step)
+    disable_credential_on_auth_error(error)
     create_feed_refresh_error_event(error)
   end
 
@@ -197,6 +198,13 @@ class FeedRefreshWorkflow
       message: "",
       metadata: { stats: stats }
     )
+  end
+
+  def disable_credential_on_auth_error(error)
+    return unless error.is_a?(LlmClient::AuthError)
+    return unless feed.llm_credential
+
+    feed.llm_credential.update!(state: :inactive, last_validated_at: Time.current, last_error: error.message)
   end
 
   def create_feed_refresh_error_event(error)

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -9,6 +9,7 @@ class LlmClient
 
   Error = Class.new(StandardError)
   ProviderError = Class.new(Error)
+  AuthError = Class.new(ProviderError)
   SchemaError = Class.new(Error)
   Timeout = Class.new(Error)
   DetectionForbidden = Class.new(Error)
@@ -69,6 +70,9 @@ class LlmClient
     rescue Net::ReadTimeout, Net::OpenTimeout, Faraday::TimeoutError => e
       write_usage(ctx, outcome: :timeout, started_at: started_at, error_message: e.message)
       raise Timeout, e.message
+    rescue RubyLLM::UnauthorizedError, RubyLLM::ForbiddenError, RubyLLM::PaymentRequiredError => e
+      write_usage(ctx, outcome: :provider_error, started_at: started_at, error_message: e.message)
+      raise AuthError, e.message
     rescue RubyLLM::Error,
            RubyLLM::ConfigurationError,
            RubyLLM::ModelNotFoundError,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,9 @@ en:
     feed_refresh_error:
       name: "Feed refresh failed"
       description_html: "Feed %{subject_link} refresh failed at %{stage}: %{message}"
+    llm_credential_deactivated:
+      name: "AI credential deactivated"
+      description_html: "AI credential %{subject_link} was deactivated — the key may be invalid or expired. Update it to resume AI-backed feeds."
     post_withdrawn:
       name: "Post withdrawn"
       description_html: "Post withdrawn from FreeFeed"

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -249,8 +249,11 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal "inactive", credential.reload.state
     assert_equal "Unauthorized", credential.last_error
 
-    error_events = Event.where(subject: test_feed, type: "feed_refresh_error")
-    assert_equal 1, error_events.count
+    assert_equal 1, Event.where(subject: test_feed, type: "feed_refresh_error").count
+    deactivated_event = Event.find_by(subject: credential, type: "llm_credential_deactivated")
+    assert_not_nil deactivated_event
+    assert_equal "warning", deactivated_event.level
+    assert_equal llm_user, deactivated_event.user
   end
 
   test "#execute should not disable the credential for non-auth LLM errors" do

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -236,6 +236,36 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal "Feedjira::NoParserAvailable", error_event.metadata["error"]["class"]
   end
 
+  test "#execute should disable the LLM credential and create an error event on auth failure" do
+    llm_user = create(:user)
+    credential = create(:llm_credential, :active, user: llm_user)
+    test_feed = create(:feed, feed_profile_key: "rss", user: llm_user, llm_credential: credential)
+
+    workflow = FeedRefreshWorkflow.new(test_feed)
+    workflow.stub(:load_feed_contents, ->(_) { raise LlmClient::AuthError, "Unauthorized" }) do
+      assert_raises(LlmClient::AuthError) { workflow.execute }
+    end
+
+    assert_equal "inactive", credential.reload.state
+    assert_equal "Unauthorized", credential.last_error
+
+    error_events = Event.where(subject: test_feed, type: "feed_refresh_error")
+    assert_equal 1, error_events.count
+  end
+
+  test "#execute should not disable the credential for non-auth LLM errors" do
+    llm_user = create(:user)
+    credential = create(:llm_credential, :active, user: llm_user)
+    test_feed = create(:feed, feed_profile_key: "rss", user: llm_user, llm_credential: credential)
+
+    workflow = FeedRefreshWorkflow.new(test_feed)
+    workflow.stub(:load_feed_contents, ->(_) { raise LlmClient::ProviderError, "server error" }) do
+      assert_raises(LlmClient::ProviderError) { workflow.execute }
+    end
+
+    assert_equal "active", credential.reload.state
+  end
+
   test "#execute should handle normalization errors gracefully" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -246,12 +246,34 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_nil LlmUsage.last.stage
   end
 
-  test "#health_check should raise ProviderError when the provider rejects the call" do
+  test "#health_check should raise AuthError when the provider rejects the key" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, RubyLLM::UnauthorizedError.new("invalid key"))
 
-    assert_raises(LlmClient::ProviderError) { client.health_check }
+    assert_raises(LlmClient::AuthError) { client.health_check }
     assert_equal "provider_error", LlmUsage.last.outcome
+  end
+
+  test "#call should raise AuthError for RubyLLM::UnauthorizedError" do
+    client = LlmClient.new(credential)
+    stub_provider_to_raise(client, RubyLLM::UnauthorizedError.new("401"))
+
+    assert_raises(LlmClient::AuthError) { client.call(default_ctx, **call_opts) }
+    assert_equal "provider_error", LlmUsage.last.outcome
+  end
+
+  test "#call should raise AuthError for RubyLLM::ForbiddenError" do
+    client = LlmClient.new(credential)
+    stub_provider_to_raise(client, RubyLLM::ForbiddenError.new("403"))
+
+    assert_raises(LlmClient::AuthError) { client.call(default_ctx, **call_opts) }
+  end
+
+  test "#call should raise AuthError for RubyLLM::PaymentRequiredError" do
+    client = LlmClient.new(credential)
+    stub_provider_to_raise(client, RubyLLM::PaymentRequiredError.new("402"))
+
+    assert_raises(LlmClient::AuthError) { client.call(default_ctx, **call_opts) }
   end
 
   test "#call should map RubyLLM::ModelNotFoundError to ProviderError" do


### PR DESCRIPTION
Changes:

- Add `LlmClient::AuthError` exception class to distinguish authentication failures (401, 403, 402) from other provider errors
- Map `RubyLLM::UnauthorizedError`, `RubyLLM::ForbiddenError`, and `RubyLLM::PaymentRequiredError` to `LlmClient::AuthError` in the `call` method
- Update `health_check` to raise `AuthError` instead of `ProviderError` for unauthorized access
- Disable LLM credentials (set state to `inactive`) when an `AuthError` occurs during feed refresh, preventing repeated failed attempts with invalid keys
- Record the error message in the credential's `last_error` field for debugging
- Remove redundant error reporting in `LlmCredentialValidationJob` (error handling is now consistent across the codebase)
- Add comprehensive test coverage for auth error handling in both feed refresh and LLM client workflows

This ensures that feeds with invalid or expired LLM credentials fail gracefully and don't repeatedly attempt to use bad credentials.
