### PR TITLE
Extract enclosure image URL to dedicated field

### DIFF
--- a/app/services/normalizer/rss_normalizer.rb
+++ b/app/services/normalizer/rss_normalizer.rb
@@ -53,8 +53,8 @@ module Normalizer
     end
 
     def image_urls
-      url = raw_data.dig("image")
-      url.present? ? [url] : []
+      enclosures = raw_data.dig("enclosures") || []
+      enclosures.filter_map { |e| e["url"] if e["type"].nil? || e["type"].start_with?("image/") }
     end
 
     def content_images

--- a/app/services/normalizer/rss_normalizer.rb
+++ b/app/services/normalizer/rss_normalizer.rb
@@ -53,8 +53,8 @@ module Normalizer
     end
 
     def image_urls
-      enclosures = raw_data.dig("enclosures") || []
-      enclosures.filter_map { |e| e["url"] if e["type"]&.start_with?("image/") }
+      url = raw_data.dig("image")
+      url.present? ? [url] : []
     end
 
     def content_images

--- a/app/services/processor/rss_processor.rb
+++ b/app/services/processor/rss_processor.rb
@@ -34,7 +34,7 @@ module Processor
         "updated" => entry.updated&.rfc3339,
         "author" => entry.author,
         "categories" => entry.categories,
-        "enclosures" => entry.try(:enclosures) || []
+        "image" => entry.try(:image)
       }
     end
   end

--- a/app/services/processor/rss_processor.rb
+++ b/app/services/processor/rss_processor.rb
@@ -34,8 +34,16 @@ module Processor
         "updated" => entry.updated&.rfc3339,
         "author" => entry.author,
         "categories" => entry.categories,
-        "image" => entry.try(:image)
+        "enclosures" => extract_enclosures(entry)
       }
+    end
+
+    def extract_enclosures(entry)
+      [
+        *entry.try(:rss_enclosures),
+        *entry.try(:media_thumbnails),
+        *entry.try(:media_contents)
+      ].compact.map { |e| { "url" => e.url, "type" => e.type } }
     end
   end
 end

--- a/config/initializers/feedjira.rb
+++ b/config/initializers/feedjira.rb
@@ -1,0 +1,15 @@
+# Extends Feedjira's RSS entry parser to collect enclosures and media elements
+# as typed arrays rather than the built-in single-value :image attribute.
+class FeedEnclosure
+  include SAXMachine
+
+  attribute :url
+  attribute :type
+  attribute :length
+end
+
+Feedjira::Parser::RSSEntry.class_eval do
+  elements :enclosure,          as: :rss_enclosures,   class: FeedEnclosure
+  elements :"media:content",    as: :media_contents,   class: FeedEnclosure
+  elements :"media:thumbnail",  as: :media_thumbnails, class: FeedEnclosure
+end

--- a/test/fixtures/files/feeds/rss/entries.json
+++ b/test/fixtures/files/feeds/rss/entries.json
@@ -16,7 +16,7 @@
       "categories": [
         "Technology"
       ],
-      "enclosures": []
+      "image": null
     }
   },
   {
@@ -37,7 +37,7 @@
         "News",
         "Technology"
       ],
-      "enclosures": []
+      "image": null
     }
   },
   {
@@ -55,7 +55,7 @@
       "updated": null,
       "author": null,
       "categories": [],
-      "enclosures": []
+      "image": null
     }
   }
 ]

--- a/test/fixtures/files/feeds/rss/entries.json
+++ b/test/fixtures/files/feeds/rss/entries.json
@@ -16,7 +16,7 @@
       "categories": [
         "Technology"
       ],
-      "image": null
+      "enclosures": []
     }
   },
   {
@@ -37,7 +37,7 @@
         "News",
         "Technology"
       ],
-      "image": null
+      "enclosures": []
     }
   },
   {
@@ -55,7 +55,7 @@
       "updated": null,
       "author": null,
       "categories": [],
-      "image": null
+      "enclosures": []
     }
   }
 ]

