### PR TITLE
Fix access token error handling for auth vs transient failures

### DIFF
--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -15,9 +15,11 @@ class AccessTokenValidationService
       access_token_detail = access_token.access_token_detail || access_token.build_access_token_detail
       access_token_detail.update!(data: { user_info: user_info, managed_groups: managed_groups })
     end
-  rescue StandardError => e
-    # TBD: Use more robust approach to handle errorhere
+  rescue FreefeedClient::UnauthorizedError
     access_token.disable_token_and_feeds
+  rescue StandardError => e
+    Rails.error.report(e, context: { access_token_id: access_token.id })
+    raise
   end
 
   private

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -5,6 +5,7 @@
 class FreefeedClient
   class Error < StandardError; end
   class UnauthorizedError < Error; end
+  class InvalidTokenError < UnauthorizedError; end
   class NotFoundError < Error; end
 
   USER_AGENT = "FreeFeed-Rails-Client".freeze
@@ -165,7 +166,12 @@ class FreefeedClient
     when 200, 201
       response
     when 401, 403
-      raise UnauthorizedError, "Invalid or expired token"
+      err = (JSON.parse(response.body)["err"] rescue nil)
+      if err == "inactive or expired token"
+        raise InvalidTokenError, err
+      else
+        raise UnauthorizedError, err || "Unauthorized"
+      end
     when 404
       raise NotFoundError, "Resource not found"
     else

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -32,21 +32,21 @@ class TokenValidationJobTest < ActiveJob::TestCase
     assert access_token.inactive?
   end
 
-  test ".perform_now should mark token as inactive when HTTP error occurs" do
-    # Mock HTTP error
+  test ".perform_now should raise and not disable token on transient HTTP error" do
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .to_raise(StandardError.new("Connection failed"))
 
     assert access_token.pending?
 
-    TokenValidationJob.perform_now(access_token)
+    assert_raises(StandardError) do
+      TokenValidationJob.perform_now(access_token)
+    end
 
     access_token.reload
-    assert access_token.inactive?
+    assert access_token.validating?
   end
 
-  test ".perform_now should mark token as inactive when JSON parsing fails" do
-    # Mock response with invalid JSON
+  test ".perform_now should raise and not disable token when JSON parsing fails" do
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -58,10 +58,12 @@ class TokenValidationJobTest < ActiveJob::TestCase
 
     assert access_token.pending?
 
-    TokenValidationJob.perform_now(access_token)
+    assert_raises(FreefeedClient::Error) do
+      TokenValidationJob.perform_now(access_token)
+    end
 
     access_token.reload
-    assert access_token.inactive?
+    assert access_token.validating?
   end
 
   test ".perform_now should validate token using the token's host" do
@@ -122,8 +124,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
     assert access_token.inactive?
   end
 
-  test ".perform_now should mark token as inactive when response format is invalid" do
-    # Mock response with missing username field
+  test ".perform_now should raise and not disable token when response format is invalid" do
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -139,22 +140,26 @@ class TokenValidationJobTest < ActiveJob::TestCase
 
     assert access_token.pending?
 
-    TokenValidationJob.perform_now(access_token)
+    assert_raises(FreefeedClient::Error) do
+      TokenValidationJob.perform_now(access_token)
+    end
 
     access_token.reload
-    assert access_token.inactive?
+    assert access_token.validating?
   end
 
-  test ".perform_now should handle general exceptions in validation and broadcast errors" do
+  test ".perform_now should raise and not disable token on timeout" do
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .to_timeout
 
     assert access_token.pending?
 
-    TokenValidationJob.perform_now(access_token)
+    assert_raises(StandardError) do
+      TokenValidationJob.perform_now(access_token)
+    end
 
     access_token.reload
-    assert access_token.inactive?
+    assert access_token.validating?
   end
 
   test ".perform_later should enqueue asynchronously" do
@@ -165,8 +170,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
     end
   end
 
-  test ".perform_now should resume after failure" do
-    # First attempt fails with timeout
+  test ".perform_now should succeed on retry after transient failure" do
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .to_timeout.times(1)
       .then.to_return(
@@ -194,15 +198,14 @@ class TokenValidationJobTest < ActiveJob::TestCase
         headers: { "Content-Type" => "application/json" }
       )
 
-    # First run fails
-    TokenValidationJob.perform_now(access_token)
+    # First run raises — token stays validating
+    assert_raises(StandardError) do
+      TokenValidationJob.perform_now(access_token)
+    end
     access_token.reload
-    assert access_token.inactive?
+    assert access_token.validating?
 
-    # Reset to validating state to simulate retry
-    access_token.update!(status: :validating)
-
-    # Second run succeeds
+    # Second run (retry) succeeds
     TokenValidationJob.perform_now(access_token)
     access_token.reload
     assert access_token.active?
@@ -255,7 +258,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
       )
       .to_return(
         status: 401,
-        body: { error: "Unauthorized" }.to_json,
+        body: { err: "inactive or expired token" }.to_json,
         headers: { "Content-Type" => "application/json" }
       )
   end

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -53,7 +53,27 @@ class FreefeedClientTest < ActiveSupport::TestCase
     assert_equal "test@example.com", result[:email]
   end
 
