### PR TITLE
Surface repost time across status, feed, and post views

### DIFF
--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -52,11 +52,11 @@
         <% end %>
       <% end %>
       <span class="flex items-center gap-1">
-        <%= helpers.icon("refresh-ccw", css_class: "size-3.5") %>
+        <span class="text-slate-500">Updated:</span>
         <%= last_refreshed_tag %>
       </span>
       <span class="flex items-center gap-1">
-        <%= helpers.icon("layers", css_class: "size-3.5") %>
+        <span class="text-slate-500">Post:</span>
         <%= most_recent_post_tag %>
       </span>
     </div>

--- a/app/components/feed_card_component.rb
+++ b/app/components/feed_card_component.rb
@@ -46,16 +46,12 @@ class FeedCardComponent < ViewComponent::Base
   def last_refreshed_tag
     return "Never" unless feed.last_refreshed_at
 
-    helpers.content_tag(:time, "#{helpers.short_time_ago(feed.last_refreshed_at)} ago",
-                        datetime: feed.last_refreshed_at.rfc3339,
-                        title: helpers.long_time_format(feed.last_refreshed_at))
+    helpers.short_time_ago_tag(feed.last_refreshed_at)
   end
 
   def most_recent_post_tag
     return "None" unless feed.most_recent_post_date
 
-    helpers.content_tag(:time, "#{helpers.short_time_ago(feed.most_recent_post_date)} ago",
-                        datetime: feed.most_recent_post_date.rfc3339,
-                        title: helpers.long_time_format(feed.most_recent_post_date))
+    helpers.short_time_ago_tag(feed.most_recent_post_date)
   end
 end

--- a/app/components/feed_stats_component.rb
+++ b/app/components/feed_stats_component.rb
@@ -30,10 +30,10 @@ class FeedStatsComponent < ViewComponent::Base
         value: last_refresh_value
       },
       {
-        key: "most_recent_post",
-        label: "Most recent publication",
+        key: "most_recent_repost",
+        label: "Most recent repost",
         label_short: "Recent",
-        value: most_recent_post_value
+        value: most_recent_repost_value
       },
       {
         key: "imported_posts",
@@ -74,11 +74,11 @@ class FeedStatsComponent < ViewComponent::Base
     end
   end
 
-  def most_recent_post_value
-    if @feed.most_recent_post_date
-      helpers.short_time_ago_tag(@feed.most_recent_post_date)
+  def most_recent_repost_value
+    if @feed.most_recent_repost_at
+      helpers.short_time_ago_tag(@feed.most_recent_repost_at)
     else
-      content_tag(:span, "No posts imported", class: "text-slate-500")
+      content_tag(:span, "No reposts yet", class: "text-slate-500")
     end
   end
 

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -13,9 +13,16 @@
     <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
       <div class="flex items-center gap-3 text-sm text-slate-400">
         <% if published_time_tag %>
-          <div class="flex shrink-0 items-center" title="Published / reposted">
-            <%= published_time_tag %><% if reposted_time_tag %><span aria-hidden="true">/</span><%= reposted_time_tag %><% end %>
-          </div>
+          <span class="flex shrink-0 items-center gap-1">
+            <span class="text-slate-500">Published:</span>
+            <%= published_time_tag %>
+          </span>
+        <% end %>
+        <% if reposted_time_tag %>
+          <span class="flex shrink-0 items-center gap-1">
+            <span class="text-slate-500">Reposted:</span>
+            <%= reposted_time_tag %>
+          </span>
         <% end %>
         <% if group_label %>
           <%= link_to group_label, group_url, title: group_hint,

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -13,8 +13,8 @@
     <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
       <div class="flex items-center gap-3 text-sm text-slate-400">
         <% if published_time_tag %>
-          <div class="flex shrink-0 items-center">
-            <%= published_time_tag %>
+          <div class="flex shrink-0 items-center" title="Published / reposted">
+            <%= published_time_tag %><% if reposted_time_tag %><span aria-hidden="true">/</span><%= reposted_time_tag %><% end %>
           </div>
         <% end %>
         <% if group_label %>

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -36,6 +36,11 @@ class PostCardComponent < ViewComponent::Base
     helpers.short_time_ago_tag(post.published_at)
   end
 
+  def reposted_time_tag
+    return unless post.reposted_at
+    helpers.short_time_ago_tag(post.reposted_at)
+  end
+
   def attachment_count
     Array(post.attachment_urls).size
   end

--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -7,6 +7,7 @@ class PostDetailsComponent < ViewComponent::Base
     render(ListComponent.new) do |list|
       add_feed_item(list)
       add_published_item(list)
+      add_reposted_item(list) if @post.reposted_at
       add_attachments_item(list) if @post.attachment_urls.present?
       add_comments_item(list) if @post.comments.present?
       add_source_url_item(list)
@@ -32,6 +33,14 @@ class PostDetailsComponent < ViewComponent::Base
       label: "Published",
       value: value,
       key: "post.published"
+    ))
+  end
+
+  def add_reposted_item(component)
+    component.with_item(ListComponent::StatItemComponent.new(
+      label: "Reposted",
+      value: helpers.datetime_with_duration_tag(@post.reposted_at),
+      key: "post.reposted"
     ))
   end
 

