### PR TITLE
Create events when a feed is enabled or disabled

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -48,6 +48,7 @@ class Feed < ApplicationRecord
   PREVIEW_FRESHNESS_WINDOW = 60.minutes
 
   after_update :create_schedule_on_enable
+  after_update :create_state_change_event
 
   validates :name, uniqueness: { scope: :user_id }, length: { maximum: NAME_MAX_LENGTH }
   validates :name, presence: true, if: :enabled?
@@ -323,5 +324,19 @@ class Feed < ApplicationRecord
     return if feed_schedule.present?
 
     reset_schedule!
+  end
+
+  def create_state_change_event
+    return unless saved_change_to_state?
+
+    type = if enabled?
+      "feed_enabled"
+    elsif disabled?
+      "feed_disabled"
+    end
+
+    return unless type
+
+    Event.create!(type: type, level: :info, subject: self, user: user, message: "")
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,12 @@ en:
   hello: "Hello world"
 
   events:
+    feed_enabled:
+      name: "Feed enabled"
+      description_html: "Feed %{subject_link} was enabled"
+    feed_disabled:
+      name: "Feed disabled"
+      description_html: "Feed %{subject_link} was disabled"
     feed_refresh:
       name: "Feed refreshed"
       description_html: "Feed %{subject_link} refreshed successfully"

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -761,4 +761,46 @@ class FeedTest < ActiveSupport::TestCase
     assert_predicate feed.reload, :draft?
     assert_not_empty feed.errors
   end
+
+  test "#create_state_change_event should create feed_enabled event when feed is enabled" do
+    feed = create(:feed, :disabled)
+
+    assert_difference("Event.where(type: 'feed_enabled').count", 1) do
+      feed.update!(state: :enabled)
+    end
+
+    event = Event.where(type: "feed_enabled").last
+    assert_equal feed, event.subject
+    assert_equal feed.user, event.user
+    assert_equal "info", event.level
+  end
+
+  test "#create_state_change_event should create feed_disabled event when feed is disabled" do
+    feed = create(:feed, :enabled)
+
+    assert_difference("Event.where(type: 'feed_disabled').count", 1) do
+      feed.update!(state: :disabled)
+    end
+
+    event = Event.where(type: "feed_disabled").last
+    assert_equal feed, event.subject
+    assert_equal feed.user, event.user
+    assert_equal "info", event.level
+  end
+
+  test "#create_state_change_event should not create event when state is unchanged" do
+    feed = create(:feed, :disabled)
+
+    assert_no_difference("Event.count") do
+      feed.update!(name: "new-name")
+    end
+  end
+
+  test "#create_state_change_event should not create event when transitioning to draft" do
+    feed = create(:feed, :disabled)
+
+    assert_no_difference("Event.count") do
+      feed.update!(state: :draft)
+    end
+  end
 end


### PR DESCRIPTION
## Changes

- Add `after_update` callback on `Feed` that creates a `feed_enabled` or `feed_disabled` event whenever the feed state transitions to enabled or disabled
- Add I18n descriptions for the two new event types
- Add tests covering enable, disable, no-op updates, and draft transitions
