### PR TITLE
Refactor access tokens list to use card component

### DIFF
--- a/app/components/access_token_card_component.html.erb
+++ b/app/components/access_token_card_component.html.erb
@@ -1,0 +1,56 @@
+<div id="<%= helpers.dom_id(access_token) %>"
+     class="w-full rounded-lg border border-slate-200 bg-white shadow-xs"
+     data-key="settings.access_tokens.<%= access_token.id %>">
+  <div class="flex items-start justify-between gap-4 px-5 py-4">
+    <div class="flex min-w-0 items-center gap-2">
+      <%= link_to access_token.name, token_url,
+            class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
+    </div>
+
+    <div class="relative">
+      <button type="button"
+              id="<%= menu_id %>-button"
+              data-dropdown-toggle="<%= menu_id %>"
+              data-dropdown-placement="bottom-end"
+              class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+              aria-haspopup="true"
+              aria-expanded="false">
+        <%= helpers.icon("ellipsis", css_class: "size-4") %>
+        <span class="sr-only">More options</span>
+      </button>
+      <div id="<%= menu_id %>"
+           class="z-20 hidden w-40 rounded-lg border border-slate-200 bg-white shadow-sm"
+           role="menu"
+           aria-labelledby="<%= menu_id %>-button">
+        <ul class="py-1">
+          <li>
+            <%= link_to "Edit", edit_url,
+                  class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                  role: "menuitem" %>
+          </li>
+          <li>
+            <%= link_to "Delete", "#",
+                  class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
+                  role: "menuitem",
+                  data: { controller: "modal-trigger", modal_trigger_modal_id_value: delete_modal_id, action: "click->modal-trigger#open" } %>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-3">
+    <div class="flex items-center gap-3 text-sm text-slate-400">
+      <span><%= owner_label %></span>
+      <span class="text-slate-300" aria-hidden="true">&bull;</span>
+      <span>Created <%= helpers.short_time_ago(access_token.created_at) %></span>
+      <span class="text-slate-300" aria-hidden="true">&bull;</span>
+      <% if access_token.last_used_at %>
+        <span>Used <%= helpers.short_time_ago(access_token.last_used_at) %></span>
+      <% else %>
+        <span>Never used</span>
+      <% end %>
+    </div>
+    <span class="text-sm text-slate-400"><%= status_label %></span>
+  </div>
+</div>

--- a/app/components/access_token_card_component.rb
+++ b/app/components/access_token_card_component.rb
@@ -1,0 +1,37 @@
+class AccessTokenCardComponent < ViewComponent::Base
+  def initialize(access_token:)
+    @access_token = access_token
+  end
+
+  private
+
+  attr_reader :access_token
+
+  def token_url
+    helpers.access_token_path(access_token)
+  end
+
+  def edit_url
+    helpers.edit_access_token_path(access_token)
+  end
+
+  def menu_id
+    "access-token-menu-#{access_token.id}"
+  end
+
+  def delete_modal_id
+    "delete-token-modal-#{access_token.id}"
+  end
+
+  def owner_label
+    if access_token.owner.present?
+      "#{access_token.owner}@#{access_token.host_domain}"
+    else
+      access_token.host_domain
+    end
+  end
+
+  def status_label
+    access_token.status.capitalize
+  end
+end

--- a/app/components/access_tokens_list_component.rb
+++ b/app/components/access_tokens_list_component.rb
@@ -4,27 +4,10 @@ class AccessTokensListComponent < ViewComponent::Base
   end
 
   def call
-    render(ListComponent.new) do |list|
-      @access_tokens.each do |access_token|
-        list.with_item(ListComponent::ItemComponent.new(
-          title: access_token.name,
-          title_url: helpers.access_token_path(access_token),
-          metadata_segments: metadata_segments_for(access_token),
-          key: "settings.access_tokens.#{access_token.id}"
-        ))
-      end
-    end
-  end
+    return "" if @access_tokens.empty?
 
-  private
-
-  def metadata_segments_for(access_token)
-    owner = if access_token.owner.present?
-      "#{access_token.owner}@#{access_token.host_domain}"
-    else
-      "Host: #{access_token.host_domain}"
+    content_tag(:div, class: "space-y-4") do
+      safe_join(@access_tokens.map { |at| render(AccessTokenCardComponent.new(access_token: at)) })
     end
-    used = access_token.last_used_at ? helpers.short_time_ago(access_token.last_used_at) : "Never"
-    [owner, "Created: #{helpers.short_time_ago(access_token.created_at)}", "Used: #{used}"]
   end
 end

