### PR TITLE
Add Dev permission for system diagnostics access

### DIFF
--- a/app/controllers/admin/system_stats_controller.rb
+++ b/app/controllers/admin/system_stats_controller.rb
@@ -1,6 +1,6 @@
 class Admin::SystemStatsController < ApplicationController
   def show
-    authorize :admin, :show?
+    authorize :admin, :dev?
     @release_info = release_info
     @disk_usage = Rails.cache.fetch("admin/system_stats/v3", expires_in: 5.minutes) do
       DiskUsageService.new.call

--- a/app/controllers/development/components_controller.rb
+++ b/app/controllers/development/components_controller.rb
@@ -1,3 +1,5 @@
 class Development::ComponentsController < ApplicationController
-  allow_unauthenticated_access
+  def show
+    authorize :admin, :dev?
+  end
 end

--- a/app/controllers/development/sent_emails_controller.rb
+++ b/app/controllers/development/sent_emails_controller.rb
@@ -1,5 +1,5 @@
 class Development::SentEmailsController < ApplicationController
-  allow_unauthenticated_access
+  before_action :authorize_dev_access
 
   def index
     @emails = email_storage.ordered_list
@@ -36,6 +36,10 @@ class Development::SentEmailsController < ApplicationController
   end
 
   private
+
+  def authorize_dev_access
+    authorize :admin, :dev?
+  end
 
   def email_storage
     @email_storage ||= EmailStorageResolver.resolve(Rails.application.config.email_storage_adapter)

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,7 +1,7 @@
 class Permission < ApplicationRecord
   belongs_to :user
 
-  AVAILABLE_PERMISSIONS = %w[admin].freeze
+  AVAILABLE_PERMISSIONS = %w[admin dev].freeze
 
   validates :name, presence: true, inclusion: { in: AVAILABLE_PERMISSIONS }
   validates :user_id, uniqueness: { scope: :name }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,6 +52,10 @@ class User < ApplicationRecord
     permission?("admin")
   end
 
+  def dev?
+    permission?("dev")
+  end
+
   def suspend!
     update!(state: :suspended, suspended_at: Time.current)
   end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -2,4 +2,8 @@ class AdminPolicy < ApplicationPolicy
   def show?
     admin?
   end
+
+  def dev?
+    user&.dev?
+  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -51,6 +51,10 @@ class ApplicationPolicy
     def admin?
       user&.permissions&.exists?(name: "admin")
     end
+
+    def dev?
+      user&.permissions&.exists?(name: "dev")
+    end
   end
 
   private
@@ -61,5 +65,9 @@ class ApplicationPolicy
 
   def admin?
     user&.permissions&.exists?(name: "admin")
+  end
+
+  def dev?
+    user&.permissions&.exists?(name: "dev")
   end
 end

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -24,27 +24,27 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: admin_system_stats_path) do %>
-      <div class="space-y-4">
-        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
-          <%= icon("hard-drive", css_class: "size-5") %>
-          <span>System Info</span>
-        </h2>
-        <p class="text-slate-600">View disk usage and other system information</p>
-      </div>
-    <% end %>
+    <% if policy(:admin).dev? %>
+      <%= render CardComponent.new(href: admin_system_stats_path) do %>
+        <div class="space-y-4">
+          <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+            <%= icon("hard-drive", css_class: "size-5") %>
+            <span>System Info</span>
+          </h2>
+          <p class="text-slate-600">View disk usage and other system information</p>
+        </div>
+      <% end %>
 
-    <%= render CardComponent.new(href: mission_control_jobs.root_path, target: "_blank", rel: "noopener noreferrer") do %>
-      <div class="space-y-4">
-        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
-          <%= icon("hard-hat", css_class: "size-5") %>
-          <span>Background Jobs</span>
-        </h2>
-        <p class="text-slate-600">Monitor and manage background job queues</p>
-      </div>
-    <% end %>
+      <%= render CardComponent.new(href: mission_control_jobs.root_path, target: "_blank", rel: "noopener noreferrer") do %>
+        <div class="space-y-4">
+          <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+            <%= icon("hard-hat", css_class: "size-5") %>
+            <span>Background Jobs</span>
+          </h2>
+          <p class="text-slate-600">Monitor and manage background job queues</p>
+        </div>
+      <% end %>
 
