### PR TITLE
Polish post detail page and feed form UI

### DIFF
--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -49,11 +49,7 @@ class PostCardComponent < ViewComponent::Base
   end
 
   def freefeed_url
-    feed = post.feed
-    access_token = feed&.access_token
-    return unless feed && access_token && feed.target_group.present? && post.freefeed_post_id.present?
-
-    "#{access_token.host}/#{feed.target_group}/#{post.freefeed_post_id}"
+    post.freefeed_url
   end
 
   def withdraw_allowed?

--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -117,7 +117,8 @@ class PostDetailsComponent < ViewComponent::Base
   end
 
   def add_freefeed_post_id_item(component)
-    value = if (url = freefeed_post_url)
+    url = freefeed_post_url
+    value = if url
       helpers.link_to(url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center gap-1") do
         safe_join([
           content_tag(:code, @post.freefeed_post_id, class: "text-sm"),

--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -117,7 +117,7 @@ class PostDetailsComponent < ViewComponent::Base
   end
 
   def add_freefeed_post_id_item(component)
-    url = freefeed_post_url
+    url = @post.freefeed_url
     value = if url
       helpers.link_to(url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center gap-1") do
         safe_join([
@@ -134,13 +134,5 @@ class PostDetailsComponent < ViewComponent::Base
       value: value,
       key: "post.freefeed_post_id"
     ))
-  end
-
-  def freefeed_post_url
-    feed = @post.feed
-    token = feed&.access_token
-    return unless token && feed.target_group.present?
-
-    "#{token.host}/#{feed.target_group}/#{@post.freefeed_post_id}"
   end
 end

--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -117,10 +117,29 @@ class PostDetailsComponent < ViewComponent::Base
   end
 
   def add_freefeed_post_id_item(component)
+    value = if (url = freefeed_post_url)
+      helpers.link_to(url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center gap-1") do
+        safe_join([
+          content_tag(:code, @post.freefeed_post_id, class: "text-sm"),
+          helpers.icon("external-link", css_class: "size-3")
+        ])
+      end
+    else
+      content_tag(:code, @post.freefeed_post_id, class: "text-sm")
+    end
+
     component.with_item(ListComponent::StatItemComponent.new(
       label: "FreeFeed Post ID",
-      value: content_tag(:code, @post.freefeed_post_id, class: "text-sm"),
+      value: value,
       key: "post.freefeed_post_id"
     ))
+  end
+
+  def freefeed_post_url
+    feed = @post.feed
+    token = feed&.access_token
+    return unless token && feed.target_group.present?
+
+    "#{token.host}/#{feed.target_group}/#{@post.freefeed_post_id}"
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -39,6 +39,13 @@ class Post < ApplicationRecord
     withdrawn: 5
   }
 
+  def freefeed_url
+    token = feed&.access_token
+    return unless token && feed.target_group.present? && freefeed_post_id.present?
+
+    "#{token.host}/#{feed.target_group}/#{freefeed_post_id}"
+  end
+
   def normalized_attributes
     as_json(only: NORMALIZED_ATTRIBUTES)
   end

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -156,7 +156,7 @@
           </div>
           <div class="ml-3">
             <%= label_tag "enable_feed", "Enable feed", class: "block font-semibold text-slate-800 mb-0" %>
-            <p class="text-sm text-slate-500">Enabled feeds will automatically check for new posts and publish them to FreeFeed.</p>
+            <p class="text-sm text-slate-500">Start checking for new posts and publish them to FreeFeed.</p>
           </div>
         </div>
       </div>

--- a/app/views/feeds/_target_group_selector.html.erb
+++ b/app/views/feeds/_target_group_selector.html.erb
@@ -8,7 +8,7 @@
                      class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
                      required: true %>
       <p class="text-sm text-slate-500">
-        The FreeFeed group where posts will be published. Groups are like channels or communities.
+        The FreeFeed group where posts will be published.
       </p>
       <p class="text-sm text-slate-500">
         Need a new group?

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -19,7 +19,7 @@
       <% header.with_action_button do %>
         <%= button_to "Withdraw", post_path(@post),
                       method: :delete,
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50", "bg-red-600 hover:bg-red-500"),
+                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-red-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
                       data: {
                         turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here."
                       },

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -129,6 +129,25 @@ class PostTest < ActiveSupport::TestCase
     assert_equal ["error1"], post.validation_errors
   end
 
+  test "#freefeed_url should return the full URL when all parts are present" do
+    post = create(:post, :published, feed: feed, freefeed_post_id: "abc123")
+
+    assert_equal "#{feed.access_token.host}/testgroup/abc123", post.freefeed_url
+  end
+
+  test "#freefeed_url should return nil when freefeed_post_id is blank" do
+    post = create(:post, :published, feed: feed, freefeed_post_id: nil)
+
+    assert_nil post.freefeed_url
+  end
+
+  test "#freefeed_url should return nil when target_group is blank" do
+    feed_no_group = create(:feed, target_group: "")
+    post = create(:post, :published, feed: feed_no_group, freefeed_post_id: "abc123")
+
+    assert_nil post.freefeed_url
+  end
+
   test "should allow nil freefeed_post_id" do
     post = build(:post, freefeed_post_id: nil)
     assert post.valid?


### PR DESCRIPTION
Small UI improvements across the post detail page and feed form:

- Withdraw button on `/posts/:id` is now secondary style (border, red text) instead of a primary red button
- FreeFeed Post ID in post details links to the actual post on FreeFeed
- Removed "Groups are like channels or communities." from the group selector — redundant for anyone who knows FreeFeed
- Simplified the "Enable feed" description to "Start checking for new posts and publish them to FreeFeed."