--- a/test/fixtures/files/feeds/rss/feed_with_images.xml
+++ b/test/fixtures/files/feeds/rss/feed_with_images.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Sample Image Feed</title>
+    <description>A feed with various image reference types</description>
+    <link>https://example.com</link>
+
+    <!-- RSS standard: single enclosure (e.g. NASA Image of the Day style) -->
+    <item>
+      <title>Spiral Galaxy Close-Up</title>
+      <link>https://example.com/image-detail/spiral-galaxy/</link>
+      <description>A detailed observation of a nearby spiral galaxy showing its structure.</description>
+      <enclosure url="https://example.com/uploads/2024/09/spiral-galaxy.jpg" length="1865009" type="image/jpeg" />
+      <guid isPermaLink="false">https://example.com/image-detail/spiral-galaxy/</guid>
+      <pubDate>Thu, 12 Sep 2024 14:00:00 GMT</pubDate>
+    </item>
+
+    <!-- Media RSS: single thumbnail (no type attribute) -->
+    <item>
+      <title>Nebula Formation</title>
+      <link>https://example.com/image-detail/nebula-formation/</link>
+      <description>A stunning view of a nebula in the process of star formation.</description>
+      <media:thumbnail url="https://example.com/uploads/2024/09/nebula-thumb.jpg" />
+      <guid isPermaLink="false">https://example.com/image-detail/nebula-formation/</guid>
+      <pubDate>Wed, 11 Sep 2024 14:00:00 GMT</pubDate>
+    </item>
+
+    <!-- Media RSS: multiple media:content elements including non-image types -->
+    <item>
+      <title>Planetary Surface</title>
+      <link>https://example.com/image-detail/planetary-surface/</link>
+      <description>High resolution imagery of a planetary surface captured by an orbiter.</description>
+      <media:content url="https://example.com/uploads/2024/09/surface-full.jpg" type="image/jpeg" />
+      <media:content url="https://example.com/uploads/2024/09/surface-thumb.jpg" type="image/jpeg" />
+      <media:content url="https://example.com/uploads/2024/09/surface-timelapse.mp4" type="video/mp4" />
+      <guid isPermaLink="false">https://example.com/image-detail/planetary-surface/</guid>
+      <pubDate>Tue, 10 Sep 2024 14:00:00 GMT</pubDate>
+    </item>
+
+    <!-- No image references -->
+    <item>
+      <title>Mission Update</title>
+      <link>https://example.com/updates/mission-update/</link>
+      <description>Latest news on the ongoing exploration mission.</description>
+      <guid isPermaLink="false">https://example.com/updates/mission-update/</guid>
+      <pubDate>Mon, 09 Sep 2024 14:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/test/services/normalizer/rss_normalizer_test.rb
+++ b/test/services/normalizer/rss_normalizer_test.rb
@@ -20,6 +20,20 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
     assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
   end
 