--- a/app/components/user_stats_component.rb
+++ b/app/components/user_stats_component.rb
@@ -50,10 +50,10 @@ class UserStatsComponent < ViewComponent::Base
         value: number_with_delimiter(user.posts_published_last_week_count)
       },
       {
-        key: "most_recent_post_publication",
-        label: "Most recent post publication",
+        key: "most_recent_repost",
+        label: "Most recent repost",
         label_short: "Recent",
-        value: user.most_recent_post_published_at.present? ? "#{helpers.short_time_ago(user.most_recent_post_published_at)} ago" : "—"
+        value: user.most_recent_repost_at.present? ? "#{helpers.short_time_ago(user.most_recent_repost_at)} ago" : "—"
       }
     ]
   end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -228,6 +228,13 @@ class Feed < ApplicationRecord
     posts.maximum(:published_at)
   end
 
+  # Returns the time of the most recent repost (publication to FreeFeed),
+  # regardless of the original source publication date.
+  # @return [Time, nil] most recent repost time or nil if no published posts
+  def most_recent_repost_at
+    posts.published.maximum(:updated_at)
+  end
+
   # Returns metrics for a date range, filling gaps with zeros
   # @param start_date [Date] start date of the range
   # @param end_date [Date] end date of the range (inclusive)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -46,6 +46,14 @@ class Post < ApplicationRecord
     "#{group_url}/#{freefeed_post_id}"
   end
 
+  # Returns the time the post was reposted to FreeFeed, or nil if it hasn't
+  # been published there. This reflects the repost moment, not the original
+  # source publication date (see #published_at).
+  # @return [Time, nil]
+  def reposted_at
+    updated_at if published?
+  end
+
   def normalized_attributes
     as_json(only: NORMALIZED_ATTRIBUTES)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,10 +114,12 @@ class User < ApplicationRecord
     published_posts.count
   end
 
-  # Returns the timestamp of the most recently published post across all user's feeds
-  # @return [Time, nil] most recent publication timestamp or nil if no published posts
-  def most_recent_post_published_at
-    published_posts.maximum(:published_at)
+  # Returns the timestamp of the most recent repost across all user's feeds.
+  # This reflects when a post was published to FreeFeed, not the original
+  # source publication date.
+  # @return [Time, nil] most recent repost timestamp or nil if no published posts
+  def most_recent_repost_at
+    published_posts.maximum(:updated_at)
   end
 
   def posts_published_last_week_count

--- a/test/components/feed_card_component_test.rb
+++ b/test/components/feed_card_component_test.rb
@@ -82,4 +82,11 @@ class FeedCardComponentTest < ViewComponent::TestCase
     assert_includes result.text, "Never"
     assert_includes result.text, "None"
   end
+
+  test "#render should label the activity times" do
+    result = render_inline FeedCardComponent.new(feed: feed)
+
+    assert_includes result.text, "Updated:"
+    assert_includes result.text, "Post:"
+  end
 end

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -12,7 +12,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
   def feed_with_posts
     @feed_with_posts ||= create(:feed).tap do |f|
       create(:feed_entry, feed: f, created_at: 1.hour.ago)
