### PR TITLE
Document PR description structure and add References section

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "attribution": {
+    "pr": ""
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,7 @@ Changes:
 - Change 1
 - Change 2
 - ...
+
+References:
+
+- Closes #...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,4 @@ Changes:
 - Change 2
 - ...
 
-References:
-
-- Closes #...
+<!-- Add "References:" section with related issues/PRs only if applicable, e.g. "Closes #123". Remove this section otherwise. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,8 @@ Structure:
 - `References:` section at the bottom listing related issues/PRs (e.g. `Closes #123`); omit entirely if there are none
 - Do **not** include session links or any `https://claude.ai/...` URLs
 
+After creating a PR, check the body for any harness-injected session URLs (e.g. `https://claude.ai/code/session_...`) and remove them by updating the PR.
+
 ## Tooling Notes
 
 - Use mise for managing Ruby and Node runtimes (local dev).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ is usually enough.
 Structure:
 - `Changes:` bullet list at the top describing what was done
 - Optional prose paragraph explaining the rationale
-- `References:` section at the bottom listing related issues/PRs (e.g. `Closes #123`)
+- `References:` section at the bottom listing related issues/PRs (e.g. `Closes #123`); omit entirely if there are none
 - Do **not** include session links or any `https://claude.ai/...` URLs
 
 ## Tooling Notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,12 @@ change accomplishes and why. Don't enumerate every technical detail in
 the diff; reviewers can read the diff. A few bullets or a short paragraph
 is usually enough.
 
+Structure:
+- `Changes:` bullet list at the top describing what was done
+- Optional prose paragraph explaining the rationale
+- `References:` section at the bottom listing related issues/PRs (e.g. `Closes #123`)
+- Do **not** include session links or any `https://claude.ai/...` URLs
+
 ## Tooling Notes
 
 - Use mise for managing Ruby and Node runtimes (local dev).


### PR DESCRIPTION
Changes:

- Added structured guidance for PR descriptions in CLAUDE.md with recommended sections (Changes, optional prose, References)
- Updated `.github/pull_request_template.md` to include References section for linking related issues/PRs, with a note to omit it when unused
- Added `.claude/settings.json` configuration to disable PR attribution footer
- Clarified that session links and Claude.ai URLs should not be included in PR descriptions