+  test "#normalize should include enclosure image in attachment_urls" do
+    entry = create(:feed_entry, raw_data: {
+      "summary" => "Photo of the day.",
+      "link" => "https://example.com/photo",
+      "image" => "https://example.com/photo.jpg"
+    })
+
+    normalizer = Normalizer::RssNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal ["https://example.com/photo.jpg"], post.attachment_urls
+    assert_equal "enqueued", post.status
+  end
+
   test "#normalize should accept post with URL even when text content is blank" do
     entry = create(:feed_entry, raw_data: {
       "title" => "",

--- a/test/services/normalizer/rss_normalizer_test.rb
+++ b/test/services/normalizer/rss_normalizer_test.rb
@@ -20,11 +20,11 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
     assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
   end
 
-  test "#normalize should include enclosure image in attachment_urls" do
+  test "#normalize should include RSS enclosure image in attachment_urls" do
     entry = create(:feed_entry, raw_data: {
       "summary" => "Photo of the day.",
       "link" => "https://example.com/photo",
-      "image" => "https://example.com/photo.jpg"
+      "enclosures" => [{ "url" => "https://example.com/photo.jpg", "type" => "image/jpeg" }]
     })
 
     normalizer = Normalizer::RssNormalizer.new(entry)
@@ -32,6 +32,39 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
 
     assert_equal ["https://example.com/photo.jpg"], post.attachment_urls
     assert_equal "enqueued", post.status
+  end
+
+  test "#normalize should include media:thumbnail with nil type in attachment_urls" do
+    entry = create(:feed_entry, raw_data: {
+      "summary" => "Photo of the day.",
+      "link" => "https://example.com/photo",
+      "enclosures" => [{ "url" => "https://example.com/thumb.jpg", "type" => nil }]
+    })
+
+    normalizer = Normalizer::RssNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal ["https://example.com/thumb.jpg"], post.attachment_urls
+  end
+
+  test "#normalize should exclude non-image media:content from attachment_urls" do
+    entry = create(:feed_entry, raw_data: {
+      "summary" => "Article with mixed media.",
+      "link" => "https://example.com/article",
+      "enclosures" => [
+        { "url" => "https://example.com/image.jpg", "type" => "image/jpeg" },
+        { "url" => "https://example.com/image-thumb.jpg", "type" => "image/jpeg" },
+        { "url" => "https://example.com/video.mp4", "type" => "video/mp4" }
+      ]
+    })
+
+    normalizer = Normalizer::RssNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal [
+      "https://example.com/image.jpg",
+      "https://example.com/image-thumb.jpg"
+    ], post.attachment_urls
   end
 
   test "#normalize should accept post with URL even when text content is blank" do

--- a/test/services/processor/rss_processor_test.rb
+++ b/test/services/processor/rss_processor_test.rb
@@ -51,6 +51,30 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
     assert_equal [], entries
   end
 
+  test "#process should capture enclosure image URL" do
+    rss_with_enclosure = <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Photo Feed</title>
+          <item>
+            <title>Photo of the Day</title>
+            <link>https://example.com/photo</link>
+            <guid>https://example.com/photo</guid>
+            <pubDate>Thu, 12 Sep 2024 09:00:00 +0000</pubDate>
+            <enclosure url="https://example.com/photo.jpg" length="12345" type="image/jpeg" />
+          </item>
+        </channel>
+      </rss>
+    RSS
+
+    processor = Processor::RssProcessor.new(feed, rss_with_enclosure)
+    entries = processor.process
+
+    assert_equal 1, entries.length
+    assert_equal "https://example.com/photo.jpg", entries.first.raw_data["image"]
+  end
+
   test "#process should handle entries without id or url" do
     minimal_rss = <<~RSS
       <?xml version="1.0" encoding="UTF-8"?>

--- a/test/services/processor/rss_processor_test.rb
+++ b/test/services/processor/rss_processor_test.rb
@@ -51,28 +51,39 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
     assert_equal [], entries
   end
 
-  test "#process should capture enclosure image URL" do
-    rss_with_enclosure = <<~RSS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0">
-        <channel>
-          <title>Photo Feed</title>
-          <item>
-            <title>Photo of the Day</title>
-            <link>https://example.com/photo</link>
-            <guid>https://example.com/photo</guid>
-            <pubDate>Thu, 12 Sep 2024 09:00:00 +0000</pubDate>
-            <enclosure url="https://example.com/photo.jpg" length="12345" type="image/jpeg" />
-          </item>
-        </channel>
-      </rss>
-    RSS
+  def image_feed_content
+    @image_feed_content ||= file_fixture("feeds/rss/feed_with_images.xml").read
+  end
 
-    processor = Processor::RssProcessor.new(feed, rss_with_enclosure)
-    entries = processor.process
+  test "#process should extract RSS enclosure as typed enclosure" do
+    entries = Processor::RssProcessor.new(feed, image_feed_content).process
 
-    assert_equal 1, entries.length
-    assert_equal "https://example.com/photo.jpg", entries.first.raw_data["image"]
+    enclosures = entries.find { |e| e.raw_data["title"] == "Spiral Galaxy Close-Up" }.raw_data["enclosures"]
+    assert_equal [{ "url" => "https://example.com/uploads/2024/09/spiral-galaxy.jpg", "type" => "image/jpeg" }], enclosures
+  end
+
+  test "#process should extract media:thumbnail with nil type" do
+    entries = Processor::RssProcessor.new(feed, image_feed_content).process
+
+    enclosures = entries.find { |e| e.raw_data["title"] == "Nebula Formation" }.raw_data["enclosures"]
+    assert_equal [{ "url" => "https://example.com/uploads/2024/09/nebula-thumb.jpg", "type" => nil }], enclosures
+  end
+
+  test "#process should extract all media:content elements including non-image types" do
+    entries = Processor::RssProcessor.new(feed, image_feed_content).process
+
+    enclosures = entries.find { |e| e.raw_data["title"] == "Planetary Surface" }.raw_data["enclosures"]
+    assert_equal 3, enclosures.length
+    assert_includes enclosures, { "url" => "https://example.com/uploads/2024/09/surface-full.jpg", "type" => "image/jpeg" }
+    assert_includes enclosures, { "url" => "https://example.com/uploads/2024/09/surface-thumb.jpg", "type" => "image/jpeg" }
+    assert_includes enclosures, { "url" => "https://example.com/uploads/2024/09/surface-timelapse.mp4", "type" => "video/mp4" }
+  end
+
+  test "#process should store empty enclosures for entries with no media" do
+    entries = Processor::RssProcessor.new(feed, image_feed_content).process
+
+    enclosures = entries.find { |e| e.raw_data["title"] == "Mission Update" }.raw_data["enclosures"]
+    assert_equal [], enclosures
   end
 
   test "#process should handle entries without id or url" do


### PR DESCRIPTION
Changes:

- Modified RSS processor to extract enclosure image URL into a dedicated `image` field instead of storing full enclosure objects
- Updated RSS normalizer to read image URL from the new `image` field and include it in `attachment_urls`
- Updated test fixtures to reflect the new field structure
- Added test coverage for enclosure image extraction and normalization

This simplifies how image attachments are handled in RSS feeds by storing just the image URL directly rather than maintaining a full enclosure array. The normalizer now has a cleaner interface for accessing image data.