-    <% if Rails.configuration.x.dev_tools.enabled %>
       <%= render CardComponent.new(href: development_sent_emails_path, target: "_blank", rel: "noopener noreferrer") do %>
         <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,20 @@
 Rails.application.routes.draw do
-  if Rails.configuration.x.dev_tools.enabled
-    namespace :development do
-      resource :components, only: :show
+  namespace :development do
+    resource :components, only: :show
 
-      resources :sent_emails, only: [:index, :show], format: false do
-        collection do
-          delete :purge
-        end
+    resources :sent_emails, only: [:index, :show], format: false do
+      collection do
+        delete :purge
       end
     end
   end
 
-  mount MissionControl::Jobs::Engine, at: "/jobs"
+  constraints ->(req) {
+    session = Session.find_by(id: req.cookie_jar.signed[:session_id])
+    session&.user&.dev?
+  } do
+    mount MissionControl::Jobs::Engine, at: "/jobs"
+  end
 
   resource :session
   resource :status, only: :show, controller: "statuses"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,9 +20,10 @@ if Rails.env.development?
   User.where(password_updated_at: nil).update_all(password_updated_at: Time.current)
   puts "✅ Development user created: #{user.email_address} / #{dev_password}"
 
-  # Add admin permission to the first user
+  # Add admin and dev permissions to the first user
   user.permissions.find_or_create_by!(name: "admin")
-  puts "✅ Admin permission granted to first user"
+  user.permissions.find_or_create_by!(name: "dev")
+  puts "✅ Admin and dev permissions granted to first user"
 
   # Create fake access tokens
   if AccessToken.count == 0

--- a/test/controllers/admin/system_stats_controller_test.rb
+++ b/test/controllers/admin/system_stats_controller_test.rb
@@ -1,19 +1,15 @@
 require "test_helper"
 
 class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
-  def admin_user
-    @admin_user ||= begin
-      user = create(:user)
-      create(:permission, user: user, name: "admin")
-      user
-    end
+  def dev_user
+    @dev_user ||= create(:user, :dev)
   end
 
   def regular_user
     @regular_user ||= create(:user)
   end
 
-  test "should redirect non-admin users" do
+  test "should redirect non-dev users" do
     login_as(regular_user)
 
     get admin_system_stats_path
@@ -28,8 +24,8 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
-  test "should show system stats for admin users" do
-    login_as(admin_user)
+  test "should show system stats for dev users" do
+    login_as(dev_user)
 
     get admin_system_stats_path
 
@@ -42,7 +38,7 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
       "APP_REVISION_SHORT" => "0123456",
       "APP_DEPLOYED_AT" => "2026-05-09T12:34:56Z"
     ) do
-      login_as(admin_user)
+      login_as(dev_user)
 
       get admin_system_stats_path
     end

--- a/test/controllers/admins_controller_test.rb
+++ b/test/controllers/admins_controller_test.rb
@@ -6,11 +6,11 @@ class AdminsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def admin_user
-    @admin_user ||= begin
-      admin = create(:user)
-      create(:permission, user: admin, name: "admin")
-      admin
-    end
+    @admin_user ||= create(:user, :admin)
+  end
+
+  def admin_dev_user
+    @admin_dev_user ||= create(:user, :admin, :dev)
   end
 
   test "should show admin panel when authenticated as admin" do
@@ -21,8 +21,21 @@ class AdminsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Admin Panel"
     assert_select "a[href='#{admin_users_path}']", count: 1
     assert_select "a[href='#{admin_events_path}']", count: 1
+    assert_select "a[href='#{admin_system_stats_path}']", count: 0
+    assert_select "a[href='#{development_components_path}']", count: 0
+  end
+
+  test "should show dev cards when authenticated as admin with dev permission" do
+    sign_in_as(admin_dev_user)
+    get admin_url
+
+    assert_response :success
+    assert_select "a[href='#{admin_users_path}']", count: 1
+    assert_select "a[href='#{admin_events_path}']", count: 1
     assert_select "a[href='#{admin_system_stats_path}']", count: 1
     assert_select "a[href='#{mission_control_jobs.root_path}']", count: 1
