### PR TITLE
Add admin permissions management UI and controller

### DIFF
--- a/app/controllers/admin/permissions_controller.rb
+++ b/app/controllers/admin/permissions_controller.rb
@@ -1,0 +1,47 @@
+class Admin::PermissionsController < ApplicationController
+  def update
+    authorize User, :manage_permissions?
+    user = User.find(params[:user_id])
+
+    error = nil
+    User.transaction do
+      if removing_admin?(user) && only_admin?
+        error = "Cannot remove the admin permission from the only admin user."
+        raise ActiveRecord::Rollback
+      end
+      sync_permissions(user)
+    end
+
+    if error
+      redirect_to admin_user_path(user), alert: error
+    else
+      redirect_to admin_user_path(user), notice: "Permissions updated."
+    end
+  end
+
+  private
+
+  def permitted_names
+    params.fetch(:permissions, []).intersection(Permission::AVAILABLE_PERMISSIONS)
+  end
+
+  def removing_admin?(user)
+    user.admin? && !permitted_names.include?(Permission::ADMIN)
+  end
+
+  def only_admin?
+    User.joins(:permissions)
+      .where(permissions: { name: Permission::ADMIN })
+      .lock
+      .pluck(:id)
+      .size == 1
+  end
+
+  def sync_permissions(user)
+    current_names = user.permissions.pluck(:name)
+    to_add = permitted_names - current_names
+    to_remove = current_names - permitted_names
+    user.permissions.where(name: to_remove).destroy_all
+    to_add.each { |name| user.permissions.create!(name: name) }
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -42,9 +42,10 @@ class Admin::UsersController < ApplicationController
   end
 
   def show
-    @user = User.includes(:feeds, :access_tokens, :sessions, :created_invites).find(params[:id])
+    @user = User.includes(:feeds, :access_tokens, :sessions, :created_invites, :permissions).find(params[:id])
     authorize @user
     @stats = UserStats.new(@user)
+    @last_admin = @user.admin? && User.joins(:permissions).where(permissions: { name: Permission::ADMIN }).count == 1
   end
 
   private

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -6,6 +6,11 @@ class Permission < ApplicationRecord
 
   AVAILABLE_PERMISSIONS = [ADMIN, DEV].freeze
 
+  LABELS = {
+    ADMIN => { name: "Admin", description: "Full admin panel access and user management." },
+    DEV   => { name: "Dev", description: "Developer tools and experimental features." }
+  }.freeze
+
   validates :name, presence: true, inclusion: { in: AVAILABLE_PERMISSIONS }
   validates :user_id, uniqueness: { scope: :name }
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -31,6 +31,10 @@ class UserPolicy < ApplicationPolicy
     admin?
   end
 
+  def manage_permissions?
+    admin?
+  end
+
   private
 
   def self_or_admin?

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -9,6 +9,33 @@
 
   <%= render Admin::UserDetailsComponent.new(user: @user, stats: @stats) %>
 
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Permissions</h2>
+    <%= form_with url: admin_user_permissions_path(@user), method: :patch do |f| %>
+      <div class="space-y-3 mb-6">
+        <% Permission::AVAILABLE_PERMISSIONS.each do |perm| %>
+          <% label = Permission::LABELS[perm] %>
+          <% disabled = perm == Permission::ADMIN && @last_admin %>
+          <div class="flex items-start gap-3">
+            <div class="flex h-6 items-center">
+              <%= check_box_tag "permissions[]", perm,
+                @user.permission?(perm),
+                id: "permission_#{perm}",
+                disabled: disabled,
+                class: "h-4 w-4 rounded border-slate-300 text-sky-600 focus:ring-sky-500 disabled:opacity-50 disabled:cursor-not-allowed",
+                data: { key: "permissions.#{perm}" } %>
+            </div>
+            <div class="text-sm leading-6">
+              <%= label_tag "permission_#{perm}", label[:name], class: "font-semibold text-slate-800" %>
+              <p class="text-slate-500"><%= label[:description] %></p>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      <%= f.submit "Save permissions", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+    <% end %>
+  </section>
+
   <% if @user.email_deactivated? %>
     <section class="space-y-4">
       <h2 class="text-2xl font-semibold mb-3 text-slate-900">Email Status</h2>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -18,6 +18,9 @@
           <% disabled = perm == Permission::ADMIN && @last_admin %>
           <div class="flex items-start gap-3">
             <div class="flex h-6 items-center">
+              <% if disabled %>
+                <%= hidden_field_tag "permissions[]", perm %>
+              <% end %>
               <%= check_box_tag "permissions[]", perm,
                 @user.permission?(perm),
                 id: "permission_#{perm}",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users, only: [:index, :show] do
+      resource :permissions, only: :update
       resource :email_update, only: [:edit, :update]
       resource :password_reset, only: :create
       resource :suspension, only: [:create, :destroy]

