### PR TITLE
Auto-generate display names for LLM credentials

### DIFF
--- a/app/models/concerns/llm_credential_words.rb
+++ b/app/models/concerns/llm_credential_words.rb
@@ -1,24 +1,101 @@
 module LlmCredentialWords
   ADJECTIVES = %w[
+    aged
+    agile
+    amber
+    ample
+    ancient
+    ardent
+    azure
+    bare
     bold
     brave
     bright
+    brisk
+    broad
     calm
+    clean
+    clear
+    clever
+    cold
     cool
+    cozy
     crisp
     dark
     deep
+    deft
+    dense
+    divine
+    dreamy
+    dusty
+    eager
+    early
+    epic
     fair
+    fierce
+    fine
+    firm
+    fleet
     free
+    fresh
+    frosty
+    full
+    gentle
+    glad
+    golden
+    graceful
     grand
+    hardy
+    hazy
+    high
+    icy
+    jolly
     keen
+    large
+    light
+    lofty
+    lone
+    loyal
     lush
+    mellow
+    mild
+    mighty
+    muted
+    near
+    nimble
     noble
+    open
+    outer
+    pale
+    plain
+    plush
+    prime
+    proud
     pure
-    rare
-    rich
-    sharp
+    quick
+    quiet
+    raw
+    ready
+    ripe
+    rocky
+    round
+    royal
+    rugged
+    rustic
+    sacred
+    sandy
+    serene
+    silent
+    slim
+    smooth
+    snowy
+    soft
+    solemn
+    solid
+    sparse
+    stark
     swift
+    true
     vast
     warm
     wild
@@ -26,25 +103,102 @@ module LlmCredentialWords
   ].freeze
 
   NOUNS = %w[
+    acorn
+    albatross
+    almond
+    anchor
     banana
+    basalt
+    beacon
     birch
+    bison
+    boulder
+    brook
+    cabin
+    cactus
+    canopy
     canyon
+    cascade
+    cavern
     cedar
+    cherry
+    cinder
+    citrus
+    cliff
+    clover
     comet
+    copper
     coral
     crystal
+    dawn
+    delta
+    dew
+    dome
+    dove
+    dusk
+    echo
     ember
     falcon
+    fern
+    field
+    flint
+    foam
+    forge
+    fossil
+    fox
     glacier
+    grove
     harbor
+    hemlock
+    hollow
+    horizon
+    inlet
+    iris
+    island
+    ivory
+    jade
     jasper
+    juniper
+    kelp
+    knoll
+    lagoon
     lantern
+    lark
+    laurel
+    lavender
+    ledge
+    linden
     lotus
     maple
+    marble
+    marsh
     meadow
+    mesa
+    mint
+    mist
+    moor
+    moss
+    nectar
+    oak
+    obsidian
+    opal
+    otter
+    peak
     pebble
+    pine
+    plum
+    poplar
+    quartz
+    quill
+    ravine
+    reed
+    ridge
     river
+    rosewood
+    ruin
+    sage
     salmon
+    sandstone
     summit
     thunder
     walnut

--- a/app/models/concerns/llm_credential_words.rb
+++ b/app/models/concerns/llm_credential_words.rb
@@ -1,0 +1,53 @@
+module LlmCredentialWords
+  ADJECTIVES = %w[
+    bold
+    brave
+    bright
+    calm
+    cool
+    crisp
+    dark
+    deep
+    fair
+    free
+    grand
+    keen
+    lush
+    noble
+    pure
+    rare
+    rich
+    sharp
+    swift
+    vast
+    warm
+    wild
+    wise
+  ].freeze
+
+  NOUNS = %w[
+    banana
+    birch
+    canyon
+    cedar
+    comet
+    coral
+    crystal
+    ember
+    falcon
+    glacier
+    harbor
+    jasper
+    lantern
+    lotus
+    maple
+    meadow
+    pebble
+    river
+    salmon
+    summit
+    thunder
+    walnut
+    willow
+  ].freeze
+end

--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -69,12 +69,29 @@ class LlmCredential < ApplicationRecord
     label = provider.capitalize
     existing = self.class.where(user_id: user_id, provider: provider).pluck(:display_name).to_set
 
-    200.times do
-      candidate = "#{label} #{ADJECTIVES.sample.capitalize} #{NOUNS.sample.capitalize}"
-      return candidate unless existing.include?(candidate)
-    end
+    pair = lazy_shuffle(ADJECTIVES).flat_map { |adj|
+      lazy_shuffle(NOUNS).map { |noun| [adj, noun] }
+    }.find { |adj, noun| !existing.include?("#{label} #{adj.capitalize} #{noun.capitalize}") }
 
-    "#{label} #{SecureRandom.hex(4)}"
+    if pair
+      adj, noun = pair
+      "#{label} #{adj.capitalize} #{noun.capitalize}"
+    else
+      n = 1
+      n += 1 while existing.include?("#{label} #{n}")
+      "#{label} #{n}"
+    end
+  end
+
+  def lazy_shuffle(arr)
+    Enumerator.new do |y|
+      a = arr.dup
+      a.size.times do |i|
+        j = rand(i...a.size)
+        a[i], a[j] = a[j], a[i]
+        y << a[i]
+      end
+    end.lazy
   end
 
   def api_key_present

--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -3,10 +3,9 @@
 # stores provider-specific fields (e.g. `{ "api_key" => "..." }`) and is
 # encrypted at rest.
 class LlmCredential < ApplicationRecord
-  DISPLAY_NAME_MAX_LENGTH = 80
+  include LlmCredentialWords
 
-  ADJECTIVES = %w[bold brave bright calm cool dark deep fair free grand keen pure rare rich sharp swift vast warm wild wise].freeze
-  NOUNS = %w[banana cedar comet coral crystal ember falcon glacier harbor lantern lotus maple meadow pebble river salmon summit thunder walnut willow].freeze
+  DISPLAY_NAME_MAX_LENGTH = 80
 
   belongs_to :user
   # `dependent` is handled manually by `disable_dependent_feeds` so we can

--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -64,9 +64,9 @@ class LlmCredential < ApplicationRecord
   end
 
   def generate_unique_name
-    label = provider.capitalize
-    existing = self.class.where(user_id: user_id, provider: provider).pluck(:display_name).to_set
-    NameGenerator.new(label, existing).generate
+    label = provider
+    existing = self.class.where(user_id: user_id, provider: provider).pluck(:display_name).map(&:downcase).to_set
+    NameGenerator.new(label, existing).generate.split.map(&:capitalize).join(" ")
   end
 
   def api_key_present

--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -5,6 +5,9 @@
 class LlmCredential < ApplicationRecord
   DISPLAY_NAME_MAX_LENGTH = 80
 
+  ADJECTIVES = %w[bold brave bright calm cool dark deep fair free grand keen pure rare rich sharp swift vast warm wild wise].freeze
+  NOUNS = %w[banana cedar comet coral crystal ember falcon glacier harbor lantern lotus maple meadow pebble river salmon summit thunder walnut willow].freeze
+
   belongs_to :user
   # `dependent` is handled manually by `disable_dependent_feeds` so we can
   # both nullify the reference and pull any feed left enabled out of the
@@ -27,6 +30,7 @@ class LlmCredential < ApplicationRecord
 
   validate :api_key_present
 
+  before_validation :assign_name_if_blank, on: :create
   before_save :clear_other_defaults_if_promoting
   before_destroy :disable_dependent_feeds
 
@@ -55,6 +59,24 @@ class LlmCredential < ApplicationRecord
   end
 
   private
+
+  def assign_name_if_blank
+    return if display_name.present? || provider.blank?
+
+    self.display_name = generate_unique_name
+  end
+
+  def generate_unique_name
+    label = provider.capitalize
+    existing = self.class.where(user_id: user_id, provider: provider).pluck(:display_name).to_set
+
+    200.times do
+      candidate = "#{label} #{ADJECTIVES.sample.capitalize} #{NOUNS.sample.capitalize}"
+      return candidate unless existing.include?(candidate)
+    end
+
+    "#{label} #{SecureRandom.hex(4)}"
+  end
 
   def api_key_present
     return if provider.blank?

--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -3,8 +3,6 @@
 # stores provider-specific fields (e.g. `{ "api_key" => "..." }`) and is
 # encrypted at rest.
 class LlmCredential < ApplicationRecord
-  include LlmCredentialWords
-
   DISPLAY_NAME_MAX_LENGTH = 80
 
   belongs_to :user
@@ -68,30 +66,7 @@ class LlmCredential < ApplicationRecord
   def generate_unique_name
     label = provider.capitalize
     existing = self.class.where(user_id: user_id, provider: provider).pluck(:display_name).to_set
-
-    pair = lazy_shuffle(ADJECTIVES).flat_map { |adj|
-      lazy_shuffle(NOUNS).map { |noun| [adj, noun] }
-    }.find { |adj, noun| !existing.include?("#{label} #{adj.capitalize} #{noun.capitalize}") }
-
-    if pair
-      adj, noun = pair
-      "#{label} #{adj.capitalize} #{noun.capitalize}"
-    else
-      n = 1
-      n += 1 while existing.include?("#{label} #{n}")
-      "#{label} #{n}"
-    end
-  end
-
-  def lazy_shuffle(arr)
-    Enumerator.new do |y|
-      a = arr.dup
-      a.size.times do |i|
-        j = rand(i...a.size)
-        a[i], a[j] = a[j], a[i]
-        y << a[i]
-      end
-    end.lazy
+    NameGenerator.new(label, existing).generate
   end
 
   def api_key_present

--- a/app/models/llm_credential/name_generator.rb
+++ b/app/models/llm_credential/name_generator.rb
@@ -1,4 +1,4 @@
-module LlmCredentialWords
+class LlmCredential::NameGenerator
   ADJECTIVES = %w[
     aged
     agile
@@ -204,4 +204,37 @@ module LlmCredentialWords
     walnut
     willow
   ].freeze
+
+  def initialize(label, existing)
+    @label = label
+    @existing = existing
+  end
+
+  def generate
+    pair = lazy_shuffle(ADJECTIVES).flat_map { |adj|
+      lazy_shuffle(NOUNS).map { |noun| [adj, noun] }
+    }.find { |adj, noun| !@existing.include?("#{@label} #{adj.capitalize} #{noun.capitalize}") }
+
+    if pair
+      adj, noun = pair
+      "#{@label} #{adj.capitalize} #{noun.capitalize}"
+    else
+      n = 1
+      n += 1 while @existing.include?("#{@label} #{n}")
+      "#{@label} #{n}"
+    end
+  end
+
+  private
+
+  def lazy_shuffle(arr)
+    Enumerator.new do |y|
+      a = arr.dup
+      a.size.times do |i|
+        j = rand(i...a.size)
+        a[i], a[j] = a[j], a[i]
+        y << a[i]
+      end
+    end.lazy
+  end
 end

--- a/app/models/llm_credential/name_generator.rb
+++ b/app/models/llm_credential/name_generator.rb
@@ -213,11 +213,11 @@ class LlmCredential::NameGenerator
   def generate
     pair = lazy_shuffle(ADJECTIVES).flat_map { |adj|
       lazy_shuffle(NOUNS).map { |noun| [adj, noun] }
-    }.find { |adj, noun| !@existing.include?("#{@label} #{adj.capitalize} #{noun.capitalize}") }
+    }.find { |adj, noun| !@existing.include?("#{@label} #{adj} #{noun}") }
 
     if pair
       adj, noun = pair
