### PR TITLE
Add OpenRouter LLM provider support

### DIFF
--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -16,8 +16,13 @@ class LlmProvider
   PROVIDERS = {
     "anthropic" => new(
       name: "anthropic",
-      display_name: "Anthropic (Claude)",
+      display_name: "Anthropic",
       ruby_llm_provider: :anthropic
+    ),
+    "openrouter" => new(
+      name: "openrouter",
+      display_name: "OpenRouter",
+      ruby_llm_provider: :openrouter
     )
   }.freeze
 

--- a/config/llm_rates.yml
+++ b/config/llm_rates.yml
@@ -24,3 +24,26 @@ anthropic:
     output_per_million: 4.00
     cache_write_per_million: 1.00
     cache_read_per_million: 0.08
+
+openrouter:
+  anthropic/claude-opus-4-7:
+    input_per_million: 15.00
+    output_per_million: 75.00
+  anthropic/claude-sonnet-4-6:
+    input_per_million: 3.00
+    output_per_million: 15.00
+  anthropic/claude-haiku-4-5:
+    input_per_million: 0.80
+    output_per_million: 4.00
+  openai/gpt-4o:
+    input_per_million: 2.50
+    output_per_million: 10.00
+  openai/gpt-4o-mini:
+    input_per_million: 0.15
+    output_per_million: 0.60
+  google/gemini-flash-2.0:
+    input_per_million: 0.10
+    output_per_million: 0.40
+  meta-llama/llama-3.3-70b-instruct:
+    input_per_million: 0.12
+    output_per_million: 0.40

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -3,16 +3,20 @@ require "test_helper"
 class LlmProviderTest < ActiveSupport::TestCase
   test "#all should return registered provider instances" do
     assert_includes LlmProvider.all.map(&:name), "anthropic"
+    assert_includes LlmProvider.all.map(&:name), "openrouter"
     assert LlmProvider.all.all? { |p| p.is_a?(LlmProvider) }
   end
 
   test "#names should list registered provider keys" do
     assert_includes LlmProvider.names, "anthropic"
+    assert_includes LlmProvider.names, "openrouter"
   end
 
   test "#exists? should return true for registered providers" do
     assert LlmProvider.exists?("anthropic")
     assert LlmProvider.exists?(:anthropic)
+    assert LlmProvider.exists?("openrouter")
+    assert LlmProvider.exists?(:openrouter)
   end
 
   test "#exists? should return false for unknown providers" do
@@ -20,16 +24,25 @@ class LlmProviderTest < ActiveSupport::TestCase
     refute LlmProvider.exists?(nil)
   end
 
-  test "#find should return the provider instance" do
+  test "#find should return the anthropic provider instance" do
     provider = LlmProvider.find("anthropic")
     assert_kind_of LlmProvider, provider
     assert_equal "anthropic", provider.name
-    assert_equal "Anthropic (Claude)", provider.display_name
+    assert_equal "Anthropic", provider.display_name
     assert_equal :anthropic, provider.ruby_llm_provider
+  end
+
+  test "#find should return the openrouter provider instance" do
+    provider = LlmProvider.find("openrouter")
+    assert_kind_of LlmProvider, provider
+    assert_equal "openrouter", provider.name
+    assert_equal "OpenRouter", provider.display_name
+    assert_equal :openrouter, provider.ruby_llm_provider
   end
 
   test "#find should accept symbol keys" do
     assert_equal "anthropic", LlmProvider.find(:anthropic).name
+    assert_equal "openrouter", LlmProvider.find(:openrouter).name
   end
 
   test "#find should return nil for unknown providers" do
@@ -39,6 +52,7 @@ class LlmProviderTest < ActiveSupport::TestCase
 
   test "instances should be frozen" do
     assert LlmProvider.find("anthropic").frozen?
+    assert LlmProvider.find("openrouter").frozen?
   end
 
   test "registry should be frozen" do


### PR DESCRIPTION
Changes:

- Add OpenRouter provider configuration with pricing for 7 models (Claude Opus/Sonnet/Haiku, GPT-4o/4o-mini, Gemini Flash 2.0, Llama 3.3 70B)
- Register OpenRouter as a new LLM provider in the application
- Update Anthropic provider display name from "Anthropic (Claude)" to "Anthropic" for consistency
- Add comprehensive test coverage for the new OpenRouter provider

The OpenRouter integration enables support for multiple model families through a single provider interface, expanding the available LLM options for the application.
