### PR TITLE
Add refresh button to feed page

### DIFF
--- a/app/controllers/feeds/refreshes_controller.rb
+++ b/app/controllers/feeds/refreshes_controller.rb
@@ -1,0 +1,10 @@
+class Feeds::RefreshesController < ApplicationController
+  def create
+    feed = Current.user.feeds.find(params[:feed_id])
+    authorize feed, :refresh?
+
+    FeedRefreshJob.perform_later(feed.id)
+
+    redirect_to feed_path(feed), notice: "Feed refresh started"
+  end
+end

--- a/app/controllers/feeds/refreshes_controller.rb
+++ b/app/controllers/feeds/refreshes_controller.rb
@@ -1,10 +1,13 @@
 class Feeds::RefreshesController < ApplicationController
   def create
-    feed = Current.user.feeds.find(params[:feed_id])
-    authorize feed, :refresh?
+    @feed = Current.user.feeds.find(params[:feed_id])
+    authorize @feed, :refresh?
 
-    FeedRefreshJob.perform_later(feed.id)
+    FeedRefreshJob.perform_later(@feed.id)
 
-    redirect_to feed_path(feed), notice: "Feed refresh started"
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to feed_path(@feed), notice: "Feed refresh started" }
+    end
   end
 end

--- a/app/controllers/feeds/refreshes_controller.rb
+++ b/app/controllers/feeds/refreshes_controller.rb
@@ -6,7 +6,7 @@ class Feeds::RefreshesController < ApplicationController
     FeedRefreshJob.perform_later(@feed.id)
 
     respond_to do |format|
-      format.turbo_stream
+      format.turbo_stream { render turbo_stream: "" }
       format.html { redirect_to feed_path(@feed), notice: "Feed refresh started" }
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,7 @@ module ApplicationHelper
     "external-link"  => '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>',
     "key"            => '<path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4"/><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/>',
     "refresh-ccw"    => '<path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 16h5v5"/>',
+    "loader-circle"  => '<path d="M21 12a9 9 0 1 1-6.219-8.56"/>',
     "menu"           => '<path d="M4 5h16"/><path d="M4 12h16"/><path d="M4 19h16"/>',
     "square-pen"     => '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>',
     "trash-2"        => '<path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>',

--- a/app/javascript/controllers/loading_button_controller.js
+++ b/app/javascript/controllers/loading_button_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drives a button's loading state across a Turbo form submission:
+// - on submit start, disables the button and swaps the default icon for a spinner
+// - on submit end, resets it — but never sooner than minDuration after the start,
+//   so the spinner stays visible long enough to read even when the server is fast
+export default class extends Controller {
+  static targets = ["button", "default", "loading"]
+  static values = { minDuration: { type: Number, default: 500 } }
+
+  start() {
+    this._startedAt = performance.now()
+    this._setLoading(true)
+  }
+
+  end() {
+    // Turbo re-enables its submitter when the request finishes; re-assert the
+    // loading state so the button stays disabled until the minimum duration is up.
+    this._setLoading(true)
+    const elapsed = performance.now() - (this._startedAt ?? 0)
+    const remaining = Math.max(0, this.minDurationValue - elapsed)
+    setTimeout(() => this._setLoading(false), remaining)
+  }
+
+  _setLoading(loading) {
+    if (this.hasButtonTarget) this.buttonTarget.disabled = loading
+    if (this.hasDefaultTarget) this.defaultTarget.classList.toggle("hidden", loading)
+    if (this.hasLoadingTarget) this.loadingTarget.classList.toggle("hidden", !loading)
+  }
+}

--- a/app/policies/feed_policy.rb
+++ b/app/policies/feed_policy.rb
@@ -19,6 +19,10 @@ class FeedPolicy < ApplicationPolicy
     owner?
   end
 
+  def refresh?
+    owner?
+  end
+
   def purge?
     owner?
   end

--- a/app/views/feeds/refreshes/create.turbo_stream.erb
+++ b/app/views/feeds/refreshes/create.turbo_stream.erb
@@ -1,2 +1,0 @@
-<%# Placeholder Turbo Stream response. The refresh runs in the background, %>
-<%# so there's nothing on the page to update yet. %>

