### PR TITLE
Move post card timestamp to bottom section

### DIFF
--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -7,15 +7,16 @@
         <%= render BadgeComponent.new(text: "Withdrawn", color: :gray) %>
       <% end %>
     </div>
-
-    <div class="flex shrink-0 items-center text-sm text-slate-400">
-      <%= published_time_tag %>
-    </div>
   </div>
 
   <% if footer? %>
     <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-3">
       <div class="flex items-center gap-3 text-sm text-slate-400">
+        <% if published_time_tag %>
+          <div class="flex shrink-0 items-center">
+            <%= published_time_tag %>
+          </div>
+        <% end %>
         <% if group_label %>
           <%= link_to group_label, group_url, title: group_hint,
                 class: "transition hover:text-slate-600" %>

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -65,7 +65,7 @@ class PostCardComponent < ViewComponent::Base
   end
 
   def footer?
-    group_label.present? || attachment_count > 0 || comment_count > 0 || source_url || freefeed_url || withdraw_allowed?
+    published_time_tag || group_label.present? || attachment_count > 0 || comment_count > 0 || source_url || freefeed_url || withdraw_allowed?
   end
 
   def menu_id


### PR DESCRIPTION
Moves the published timestamp from the top section of the post card to the bottom section, as the leftmost item before the group name. This makes the layout consistent with how other metadata (group, attachments, links) is presented in the footer row.