-      create(:post, :published, feed: f, published_at: 2.hours.ago)
+      create(:post, :published, feed: f, published_at: 2.hours.ago, updated_at: 1.hour.ago)
       create(:post, feed: f, published_at: 3.hours.ago)
     end
   end
@@ -24,8 +24,9 @@ class FeedStatsComponentTest < ViewComponent::TestCase
       last_refresh = result.css('[data-key="stats.last_refresh"]').first
       assert_not_nil last_refresh
 
-      most_recent = result.css('[data-key="stats.most_recent_post"]').first
+      most_recent = result.css('[data-key="stats.most_recent_repost"]').first
       assert_not_nil most_recent
+      assert_equal "1h", result.css('[data-key="stats.most_recent_repost.value"]').first.text.strip
 
       imported = result.css('[data-key="stats.imported_posts"]').first
       assert_not_nil imported
@@ -43,7 +44,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     mobile_layout = result.css(".md\\:hidden").first
     assert_not_nil mobile_layout
     assert_equal "Last refresh", result.css(".md\\:hidden [data-key=\"stats.last_refresh.label\"]").first.text
-    assert_equal "Most recent publication", result.css(".md\\:hidden [data-key=\"stats.most_recent_post.label\"]").first.text
+    assert_equal "Most recent repost", result.css(".md\\:hidden [data-key=\"stats.most_recent_repost.label\"]").first.text
     assert_equal "Imported posts", result.css(".md\\:hidden [data-key=\"stats.imported_posts.label\"]").first.text
   end
 
@@ -53,7 +54,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     desktop_layout = result.css(".hidden.md\\:flex").first
     assert_not_nil desktop_layout
     assert_equal "Refreshed", result.css(".hidden.md\\:flex [data-key=\"stats.last_refresh.label\"]").first.text
-    assert_equal "Recent", result.css(".hidden.md\\:flex [data-key=\"stats.most_recent_post.label\"]").first.text
+    assert_equal "Recent", result.css(".hidden.md\\:flex [data-key=\"stats.most_recent_repost.label\"]").first.text
     assert_equal "Imported", result.css(".hidden.md\\:flex [data-key=\"stats.imported_posts.label\"]").first.text
     assert_equal "Published", result.css(".hidden.md\\:flex [data-key=\"stats.published_posts.label\"]").first.text
   end
@@ -66,7 +67,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     last_refresh_value = result.css('[data-key="stats.last_refresh.value"]').first.text
     assert_equal "Never", last_refresh_value
 
-    most_recent_value = result.css('[data-key="stats.most_recent_post.value"]').first.text
-    assert_equal "No posts imported", most_recent_value
+    most_recent_value = result.css('[data-key="stats.most_recent_repost.value"]').first.text
+    assert_equal "No reposts yet", most_recent_value
   end
 end

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -62,4 +62,21 @@ class PostCardComponentTest < ViewComponent::TestCase
 
     assert_not_empty result.css(".border-t.border-slate-200")
   end
+
+  test "#render should show both published and reposted times for published posts" do
+    published_post = create(:post, :published, feed: feed, published_at: 11.hours.ago, updated_at: 10.hours.ago)
+    result = render_inline PostCardComponent.new(post: published_post)
+
+    times = result.css("time").map { |t| t.text.strip }
+    assert_includes times, "11h"
+    assert_includes times, "10h"
+  end
+
+  test "#render should not show a reposted time for unpublished posts" do
+    draft_post = create(:post, feed: feed, status: :draft, published_at: 11.hours.ago)
+    result = render_inline PostCardComponent.new(post: draft_post)
+
+    times = result.css("time").map { |t| t.text.strip }
+    assert_equal ["11h"], times
+  end
 end

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -63,10 +63,12 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_not_empty result.css(".border-t.border-slate-200")
   end
 
-  test "#render should show both published and reposted times for published posts" do
+  test "#render should show labeled published and reposted times for published posts" do
     published_post = create(:post, :published, feed: feed, published_at: 11.hours.ago, updated_at: 10.hours.ago)
     result = render_inline PostCardComponent.new(post: published_post)
 
+    assert_includes result.text, "Published:"
+    assert_includes result.text, "Reposted:"
     times = result.css("time").map { |t| t.text.strip }
     assert_includes times, "11h"
     assert_includes times, "10h"
