### PR TITLE
Refactor event log entry layout and rename to "Events Log"

### DIFF
--- a/app/components/admin/event_log_entry_component.html.erb
+++ b/app/components/admin/event_log_entry_component.html.erb
@@ -1,18 +1,21 @@
-<%= render CardComponent.new(class: "p-4") do %>
-  <div class="flex items-start justify-between gap-4" data-key="events.<%= event.id %>">
-    <div class="min-w-0 space-y-2">
-      <div class="flex flex-wrap items-center gap-2">
-        <%= render BadgeComponent.new(text: event.level.humanize, color: badge_color(event.level)) %>
-        <code class="text-sm font-semibold text-slate-800" data-key="events.type"><%= event.type %></code>
-      </div>
-      <div class="truncate text-sm text-slate-600">
-        <%= render EventDescriptionComponent.new(event: event) %>
-      </div>
-      <div class="text-sm text-slate-500"><%= safe_join([user_label, subject_label].compact, " • ") %></div>
+<div class="w-full rounded-lg border border-slate-200 bg-white shadow-xs" data-key="events.<%= event.id %>">
+  <div class="flex items-start justify-between gap-4 px-5 py-4">
+    <div class="flex min-w-0 flex-wrap items-center gap-2">
+      <%= render BadgeComponent.new(text: event.level.humanize, color: badge_color(event.level)) %>
+      <code class="text-sm font-semibold text-slate-800" data-key="events.type"><%= event.type %></code>
     </div>
     <%= link_to helpers.short_time_ago(event.created_at), href,
-                class: "shrink-0 text-sm font-medium text-slate-500 hover:text-slate-700",
+                class: "shrink-0 text-sm font-medium text-slate-400 hover:text-slate-700",
                 title: event.created_at.rfc3339,
                 data: { key: "events.timestamp" } %>
   </div>
-<% end %>
+  <div class="flex items-center gap-3 border-t border-slate-200 px-5 py-2 text-sm text-slate-500">
+    <div class="min-w-0 truncate text-slate-600">
+      <%= render EventDescriptionComponent.new(event: event) %>
+    </div>
+    <% meta = safe_join([user_label, subject_label].compact, " • ") %>
+    <% if meta.present? %>
+      <div class="shrink-0"><%= meta %></div>
+    <% end %>
+  </div>
+</div>

--- a/app/components/event_log_entry_component.html.erb
+++ b/app/components/event_log_entry_component.html.erb
@@ -1,20 +1,20 @@
-<%= render CardComponent.new(class: "p-4") do %>
-  <div class="flex items-start justify-between gap-4" data-key="events.<%= event.id %>">
-    <div class="min-w-0 space-y-2">
-      <div class="flex flex-wrap items-center gap-2">
-        <%= render BadgeComponent.new(text: event.level.humanize, color: badge_color(event.level)) %>
-        <code class="text-sm font-semibold text-slate-800" data-key="events.type"><%= event.type %></code>
-      </div>
-      <div class="truncate text-sm text-slate-600">
-        <%= render EventDescriptionComponent.new(event: event) %>
-      </div>
-      <% if (label = subject_label) %>
-        <div class="text-sm text-slate-500"><%= label %></div>
-      <% end %>
+<div class="w-full rounded-lg border border-slate-200 bg-white shadow-xs" data-key="events.<%= event.id %>">
+  <div class="flex items-start justify-between gap-4 px-5 py-4">
+    <div class="flex min-w-0 flex-wrap items-center gap-2">
+      <%= render BadgeComponent.new(text: event.level.humanize, color: badge_color(event.level)) %>
+      <code class="text-sm font-semibold text-slate-800" data-key="events.type"><%= event.type %></code>
     </div>
     <%= link_to helpers.short_time_ago(event.created_at), href,
-                class: "shrink-0 text-sm font-medium text-slate-500 hover:text-slate-700",
+                class: "shrink-0 text-sm font-medium text-slate-400 hover:text-slate-700",
                 title: event.created_at.rfc3339,
                 data: { key: "events.timestamp" } %>
   </div>
-<% end %>
+  <div class="flex items-center gap-3 border-t border-slate-200 px-5 py-2 text-sm text-slate-500">
+    <div class="min-w-0 truncate text-slate-600">
+      <%= render EventDescriptionComponent.new(event: event) %>
+    </div>
+    <% if (label = subject_label) %>
+      <span class="shrink-0"><%= label %></span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "System Events" %>
+<% content_for :title, "Events Log" %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "System Events") do |header| %>
+  <%= render PageHeaderComponent.new(title: "Events Log") do |header| %>
     <% if @filter.present? %>
       <% header.with_context_paragraph do %>
         <span class="text-sm text-slate-500" data-key="admin.events.filter-summary">

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -18,7 +18,7 @@
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("calendar", css_class: "size-5") %>
-          <span>System Events</span>
+          <span>Events Log</span>
         </h2>
         <p class="text-slate-600">View system events, logs, and activity</p>
       </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "Events" %>
+<% content_for :title, "Events Log" %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Events") do |header| %>
+  <%= render PageHeaderComponent.new(title: "Events Log") do |header| %>
     <% header.with_context_paragraph "Everything Feeder has done on your feeds, newest first." %>
     <% header.with_action_button do %>
       <%= link_to "Back to Status", status_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -36,7 +36,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     get admin_events_path
 
     assert_response :success
-    assert_select "h1", "System Events"
+    assert_select "h1", "Events Log"
     assert_select '[data-key="events.type"]', "TestEvent"
     assert_select 'a[data-key="events.user"]', "User ##{user.id}"
   end
@@ -85,7 +85,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     get admin_events_path
 
     assert_response :success
-    assert_select "h1", "System Events"
+    assert_select "h1", "Events Log"
     assert_select '[data-key="empty-state"]'
     assert_select "p", "No events to show yet"
   end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -60,7 +60,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     get events_path
 
     assert_response :success
-    assert_select "h1", "Events"
+    assert_select "h1", "Events Log"
     assert_select "#events_log"
     assert_select '[data-key="events.type"]', text: "my_event"
     assert_select '[data-key="events.type"]', text: "someone_elses", count: 0


### PR DESCRIPTION
Changes:

- Replace CardComponent wrapper with custom div structure in event log entry components for better layout control
- Reorganize event entry layout: move description and metadata to a separate bottom section with border separator
- Update timestamp link color from `text-slate-500` to `text-slate-400` for better visual hierarchy
- Rename "System Events" and "Events" page titles to "Events Log" across admin and user-facing views
- Improve metadata display in admin event entries with conditional rendering
- Update test assertions to match new page title

The refactoring provides a cleaner visual separation between event header (type, level, timestamp) and details (description, metadata), while the naming change makes the feature more approachable and consistent across the application.
