### PR TITLE
Add reusable refresh button component

### DIFF
--- a/app/components/refresh_button_component.html.erb
+++ b/app/components/refresh_button_component.html.erb
@@ -1,0 +1,6 @@
+<%= tag.button(**button_attributes) do %>
+  <%= tag.span helpers.icon("refresh-ccw", css_class: "size-4", aria_label: @title),
+               data: { loading_button_target: "default" } %>
+  <%= tag.span helpers.icon("loader-circle", css_class: "size-4 animate-spin", aria_label: "Refreshing"),
+               class: "hidden", data: { loading_button_target: "loading" } %>
+<% end %>

--- a/app/components/refresh_button_component.rb
+++ b/app/components/refresh_button_component.rb
@@ -1,0 +1,40 @@
+class RefreshButtonComponent < ViewComponent::Base
+  BUTTON_CLASSES = "inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 " \
+    "text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 " \
+    "focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50".freeze
+
+  # An icon refresh button with a built-in spinner loading state.
+  #
+  # The button and its two icons are wired as loading-button targets, so a
+  # loading-button Stimulus controller — mounted on the button itself or an
+  # enclosing form — swaps the static icon for a spinner while a refresh runs.
+  #
+  # The trigger is the caller's concern: pass whatever attributes it needs and
+  # they're merged onto the button. For example, a polling refresh:
+  #
+  #   render RefreshButtonComponent.new(data: {
+  #     controller: "refresh-trigger loading-button",
+  #     refresh_trigger_target_id_value: EventLogComponent::DOM_ID,
+  #     action: "click->refresh-trigger#trigger"
+  #   })
+  #
+  # or a form submit, where the form hosts the loading-button controller:
+  #
+  #   render RefreshButtonComponent.new(title: "Refresh now", type: "submit")
+  def initialize(title: "Refresh", **attrs)
+    @title = title
+    @attrs = attrs
+  end
+
+  private
+
+  def button_attributes
+    attrs = @attrs.dup
+    {
+      type: attrs.delete(:type) || "button",
+      title: @title,
+      class: [BUTTON_CLASSES, attrs.delete(:class)],
+      data: { loading_button_target: "button" }.merge(attrs.delete(:data) || {})
+    }.merge(attrs)
+  end
+end