@@ -76,6 +78,8 @@ class PostCardComponentTest < ViewComponent::TestCase
     draft_post = create(:post, feed: feed, status: :draft, published_at: 11.hours.ago)
     result = render_inline PostCardComponent.new(post: draft_post)
 
+    assert_includes result.text, "Published:"
+    assert_not_includes result.text, "Reposted:"
     times = result.css("time").map { |t| t.text.strip }
     assert_equal ["11h"], times
   end

--- a/test/components/post_details_component_test.rb
+++ b/test/components/post_details_component_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+require "view_component/test_case"
+
+class PostDetailsComponentTest < ViewComponent::TestCase
+  def feed
+    @feed ||= create(:feed)
+  end
+
+  test "#render should show the reposted time for published posts" do
+    post = create(:post, :published, feed: feed, published_at: 1.day.ago, updated_at: 1.hour.ago)
+
+    result = render_inline(PostDetailsComponent.new(post: post))
+
+    assert_not_nil result.css('[data-key="post.reposted"]').first
+    assert_includes result.css('[data-key="post.reposted.label"]').first.text, "Reposted"
+  end
+
+  test "#render should not show the reposted field for unpublished posts" do
+    post = create(:post, feed: feed, status: :draft)
+
+    result = render_inline(PostDetailsComponent.new(post: post))
+
+    assert_nil result.css('[data-key="post.reposted"]').first
+  end
+end

--- a/test/components/user_stats_component_test.rb
+++ b/test/components/user_stats_component_test.rb
@@ -19,7 +19,7 @@ class UserStatsComponentTest < ViewComponent::TestCase
     published = result.css('[data-key="stats.total_published_posts"]').first
     assert_not_nil published
 
-    recent = result.css('[data-key="stats.most_recent_post_publication"]').first
+    recent = result.css('[data-key="stats.most_recent_repost"]').first
     assert_not_nil recent
 
     average = result.css('[data-key="stats.posts_last_week"]').first
@@ -50,7 +50,7 @@ class UserStatsComponentTest < ViewComponent::TestCase
 
     result = render_inline(UserStatsComponent.new(user: user_without_posts))
 
-    recent_value = result.css('[data-key="stats.most_recent_post_publication.value"]').first.text
+    recent_value = result.css('[data-key="stats.most_recent_repost.value"]').first.text
     assert_equal "—", recent_value
   end
 end

--- a/test/controllers/statuses_controller_test.rb
+++ b/test/controllers/statuses_controller_test.rb
@@ -66,24 +66,24 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "2", css_select('[data-key="stats.total_published_posts.value"]').first.text.strip
   end
 
-  test "#show should display most recent post publication timestamp" do
+  test "#show should display most recent repost timestamp" do
     sign_in_as user
     feed = create(:feed, user: user)
     entry = create(:feed_entry, feed: feed)
-    create(:post, feed: feed, feed_entry: entry, status: :published, published_at: 1.day.ago)
+    create(:post, feed: feed, feed_entry: entry, status: :published, published_at: 1.year.ago, updated_at: 1.day.ago)
 
     get status_path
     assert_response :success
-    assert_not_nil css_select('[data-key="stats.most_recent_post_publication"]').first
-    assert_match(/1d ago/, css_select('[data-key="stats.most_recent_post_publication.value"]').first.text)
+    assert_not_nil css_select('[data-key="stats.most_recent_repost"]').first
+    assert_match(/1d ago/, css_select('[data-key="stats.most_recent_repost.value"]').first.text)
   end
 
-  test "#show should hide most recent post publication when no published posts" do
+  test "#show should hide most recent repost when no published posts" do
     sign_in_as user
 
     get status_path
     assert_response :success
-    assert css_select('[data-key="stats.most_recent_post_publication"]').empty?
+    assert css_select('[data-key="stats.most_recent_repost"]').empty?
   end
 
   test "#show should display posts published last week" do
@@ -115,7 +115,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert css_select('[data-key="stats.total_imported_posts"]').empty?
     assert css_select('[data-key="stats.total_published_posts"]').empty?
-    assert css_select('[data-key="stats.most_recent_post_publication"]').empty?
+    assert css_select('[data-key="stats.most_recent_repost"]').empty?
     assert css_select('[data-key="stats.posts_last_week"]').empty?
   end
 

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -821,4 +821,21 @@ class FeedTest < ActiveSupport::TestCase
 
     assert_nil feed.target_group_url
   end