+    assert_select "a[href='#{development_sent_emails_path}']", count: 1
+    assert_select "a[href='#{development_components_path}']", count: 1
   end
 
   test "should redirect when authenticated as regular user" do

--- a/test/controllers/development/components_controller_test.rb
+++ b/test/controllers/development/components_controller_test.rb
@@ -1,12 +1,17 @@
 require "test_helper"
 
 class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
-  test "dev tools should be enabled in the test environment" do
-    assert Rails.configuration.x.dev_tools.enabled,
-           "dev tools must be enabled so the component reference route is drawn"
+  def dev_user
+    @dev_user ||= create(:user, :dev)
+  end
+
+  def regular_user
+    @regular_user ||= create(:user)
   end
 
   test "#show should render the UI elements reference" do
+    login_as(dev_user)
+
     get development_components_path
 
     assert_response :success
@@ -17,13 +22,24 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
     assert_select '[data-key="section.event-description"]'
   end
 
-  test "#show should not require authentication" do
+  test "#show should require authentication" do
     get development_components_path
 
-    assert_response :success
+    assert_redirected_to new_session_path
+  end
+
+  test "#show should require dev permission" do
+    login_as(regular_user)
+
+    get development_components_path
+
+    assert_redirected_to root_path
+    assert_equal "Access denied. You don't have permission to perform this action.", flash[:alert]
   end
 
   test "#show should associate checkbox and radio labels with their controls" do
+    login_as(dev_user)
+
     get development_components_path
 
     # Clickable labels require a matching id/for pair (the production idiom).
@@ -36,5 +52,11 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
     # Form-group label points at its input.
     assert_select "input[type=text]#group_feed_name"
     assert_select "label[for=group_feed_name]"
+  end
+
+  private
+
+  def login_as(user)
+    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/development/sent_emails_controller_test.rb
+++ b/test/controllers/development/sent_emails_controller_test.rb
@@ -3,11 +3,34 @@ require "test_helper"
 class Development::SentEmailsControllerTest < ActionDispatch::IntegrationTest
   setup do
     email_storage.purge
-    Rails.application.reload_routes!
+    login_as(dev_user)
+  end
+
+  def dev_user
+    @dev_user ||= create(:user, :dev)
+  end
+
+  def regular_user
+    @regular_user ||= create(:user)
   end
 
   def email_storage
     EmailStorageResolver.resolve(Rails.application.config.email_storage_adapter)
+  end
+
+  test "#index should require authentication" do
+    delete session_path
+    get development_sent_emails_path
+
+    assert_redirected_to new_session_path
+  end
+
+  test "#index should require dev permission" do
+    login_as(regular_user)
+    get development_sent_emails_path
+
+    assert_redirected_to root_path
+    assert_equal "Access denied. You don't have permission to perform this action.", flash[:alert]
   end
 
   test "#index should get with no emails" do
@@ -114,6 +137,10 @@ class Development::SentEmailsControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def login_as(user)
+    post session_path, params: { email_address: user.email_address, password: "password123" }
+  end
 
   def create_test_email(uuid, subject, body)
     multipart = body.is_a?(Hash)

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -11,6 +11,12 @@ FactoryBot.define do
       end
     end
 
+    trait :dev do
+      after(:create) do |user|
+        create(:permission, user: user, name: "dev")
+      end
+    end
+
     trait :suspended do
       state { :suspended }
       suspended_at { Time.current }


### PR DESCRIPTION
Changes:

- Adds a `dev` permission alongside the existing `admin` permission
- Gates System Info, Background Jobs, UI Reference, and Sent Emails behind the `dev` permission instead of the `dev_tools` environment flag
- Development namespace routes are now drawn in all environments (including production); MissionControl::Jobs is protected by a routing constraint that checks `dev` permission
- Admin panel only shows dev tool cards to users who have the `dev` permission
- Seed user (`test@example.com`) gets both `admin` and `dev` permissions

**To grant dev permission to a user in Rails console:**

```ruby
User.find_by(email_address: "test@example.com").permissions.find_or_create_by!(name: "dev")
```