--- a/app/javascript/controllers/polling_controller.js
+++ b/app/javascript/controllers/polling_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
   refresh() {
     if (!this._running) this._running = true
     clearTimeout(this._timerId)
-    this._tick({ force: true })
+    return this._tick({ force: true })
   }
 
   stopPolling() {

--- a/app/javascript/controllers/refresh_trigger_controller.js
+++ b/app/javascript/controllers/refresh_trigger_controller.js
@@ -1,10 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
 
+// Triggers a forced refresh on a target element's polling controller. When the
+// same element also hosts a loading-button controller, its loading state is held
+// for the duration of the refresh so the button shows a spinner while it runs.
 export default class extends Controller {
   static values = { targetId: String }
 
-  trigger() {
+  async trigger() {
     const el = document.getElementById(this.targetIdValue)
-    this.application.getControllerForElementAndIdentifier(el, "polling")?.refresh()
+    const polling = el && this.application.getControllerForElementAndIdentifier(el, "polling")
+    if (!polling) return
+
+    const loading = this.application.getControllerForElementAndIdentifier(this.element, "loading-button")
+    loading?.start()
+    try {
+      await polling.refresh()
+    } finally {
+      loading?.end()
+    }
   }
 }

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -21,14 +21,7 @@
     <% end %>
     <% if @log_endpoint %>
       <% header.with_action_button do %>
-        <button data-controller="refresh-trigger"
-                data-refresh-trigger-target-id-value="<%= EventLogComponent::DOM_ID %>"
-                data-action="click->refresh-trigger#trigger"
-                data-key="events.refresh"
-                title="Refresh"
-                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">
-          <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
-        </button>
+        <%= render RefreshButtonComponent.new(target_id: EventLogComponent::DOM_ID, key: "events.refresh") %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -21,7 +21,12 @@
     <% end %>
     <% if @log_endpoint %>
       <% header.with_action_button do %>
-        <%= render RefreshButtonComponent.new(target_id: EventLogComponent::DOM_ID, key: "events.refresh") %>
+        <%= render RefreshButtonComponent.new(data: {
+              controller: "refresh-trigger loading-button",
+              refresh_trigger_target_id_value: EventLogComponent::DOM_ID,
+              action: "click->refresh-trigger#trigger",
+              key: "events.refresh"
+            }) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,14 +8,7 @@
     <% end %>
     <% if @log_endpoint %>
       <% header.with_action_button do %>
-        <button data-controller="refresh-trigger"
-                data-refresh-trigger-target-id-value="<%= EventLogComponent::DOM_ID %>"
-                data-action="click->refresh-trigger#trigger"
-                data-key="events.refresh"
-                title="Refresh"
-                class="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">
-          <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh") %>
-        </button>
+        <%= render RefreshButtonComponent.new(target_id: EventLogComponent::DOM_ID, key: "events.refresh") %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,7 +8,12 @@
     <% end %>
     <% if @log_endpoint %>
       <% header.with_action_button do %>
-        <%= render RefreshButtonComponent.new(target_id: EventLogComponent::DOM_ID, key: "events.refresh") %>
+        <%= render RefreshButtonComponent.new(data: {
+              controller: "refresh-trigger loading-button",
+              refresh_trigger_target_id_value: EventLogComponent::DOM_ID,
+              action: "click->refresh-trigger#trigger",
+              key: "events.refresh"
+            }) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -20,7 +20,12 @@
       <% end %>
     <% end %>
     <% header.with_action_button do %>
-      <%= render RefreshButtonComponent.new(url: feed_refresh_path(@feed), title: "Refresh now") %>
+      <%= form_with url: feed_refresh_path(@feed), method: :post, class: "inline-block", data: {
+            controller: "loading-button",
+            action: "turbo:submit-start->loading-button#start turbo:submit-end->loading-button#end"
+          } do %>
+        <%= render RefreshButtonComponent.new(title: "Refresh now", type: "submit") %>
+      <% end %>
     <% end %>
     <% header.with_action_button do %>
       <%= link_to "Edit", edit_feed_path(@feed), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -20,25 +20,7 @@
       <% end %>
     <% end %>
     <% header.with_action_button do %>
-      <%= button_to feed_refresh_path(@feed),
-                    method: :post,
-                    title: "Refresh now",
-                    class: class_names("inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
-                    data: { loading_button_target: "button" },
-                    form: {
-                      class: "inline-block",
-                      data: {
-                        controller: "loading-button",
-                        action: "turbo:submit-start->loading-button#start turbo:submit-end->loading-button#end"
-                      }
-                    } do %>
-        <span data-loading-button-target="default">
-          <%= icon("refresh-ccw", css_class: "size-4", aria_label: "Refresh now") %>
-        </span>
-        <span class="hidden" data-loading-button-target="loading">
-          <%= icon("loader-circle", css_class: "size-4 animate-spin", aria_label: "Refreshing") %>
-        </span>
-      <% end %>
+      <%= render RefreshButtonComponent.new(url: feed_refresh_path(@feed), title: "Refresh now") %>
     <% end %>
     <% header.with_action_button do %>
       <%= link_to "Edit", edit_feed_path(@feed), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>

--- a/test/components/refresh_button_component_test.rb
+++ b/test/components/refresh_button_component_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+require "view_component/test_case"
+
+class RefreshButtonComponentTest < ViewComponent::TestCase
+  test "#render should render a button wired as the loading-button target" do
+    result = render_inline(RefreshButtonComponent.new(title: "Refresh now"))
+
+    button = result.at_css("button")
+    assert_equal "button", button["type"]
+    assert_equal "Refresh now", button["title"]
+    assert_equal "button", button["data-loading-button-target"]
+  end
+
+  test "#render should show a default icon and a hidden spinner" do
+    result = render_inline(RefreshButtonComponent.new)
+
+    default_icon = result.at_css('[data-loading-button-target="default"]')
+    loading_icon = result.at_css('[data-loading-button-target="loading"]')
+
+    assert_not_nil default_icon.at_css("svg")
+    assert_not_nil loading_icon.at_css("svg.animate-spin")
+    assert_includes loading_icon["class"], "hidden"
+  end
+
+  test "#render should merge arbitrary attributes onto the button" do
+    result = render_inline(RefreshButtonComponent.new(type: "submit", class: "extra", data: {
+      controller: "refresh-trigger loading-button",
+      action: "click->refresh-trigger#trigger",
+      key: "events.refresh"
+    }))
+
+    button = result.at_css("button")
+    assert_equal "submit", button["type"]
+    assert_includes button["class"], "extra"
+    assert_includes button["class"], "rounded-md"
+    assert_equal "refresh-trigger loading-button", button["data-controller"]
+    assert_equal "click->refresh-trigger#trigger", button["data-action"]
+    assert_equal "events.refresh", button["data-key"]
+    # caller data is merged alongside the built-in loading-button target
+    assert_equal "button", button["data-loading-button-target"]
+  end
+end


### PR DESCRIPTION
Changes:

- Add `RefreshButtonComponent` — an icon refresh button with a spinner loading state, usable in two modes: a Turbo form POST (`url:`) or a client-side polling refresh (`target_id:`)
- Give the events and admin events refresh buttons the same loading feedback (disable + spinner, with a 0.5s minimum) they previously lacked
- Replace the hand-rolled refresh buttons on the feed, events, and admin events pages with the shared component
- Have `refresh-trigger` hold the loading state for the duration of an awaited polling refresh; `polling#refresh` now returns its promise

The feed refresh button (form-based) and the events log refresh buttons (polling-based) were visually identical but built separately, and only the feed one showed a loading spinner. This pulls both into one component so the markup and loading behavior live in a single place.