+
+  test "#most_recent_repost_at should return latest repost time regardless of original publication date" do
+    feed = create(:feed)
+    # Older original publication date, but reposted most recently.
+    create(:post, :published, feed: feed, published_at: 10.days.ago, updated_at: 1.hour.ago)
+    create(:post, :published, feed: feed, published_at: 1.day.ago, updated_at: 2.days.ago)
+    create(:post, feed: feed, status: :draft, updated_at: Time.current)
+
+    assert_in_delta 1.hour.ago.to_i, feed.most_recent_repost_at.to_i, 1
+  end
+
+  test "#most_recent_repost_at should return nil when no published posts" do
+    feed = create(:feed)
+    create(:post, feed: feed, status: :draft)
+
+    assert_nil feed.most_recent_repost_at
+  end
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -153,6 +153,18 @@ class PostTest < ActiveSupport::TestCase
     assert post.valid?
   end
 
+  test "#reposted_at should return the update time for published posts" do
+    post = create(:post, :published, feed: feed, feed_entry: feed_entry, updated_at: 1.hour.ago)
+
+    assert_in_delta 1.hour.ago.to_i, post.reposted_at.to_i, 1
+  end
+
+  test "#reposted_at should return nil for posts that are not published" do
+    post = create(:post, feed: feed, feed_entry: feed_entry, status: :draft)
+
+    assert_nil post.reposted_at
+  end
+
   test "should validate content length within FreeFeed limits" do
     post = build(:post, content: "a" * Post::MAX_CONTENT_LENGTH)
     assert post.valid?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -181,27 +181,28 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 2, user.total_published_posts_count
   end
 
-  test "#most_recent_post_published_at returns timestamp of most recent published post" do
+  test "#most_recent_repost_at returns the most recent repost timestamp regardless of original publication date" do
     user = create(:user)
     feed = create(:feed, user: user)
     entry1 = create(:feed_entry, feed: feed)
     entry2 = create(:feed_entry, feed: feed)
     entry3 = create(:feed_entry, feed: feed)
 
-    create(:post, feed: feed, feed_entry: entry1, status: :published, published_at: 3.days.ago)
-    create(:post, feed: feed, feed_entry: entry2, status: :published, published_at: 1.day.ago)
-    create(:post, feed: feed, feed_entry: entry3, status: :draft, published_at: Time.current)
+    # Older original publication date, but reposted most recently.
+    create(:post, feed: feed, feed_entry: entry1, status: :published, published_at: 10.days.ago, updated_at: 1.hour.ago)
+    create(:post, feed: feed, feed_entry: entry2, status: :published, published_at: 1.day.ago, updated_at: 2.days.ago)
+    create(:post, feed: feed, feed_entry: entry3, status: :draft, updated_at: Time.current)
 
-    assert_in_delta 1.day.ago.to_i, user.most_recent_post_published_at.to_i, 1
+    assert_in_delta 1.hour.ago.to_i, user.most_recent_repost_at.to_i, 1
   end
 
-  test "#most_recent_post_published_at returns nil when no published posts" do
+  test "#most_recent_repost_at returns nil when no published posts" do
     user = create(:user)
     feed = create(:feed, user: user)
     entry = create(:feed_entry, feed: feed)
     create(:post, feed: feed, feed_entry: entry, status: :draft)
 
-    assert_nil user.most_recent_post_published_at
+    assert_nil user.most_recent_repost_at
   end
 
   test "#posts_published_last_week_count should return count of posts from the last 7 days" do


### PR DESCRIPTION
Changes:

- Status page and feed stats "Recent" metric now report time since the most recent repost to FreeFeed, instead of the original source publication date
- Post detail page shows a "Reposted" timestamp under "Published"
- Post cards show both "Published:" and "Reposted:" times with clear text labels
- Feed cards use text labels ("Updated:", "Post:") in place of icons for their activity times

Previously these views keyed off `published_at`, the original publication date carried over from the source. A post that came out long ago but was reposted today looked stale. The app now distinguishes when content was originally published from when it was reposted to FreeFeed, and surfaces whichever is relevant to each view.