### PR TITLE
Link to Freefeed group on feed show page

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -100,6 +100,14 @@ class Feed < ApplicationRecord
     SCHEDULE_INTERVALS.dig(schedule_interval, :display) || cron_expression
   end
 
+  # Link to the target group on its FreeFeed instance. Post#freefeed_url
+  # builds on top of this to point at individual published posts.
+  def target_group_url
+    return unless access_token && target_group.present?
+
+    "#{access_token.host}/#{target_group}"
+  end
+
   def url
     params&.dig("url")
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -40,10 +40,10 @@ class Post < ApplicationRecord
   }
 
   def freefeed_url
-    token = feed&.access_token
-    return unless token && feed.target_group.present? && freefeed_post_id.present?
+    group_url = feed&.target_group_url
+    return unless group_url && freefeed_post_id.present?
 
-    "#{token.host}/#{feed.target_group}/#{freefeed_post_id}"
+    "#{group_url}/#{freefeed_post_id}"
   end
 
   def normalized_attributes

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -10,11 +10,11 @@
     <% if (status_summary = feed_status_summary(@feed)).present? %>
       <% header.with_context_paragraph(status_summary) %>
     <% end %>
-    <% if @feed.access_token.present? && @feed.target_group.present? %>
+    <% if @feed.target_group_url.present? %>
       <% header.with_context_paragraph do %>
         Target group:
         <%= link_to "#{@feed.access_token.host_domain}/#{@feed.target_group}",
-                    "#{@feed.access_token.host}/#{@feed.target_group}",
+                    @feed.target_group_url,
                     class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
                     target: "_blank", rel: "noopener" %>
       <% end %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -10,8 +10,9 @@
     <% if (status_summary = feed_status_summary(@feed)).present? %>
       <% header.with_context_paragraph(status_summary) %>
     <% end %>
-    <% if @feed.enabled? && @feed.access_token.present? && @feed.target_group.present? %>
+    <% if @feed.access_token.present? && @feed.target_group.present? %>
       <% header.with_context_paragraph do %>
+        Target group:
         <%= link_to "#{@feed.access_token.host_domain}/#{@feed.target_group}",
                     "#{@feed.access_token.host}/#{@feed.target_group}",
                     class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500",

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -10,6 +10,14 @@
     <% if (status_summary = feed_status_summary(@feed)).present? %>
       <% header.with_context_paragraph(status_summary) %>
     <% end %>
+    <% if @feed.enabled? && @feed.access_token.present? && @feed.target_group.present? %>
+      <% header.with_context_paragraph do %>
+        <%= link_to "#{@feed.access_token.host_domain}/#{@feed.target_group}",
+                    "#{@feed.access_token.host}/#{@feed.target_group}",
+                    class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
+                    target: "_blank", rel: "noopener" %>
+      <% end %>
+    <% end %>
     <% header.with_action_button do %>
       <%= link_to "Edit", edit_feed_path(@feed), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -417,6 +417,26 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{edit_feed_path(feed)}']", text: "Edit"
   end
 
+  test "#show should link to the Freefeed group for an enabled feed" do
+    sign_in_as(user)
+    enabled = create(:feed, :enabled, user: user, access_token: access_token, target_group: "testgroup")
+
+    get feed_url(enabled)
+
+    assert_response :success
+    assert_select "a[href='#{access_token.host}/testgroup']",
+                  text: "#{access_token.host_domain}/testgroup"
+  end
+
+  test "#show should not link to the Freefeed group for a disabled feed" do
+    sign_in_as(user)
+
+    get feed_url(feed)
+
+    assert_response :success
+    assert_select "a[href='#{feed.access_token.host}/#{feed.target_group}']", count: 0
+  end
+
   test "#show should not offer a status toggle for a draft feed" do
     sign_in_as(user)
     draft = create(:feed, :draft, user: user)

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -417,24 +417,25 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{edit_feed_path(feed)}']", text: "Edit"
   end
 
-  test "#show should link to the Freefeed group for an enabled feed" do
+  test "#show should link to the Freefeed group regardless of feed state" do
     sign_in_as(user)
-    enabled = create(:feed, :enabled, user: user, access_token: access_token, target_group: "testgroup")
+    disabled = create(:feed, :disabled, user: user, access_token: access_token, target_group: "testgroup")
 
-    get feed_url(enabled)
+    get feed_url(disabled)
 
     assert_response :success
     assert_select "a[href='#{access_token.host}/testgroup']",
                   text: "#{access_token.host_domain}/testgroup"
   end
 
-  test "#show should not link to the Freefeed group for a disabled feed" do
+  test "#show should not link to the Freefeed group when target group is missing" do
     sign_in_as(user)
+    no_group = create(:feed, :without_access_token, user: user)
 
-    get feed_url(feed)
+    get feed_url(no_group)
 
     assert_response :success
-    assert_select "a[href='#{feed.access_token.host}/#{feed.target_group}']", count: 0
+    assert_select "a[href$='/testgroup']", count: 0
   end
 
   test "#show should not offer a status toggle for a draft feed" do

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -803,4 +803,22 @@ class FeedTest < ActiveSupport::TestCase
       feed.update!(state: :draft)
     end
   end
+
+  test "#target_group_url should return the group URL when token and group are present" do
+    feed = create(:feed, target_group: "testgroup")
+
+    assert_equal "#{feed.access_token.host}/testgroup", feed.target_group_url
+  end
+
+  test "#target_group_url should return nil when target_group is blank" do
+    feed = create(:feed, target_group: "")
+
+    assert_nil feed.target_group_url
+  end
+
+  test "#target_group_url should return nil when access_token is missing" do
+    feed = create(:feed, :without_access_token)
+
+    assert_nil feed.target_group_url
+  end
 end


### PR DESCRIPTION
Changes:

- Show a "Target group:" line with a direct link to the Freefeed group on the feed page
- Display it as `host/group-name` (e.g. `freefeed.net/my-group`), linking to the group on its Freefeed instance
- Render whenever the feed has an access token and target group, regardless of feed state

The feed page didn't offer a quick way to jump to where a feed's posts actually land. This adds a one-click path to the group on Freefeed.