### PR TITLE
Feed card: dropdown actions and status badges

### DIFF
--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -3,21 +3,40 @@
     <div class="flex min-w-0 items-center gap-2">
       <%= link_to title, feed_url,
             class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
-      <% if draft? %>
-        <%= render BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge") %>
-      <% end %>
+      <%= render status_badge %>
     </div>
 
     <% if draft? %>
-      <div class="flex shrink-0 items-center gap-2">
-        <%= link_to "Continue setup", helpers.edit_feed_path(feed),
-              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1",
-              data: { key: "feed.#{feed.id}.continue_setup" } %>
-        <%= button_to "Discard", helpers.feed_path(feed),
-              method: :delete,
-              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
-              data: { key: "feed.#{feed.id}.discard" },
-              form: { data: { turbo_confirm: DISCARD_CONFIRM } } %>
+      <div class="relative shrink-0">
+        <button type="button"
+                id="<%= menu_id %>-button"
+                data-dropdown-toggle="<%= menu_id %>"
+                data-dropdown-placement="bottom-end"
+                class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+                aria-haspopup="true"
+                aria-expanded="false">
+          <%= helpers.icon("ellipsis", css_class: "size-4") %>
+          <span class="sr-only">More options</span>
+        </button>
+        <div id="<%= menu_id %>"
+             class="z-20 hidden w-44 rounded-lg border border-slate-200 bg-white shadow-sm"
+             role="menu"
+             aria-labelledby="<%= menu_id %>-button">
+          <ul class="py-1">
+            <li>
+              <%= link_to "Continue setup", helpers.edit_feed_path(feed),
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem",
+                    data: { key: "feed.#{feed.id}.continue_setup" } %>
+            </li>
+            <li>
+              <%= link_to "Discard", helpers.feed_path(feed),
+                    class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
+                    role: "menuitem",
+                    data: { key: "feed.#{feed.id}.discard", turbo_method: :delete, turbo_confirm: DISCARD_CONFIRM } %>
+            </li>
+          </ul>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/components/feed_card_component.rb
+++ b/app/components/feed_card_component.rb
@@ -21,6 +21,18 @@ class FeedCardComponent < ViewComponent::Base
     feed.draft?
   end
 
+  def status_badge
+    case feed.state.to_sym
+    when :draft    then BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge")
+    when :disabled then BadgeComponent.new(text: "Disabled", color: :yellow, key: "feed.#{feed.id}.disabled_badge")
+    when :enabled  then BadgeComponent.new(text: "Active", color: :green, key: "feed.#{feed.id}.enabled_badge")
+    end
+  end
+
+  def menu_id
+    "feed-menu-#{feed.id}"
+  end
+
   def target_group_label
     "@#{feed.target_group}" if feed.target_group.present?
   end

--- a/test/components/feed_card_component_test.rb
+++ b/test/components/feed_card_component_test.rb
@@ -33,10 +33,21 @@ class FeedCardComponentTest < ViewComponent::TestCase
     assert_equal "Draft", badge.text.strip
   end
 
-  test "#render should not show Draft badge for non-draft feeds" do
+  test "#render should show Disabled badge for disabled feeds" do
     result = render_inline FeedCardComponent.new(feed: feed)
 
-    assert_empty result.css("[data-key='feed.#{feed.id}.draft_badge']")
+    badge = result.css("[data-key='feed.#{feed.id}.disabled_badge']").first
+    assert_not_nil badge
+    assert_equal "Disabled", badge.text.strip
+  end
+
+  test "#render should show Active badge for enabled feeds" do
+    enabled_feed = create(:feed, :enabled, user: user)
+    result = render_inline FeedCardComponent.new(feed: enabled_feed)
+
+    badge = result.css("[data-key='feed.#{enabled_feed.id}.enabled_badge']").first
+    assert_not_nil badge
+    assert_equal "Active", badge.text.strip
   end
 
   test "#render should show @group label when target_group present" do
@@ -45,7 +56,7 @@ class FeedCardComponentTest < ViewComponent::TestCase
     assert_includes result.text, "@testgroup"
   end
 
-  test "#render should show Continue setup and Discard for draft feeds" do
+  test "#render should show Continue setup and Discard in dropdown for draft feeds" do
     draft_feed = create(:feed, :draft, user: user)
 
     with_request_url("/feeds") do

--- a/test/components/feeds_list_component_test.rb
+++ b/test/components/feeds_list_component_test.rb
@@ -71,17 +71,13 @@ class FeedsListComponentTest < ViewComponent::TestCase
       assert_equal "Continue setup", continue_link.text.strip
       assert_equal Rails.application.routes.url_helpers.edit_feed_path(feed), continue_link["href"]
 
-      discard_button = result.css(%([data-key="feed.#{feed.id}.discard"])).first
-      assert_not_nil discard_button, "Expected Discard button"
-      assert_equal "Discard", discard_button.text.strip
-
-      discard_form = discard_button.ancestors("form").first
-      assert_not_nil discard_form, "Expected Discard button to be inside a form"
-      assert_equal Rails.application.routes.url_helpers.feed_path(feed), discard_form["action"]
+      discard_link = result.css(%([data-key="feed.#{feed.id}.discard"])).first
+      assert_not_nil discard_link, "Expected Discard link"
+      assert_equal "Discard", discard_link.text.strip
+      assert_equal Rails.application.routes.url_helpers.feed_path(feed), discard_link["href"]
+      assert_equal "delete", discard_link["data-turbo-method"]
       assert_equal "Discard this draft? No data will be lost since it hasn't been activated.",
-                   discard_form["data-turbo-confirm"]
-      assert_equal "post", discard_form["method"]
-      assert_equal "delete", discard_form.css("input[name='_method']").first&.[]("value")
+                   discard_link["data-turbo-confirm"]
     end
   end
 


### PR DESCRIPTION
Changes:

- Draft feed actions (Continue setup, Discard) moved from inline buttons to an ellipsis dropdown menu, consistent with the posts index page
- Feed cards now show a status badge for every state: "Draft" (gray), "Disabled" (yellow), "Active" (green)
