### PR TITLE
Redesign feed preview card metadata as key-value rows

### DIFF
--- a/app/components/post_preview_component.html.erb
+++ b/app/components/post_preview_component.html.erb
@@ -1,28 +1,36 @@
 <%= render(CardComponent.new(id: card_id)) do |card| %>
-  <% if metadata_segments.any? || source_url %>
-    <% card.with_section(class: "px-6 py-4") do %>
-      <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-slate-600">
-        <% metadata_segments.each_with_index do |segment, index| %>
-          <% if index.positive? %>
-            <span aria-hidden="true" class="text-slate-300">•</span>
-          <% end %>
-          <span><%= segment %></span>
-        <% end %>
-        <% if source_url %>
-          <% if metadata_segments.any? %>
-            <span aria-hidden="true" class="text-slate-300">•</span>
-          <% end %>
-          <%= link_to source_url, target: "_blank", rel: "noopener", class: "inline-flex items-center gap-1 font-medium text-sky-600 transition hover:text-sky-500" do %>
-            <span class="underline underline-offset-4">View source</span>
-            <%= helpers.icon("external-link", css_class: "size-3.5", aria_label: "Opens in a new window") %>
-          <% end %>
-        <% end %>
+  <% if uid %>
+    <% card.with_section(class: "px-4 py-2") do %>
+      <div class="flex items-center gap-3 text-xs">
+        <span class="w-20 shrink-0 text-slate-500">UID:</span>
+        <span class="min-w-0 truncate text-slate-900" title="<%= uid %>"><%= uid %></span>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% if published_at %>
+    <% card.with_section(class: "px-4 py-2") do %>
+      <div class="flex items-center gap-3 text-xs">
+        <span class="w-20 shrink-0 text-slate-500">Published:</span>
+        <time datetime="<%= published_at.iso8601 %>" title="<%= published_at %>"><%= published_compact %></time>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% if source_url %>
+    <% card.with_section(class: "px-4 py-2") do %>
+      <div class="flex items-center gap-3 text-xs">
+        <span class="w-20 shrink-0 text-slate-500">URL:</span>
+        <span class="min-w-0 truncate">
+          <%= link_to source_url, source_url, target: "_blank", rel: "noopener",
+                class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
+        </span>
       </div>
     <% end %>
   <% end %>
 
   <% if formatted_content || attachments? %>
-    <% card.with_section do %>
+    <% card.with_section(class: "p-4") do %>
       <div class="space-y-4">
         <% if formatted_content %>
           <%= formatted_content %>

--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -4,6 +4,10 @@ class PostPreviewComponent < ViewComponent::Base
     @index = index
   end
 
+  def uid
+    post_data["uid"].presence
+  end
+
   def source_url
     post_data["source_url"].presence
   end
@@ -18,15 +22,22 @@ class PostPreviewComponent < ViewComponent::Base
     end
   end
 
-  def metadata_segments
-    [].tap do |segments|
-      segments << "UID: #{post_data["uid"]}" if post_data["uid"].present?
+  def published_compact
+    return unless published_at
 
-      if published_at
-        segments << "Published #{helpers.time_ago_in_words(published_at)} ago"
-      end
-
-      segments << "Attachments: #{valid_attachments.size}" if valid_attachments.any?
+    diff = (Time.zone.now - published_at).abs.to_i
+    if diff < 60
+      "#{diff}s"
+    elsif diff < 3_600
+      "#{diff / 60}m"
+    elsif diff < 86_400
+      "#{diff / 3_600}h"
+    elsif diff < 604_800
+      "#{diff / 86_400}d"
+    elsif diff < 2_592_000
+      "#{diff / 604_800}w"
+    else
+      helpers.l(published_at.to_date)
     end
   end
 

--- a/test/components/post_preview_component_test.rb
+++ b/test/components/post_preview_component_test.rb
@@ -22,22 +22,34 @@ class PostPreviewComponentTest < ViewComponent::TestCase
 
     card = result.at_css("#feed-preview-post-1")
     assert_not_nil card
-    assert_includes card.text, "UID: post-123"
-    assert_includes card.text, "Published about 1 hour ago"
-    assert_includes card.text, "Attachments: 1"
+    assert_includes card.text, "UID:"
+    assert_includes card.text, "post-123"
+    assert_includes card.text, "Published:"
+    assert_includes card.text, "1h"
+    assert_includes card.text, "URL:"
     assert_includes card.text, "Hello world"
 
-    source_link = card.css("a").find { |link| link.text.include?("View source") }
+    source_link = card.css("a").find { |link| link["href"] == "https://example.com/post/123" }
     assert_not_nil source_link
-    assert_not_nil source_link.at_css("svg"), "expected an external-link icon in the source link"
   end
 
-  test "omits the attachments count when there are none" do
+  test "omits metadata rows when fields are absent" do
+    post_data = { "content" => "Body" }
+
+    result = render_inline(PostPreviewComponent.new(post_data: post_data))
+
+    refute_includes result.text, "UID:"
+    refute_includes result.text, "Published:"
+    refute_includes result.text, "URL:"
+  end
+
+  test "omits attachments section when not present" do
     post_data = { "content" => "Body", "uid" => "post-1" }
 
     result = render_inline(PostPreviewComponent.new(post_data: post_data))
 
     refute_includes result.text, "Attachments"
+    assert_includes result.text, "Body"
   end
 
   test "renders content without a synthesized title heading" do
@@ -54,16 +66,23 @@ class PostPreviewComponentTest < ViewComponent::TestCase
 
     Rails.logger.stub(:warn, nil) do
       result = render_inline(PostPreviewComponent.new(post_data: post_data))
-      refute_includes result.text, "Published"
+      refute_includes result.text, "Published:"
     end
   end
 
-  test "omits attachments section when not present" do
-    post_data = { "content" => "Text only" }
+  test "#published_compact should return compact duration for recent times" do
+    component = PostPreviewComponent.new(post_data: { "published_at" => 7.hours.ago.iso8601 })
+    assert_equal "7h", component.published_compact
 
-    result = render_inline(PostPreviewComponent.new(post_data: post_data))
+    component = PostPreviewComponent.new(post_data: { "published_at" => 45.minutes.ago.iso8601 })
+    assert_equal "45m", component.published_compact
 
-    refute_includes result.text, "Attachments"
-    assert_includes result.text, "Text only"
+    component = PostPreviewComponent.new(post_data: { "published_at" => 3.days.ago.iso8601 })
+    assert_equal "3d", component.published_compact
+  end
+
+  test "#published_compact should return nil when published_at is absent" do
+    component = PostPreviewComponent.new(post_data: {})
+    assert_nil component.published_compact
   end
 end


### PR DESCRIPTION
## Changes

- Each metadata field (UID, Published, URL) now renders in its own card section with `px-4 py-2` padding
- Published time uses a compact format (e.g. `7h`) instead of "about 7 hours ago"
- Body section padding changed to `p-4`
- Removed the inline attachments count from the metadata area (attachments are still listed in the body section)

The metadata area now reads as a clean key-value table rather than a cramped inline list, making it easier to scan individual fields at a glance.
