### PR TITLE
Stop attaching YouTube thumbnails to posts

### DIFF
--- a/app/services/normalizer/youtube_normalizer.rb
+++ b/app/services/normalizer/youtube_normalizer.rb
@@ -7,8 +7,9 @@ module Normalizer
     end
 
     def normalize_attachment_urls
-      thumbnail = raw_data.dig("thumbnail")
-      thumbnail.present? ? [thumbnail] : []
+      # Freefeed renders the video preview from the source URL, so attaching
+      # the thumbnail would just duplicate it.
+      []
     end
 
     def normalize_comments

--- a/test/fixtures/files/feeds/youtube/normalized.json
+++ b/test/fixtures/files/feeds/youtube/normalized.json
@@ -1,7 +1,5 @@
 {
-  "attachment_urls": [
-    "https://i.ytimg.com/vi/aAbBcCdDeEf/hqdefault.jpg"
-  ],
+  "attachment_urls": [],
   "comments": [
     "A beginner-friendly introduction to building web applications with Ruby on Rails. In this video we cover: - Setting up your development environment - Creating your first Rails app - Understanding the MVC pattern Subscribe for more tutorials: https://www.youtube.com/channel/UCabc123def456ghi789jkl"
   ],

--- a/test/services/normalizer/youtube_normalizer_test.rb
+++ b/test/services/normalizer/youtube_normalizer_test.rb
@@ -32,7 +32,7 @@ class Normalizer::YoutubeNormalizerTest < ActiveSupport::TestCase
     assert_includes post.content, "My Video"
   end
 
-  test "#normalize should include thumbnail as attachment" do
+  test "#normalize should not attach thumbnail" do
     entry = create(:feed_entry, raw_data: {
       "title" => "Video",
       "link" => "https://www.youtube.com/watch?v=abc123",
@@ -42,7 +42,7 @@ class Normalizer::YoutubeNormalizerTest < ActiveSupport::TestCase
     normalizer = Normalizer::YoutubeNormalizer.new(entry)
     post = normalizer.normalize
 
-    assert_equal ["https://i.ytimg.com/vi/abc123/hqdefault.jpg"], post.attachment_urls
+    assert_equal [], post.attachment_urls
   end
 
   test "#normalize should include description as comment" do
@@ -100,7 +100,7 @@ class Normalizer::YoutubeNormalizerTest < ActiveSupport::TestCase
     post = normalizer.normalize
 
     assert_includes post.content, "Getting Started with Ruby on Rails"
-    assert_equal ["https://i.ytimg.com/vi/aAbBcCdDeEf/hqdefault.jpg"], post.attachment_urls
+    assert_equal [], post.attachment_urls
     assert_equal 1, post.comments.length
     assert_includes post.comments.first, "beginner-friendly introduction"
   end


### PR DESCRIPTION
Changes:

- Stop attaching the video thumbnail when normalizing YouTube posts

Freefeed renders a video preview directly from the YouTube source URL, so attaching the thumbnail just duplicated that preview. Dropping it keeps the normalized output clean and avoids a redundant attachment. The raw thumbnail is still captured in `raw_data` — only the presentation changes.