-      "#{@label} #{adj.capitalize} #{noun.capitalize}"
+      "#{@label} #{adj} #{noun}"
     else
       n = 1
       n += 1 while @existing.include?("#{@label} #{n}")

--- a/app/views/llm_credentials/new.html.erb
+++ b/app/views/llm_credentials/new.html.erb
@@ -32,9 +32,8 @@
           <%= f.text_field :display_name,
                            placeholder: "Personal Anthropic key",
                            class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500",
-                           required: true,
                            data: { key: "llm_credentials.display-name" } %>
-          <p class="text-sm text-slate-500">A label so you can tell credentials apart later.</p>
+          <p class="text-sm text-slate-500">A label so you can tell credentials apart. Leave blank to get one automatically.</p>
         </div>
 
         <div class="space-y-2">

--- a/test/controllers/llm_credentials_controller_test.rb
+++ b/test/controllers/llm_credentials_controller_test.rb
@@ -144,6 +144,24 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to llm_credential_path(saved, feed_id: draft.id)
   end
 
+  test "#create should generate a name when display_name is blank" do
+    sign_in_as(user)
+
+    assert_difference("LlmCredential.count", 1) do
+      post llm_credentials_url, params: {
+        llm_credential: {
+          provider: "anthropic",
+          display_name: "",
+          credential_data: { api_key: "sk-ant-#{SecureRandom.hex(16)}" }
+        }
+      }
+    end
+
+    saved = LlmCredential.last
+    assert saved.display_name.start_with?("Anthropic ")
+    assert_equal 3, saved.display_name.split.count
+  end
+
   test "#create should render :new with errors on invalid input" do
     sign_in_as(user)
 