-  test "whoami raises UnauthorizedError on 401" do
+  test "whoami raises InvalidTokenError on 401 with inactive or expired token body" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
+
+    assert_raises(FreefeedClient::InvalidTokenError) do
+      @client.whoami
+    end
+  end
+
+  test "whoami raises UnauthorizedError on 401 with malformed token body" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 401, body: { err: "invalid JWT payload format" }.to_json)
+
+    error = assert_raises(FreefeedClient::UnauthorizedError) do
+      @client.whoami
+    end
+    assert_not_kind_of FreefeedClient::InvalidTokenError, error
+    assert_equal "invalid JWT payload format", error.message
+  end
+
+  test "whoami raises UnauthorizedError on 401 with non-JSON body" do
     stub_request(:get, "#{@host}/v4/users/whoami")
       .to_return(status: 401, body: "Unauthorized")
 
@@ -64,7 +84,7 @@ class FreefeedClientTest < ActiveSupport::TestCase
 
   test "whoami raises UnauthorizedError on 403" do
     stub_request(:get, "#{@host}/v4/users/whoami")
-      .to_return(status: 403, body: "Forbidden")
+      .to_return(status: 403, body: { err: "invalid JWT payload format" }.to_json)
 
     assert_raises(FreefeedClient::UnauthorizedError) do
       @client.whoami
@@ -168,11 +188,11 @@ class FreefeedClientTest < ActiveSupport::TestCase
     assert_equal false, second_group[:is_restricted]
   end
 
-  test "managed_groups raises UnauthorizedError on 401" do
+  test "managed_groups raises InvalidTokenError on 401 with inactive or expired token body" do
     stub_request(:get, "#{@host}/v4/managedGroups")
-      .to_return(status: 401, body: "Unauthorized")
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
 
-    assert_raises(FreefeedClient::UnauthorizedError) do
+    assert_raises(FreefeedClient::InvalidTokenError) do
       @client.managed_groups
     end
   end
@@ -268,13 +288,13 @@ class FreefeedClientTest < ActiveSupport::TestCase
     assert_equal true, result
   end
 
-  test "delete_post raises UnauthorizedError on 401" do
+  test "delete_post raises InvalidTokenError on 401 with inactive or expired token body" do
     post_id = "post123"
 
     stub_request(:delete, "#{@host}/v4/posts/#{post_id}")
-      .to_return(status: 401)
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
 
-    assert_raises(FreefeedClient::UnauthorizedError) do
+    assert_raises(FreefeedClient::InvalidTokenError) do
       @client.delete_post(post_id)
     end
   end

--- a/test/services/access_token_validation_service_test.rb
+++ b/test/services/access_token_validation_service_test.rb
@@ -137,7 +137,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     assert_equal "newuser", detail.data["user_info"]["username"]
   end
 
-  test "#call should deactivate token on validation failure" do
+  test "#call should deactivate token on invalid token error" do
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -145,7 +145,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
           "Accept" => "application/json"
         }
       )
-      .to_return(status: 401, body: "Unauthorized")
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
 
     service = AccessTokenValidationService.new(access_token)
     service.call
@@ -153,7 +153,26 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     assert_equal "inactive", access_token.reload.status
   end
 
-  test "#call should disable enabled feeds on validation failure" do
+  test "#call should not disable token on transient errors" do
+    stub_request(:get, "#{access_token.host}/v4/users/whoami")
+      .with(
+        headers: {
+          "Authorization" => "Bearer #{access_token.encrypted_token}",
+          "Accept" => "application/json"
+        }
+      )
+      .to_return(status: 500, body: "Internal Server Error")
+
+    service = AccessTokenValidationService.new(access_token)
+
+    assert_raises(FreefeedClient::Error) do
+      service.call
+    end
+
+    assert_equal "validating", access_token.reload.status
+  end
+
+  test "#call should disable enabled feeds on invalid token error" do
     feed1 = create(:feed, user: user, access_token: access_token, state: :enabled)
     feed2 = create(:feed, user: user, access_token: access_token, state: :enabled)
     feed3 = create(:feed, user: user, access_token: access_token, state: :disabled)
@@ -165,7 +184,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
           "Accept" => "application/json"
         }
       )
-      .to_return(status: 500, body: "Internal Server Error")
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
 
     service = AccessTokenValidationService.new(access_token)
 
@@ -198,7 +217,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
           "Accept" => "application/json"
         }
       )
-      .to_return(status: 401, body: "Unauthorized")
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
 
     service = AccessTokenValidationService.new(access_token)
 
@@ -209,7 +228,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     assert_equal "inactive", access_token.reload.status
   end
 
-  test "#call should deactivate token when managed_groups fails" do
+  test "#call should deactivate token when managed_groups returns invalid token error" do
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -235,12 +254,11 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
           "Accept" => "application/json"
         }
       )
-      .to_return(status: 500, body: "Internal Server Error")
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
 
     service = AccessTokenValidationService.new(access_token)
     service.call
 
-    # Token should be inactive when managed_groups fails during cache_token_details
     assert_equal "inactive", access_token.reload.status
   end
 end


### PR DESCRIPTION
## Summary

- Add `FreefeedClient::InvalidTokenError` (subclass of `UnauthorizedError`) raised when the server returns `"inactive or expired token"`, distinguishing it from a malformed JWT or other 401/403 — callers and UI can surface a more specific message per case.
- Fix `AccessTokenValidationService`: previously rescued `StandardError`, so a transient network error or 5xx during validation would permanently disable a valid token and all its feeds. Now only `UnauthorizedError` triggers `disable_token_and_feeds`; other errors are reported via `Rails.error` and re-raised for job retry.

## References

- Closes #487