### PR TITLE
Refactor LLM credentials list to use card component

### DIFF
--- a/app/components/llm_credential_card_component.html.erb
+++ b/app/components/llm_credential_card_component.html.erb
@@ -1,0 +1,62 @@
+<div id="<%= helpers.dom_id(credential) %>"
+     class="w-full rounded-lg border border-slate-200 bg-white shadow-xs"
+     data-key="llm_credential.<%= credential.id %>">
+  <div class="flex items-start justify-between gap-4 px-5 py-4">
+    <div class="flex min-w-0 items-center gap-2">
+      <%= link_to credential.display_name, credential_url,
+            class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
+      <% if default? %>
+        <%= render BadgeComponent.new(text: "Default", color: :blue, key: "llm_credential.default-badge") %>
+      <% end %>
+    </div>
+
+    <div class="relative">
+      <button type="button"
+              id="<%= menu_id %>-button"
+              data-dropdown-toggle="<%= menu_id %>"
+              data-dropdown-placement="bottom-end"
+              class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+              aria-haspopup="true"
+              aria-expanded="false">
+        <%= helpers.icon("ellipsis", css_class: "size-4") %>
+        <span class="sr-only">More options</span>
+      </button>
+      <div id="<%= menu_id %>"
+           class="z-20 hidden w-40 rounded-lg border border-slate-200 bg-white shadow-sm"
+           role="menu"
+           aria-labelledby="<%= menu_id %>-button">
+        <ul class="py-1">
+          <% unless default? %>
+            <li>
+              <%= link_to "Make default",
+                    helpers.llm_credential_default_path(credential),
+                    data: { turbo_method: :patch },
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem" %>
+            </li>
+          <% end %>
+          <li>
+            <%= link_to "Delete",
+                  helpers.llm_credential_path(credential),
+                  data: { turbo_method: :delete, turbo_confirm: DELETE_CONFIRM },
+                  class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
+                  role: "menuitem" %>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-3">
+    <div class="flex items-center gap-3 text-sm text-slate-400">
+      <% if provider_name %>
+        <span><%= provider_name %></span>
+        <span class="text-slate-300" aria-hidden="true">&bull;</span>
+      <% end %>
+      <span>Status: <%= status_label %></span>
+    </div>
+    <% if inactive? %>
+      <p class="text-sm text-red-600">This key didn't work. Open it to add a new one.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/components/llm_credential_card_component.html.erb
+++ b/app/components/llm_credential_card_component.html.erb
@@ -38,7 +38,7 @@
           <li>
             <%= link_to "Delete",
                   helpers.llm_credential_path(credential),
-                  data: { turbo_method: :delete, turbo_confirm: DELETE_CONFIRM },
+                  data: { turbo_method: :delete, turbo_confirm: "Delete this AI credential? Feeds using it will be disabled." },
                   class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
                   role: "menuitem" %>
           </li>

--- a/app/components/llm_credential_card_component.rb
+++ b/app/components/llm_credential_card_component.rb
@@ -1,6 +1,4 @@
 class LlmCredentialCardComponent < ViewComponent::Base
-  DELETE_CONFIRM = "Delete this AI credential? Feeds using it will be disabled.".freeze
-
   def initialize(credential:)
     @credential = credential
   end

--- a/app/components/llm_credential_card_component.rb
+++ b/app/components/llm_credential_card_component.rb
@@ -1,0 +1,35 @@
+class LlmCredentialCardComponent < ViewComponent::Base
+  DELETE_CONFIRM = "Delete this AI credential? Feeds using it will be disabled.".freeze
+
+  def initialize(credential:)
+    @credential = credential
+  end
+
+  private
+
+  attr_reader :credential
+
+  def credential_url
+    helpers.llm_credential_path(credential)
+  end
+
+  def provider_name
+    LlmProvider.find(credential.provider)&.display_name
+  end
+
+  def status_label
+    credential.state.to_s.capitalize
+  end
+
+  def default?
+    credential.is_default?
+  end
+
+  def inactive?
+    credential.inactive?
+  end
+
+  def menu_id
+    "llm-credential-menu-#{credential.id}"
+  end
+end

--- a/app/components/llm_credentials_list_component.rb
+++ b/app/components/llm_credentials_list_component.rb
@@ -1,66 +1,11 @@
 class LlmCredentialsListComponent < ViewComponent::Base
-  MAKE_DEFAULT_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
-  DELETE_CLASSES = "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-700 shadow-sm transition hover:bg-red-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
-  DELETE_CONFIRM = "Delete this AI credential? Feeds using it will be disabled.".freeze
-
   def initialize(credentials:)
     @credentials = credentials
   end
 
   def call
-    render(ListComponent.new) do |list|
-      @credentials.each do |credential|
-        list.with_item(ListComponent::ItemComponent.new(
-          title: credential.display_name,
-          title_url: helpers.llm_credential_path(credential),
-          badge: default_badge_for(credential),
-          metadata_segments: metadata_segments_for(credential),
-          note: inactive_note_for(credential),
-          actions: actions_for(credential),
-          key: "llm_credential.#{credential.id}"
-        ))
-      end
+    content_tag(:div, class: "space-y-4") do
+      safe_join(@credentials.map { |credential| render(LlmCredentialCardComponent.new(credential: credential)) })
     end
-  end
-
-  private
-
-  def default_badge_for(credential)
-    return unless credential.is_default?
-
-    render(BadgeComponent.new(text: "Default", color: :blue, key: "llm_credential.default-badge"))
-  end
-
-  def metadata_segments_for(credential)
-    provider_name = LlmProvider.find(credential.provider)&.display_name
-    [provider_name, "status: #{credential.state}"].compact
-  end
-
-  def inactive_note_for(credential)
-    return unless credential.inactive?
-
-    content_tag(:p, "This key didn't work. Open it to add a new one.", class: "text-sm text-red-600")
-  end
-
-  def actions_for(credential)
-    buttons = []
-    unless credential.is_default?
-      buttons << helpers.button_to(
-        "Make default",
-        helpers.llm_credential_default_path(credential),
-        method: :patch,
-        class: MAKE_DEFAULT_CLASSES,
-        data: { key: "llm_credential.make-default" }
-      )
-    end
-    buttons << helpers.button_to(
-      "Delete",
-      helpers.llm_credential_path(credential),
-      method: :delete,
-      form: { data: { turbo_confirm: DELETE_CONFIRM } },
-      class: DELETE_CLASSES,
-      data: { key: "llm_credential.delete" }
-    )
-    safe_join(buttons)
   end
 end

--- a/test/components/llm_credentials_list_component_test.rb
+++ b/test/components/llm_credentials_list_component_test.rb
@@ -49,4 +49,10 @@ class LlmCredentialsListComponentTest < ViewComponent::TestCase
 
     assert_not_includes result.text, "This key didn't work"
   end
+
+  test "#call should show capitalized status" do
+    result = render_inline(LlmCredentialsListComponent.new(credentials: [credential]))
+
+    assert_includes result.text, "Status: Active"
+  end
 end


### PR DESCRIPTION
Changes:

- Extract LLM credential card UI into a new `LlmCredentialCardComponent` with a dropdown menu for actions
- Simplify `LlmCredentialsListComponent` to render credential cards instead of using the generic `ListComponent`
- Move credential-specific logic (provider name, status label, default badge, inactive note) into the card component
- Update card styling to use a modern card layout with border, shadow, and improved spacing
- Replace button-based actions with a dropdown menu for "Make default" and "Delete" options
- Add test coverage for capitalized status display