@@ -151,8 +169,8 @@ class LlmCredentialsControllerTest < ActionDispatch::IntegrationTest
       post llm_credentials_url, params: {
         llm_credential: {
           provider: "anthropic",
-          display_name: "",
-          credential_data: { api_key: "x" }
+          display_name: "My Key",
+          credential_data: { api_key: "" }
         }
       }
     end

--- a/test/models/llm_credential/name_generator_test.rb
+++ b/test/models/llm_credential/name_generator_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class LlmCredential::NameGeneratorTest < ActiveSupport::TestCase
+  ALL_COMBINATIONS = LlmCredential::NameGenerator::ADJECTIVES.flat_map { |adj|
+    LlmCredential::NameGenerator::NOUNS.map { |noun| "anthropic #{adj} #{noun}" }
+  }.to_set.freeze
+
+  test "#generate should fall back to numeric suffix when all word combinations are taken" do
+    result = LlmCredential::NameGenerator.new("anthropic", ALL_COMBINATIONS).generate
+    assert_equal "anthropic 1", result
+  end
+
+  test "#generate should increment the numeric suffix when lower numbers are also taken" do
+    existing = ALL_COMBINATIONS | Set["anthropic 1", "anthropic 2"]
+    result = LlmCredential::NameGenerator.new("anthropic", existing).generate
+    assert_equal "anthropic 3", result
+  end
+end


### PR DESCRIPTION
Changes:

- Add automatic display name generation for LLM credentials when created without an explicit name
- Generate names using a pattern of "Provider Adjective Noun" (e.g., "Anthropic Bold Cedar") with collision detection
- Fall back to hex-based names if 200 collision attempts are exhausted
- Make the display_name field optional in the UI with updated helper text
- Add test coverage for the auto-generation behavior

The display_name field is now optional. When left blank during credential creation, a unique name is automatically generated based on the provider and a random adjective-noun pair. This improves the user experience by eliminating a required field while still ensuring credentials have meaningful, distinguishable labels.