--- a/app/views/feeds/refreshes/create.turbo_stream.erb
+++ b/app/views/feeds/refreshes/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%# Placeholder Turbo Stream response. The refresh runs in the background, %>
+<%# so there's nothing on the page to update yet. %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -20,6 +20,15 @@
       <% end %>
     <% end %>
     <% header.with_action_button do %>
+      <%= button_to feed_refresh_path(@feed),
+                    method: :post,
+                    title: "Refresh now",
+                    class: class_names("inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
+                    form: { class: "inline-block" } do %>
+        <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh now") %>
+      <% end %>
+    <% end %>
+    <% header.with_action_button do %>
       <%= link_to "Edit", edit_feed_path(@feed), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>
     <% if @feed.enabled? %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -32,10 +32,10 @@
                         action: "turbo:submit-start->loading-button#start turbo:submit-end->loading-button#end"
                       }
                     } do %>
-        <span class="inline-flex" data-loading-button-target="default">
+        <span data-loading-button-target="default">
           <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh now") %>
         </span>
-        <span class="hidden inline-flex" data-loading-button-target="loading">
+        <span class="hidden" data-loading-button-target="loading">
           <%= icon("loader-circle", css_class: "size-4 animate-spin", aria_label: "Refreshing") %>
         </span>
       <% end %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -24,8 +24,20 @@
                     method: :post,
                     title: "Refresh now",
                     class: class_names("inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
-                    form: { class: "inline-block" } do %>
-        <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh now") %>
+                    data: { loading_button_target: "button" },
+                    form: {
+                      class: "inline-block",
+                      data: {
+                        controller: "loading-button",
+                        action: "turbo:submit-start->loading-button#start turbo:submit-end->loading-button#end"
+                      }
+                    } do %>
+        <span class="inline-flex" data-loading-button-target="default">
+          <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh now") %>
+        </span>
+        <span class="hidden inline-flex" data-loading-button-target="loading">
+          <%= icon("loader-circle", css_class: "size-4 animate-spin", aria_label: "Refreshing") %>
+        </span>
       <% end %>
     <% end %>
     <% header.with_action_button do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
 
   resources :feeds do
     resource :status, only: :update, controller: "feed_statuses"
+    resource :refresh, only: :create, controller: "feeds/refreshes"
     resource :purge, only: :create, controller: "feeds/purges"
   end
 

--- a/test/controllers/feeds/refreshes_controller_test.rb
+++ b/test/controllers/feeds/refreshes_controller_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Feeds::RefreshesControllerTest < ActionDispatch::IntegrationTest
+  def user
+    @user ||= create(:user)
+  end
+
+  def other_user
+    @other_user ||= create(:user)
+  end
+
+  def feed
+    @feed ||= create(:feed, user: user)
+  end
+
+  test "create requires authentication" do
+    post feed_refresh_path(feed)
+    assert_redirected_to new_session_path
+  end
+
+  test "create requires ownership" do
+    sign_in_as(other_user)
+    post feed_refresh_path(feed)
+    assert_response :not_found
+  end
+
+  test "create schedules refresh job" do
+    sign_in_as(user)
+
+    assert_enqueued_with(job: FeedRefreshJob, args: [feed.id]) do
+      post feed_refresh_path(feed)
+    end
+
+    assert_redirected_to feed_path(feed)
+    assert_equal "Feed refresh started", flash[:notice]
+  end
+end

--- a/test/controllers/feeds/refreshes_controller_test.rb
+++ b/test/controllers/feeds/refreshes_controller_test.rb
@@ -34,4 +34,15 @@ class Feeds::RefreshesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to feed_path(feed)
     assert_equal "Feed refresh started", flash[:notice]
   end
+
+  test "create responds with turbo stream" do
+    sign_in_as(user)
+
+    assert_enqueued_with(job: FeedRefreshJob, args: [feed.id]) do
+      post feed_refresh_path(feed), as: :turbo_stream
+    end
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+  end
 end


### PR DESCRIPTION
Changes:

- Add a refresh button to the feed show page header that triggers a background refresh
- Add `Feeds::RefreshesController` to enqueue `FeedRefreshJob` for the current user's feed
- Add a `refresh?` feed policy (owner-only) and the nested `refresh` route

Lets users kick off an immediate feed refresh from the feed page instead of waiting for the next scheduled run. The button mirrors the Events Log refresh styling. The refresh workflow already logs its own `feed_refresh` event, so no extra event is recorded here.