### PR TITLE
Replace AI Provider display with disabled text field

### DIFF
--- a/app/views/llm_credentials/edit.html.erb
+++ b/app/views/llm_credentials/edit.html.erb
@@ -19,8 +19,11 @@
 
       <div class="space-y-10">
         <div class="space-y-2">
-          <p class="block font-semibold text-slate-800">AI Provider</p>
-          <p class="text-slate-700"><%= LlmProvider.find(@llm_credential.provider).display_name %></p>
+          <%= label_tag "llm_credential_provider", "AI Provider", class: "block font-semibold text-slate-800" %>
+          <%= text_field_tag "llm_credential_provider",
+                             LlmProvider.find(@llm_credential.provider).display_name,
+                             disabled: true,
+                             class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed" %>
         </div>
 
         <div class="space-y-2">


### PR DESCRIPTION
Changes:

- Replace static text display of AI Provider with a disabled text field that shows the provider name
- Apply consistent form styling to the AI Provider field using the same classes as other form inputs
- Use semantic form helpers (`label_tag` and `text_field_tag`) instead of plain HTML elements

This change makes the AI Provider field visually consistent with other form fields on the page while maintaining its read-only nature through the `disabled` attribute.
