### PR TITLE
Add Telegram and X/Twitter feed profiles

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -163,6 +163,26 @@ class FeedProfile
       title_extractor: "TitleExtractor::RssTitleExtractor",
       output_schema: nil
     },
+    "telegram" => {
+      display_name: "Telegram",
+      description: "Posts from a public Telegram channel, images included",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::TelegramProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "minLength" => 2 }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::TelegramLoader", config: {} },
+      processor: { class: "Processor::TelegramProcessor", config: {} },
+      normalizer: { class: "Normalizer::TelegramNormalizer", config: {} },
+      title_extractor: "TitleExtractor::TelegramTitleExtractor",
+      output_schema: nil
+    },
     "llm_web_search" => {
       display_name: "AI search",
       description: "Uses AI to follow an account, handle, or search topic as an evergreen subscription",

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -183,6 +183,26 @@ class FeedProfile
       title_extractor: "TitleExtractor::TelegramTitleExtractor",
       output_schema: nil
     },
+    "twitter" => {
+      display_name: "X / Twitter",
+      description: "Posts from a public X (Twitter) account",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::TwitterProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "minLength" => 2 }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::TwitterLoader", config: {} },
+      processor: { class: "Processor::TwitterProcessor", config: {} },
+      normalizer: { class: "Normalizer::TwitterNormalizer", config: {} },
+      title_extractor: "TitleExtractor::TwitterTitleExtractor",
+      output_schema: nil
+    },
     "llm_web_search" => {
       display_name: "AI search",
       description: "Uses AI to follow an account, handle, or search topic as an evergreen subscription",

--- a/app/services/loader/telegram_loader.rb
+++ b/app/services/loader/telegram_loader.rb
@@ -1,0 +1,49 @@
+module Loader
+  # Fetches a public Telegram channel's web preview at t.me/s/<channel>.
+  #
+  # Telegram renders recent channel posts — text and photos — as plain HTML
+  # on this preview page, with no API key or login. We reuse it instead of
+  # the MTProto API, which keeps the integration simple and free; the trade-off
+  # is that channels which disabled their public web preview return no posts.
+  #
+  # Accepts the channel as a full URL (https://t.me/durov, https://t.me/s/durov),
+  # a short form (t.me/durov), an @handle, or a bare username.
+  class TelegramLoader < Base
+    PREVIEW_BASE = "https://t.me/s".freeze
+    HOSTS = %w[t.me telegram.me www.t.me].freeze
+    USERNAME = /\A[A-Za-z0-9_]{2,64}\z/
+    DEFAULT_MAX_REDIRECTS = 3
+
+    # t.me serves the lightweight preview markup to ordinary desktop browsers.
+    USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " \
+                 "(KHTML, like Gecko) Chrome/124.0 Safari/537.36".freeze
+
+    def load
+      name = channel_name
+      raise StandardError, "Could not determine Telegram channel from #{feed.url.inspect}" unless name.match?(USERNAME)
+
+      response = http_client.get("#{PREVIEW_BASE}/#{name}", headers: { "User-Agent" => USER_AGENT })
+      raise StandardError, "HTTP #{response.status}" unless response.success?
+
+      response.body
+    rescue HttpClient::Error => e
+      raise StandardError, e.message
+    end
+
+    private
+
+    def channel_name
+      raw = feed.url.to_s.strip.sub(/\A@/, "").sub(%r{\Ahttps?://}i, "")
+      parts = raw.split("/").reject(&:empty?)
+      parts.shift if parts.first && HOSTS.include?(parts.first.downcase)
+      parts.shift if parts.first&.casecmp?("s")
+      parts.first.to_s
+    end
+
+    def http_client
+      @http_client ||= options.fetch(:http_client) do
+        HttpClient.build(max_redirects: options.fetch(:max_redirects, DEFAULT_MAX_REDIRECTS))
+      end
+    end
+  end
+end

--- a/app/services/loader/telegram_loader.rb
+++ b/app/services/loader/telegram_loader.rb
@@ -6,8 +6,9 @@ module Loader
   # the MTProto API, which keeps the integration simple and free; the trade-off
   # is that channels which disabled their public web preview return no posts.
   #
-  # Accepts the channel as a full URL (https://t.me/durov, https://t.me/s/durov),
-  # a short form (t.me/durov), an @handle, or a bare username.
+  # Accepts the channel as a full URL (https://t.me/examplechannel,
+  # https://t.me/s/examplechannel), a short form (t.me/examplechannel), an
+  # @handle, or a bare username.
   class TelegramLoader < Base
     PREVIEW_BASE = "https://t.me/s".freeze
     HOSTS = %w[t.me telegram.me www.t.me].freeze

--- a/app/services/loader/twitter_loader.rb
+++ b/app/services/loader/twitter_loader.rb
@@ -1,0 +1,50 @@
+module Loader
+  # Fetches a public X/Twitter timeline through the syndication endpoint
+  # (syndication.twitter.com/srv/timeline-profile/screen-name/<handle>) — the
+  # same server-rendered feed that powers embeddable timelines. It needs no API
+  # key or login and returns recent tweets as JSON inside the page.
+  #
+  # This is the most robust no-auth path available, but it is an unofficial
+  # endpoint: it only exposes a short window of recent tweets, omits protected
+  # accounts, and X may change or gate it at any time. Accepts a twitter.com /
+  # x.com profile URL, an @handle, or a bare handle.
+  class TwitterLoader < Base
+    SYNDICATION_BASE = "https://syndication.twitter.com/srv/timeline-profile/screen-name".freeze
+    HOSTS = %w[twitter.com www.twitter.com mobile.twitter.com x.com www.x.com].freeze
+    HANDLE = /\A[A-Za-z0-9_]{1,15}\z/
+    DEFAULT_MAX_REDIRECTS = 3
+
+    USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " \
+                 "(KHTML, like Gecko) Chrome/124.0 Safari/537.36".freeze
+
+    def load
+      handle = screen_name
+      raise StandardError, "Could not determine X/Twitter handle from #{feed.url.inspect}" unless handle.match?(HANDLE)
+
+      response = http_client.get(
+        "#{SYNDICATION_BASE}/#{handle}",
+        headers: { "User-Agent" => USER_AGENT, "Accept" => "text/html" }
+      )
+      raise StandardError, "HTTP #{response.status}" unless response.success?
+
+      response.body
+    rescue HttpClient::Error => e
+      raise StandardError, e.message
+    end
+
+    private
+
+    def screen_name
+      raw = feed.url.to_s.strip.sub(/\A@/, "").sub(%r{\Ahttps?://}i, "")
+      parts = raw.split("/").reject(&:empty?)
+      parts.shift if parts.first && HOSTS.include?(parts.first.downcase)
+      parts.first.to_s
+    end
+
+    def http_client
+      @http_client ||= options.fetch(:http_client) do
+        HttpClient.build(max_redirects: options.fetch(:max_redirects, DEFAULT_MAX_REDIRECTS))
+      end
+    end
+  end
+end

--- a/app/services/normalizer/telegram_normalizer.rb
+++ b/app/services/normalizer/telegram_normalizer.rb
@@ -1,0 +1,25 @@
+module Normalizer
+  # Maps a parsed Telegram message into a Post. The message text becomes the
+  # content (with the t.me permalink appended, like the other profiles), and
+  # channel photos / video thumbnails become attachments.
+  class TelegramNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      html = raw_data["text_html"].to_s
+      return "" if html.blank?
+
+      fragment = Nokogiri::HTML::DocumentFragment.parse(html)
+      fragment.css("br").each { |br| br.replace("\n") }
+      fragment.text.strip
+    end
+
+    def normalize_attachment_urls
+      Array(raw_data["images"]).uniq
+    end
+
+    def original_url
+      @original_url ||= raw_data["url"].to_s
+    end
+  end
+end

--- a/app/services/normalizer/twitter_normalizer.rb
+++ b/app/services/normalizer/twitter_normalizer.rb
@@ -1,0 +1,20 @@
+module Normalizer
+  # Maps a parsed tweet into a Post: the tweet text becomes the content (with
+  # the tweet permalink appended, like the other profiles) and any photos or
+  # video thumbnails become attachments.
+  class TwitterNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      raw_data["text"].to_s
+    end
+
+    def normalize_attachment_urls
+      Array(raw_data["images"]).uniq
+    end
+
+    def original_url
+      @original_url ||= raw_data["url"].to_s
+    end
+  end
+end

--- a/app/services/processor/telegram_processor.rb
+++ b/app/services/processor/telegram_processor.rb
@@ -1,0 +1,68 @@
+module Processor
+  # Turns the t.me/s/<channel> HTML preview into one FeedEntry per message.
+  #
+  # Each message lives in a `.tgme_widget_message_wrap` block carrying a stable
+  # `data-post` id ("channel/123"), a permalink, an ISO-8601 timestamp, optional
+  # text, and photos/video thumbnails exposed as CSS `background-image` URLs.
+  # Service messages without a `data-post` id are skipped.
+  class TelegramProcessor < Base
+    MESSAGE_SELECTOR = "div.tgme_widget_message_wrap".freeze
+    IMAGE_SELECTOR = [
+      ".tgme_widget_message_photo_wrap",
+      ".tgme_widget_message_video_thumb",
+      ".tgme_widget_message_roundvideo_thumb"
+    ].join(", ").freeze
+    BACKGROUND_IMAGE = /background-image:\s*url\(['"]?(.*?)['"]?\)/i
+
+    def process
+      document.css(MESSAGE_SELECTOR).filter_map { |wrap| build_entry(wrap) }
+    end
+
+    private
+
+    def document
+      Nokogiri::HTML.parse(raw_data, nil, "UTF-8")
+    end
+
+    def build_entry(wrap)
+      message = wrap.at_css(".tgme_widget_message")
+      uid = message&.[]("data-post").presence
+      return nil unless uid
+
+      # The publish-date <time datetime> sits inside the message footer; video
+      # posts also carry a <time class="message_video_duration"> with no
+      # datetime, so select the dated one explicitly rather than the first.
+      published_at = parse_time(wrap.at_css("time[datetime]")&.[]("datetime"))
+      return nil unless published_at
+
+      FeedEntry.new(
+        feed: feed,
+        uid: uid,
+        published_at: published_at,
+        status: :pending,
+        raw_data: {
+          "uid" => uid,
+          "url" => message_url(wrap, uid),
+          "text_html" => wrap.at_css(".tgme_widget_message_text")&.inner_html.to_s,
+          "images" => image_urls(wrap)
+        }
+      )
+    end
+
+    def message_url(wrap, uid)
+      wrap.at_css(".tgme_widget_message_date")&.[]("href").presence || "https://t.me/#{uid}"
+    end
+
+    def image_urls(wrap)
+      wrap.css(IMAGE_SELECTOR).filter_map { |el| el["style"]&.[](BACKGROUND_IMAGE, 1) }.uniq
+    end
+
+    def parse_time(value)
+      return nil if value.blank?
+
+      Time.zone.parse(value)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/services/processor/twitter_processor.rb
+++ b/app/services/processor/twitter_processor.rb
@@ -1,0 +1,80 @@
+module Processor
+  # Parses the X/Twitter syndication timeline into FeedEntry objects. The
+  # endpoint returns a Next.js page whose `__NEXT_DATA__` script carries the
+  # tweets as JSON under props.pageProps.timeline.entries[].content.tweet.
+  class TwitterProcessor < Base
+    TWITTER_FORMAT = "%a %b %d %H:%M:%S %z %Y".freeze
+
+    def process
+      timeline_tweets.filter_map { |tweet| build_entry(tweet) }
+    end
+
+    private
+
+    def timeline_tweets
+      script = Nokogiri::HTML.parse(raw_data, nil, "UTF-8").at_css("script#__NEXT_DATA__")
+      return [] unless script
+
+      data = JSON.parse(script.text)
+      entries = data.dig("props", "pageProps", "timeline", "entries") || []
+      entries.filter_map { |entry| entry.dig("content", "tweet") }
+    rescue JSON::ParserError
+      []
+    end
+
+    def build_entry(tweet)
+      uid = tweet["id_str"].presence
+      return nil unless uid
+
+      published_at = parse_time(tweet["created_at"])
+      return nil unless published_at
+
+      FeedEntry.new(
+        feed: feed,
+        uid: uid,
+        published_at: published_at,
+        status: :pending,
+        raw_data: {
+          "uid" => uid,
+          "url" => tweet_url(tweet),
+          "text" => tweet_text(tweet),
+          "images" => media_urls(tweet)
+        }
+      )
+    end
+
+    def tweet_url(tweet)
+      permalink = tweet["permalink"].to_s
+      return "https://twitter.com#{permalink}" if permalink.start_with?("/")
+
+      permalink.presence || "https://twitter.com/i/web/status/#{tweet['id_str']}"
+    end
+
+    # Rebuilds readable text: expand t.co links to their targets and drop the
+    # trailing t.co link that points to attached media.
+    def tweet_text(tweet)
+      text = tweet["full_text"].to_s
+      Array(tweet.dig("entities", "urls")).each do |url|
+        text = text.gsub(url["url"], url["expanded_url"]) if url["url"].present? && url["expanded_url"].present?
+      end
+      media(tweet).each { |item| text = text.gsub(item["url"], "") if item["url"].present? }
+      text.strip
+    end
+
+    def media_urls(tweet)
+      media(tweet).filter_map { |item| item["media_url_https"] || item["media_url"] }.uniq
+    end
+
+    def media(tweet)
+      tweet.dig("extended_entities", "media") || tweet.dig("entities", "media") || []
+    end
+
+    def parse_time(value)
+      return nil if value.blank?
+
+      Time.strptime(value, TWITTER_FORMAT)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/services/profile_matcher/telegram_profile_matcher.rb
+++ b/app/services/profile_matcher/telegram_profile_matcher.rb
@@ -1,0 +1,28 @@
+module ProfileMatcher
+  # Matches public Telegram channel URLs: t.me/<channel> and t.me/s/<channel>
+  # (also telegram.me). Invite links, sticker packs, and other reserved paths
+  # are rejected so they fall through to the generic profiles.
+  class TelegramProfileMatcher < Base
+    input_shape :url
+    match_specificity 100
+
+    HOSTS = %w[t.me telegram.me www.t.me].freeze
+    RESERVED = %w[s joinchat addstickers addtheme proxy socks setlanguage share login iv].freeze
+    USERNAME = /\A[A-Za-z0-9_]{2,64}\z/
+
+    def match?
+      return false if input.blank?
+
+      uri = URI.parse(input.strip)
+      return false unless HOSTS.include?(uri.host)
+
+      segments = uri.path.to_s.split("/").reject(&:empty?)
+      segments.shift if segments.first == "s"
+      name = segments.first
+
+      name.present? && !RESERVED.include?(name.downcase) && name.match?(USERNAME)
+    rescue URI::InvalidURIError
+      false
+    end
+  end
+end

--- a/app/services/profile_matcher/twitter_profile_matcher.rb
+++ b/app/services/profile_matcher/twitter_profile_matcher.rb
@@ -1,0 +1,27 @@
+module ProfileMatcher
+  # Matches public X/Twitter profile URLs: twitter.com/<handle> and
+  # x.com/<handle> (also www/mobile subdomains). Reserved paths like /home or
+  # /search are rejected so they fall through to the generic profiles.
+  class TwitterProfileMatcher < Base
+    input_shape :url
+    match_specificity 100
+
+    HOSTS = %w[twitter.com www.twitter.com mobile.twitter.com x.com www.x.com].freeze
+    RESERVED = %w[home search explore notifications messages settings i compose intent hashtag share login signup].freeze
+    HANDLE = /\A[A-Za-z0-9_]{1,15}\z/
+
+    def match?
+      return false if input.blank?
+
+      uri = URI.parse(input.strip)
+      return false unless HOSTS.include?(uri.host)
+
+      segments = uri.path.to_s.split("/").reject(&:empty?)
+      name = segments.first
+
+      name.present? && !RESERVED.include?(name.downcase) && name.match?(HANDLE)
+    rescue URI::InvalidURIError
+      false
+    end
+  end
+end

--- a/app/services/title_extractor/telegram_title_extractor.rb
+++ b/app/services/title_extractor/telegram_title_extractor.rb
@@ -1,0 +1,27 @@
+module TitleExtractor
+  # Suggests a feed title for a Telegram channel. Prefers the channel's
+  # display name from the fetched page's og:title, falling back to the
+  # username from the input.
+  class TelegramTitleExtractor < Base
+    def title
+      og_title.presence || username.presence
+    end
+
+    private
+
+    def og_title
+      return nil if fetched_body.blank?
+
+      doc = Nokogiri::HTML.parse(fetched_body, nil, "UTF-8")
+      doc.at_css('meta[property="og:title"]')&.[]("content")&.strip
+    rescue StandardError
+      nil
+    end
+
+    def username
+      input.to_s.strip.sub(/\A@/, "").sub(%r{\Ahttps?://}i, "")
+           .sub(%r{\A(?:www\.)?t\.me/}i, "").sub(%r{\Atelegram\.me/}i, "")
+           .sub(%r{\As/}i, "").split("/").first.to_s
+    end
+  end
+end

--- a/app/services/title_extractor/twitter_title_extractor.rb
+++ b/app/services/title_extractor/twitter_title_extractor.rb
@@ -1,0 +1,28 @@
+module TitleExtractor
+  # Suggests a feed title for an X/Twitter account. Prefers the account's
+  # display name from the fetched page's og:title, falling back to the
+  # @handle from the input.
+  class TwitterTitleExtractor < Base
+    def title
+      og_title.presence || handle.presence
+    end
+
+    private
+
+    def og_title
+      return nil if fetched_body.blank?
+
+      doc = Nokogiri::HTML.parse(fetched_body, nil, "UTF-8")
+      doc.at_css('meta[property="og:title"]')&.[]("content")&.strip
+    rescue StandardError
+      nil
+    end
+
+    def handle
+      name = input.to_s.strip.sub(/\A@/, "").sub(%r{\Ahttps?://}i, "")
+                  .sub(%r{\A(?:www\.|mobile\.)?(?:twitter|x)\.com/}i, "")
+                  .split("/").first.to_s
+      name.empty? ? "" : "@#{name}"
+    end
+  end
+end

--- a/test/fixtures/files/feeds/telegram/channel.html
+++ b/test/fixtures/files/feeds/telegram/channel.html
@@ -1,0 +1,65 @@
+<!-- Trimmed, structurally faithful sample of a t.me/s/<channel> preview page.
+     Covers: text-only, photo-only, a video post (whose duration <time> precedes
+     the dated <time>), and a service message with no data-post (skipped). -->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta property="og:title" content="Test Channel">
+</head>
+<body>
+<main>
+  <section class="tgme_channel_history js-message_history">
+
+    <div class="tgme_widget_message_wrap js-widget_message_wrap">
+      <div class="tgme_widget_message js-widget_message" data-post="testchannel/1">
+        <div class="tgme_widget_message_text js-message_text">Hello <b>world</b> 🚀<br>Second line</div>
+        <div class="tgme_widget_message_footer compact js-message_footer">
+          <a class="tgme_widget_message_date" href="https://t.me/testchannel/1">
+            <time datetime="2026-06-01T12:00:00+00:00" class="time">12:00</time>
+          </a>
+          <span class="tgme_widget_message_views">1.2K</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="tgme_widget_message_wrap js-widget_message_wrap">
+      <div class="tgme_widget_message js-widget_message" data-post="testchannel/2">
+        <a class="tgme_widget_message_photo_wrap"
+           style="width:100%;background-image:url('https://cdn-test.telesco.pe/file/photo2.jpg')"
+           href="https://t.me/testchannel/2"></a>
+        <div class="tgme_widget_message_footer compact js-message_footer">
+          <a class="tgme_widget_message_date" href="https://t.me/testchannel/2">
+            <time datetime="2026-06-01T12:05:00+00:00" class="time">12:05</time>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="tgme_widget_message_wrap js-widget_message_wrap">
+      <div class="tgme_widget_message js-widget_message" data-post="testchannel/3">
+        <div class="tgme_widget_message_text js-message_text">Watch this</div>
+        <a class="tgme_widget_message_video_player js-message_video_player" href="https://t.me/testchannel/3">
+          <i class="tgme_widget_message_video_thumb"
+             style="background-image:url('https://cdn-test.telesco.pe/file/vthumb3.jpg')"></i>
+          <video class="tgme_widget_message_video js-message_video"
+                 src="https://cdn-test.telesco.pe/file/video3.mp4"></video>
+          <time class="message_video_duration js-message_video_duration">0:16</time>
+        </a>
+        <div class="tgme_widget_message_footer compact js-message_footer">
+          <a class="tgme_widget_message_date" href="https://t.me/testchannel/3">
+            <time datetime="2026-06-01T12:10:00+00:00" class="time">12:10</time>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="tgme_widget_message_wrap js-widget_message_wrap">
+      <div class="tgme_widget_message service_message js-widget_message">
+        <div class="tgme_widget_message_text js-message_text">Channel created</div>
+      </div>
+    </div>
+
+  </section>
+</main>
+</body>
+</html>

--- a/test/fixtures/files/feeds/telegram/normalized.json
+++ b/test/fixtures/files/feeds/telegram/normalized.json
@@ -1,0 +1,36 @@
+[
+  {
+    "attachment_urls": [],
+    "comments": [],
+    "content": "Hello world 🚀\nSecond line - https://t.me/testchannel/1",
+    "published_at": "2026-06-01T12:00:00.000Z",
+    "source_url": "https://t.me/testchannel/1",
+    "status": "enqueued",
+    "uid": "testchannel/1",
+    "validation_errors": []
+  },
+  {
+    "attachment_urls": [
+      "https://cdn-test.telesco.pe/file/photo2.jpg"
+    ],
+    "comments": [],
+    "content": "https://t.me/testchannel/2",
+    "published_at": "2026-06-01T12:05:00.000Z",
+    "source_url": "https://t.me/testchannel/2",
+    "status": "enqueued",
+    "uid": "testchannel/2",
+    "validation_errors": []
+  },
+  {
+    "attachment_urls": [
+      "https://cdn-test.telesco.pe/file/vthumb3.jpg"
+    ],
+    "comments": [],
+    "content": "Watch this - https://t.me/testchannel/3",
+    "published_at": "2026-06-01T12:10:00.000Z",
+    "source_url": "https://t.me/testchannel/3",
+    "status": "enqueued",
+    "uid": "testchannel/3",
+    "validation_errors": []
+  }
+]

--- a/test/fixtures/files/feeds/twitter/normalized.json
+++ b/test/fixtures/files/feeds/twitter/normalized.json
@@ -1,0 +1,36 @@
+[
+  {
+    "attachment_urls": [],
+    "comments": [],
+    "content": "Check our docs https://developer.x.com/docs and more - https://twitter.com/testuser/status/1001",
+    "published_at": "2026-06-04T18:00:00.000Z",
+    "source_url": "https://twitter.com/testuser/status/1001",
+    "status": "enqueued",
+    "uid": "1001",
+    "validation_errors": []
+  },
+  {
+    "attachment_urls": [
+      "https://pbs.twimg.com/media/photoB.jpg"
+    ],
+    "comments": [],
+    "content": "Photo time - https://twitter.com/testuser/status/1002",
+    "published_at": "2026-06-04T19:00:00.000Z",
+    "source_url": "https://twitter.com/testuser/status/1002",
+    "status": "enqueued",
+    "uid": "1002",
+    "validation_errors": []
+  },
+  {
+    "attachment_urls": [
+      "https://pbs.twimg.com/tweet_video_thumb/vidD.jpg"
+    ],
+    "comments": [],
+    "content": "Watch - https://twitter.com/testuser/status/1003",
+    "published_at": "2026-06-04T20:00:00.000Z",
+    "source_url": "https://twitter.com/testuser/status/1003",
+    "status": "enqueued",
+    "uid": "1003",
+    "validation_errors": []
+  }
+]

--- a/test/fixtures/files/feeds/twitter/timeline.html
+++ b/test/fixtures/files/feeds/twitter/timeline.html
@@ -1,0 +1,46 @@
+<!-- Trimmed sample of a syndication.twitter.com timeline-profile page. The
+     tweets live in the __NEXT_DATA__ JSON under
+     props.pageProps.timeline.entries[].content.tweet. Covers: a text tweet with
+     a t.co link to expand, a photo tweet, a video tweet (thumbnail), and a
+     tombstone entry with no tweet (skipped). -->
+<!DOCTYPE html>
+<html>
+<head><meta property="og:title" content="Test User (@testuser) / X"></head>
+<body>
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "timeline": {
+        "entries": [
+          { "content": { "tweet": {
+            "id_str": "1001",
+            "created_at": "Wed Jun 04 18:00:00 +0000 2026",
+            "full_text": "Check our docs https://t.co/abc and more",
+            "permalink": "/testuser/status/1001",
+            "entities": { "urls": [ { "url": "https://t.co/abc", "expanded_url": "https://developer.x.com/docs" } ] }
+          } } },
+          { "content": { "tweet": {
+            "id_str": "1002",
+            "created_at": "Wed Jun 04 19:00:00 +0000 2026",
+            "full_text": "Photo time https://t.co/img",
+            "permalink": "/testuser/status/1002",
+            "entities": { "media": [ { "type": "photo", "media_url_https": "https://pbs.twimg.com/media/photoB.jpg", "url": "https://t.co/img" } ] },
+            "extended_entities": { "media": [ { "type": "photo", "media_url_https": "https://pbs.twimg.com/media/photoB.jpg", "url": "https://t.co/img" } ] }
+          } } },
+          { "content": { "tweet": {
+            "id_str": "1003",
+            "created_at": "Wed Jun 04 20:00:00 +0000 2026",
+            "full_text": "Watch https://t.co/vid",
+            "permalink": "/testuser/status/1003",
+            "extended_entities": { "media": [ { "type": "video", "media_url_https": "https://pbs.twimg.com/tweet_video_thumb/vidD.jpg", "url": "https://t.co/vid" } ] }
+          } } },
+          { "content": { "tombstone": { "text": "This Tweet is unavailable" } } }
+        ]
+      }
+    }
+  }
+}
+</script>
+</body>
+</html>

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
-    assert_equal ["llm_web_search", "llm_website_extractor", "reddit", "rss", "xkcd", "youtube"], FeedProfile.all.sort
+    assert_equal ["llm_web_search", "llm_website_extractor", "reddit", "rss", "telegram", "xkcd", "youtube"], FeedProfile.all.sort
   end
 
   test ".exists? returns true for valid profile key" do

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
-    assert_equal ["llm_web_search", "llm_website_extractor", "reddit", "rss", "telegram", "xkcd", "youtube"], FeedProfile.all.sort
+    assert_equal ["llm_web_search", "llm_website_extractor", "reddit", "rss", "telegram", "twitter", "xkcd", "youtube"], FeedProfile.all.sort
   end
 
   test ".exists? returns true for valid profile key" do

--- a/test/services/loader/telegram_loader_test.rb
+++ b/test/services/loader/telegram_loader_test.rb
@@ -16,47 +16,47 @@ class Loader::TelegramLoaderTest < ActiveSupport::TestCase
 
   test "#load should fetch the t.me/s preview for a bare channel name" do
     client = mock_client
-    loader("durov", http_client: client).load
-    assert_equal "https://t.me/s/durov", client.last_request_url
+    loader("examplechannel", http_client: client).load
+    assert_equal "https://t.me/s/examplechannel", client.last_request_url
   end
 
   test "#load should strip a leading @ from the channel handle" do
     client = mock_client
-    loader("@durov", http_client: client).load
-    assert_equal "https://t.me/s/durov", client.last_request_url
+    loader("@examplechannel", http_client: client).load
+    assert_equal "https://t.me/s/examplechannel", client.last_request_url
   end
 
   test "#load should accept a schemeless t.me URL" do
     client = mock_client
-    loader("t.me/durov", http_client: client).load
-    assert_equal "https://t.me/s/durov", client.last_request_url
+    loader("t.me/examplechannel", http_client: client).load
+    assert_equal "https://t.me/s/examplechannel", client.last_request_url
   end
 
   test "#load should accept a full t.me channel URL" do
     client = mock_client
-    loader("https://t.me/durov", http_client: client).load
-    assert_equal "https://t.me/s/durov", client.last_request_url
+    loader("https://t.me/examplechannel", http_client: client).load
+    assert_equal "https://t.me/s/examplechannel", client.last_request_url
   end
 
   test "#load should accept a t.me/s preview URL" do
     client = mock_client
-    loader("https://t.me/s/durov", http_client: client).load
-    assert_equal "https://t.me/s/durov", client.last_request_url
+    loader("https://t.me/s/examplechannel", http_client: client).load
+    assert_equal "https://t.me/s/examplechannel", client.last_request_url
   end
 
   test "#load should send a desktop User-Agent header" do
     client = mock_client
-    loader("durov", http_client: client).load
+    loader("examplechannel", http_client: client).load
     assert_match %r{Mozilla/5\.0}, client.last_headers["User-Agent"]
   end
 
   test "#load should return the response body on success" do
-    assert_equal PREVIEW_BODY, loader("durov", http_client: mock_client).load
+    assert_equal PREVIEW_BODY, loader("examplechannel", http_client: mock_client).load
   end
 
   test "#load should raise on HTTP error" do
     client = mock_client(response: HttpClient::Response.new(status: 404, body: ""))
-    error = assert_raises(StandardError) { loader("durov", http_client: client).load }
+    error = assert_raises(StandardError) { loader("examplechannel", http_client: client).load }
     assert_equal "HTTP 404", error.message
   end
 

--- a/test/services/loader/telegram_loader_test.rb
+++ b/test/services/loader/telegram_loader_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class Loader::TelegramLoaderTest < ActiveSupport::TestCase
+  PREVIEW_BODY = "<html>telegram preview</html>"
+
+  def mock_client(response: nil, error: nil)
+    response ||= HttpClient::Response.new(status: 200, body: PREVIEW_BODY)
+    MockHttpClient.new(response: response, error: error)
+  end
+
+  def loader(input, http_client: nil)
+    feed = create(:feed, feed_profile_key: "telegram", url: input)
+    opts = http_client ? { http_client: http_client } : {}
+    Loader::TelegramLoader.new(feed, opts)
+  end
+
+  test "#load should fetch the t.me/s preview for a bare channel name" do
+    client = mock_client
+    loader("durov", http_client: client).load
+    assert_equal "https://t.me/s/durov", client.last_request_url
+  end
+
+  test "#load should strip a leading @ from the channel handle" do
+    client = mock_client
+    loader("@durov", http_client: client).load
+    assert_equal "https://t.me/s/durov", client.last_request_url
+  end
+
+  test "#load should accept a schemeless t.me URL" do
+    client = mock_client
+    loader("t.me/durov", http_client: client).load
+    assert_equal "https://t.me/s/durov", client.last_request_url
+  end
+
+  test "#load should accept a full t.me channel URL" do
+    client = mock_client
+    loader("https://t.me/durov", http_client: client).load
+    assert_equal "https://t.me/s/durov", client.last_request_url
+  end
+
+  test "#load should accept a t.me/s preview URL" do
+    client = mock_client
+    loader("https://t.me/s/durov", http_client: client).load
+    assert_equal "https://t.me/s/durov", client.last_request_url
+  end
+
+  test "#load should send a desktop User-Agent header" do
+    client = mock_client
+    loader("durov", http_client: client).load
+    assert_match %r{Mozilla/5\.0}, client.last_headers["User-Agent"]
+  end
+
+  test "#load should return the response body on success" do
+    assert_equal PREVIEW_BODY, loader("durov", http_client: mock_client).load
+  end
+
+  test "#load should raise on HTTP error" do
+    client = mock_client(response: HttpClient::Response.new(status: 404, body: ""))
+    error = assert_raises(StandardError) { loader("durov", http_client: client).load }
+    assert_equal "HTTP 404", error.message
+  end
+
+  test "#load should raise when the channel cannot be determined" do
+    error = assert_raises(StandardError) { loader("https://t.me/", http_client: mock_client).load }
+    assert_match(/Could not determine/, error.message)
+  end
+
+  private
+
+  class MockHttpClient
+    attr_reader :last_request_url, :last_headers
+
+    def initialize(response: nil, error: nil)
+      @response = response
+      @error = error
+    end
+
+    def get(url, headers: {}, options: {})
+      @last_request_url = url
+      @last_headers = headers
+      raise @error if @error
+      @response
+    end
+  end
+end

--- a/test/services/loader/twitter_loader_test.rb
+++ b/test/services/loader/twitter_loader_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class Loader::TwitterLoaderTest < ActiveSupport::TestCase
+  TIMELINE_BODY = "<html>syndication timeline</html>"
+
+  def mock_client(response: nil, error: nil)
+    response ||= HttpClient::Response.new(status: 200, body: TIMELINE_BODY)
+    MockHttpClient.new(response: response, error: error)
+  end
+
+  def loader(input, http_client: nil)
+    feed = create(:feed, feed_profile_key: "twitter", url: input)
+    opts = http_client ? { http_client: http_client } : {}
+    Loader::TwitterLoader.new(feed, opts)
+  end
+
+  test "#load should request the syndication endpoint for a bare handle" do
+    client = mock_client
+    loader("XDevelopers", http_client: client).load
+    assert_equal "https://syndication.twitter.com/srv/timeline-profile/screen-name/XDevelopers", client.last_request_url
+  end
+
+  test "#load should strip a leading @ from the handle" do
+    client = mock_client
+    loader("@XDevelopers", http_client: client).load
+    assert_equal "https://syndication.twitter.com/srv/timeline-profile/screen-name/XDevelopers", client.last_request_url
+  end
+
+  test "#load should accept a twitter.com profile URL" do
+    client = mock_client
+    loader("https://twitter.com/XDevelopers", http_client: client).load
+    assert_equal "https://syndication.twitter.com/srv/timeline-profile/screen-name/XDevelopers", client.last_request_url
+  end
+
+  test "#load should accept an x.com profile URL" do
+    client = mock_client
+    loader("https://x.com/XDevelopers", http_client: client).load
+    assert_equal "https://syndication.twitter.com/srv/timeline-profile/screen-name/XDevelopers", client.last_request_url
+  end
+
+  test "#load should send a desktop User-Agent header" do
+    client = mock_client
+    loader("XDevelopers", http_client: client).load
+    assert_match %r{Mozilla/5\.0}, client.last_headers["User-Agent"]
+  end
+
+  test "#load should return the response body on success" do
+    assert_equal TIMELINE_BODY, loader("XDevelopers", http_client: mock_client).load
+  end
+
+  test "#load should raise on HTTP error" do
+    client = mock_client(response: HttpClient::Response.new(status: 404, body: ""))
+    error = assert_raises(StandardError) { loader("XDevelopers", http_client: client).load }
+    assert_equal "HTTP 404", error.message
+  end
+
+  test "#load should raise when the handle cannot be determined" do
+    error = assert_raises(StandardError) { loader("https://x.com/", http_client: mock_client).load }
+    assert_match(/Could not determine/, error.message)
+  end
+
+  private
+
+  class MockHttpClient
+    attr_reader :last_request_url, :last_headers
+
+    def initialize(response: nil, error: nil)
+      @response = response
+      @error = error
+    end
+
+    def get(url, headers: {}, options: {})
+      @last_request_url = url
+      @last_headers = headers
+      raise @error if @error
+      @response
+    end
+  end
+end

--- a/test/services/normalizer/telegram_normalizer_test.rb
+++ b/test/services/normalizer/telegram_normalizer_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class Normalizer::TelegramNormalizerTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, feed_profile_key: "telegram", url: "testchannel")
+  end
+
+  def posts
+    @posts ||= Processor::TelegramProcessor.new(feed, file_fixture("feeds/telegram/channel.html").read)
+      .process
+      .map { |entry| Normalizer::TelegramNormalizer.new(entry).normalize }
+  end
+
+  test "#normalize should match the expected normalization result" do
+    assert_matches_snapshot(posts.map(&:normalized_attributes), snapshot: "feeds/telegram/normalized.json")
+  end
+
+  test "#normalize should preserve line breaks in message text" do
+    assert_includes posts.first.content, "Hello world 🚀\nSecond line"
+  end
+
+  test "#normalize should append the permalink to the content" do
+    assert_includes posts.first.content, "https://t.me/testchannel/1"
+  end
+
+  test "#normalize should fall back to the permalink for a photo-only post" do
+    assert_equal "https://t.me/testchannel/2", posts[1].content
+  end
+
+  test "#normalize should expose photos as attachments" do
+    assert_equal ["https://cdn-test.telesco.pe/file/photo2.jpg"], posts[1].attachment_urls
+  end
+
+  test "#normalize should expose video thumbnails as attachments" do
+    assert_equal ["https://cdn-test.telesco.pe/file/vthumb3.jpg"], posts[2].attachment_urls
+  end
+
+  test "#normalize should enqueue valid posts" do
+    assert(posts.all? { |post| post.status == "enqueued" })
+    assert(posts.all? { |post| post.validation_errors.empty? })
+  end
+end

--- a/test/services/normalizer/twitter_normalizer_test.rb
+++ b/test/services/normalizer/twitter_normalizer_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class Normalizer::TwitterNormalizerTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, feed_profile_key: "twitter", url: "testuser")
+  end
+
+  def posts
+    @posts ||= Processor::TwitterProcessor.new(feed, file_fixture("feeds/twitter/timeline.html").read)
+      .process
+      .map { |entry| Normalizer::TwitterNormalizer.new(entry).normalize }
+  end
+
+  test "#normalize should match the expected normalization result" do
+    assert_matches_snapshot(posts.map(&:normalized_attributes), snapshot: "feeds/twitter/normalized.json")
+  end
+
+  test "#normalize should append the tweet permalink to the content" do
+    assert_includes posts.first.content, "https://twitter.com/testuser/status/1001"
+  end
+
+  test "#normalize should expose photo media as attachments" do
+    assert_equal ["https://pbs.twimg.com/media/photoB.jpg"], posts[1].attachment_urls
+  end
+
+  test "#normalize should expose video thumbnails as attachments" do
+    assert_equal ["https://pbs.twimg.com/tweet_video_thumb/vidD.jpg"], posts[2].attachment_urls
+  end
+
+  test "#normalize should enqueue valid posts" do
+    assert(posts.all? { |post| post.status == "enqueued" })
+    assert(posts.all? { |post| post.validation_errors.empty? })
+  end
+end

--- a/test/services/processor/telegram_processor_test.rb
+++ b/test/services/processor/telegram_processor_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class Processor::TelegramProcessorTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, feed_profile_key: "telegram", url: "testchannel")
+  end
+
+  def sample_html
+    @sample_html ||= file_fixture("feeds/telegram/channel.html").read
+  end
+
+  def entries
+    @entries ||= Processor::TelegramProcessor.new(feed, sample_html).process
+  end
+
+  test "#process should create a FeedEntry per message with a data-post id" do
+    assert_equal 3, entries.size
+    assert entries.all? { |entry| entry.is_a?(FeedEntry) }
+    assert entries.all? { |entry| entry.feed == feed }
+    assert entries.all? { |entry| entry.status == "pending" }
+  end
+
+  test "#process should skip service messages without a data-post id" do
+    assert_not_includes entries.map(&:uid), nil
+    assert_equal %w[testchannel/1 testchannel/2 testchannel/3], entries.map(&:uid)
+  end
+
+  test "#process should store the message permalink and text html" do
+    entry = entries.first
+
+    assert_equal "https://t.me/testchannel/1", entry.raw_data["url"]
+    assert_includes entry.raw_data["text_html"], "Hello"
+    assert_includes entry.raw_data["text_html"], "<br>"
+  end
+
+  test "#process should extract photo URLs from the background-image style" do
+    photo_entry = entries[1]
+
+    assert_equal ["https://cdn-test.telesco.pe/file/photo2.jpg"], photo_entry.raw_data["images"]
+  end
+
+  test "#process should extract video thumbnail URLs" do
+    video_entry = entries[2]
+
+    assert_equal ["https://cdn-test.telesco.pe/file/vthumb3.jpg"], video_entry.raw_data["images"]
+  end
+
+  test "#process should use the dated time, not the video duration, for published_at" do
+    video_entry = entries[2]
+
+    assert_equal Time.utc(2026, 6, 1, 12, 10, 0), video_entry.published_at
+  end
+end

--- a/test/services/processor/twitter_processor_test.rb
+++ b/test/services/processor/twitter_processor_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class Processor::TwitterProcessorTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, feed_profile_key: "twitter", url: "testuser")
+  end
+
+  def sample_html
+    @sample_html ||= file_fixture("feeds/twitter/timeline.html").read
+  end
+
+  def entries
+    @entries ||= Processor::TwitterProcessor.new(feed, sample_html).process
+  end
+
+  test "#process should create a FeedEntry per tweet and skip non-tweet entries" do
+    assert_equal 3, entries.size
+    assert entries.all? { |entry| entry.is_a?(FeedEntry) }
+    assert entries.all? { |entry| entry.status == "pending" }
+    assert_equal %w[1001 1002 1003], entries.map(&:uid)
+  end
+
+  test "#process should build the permalink from the relative path" do
+    assert_equal "https://twitter.com/testuser/status/1001", entries.first.raw_data["url"]
+  end
+
+  test "#process should parse the tweet timestamp" do
+    assert_equal Time.utc(2026, 6, 4, 18, 0, 0), entries.first.published_at
+  end
+
+  test "#process should expand t.co links in the text" do
+    assert_equal "Check our docs https://developer.x.com/docs and more", entries.first.raw_data["text"]
+  end
+
+  test "#process should drop the trailing media link from the text" do
+    assert_equal "Photo time", entries[1].raw_data["text"]
+  end
+
+  test "#process should extract photo media URLs" do
+    assert_equal ["https://pbs.twimg.com/media/photoB.jpg"], entries[1].raw_data["images"]
+  end
+
+  test "#process should extract the video thumbnail URL" do
+    assert_equal ["https://pbs.twimg.com/tweet_video_thumb/vidD.jpg"], entries[2].raw_data["images"]
+  end
+
+  test "#process should return an empty array when JSON is missing" do
+    assert_equal [], Processor::TwitterProcessor.new(feed, "<html>no data</html>").process
+  end
+end

--- a/test/services/profile_matcher/telegram_profile_matcher_test.rb
+++ b/test/services/profile_matcher/telegram_profile_matcher_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class ProfileMatcher::TelegramProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::TelegramProfileMatcher.new(url)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::TelegramProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 100" do
+    assert_equal 100, ProfileMatcher::TelegramProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::TelegramProfileMatcher.depends_on_ai
+  end
+
+  test ".profile_key should be telegram" do
+    assert_equal "telegram", ProfileMatcher::TelegramProfileMatcher.profile_key
+  end
+
+  test "#match? should match a t.me channel URL" do
+    assert matcher("https://t.me/durov").match?
+  end
+
+  test "#match? should match a t.me/s preview URL" do
+    assert matcher("https://t.me/s/durov").match?
+  end
+
+  test "#match? should match a telegram.me URL" do
+    assert matcher("https://telegram.me/durov").match?
+  end
+
+  test "#match? should not match invite links" do
+    assert_not matcher("https://t.me/joinchat/AAAAAEHbZ").match?
+    assert_not matcher("https://t.me/+AbCdEfGh").match?
+  end
+
+  test "#match? should not match the t.me root" do
+    assert_not matcher("https://t.me/").match?
+  end
+
+  test "#match? should not match sticker packs" do
+    assert_not matcher("https://t.me/addstickers/AnimatedEmojies").match?
+  end
+
+  test "#match? should not match non-telegram URLs" do
+    assert_not matcher("https://example.com/durov").match?
+  end
+
+  test "#match? should handle blank input" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+end

--- a/test/services/profile_matcher/telegram_profile_matcher_test.rb
+++ b/test/services/profile_matcher/telegram_profile_matcher_test.rb
@@ -22,15 +22,15 @@ class ProfileMatcher::TelegramProfileMatcherTest < ActiveSupport::TestCase
   end
 
   test "#match? should match a t.me channel URL" do
-    assert matcher("https://t.me/durov").match?
+    assert matcher("https://t.me/examplechannel").match?
   end
 
   test "#match? should match a t.me/s preview URL" do
-    assert matcher("https://t.me/s/durov").match?
+    assert matcher("https://t.me/s/examplechannel").match?
   end
 
   test "#match? should match a telegram.me URL" do
-    assert matcher("https://telegram.me/durov").match?
+    assert matcher("https://telegram.me/examplechannel").match?
   end
 
   test "#match? should not match invite links" do
@@ -47,7 +47,7 @@ class ProfileMatcher::TelegramProfileMatcherTest < ActiveSupport::TestCase
   end
 
   test "#match? should not match non-telegram URLs" do
-    assert_not matcher("https://example.com/durov").match?
+    assert_not matcher("https://example.com/examplechannel").match?
   end
 
   test "#match? should handle blank input" do

--- a/test/services/profile_matcher/twitter_profile_matcher_test.rb
+++ b/test/services/profile_matcher/twitter_profile_matcher_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class ProfileMatcher::TwitterProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::TwitterProfileMatcher.new(url)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::TwitterProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 100" do
+    assert_equal 100, ProfileMatcher::TwitterProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::TwitterProfileMatcher.depends_on_ai
+  end
+
+  test ".profile_key should be twitter" do
+    assert_equal "twitter", ProfileMatcher::TwitterProfileMatcher.profile_key
+  end
+
+  test "#match? should match a twitter.com profile URL" do
+    assert matcher("https://twitter.com/XDevelopers").match?
+  end
+
+  test "#match? should match an x.com profile URL" do
+    assert matcher("https://x.com/XDevelopers").match?
+  end
+
+  test "#match? should match a mobile.twitter.com profile URL" do
+    assert matcher("https://mobile.twitter.com/XDevelopers").match?
+  end
+
+  test "#match? should not match reserved paths" do
+    assert_not matcher("https://x.com/home").match?
+    assert_not matcher("https://twitter.com/search").match?
+    assert_not matcher("https://x.com/i/lists/123").match?
+  end
+
+  test "#match? should not match the site root" do
+    assert_not matcher("https://x.com/").match?
+  end
+
+  test "#match? should match a status URL by its handle segment" do
+    # Only the first path segment matters; "XDevelopers" is a valid handle.
+    assert matcher("https://x.com/XDevelopers/status/1").match?
+  end
+
+  test "#match? should not match non-twitter URLs" do
+    assert_not matcher("https://example.com/XDevelopers").match?
+  end
+
+  test "#match? should handle blank input" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+end

--- a/test/services/title_extractor/telegram_title_extractor_test.rb
+++ b/test/services/title_extractor/telegram_title_extractor_test.rb
@@ -11,18 +11,18 @@ class TitleExtractor::TelegramTitleExtractorTest < ActiveSupport::TestCase
   end
 
   test "#title should fall back to the username from a full URL" do
-    assert_equal "durov", extractor("https://t.me/durov").title
+    assert_equal "examplechannel", extractor("https://t.me/examplechannel").title
   end
 
   test "#title should fall back to the username from an @handle" do
-    assert_equal "durov", extractor("@durov").title
+    assert_equal "examplechannel", extractor("@examplechannel").title
   end
 
   test "#title should fall back to a bare username" do
-    assert_equal "durov", extractor("durov").title
+    assert_equal "examplechannel", extractor("examplechannel").title
   end
 
   test "#title should ignore a blank fetched body" do
-    assert_equal "durov", extractor("https://t.me/durov", "").title
+    assert_equal "examplechannel", extractor("https://t.me/examplechannel", "").title
   end
 end

--- a/test/services/title_extractor/telegram_title_extractor_test.rb
+++ b/test/services/title_extractor/telegram_title_extractor_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class TitleExtractor::TelegramTitleExtractorTest < ActiveSupport::TestCase
+  def extractor(input, body = nil)
+    TitleExtractor::TelegramTitleExtractor.new(input, body)
+  end
+
+  test "#title should use the og:title from the fetched page" do
+    body = file_fixture("feeds/telegram/channel.html").read
+    assert_equal "Test Channel", extractor("https://t.me/testchannel", body).title
+  end
+
+  test "#title should fall back to the username from a full URL" do
+    assert_equal "durov", extractor("https://t.me/durov").title
+  end
+
+  test "#title should fall back to the username from an @handle" do
+    assert_equal "durov", extractor("@durov").title
+  end
+
+  test "#title should fall back to a bare username" do
+    assert_equal "durov", extractor("durov").title
+  end
+
+  test "#title should ignore a blank fetched body" do
+    assert_equal "durov", extractor("https://t.me/durov", "").title
+  end
+end

--- a/test/services/title_extractor/twitter_title_extractor_test.rb
+++ b/test/services/title_extractor/twitter_title_extractor_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class TitleExtractor::TwitterTitleExtractorTest < ActiveSupport::TestCase
+  def extractor(input, body = nil)
+    TitleExtractor::TwitterTitleExtractor.new(input, body)
+  end
+
+  test "#title should use the og:title from the fetched page" do
+    body = '<html><head><meta property="og:title" content="X Developers (@XDevelopers) / X"></head></html>'
+    assert_equal "X Developers (@XDevelopers) / X", extractor("https://x.com/XDevelopers", body).title
+  end
+
+  test "#title should fall back to the @handle from an x.com URL" do
+    assert_equal "@XDevelopers", extractor("https://x.com/XDevelopers").title
+  end
+
+  test "#title should fall back to the @handle from a twitter.com URL" do
+    assert_equal "@XDevelopers", extractor("https://twitter.com/XDevelopers").title
+  end
+
+  test "#title should fall back to the @handle from an @handle input" do
+    assert_equal "@XDevelopers", extractor("@XDevelopers").title
+  end
+
+  test "#title should fall back to the @handle from a bare handle" do
+    assert_equal "@XDevelopers", extractor("XDevelopers").title
+  end
+end


### PR DESCRIPTION
Changes:

- Add a **Telegram** feed profile: subscribe to a public channel by its `t.me` URL or `@handle`. Text, photos, and video poster frames are read from the public `t.me/s/<channel>` web preview — no API key or login.
- Add an **X / Twitter** feed profile: subscribe to a public account by its profile URL or `@handle`. Tweets (with links expanded and media links trimmed) plus photo and video-thumbnail attachments come from the public syndication timeline — no API key or login.
- Both plug into the existing loader → processor → normalizer pipeline with a matcher and title extractor, and are registered in `FeedProfile`. Tests and fixtures included.

These were modeled on how RSSHub fetches the same sources — which endpoints to hit and which markup/JSON holds the data — but reimplemented natively with Nokogiri rather than ported. Both use public, unauthenticated endpoints. Telegram's preview is stable and ready for everyday use; the Twitter syndication endpoint is unofficial and best-effort — it exposes only recent tweets, skips protected accounts, and degrades to "no new posts" if X changes it.

References:

- Refs #437