--- a/test/components/access_token_card_component_test.rb
+++ b/test/components/access_token_card_component_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+require "view_component/test_case"
+
+class AccessTokenCardComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def access_token
+    @access_token ||= create(:access_token, :active, user: user)
+  end
+
+  test "#call should render the token name as a link to the show page" do
+    result = render_inline(AccessTokenCardComponent.new(access_token: access_token))
+    link = result.css("a[href*='/access_tokens/#{access_token.id}']").first
+
+    assert_not_nil link
+    assert_equal access_token.name, link.text.strip
+  end
+
+  test "#call should render the Edit menu item linking to the edit page" do
+    result = render_inline(AccessTokenCardComponent.new(access_token: access_token))
+    edit_link = result.css("a[href*='/access_tokens/#{access_token.id}/edit']").first
+
+    assert_not_nil edit_link
+    assert_equal "Edit", edit_link.text.strip
+  end
+
+  test "#call should render the Delete menu item with modal trigger" do
+    result = render_inline(AccessTokenCardComponent.new(access_token: access_token))
+    delete_link = result.css("a[data-controller='modal-trigger']").first
+
+    assert_not_nil delete_link
+    assert_equal "Delete", delete_link.text.strip
+    assert_equal "delete-token-modal-#{access_token.id}", delete_link["data-modal-trigger-modal-id-value"]
+  end
+
+  test "#call should display owner and host domain" do
+    result = render_inline(AccessTokenCardComponent.new(access_token: access_token))
+
+    assert_includes result.text, "#{access_token.owner}@#{access_token.host_domain}"
+  end
+
+  test "#call should display host domain when owner is blank" do
+    token = create(:access_token, user: user, owner: nil)
+    result = render_inline(AccessTokenCardComponent.new(access_token: token))
+
+    assert_includes result.text, token.host_domain
+    assert_not_includes result.text, "@"
+  end
+
+  test "#call should show 'Never used' when last_used_at is nil" do
+    result = render_inline(AccessTokenCardComponent.new(access_token: access_token))
+
+    assert_includes result.text, "Never used"
+  end
+
+  test "#call should show last used time when available" do
+    token = create(:access_token, :active, :recently_used, user: user)
+    result = render_inline(AccessTokenCardComponent.new(access_token: token))
+
+    assert_includes result.text, "Used"
+    assert_not_includes result.text, "Never used"
+  end
+
+  test "#call should display the token status" do
+    result = render_inline(AccessTokenCardComponent.new(access_token: access_token))
+
+    assert_includes result.text, "Active"
+  end
+
+  test "#call should set data-key attribute" do
+    result = render_inline(AccessTokenCardComponent.new(access_token: access_token))
+
+    assert_not_nil result.css("[data-key='settings.access_tokens.#{access_token.id}']").first
+  end
+end

--- a/test/components/access_tokens_list_component_test.rb
+++ b/test/components/access_tokens_list_component_test.rb
@@ -10,7 +10,7 @@ class AccessTokensListComponentTest < ViewComponent::TestCase
     @access_token ||= create(:access_token, :active, user: user, name: "My Token")
   end
 
-  test "#call should render each token as a list item" do
+  test "#call should render each token as a card" do
     result = render_inline(AccessTokensListComponent.new(access_tokens: [access_token]))
 
     assert_not_nil result.css("[data-key='settings.access_tokens.#{access_token.id}']").first
@@ -18,10 +18,9 @@ class AccessTokensListComponentTest < ViewComponent::TestCase
 
   test "#call should link to the token show page" do
     result = render_inline(AccessTokensListComponent.new(access_tokens: [access_token]))
-    link = result.css("a").first
+    link = result.css("a[href*='/access_tokens/#{access_token.id}']").first
 
     assert_not_nil link
-    assert_includes link["href"], "/access_tokens/#{access_token.id}"
   end
 
   test "#call should show owner and host in metadata when owner is present" do
@@ -30,22 +29,22 @@ class AccessTokensListComponentTest < ViewComponent::TestCase
     assert_includes result.text, "#{access_token.owner}@#{access_token.host_domain}"
   end
 
-  test "#call should fall back to host-only metadata when owner is blank" do
+  test "#call should fall back to host domain when owner is blank" do
     token = create(:access_token, user: user, owner: nil)
     result = render_inline(AccessTokensListComponent.new(access_tokens: [token]))
 
-    assert_includes result.text, "Host: #{token.host_domain}"
+    assert_includes result.text, token.host_domain
   end
 
-  test "#call should show Never for tokens that were never used" do
+  test "#call should show 'Never used' for tokens that were never used" do
     result = render_inline(AccessTokensListComponent.new(access_tokens: [access_token]))
 
-    assert_includes result.text, "Used: Never"
+    assert_includes result.text, "Never used"
   end
 
   test "#call should render nothing for an empty collection" do
     result = render_inline(AccessTokensListComponent.new(access_tokens: []))
 
-    assert_empty result.css("ul")
+    assert_empty result.css("div")
   end
 end

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -41,11 +41,11 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
 
   test "#index should display host when token owner is not set" do
     sign_in_as user
-    create(:access_token, user: user, owner: nil)
+    token = create(:access_token, user: user, owner: nil)
     get access_tokens_path
 
     assert_response :success
-    assert_match(/Host:/, response.body)
+    assert_match(token.host_domain, response.body)
   end
 
   test "#show should redirect to sign in form" do


### PR DESCRIPTION
Changes:

- Create `AccessTokenCardComponent` to display individual access tokens as styled cards with edit/delete actions
- Update `AccessTokensListComponent` to render tokens using the new card component instead of the generic list component
- Add comprehensive test coverage for the new card component
- Update existing list component tests to reflect the new card-based layout

The new card component provides a more polished presentation with:
- Token name as a clickable link to the detail page
- Dropdown menu with Edit and Delete actions
- Owner and host domain information
- Creation date and last usage timestamp
- Token status badge
- Improved visual hierarchy and spacing

All existing tests pass with updated selectors for the new card structure.