--- a/test/controllers/admin/permissions_controller_test.rb
+++ b/test/controllers/admin/permissions_controller_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class Admin::PermissionsControllerTest < ActionDispatch::IntegrationTest
+  def admin_user
+    @admin_user ||= create(:user, :admin)
+  end
+
+  def target_user
+    @target_user ||= create(:user)
+  end
+
+  test "#update should require authentication" do
+    patch admin_user_permissions_path(target_user), params: { permissions: [] }
+
+    assert_redirected_to new_session_path
+  end
+
+  test "#update should require admin permission" do
+    sign_in_as create(:user)
+
+    patch admin_user_permissions_path(target_user), params: { permissions: [] }
+
+    assert_redirected_to root_path
+    assert_equal "Access denied. You don't have permission to perform this action.", flash[:alert]
+  end
+
+  test "#update should add a permission" do
+    sign_in_as admin_user
+    assert_not target_user.permission?(Permission::DEV)
+
+    patch admin_user_permissions_path(target_user), params: { permissions: [Permission::DEV] }
+
+    assert_redirected_to admin_user_path(target_user)
+    assert_equal "Permissions updated.", flash[:notice]
+    assert target_user.reload.permission?(Permission::DEV)
+  end
+
+  test "#update should remove a permission" do
+    sign_in_as admin_user
+    create(:permission, user: target_user, name: Permission::DEV)
+
+    patch admin_user_permissions_path(target_user), params: { permissions: [] }
+
+    assert_redirected_to admin_user_path(target_user)
+    assert_not target_user.reload.permission?(Permission::DEV)
+  end
+
+  test "#update should add multiple permissions at once" do
+    sign_in_as admin_user
+
+    patch admin_user_permissions_path(target_user), params: { permissions: [Permission::ADMIN, Permission::DEV] }
+
+    assert_redirected_to admin_user_path(target_user)
+    target_user.reload
+    assert target_user.permission?(Permission::ADMIN)
+    assert target_user.permission?(Permission::DEV)
+  end
+
+  test "#update should ignore unknown permission names" do
+    sign_in_as admin_user
+
+    patch admin_user_permissions_path(target_user), params: { permissions: ["superuser", Permission::DEV] }
+
+    assert_redirected_to admin_user_path(target_user)
+    target_user.reload
+    assert target_user.permission?(Permission::DEV)
+    assert_not target_user.permission?("superuser")
+  end
+
+  test "#update should prevent removing admin from the only admin user" do
+    # Remove the fixture admin permission so admin_user is the sole admin
+    permissions(:admin_permission).destroy
+    sign_in_as admin_user
+
+    patch admin_user_permissions_path(admin_user), params: { permissions: [] }
+
+    assert_redirected_to admin_user_path(admin_user)
+    assert_equal "Cannot remove the admin permission from the only admin user.", flash[:alert]
+    assert admin_user.reload.permission?(Permission::ADMIN)
+  end
+
+  test "#update should allow removing admin when multiple admins exist" do
+    sign_in_as admin_user
+    second_admin = create(:user, :admin)
+
+    patch admin_user_permissions_path(second_admin), params: { permissions: [] }
+
+    assert_redirected_to admin_user_path(second_admin)
+    assert_equal "Permissions updated.", flash[:notice]
+    assert_not second_admin.reload.permission?(Permission::ADMIN)
+  end
+
+  test "show page should display disabled admin checkbox for the only admin" do
+    permissions(:admin_permission).destroy
+    sign_in_as admin_user
+
+    get admin_user_path(admin_user)
+
+    assert_response :success
+    assert_select "input[data-key='permissions.admin'][disabled]"
+  end
+
+  test "show page should display enabled admin checkbox when multiple admins exist" do
+    second_admin = create(:user, :admin)
+    sign_in_as admin_user
+
+    get admin_user_path(second_admin)
+
+    assert_response :success
+    assert_select "input[data-key='permissions.admin']:not([disabled])"
+  end
+
+  test "show page should display enabled admin checkbox for non-admin user" do
+    sign_in_as admin_user
+
+    get admin_user_path(target_user)
+
+    assert_response :success
+    assert_select "input[data-key='permissions.admin']:not([disabled])"
+  end
+end

--- a/test/controllers/admin/permissions_controller_test.rb
+++ b/test/controllers/admin/permissions_controller_test.rb
@@ -79,6 +79,17 @@ class Admin::PermissionsControllerTest < ActionDispatch::IntegrationTest
     assert admin_user.reload.permission?(Permission::ADMIN)
   end
 
+  test "#update should succeed when only admin submits form with admin permission included" do
+    permissions(:admin_permission).destroy
+    sign_in_as admin_user
+
+    patch admin_user_permissions_path(admin_user), params: { permissions: [Permission::ADMIN] }
+
+    assert_redirected_to admin_user_path(admin_user)
+    assert_equal "Permissions updated.", flash[:notice]
+    assert admin_user.reload.permission?(Permission::ADMIN)
+  end
+
   test "#update should allow removing admin when multiple admins exist" do
     sign_in_as admin_user
     second_admin = create(:user, :admin)


### PR DESCRIPTION
Changes:

- Add `Admin::PermissionsController` to handle permission updates with authorization checks
- Prevent removing admin permission from the only admin user via transaction rollback
- Filter unknown permission names and sync only valid permissions
- Add permissions section to admin user show page with checkboxes for each available permission
- Disable admin checkbox when user is the sole admin to prevent accidental lockout
- Add `manage_permissions?` policy method requiring admin role
- Include permissions in user show page query and calculate `@last_admin` flag
- Add `LABELS` constant to `Permission` model with user-friendly names and descriptions
- Add comprehensive test coverage for all permission update scenarios and UI states

The permissions management feature allows admins to grant or revoke permissions (Admin, Dev) for users through the admin panel. The implementation includes safeguards to prevent removing admin access from the only admin user, with the UI reflecting this constraint by disabling the admin checkbox in that scenario.
