### PR TITLE
Simplify feed creation success message

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -60,7 +60,7 @@ class AccessTokensController < ApplicationController
     access_token = find_access_token
     authorize access_token
     access_token.destroy!
-    redirect_to access_tokens_path, notice: "Access token '#{access_token.name}' has been deleted."
+    redirect_to access_tokens_path, notice: "Access token '#{access_token.name}' deleted."
   end
 
   private

--- a/app/controllers/admin/email_reactivations_controller.rb
+++ b/app/controllers/admin/email_reactivations_controller.rb
@@ -3,6 +3,6 @@ class Admin::EmailReactivationsController < ApplicationController
     @user = User.find(params[:user_id])
     authorize @user, :reactivate_email?
     @user.reactivate_email!
-    redirect_to admin_user_path(@user), notice: "Email reactivated successfully."
+    redirect_to admin_user_path(@user), notice: "Email reactivated."
   end
 end

--- a/app/controllers/admin/email_updates_controller.rb
+++ b/app/controllers/admin/email_updates_controller.rb
@@ -27,7 +27,7 @@ class Admin::EmailUpdatesController < ApplicationController
       ProfileMailer.email_change_confirmation(user, new_email).deliver_later
       redirect_to admin_user_path(user), notice: "Confirmation email sent to #{new_email}. User must confirm before change takes effect."
     elsif user.update(email_address: new_email)
-      redirect_to admin_user_path(user), notice: "Email address updated successfully."
+      redirect_to admin_user_path(user), notice: "Email address updated."
     else
       redirect_to edit_admin_user_email_update_path(user), alert: "Failed to update email address."
     end

--- a/app/controllers/admin/suspensions_controller.rb
+++ b/app/controllers/admin/suspensions_controller.rb
@@ -3,14 +3,14 @@ class Admin::SuspensionsController < ApplicationController
     authorize User, :suspend?
     user = find_user
     suspend_user_and_record_event(user)
-    redirect_to admin_user_path(user), notice: "User has been suspended."
+    redirect_to admin_user_path(user), notice: "User suspended."
   end
 
   def destroy
     authorize User, :unsuspend?
     user = find_user
     unsuspend_user_and_record_event(user)
-    redirect_to admin_user_path(user), notice: "User has been unsuspended."
+    redirect_to admin_user_path(user), notice: "User unsuspended."
   end
 
   private

--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -21,7 +21,7 @@ class FeedStatusesController < ApplicationController
     feed.with_lock do
       if feed.can_be_enabled?
         feed.enabled!
-        redirect_to feed, notice: "Feed was successfully enabled."
+        redirect_to feed, notice: "Feed enabled."
       else
         missing_parts = feed_missing_enablement_parts(feed)
         redirect_to feed, alert: "Cannot enable feed: missing #{missing_parts.join(' and ')}."
@@ -32,7 +32,7 @@ class FeedStatusesController < ApplicationController
   def disable(feed)
     feed.with_lock do
       feed.disabled!
-      redirect_to feed, notice: "Feed was successfully disabled."
+      redirect_to feed, notice: "Feed disabled."
     end
   end
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -119,7 +119,7 @@ class FeedsController < ApplicationController
     @feed = load_feed
     authorize @feed
     @feed.destroy!
-    redirect_to feeds_path, notice: "Feed was successfully deleted."
+    redirect_to feeds_path, notice: "Feed deleted."
   end
 
   private

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -233,7 +233,7 @@ class FeedsController < ApplicationController
   # disabled state; `#update` doesn't share this helper).
   def success_message_for(feed)
     if feed.enabled?
-      "Feed '#{feed.name}' was successfully created and is now active."
+      "Feed created and enabled."
     elsif feed.disabled?
       "Feed '#{feed.name}' was successfully created but is currently disabled. " \
         "Enable it from the feed page when you're ready to start importing posts."

--- a/app/controllers/llm_credentials_controller.rb
+++ b/app/controllers/llm_credentials_controller.rb
@@ -51,7 +51,7 @@ class LlmCredentialsController < ApplicationController
     credential = find_credential
     authorize credential
     credential.destroy!
-    redirect_to llm_credentials_path, notice: "AI credential '#{credential.display_name}' has been deleted."
+    redirect_to llm_credentials_path, notice: "AI credential '#{credential.display_name}' deleted."
   end
 
   private

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -14,7 +14,7 @@ class PasswordsController < ApplicationController
 
   def update
     if @user.update(params.permit(:password, :password_confirmation))
-      redirect_to new_session_path, notice: "Password has been reset."
+      redirect_to new_session_path, notice: "Password reset."
     else
       redirect_to edit_password_path(params[:token]), alert: "Passwords did not match."
     end

--- a/app/controllers/settings/email_confirmations_controller.rb
+++ b/app/controllers/settings/email_confirmations_controller.rb
@@ -44,7 +44,7 @@ class Settings::EmailConfirmationsController < ApplicationController
 
   def redirect_with_success
     redirect_path = authenticated? ? settings_path : new_session_path
-    redirect_to redirect_path, notice: "Email address successfully updated."
+    redirect_to redirect_path, notice: "Email address updated."
   end
 
   def redirect_with_failure

--- a/app/controllers/settings/password_updates_controller.rb
+++ b/app/controllers/settings/password_updates_controller.rb
@@ -34,7 +34,7 @@ class Settings::PasswordUpdatesController < ApplicationController
   end
 
   def redirect_with_success
-    redirect_to settings_path, notice: "Password updated successfully."
+    redirect_to settings_path, notice: "Password updated."
   end
 
   def redirect_with_validation_errors

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -54,7 +54,7 @@ The seed script creates:
 
 **Expected Results:**
 - Page redirects to feed show page (URL pattern: `/feeds/[number]`)
-- Success message appears (green background): "Feed '[name]' was successfully created and is now active. New posts will be checked every 1 hour and published to testgroup."
+- Success message appears (green background): "Feed created and enabled."
 - Page shows feed details with "Edit" button visible
 - "Disable" button is present (feed is enabled)
 

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -364,7 +364,7 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to access_tokens_path
-    assert_equal "Access token '#{access_token.name}' has been deleted.", flash[:notice]
+    assert_equal "Access token '#{access_token.name}' deleted.", flash[:notice]
   end
 
   test "cannot delete other user's token" do

--- a/test/controllers/admin/email_reactivations_controller_test.rb
+++ b/test/controllers/admin/email_reactivations_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::EmailReactivationsControllerTest < ActionDispatch::IntegrationTest
     assert_nil user.email_deactivation_reason
     assert_redirected_to admin_user_path(user)
     follow_redirect!
-    assert_select "[role=\"alert\"]", text: /Email reactivated successfully/
+    assert_select "[role=\"alert\"]", text: /Email reactivated/
   end
 
   test "should prevent non-admin from reactivating user email" do

--- a/test/controllers/admin/email_updates_controller_test.rb
+++ b/test/controllers/admin/email_updates_controller_test.rb
@@ -36,7 +36,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
     patch admin_user_email_update_path(user), params: { user: { email_address: "new@example.com" }, require_confirmation: "0" }
 
     assert_redirected_to admin_user_path(user)
-    assert_equal "Email address updated successfully.", flash[:notice]
+    assert_equal "Email address updated.", flash[:notice]
     assert_equal "new@example.com", user.reload.email_address
   end
 

--- a/test/controllers/feed_statuses_controller_test.rb
+++ b/test/controllers/feed_statuses_controller_test.rb
@@ -16,7 +16,7 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to feed
     follow_redirect!
-    assert_includes response.body, "Feed was successfully enabled"
+    assert_includes response.body, "Feed enabled"
 
     feed.reload
     assert_equal "enabled", feed.state
@@ -30,7 +30,7 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to feed
     follow_redirect!
-    assert_includes response.body, "Feed was successfully disabled"
+    assert_includes response.body, "Feed disabled"
 
     feed.reload
     assert_equal "disabled", feed.state
@@ -52,7 +52,7 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to enabled_feed
     follow_redirect!
-    assert_includes response.body, "Feed was successfully disabled"
+    assert_includes response.body, "Feed disabled"
 
     enabled_feed.reload
     assert_equal "disabled", enabled_feed.state
@@ -66,7 +66,7 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to disabled_feed
     follow_redirect!
-    assert_includes response.body, "Feed was successfully enabled"
+    assert_includes response.body, "Feed enabled"
 
     disabled_feed.reload
     assert_equal "enabled", disabled_feed.state
@@ -131,7 +131,7 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to feed
     follow_redirect!
-    assert_includes response.body, "Feed was successfully enabled"
+    assert_includes response.body, "Feed enabled"
   end
 
   test "#update should use database transaction for atomic updates" do

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -87,7 +87,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil feed.feed_schedule.next_run_at
     assert_not_nil feed.feed_schedule.last_run_at
     assert_redirected_to feed_path(feed)
-    assert_match "successfully created and is now active", flash[:notice]
+    assert_match "Feed created and enabled.", flash[:notice]
   end
 
   test "#create should save as draft with blank name" do

--- a/test/controllers/settings/email_confirmations_controller_test.rb
+++ b/test/controllers/settings/email_confirmations_controller_test.rb
@@ -23,7 +23,7 @@ class Settings::EmailConfirmationsControllerTest < ActionDispatch::IntegrationTe
     get settings_email_confirmation_url(token)
 
     assert_redirected_to settings_path
-    assert_equal "Email address successfully updated.", flash[:notice]
+    assert_equal "Email address updated.", flash[:notice]
     assert_equal new_email, user.reload.email_address
     assert_nil user.unconfirmed_email
   end

--- a/test/controllers/settings/password_updates_controller_test.rb
+++ b/test/controllers/settings/password_updates_controller_test.rb
@@ -30,7 +30,7 @@ class Settings::PasswordUpdatesControllerTest < ActionDispatch::IntegrationTest
       }
     }
     assert_redirected_to settings_path
-    assert_equal "Password updated successfully.", flash[:notice]
+    assert_equal "Password updated.", flash[:notice]
   end
 
   test "should not update password with incorrect current password" do


### PR DESCRIPTION
Changes:

- Simplify the feed creation success message to "Feed created and enabled."
- Update the controller test and manual testing docs to match

The previous message ("Feed '[name]' was successfully created and is now active.") was wordy and redundant — the green success alert already signals success. The new wording is shorter and uses "enabled," consistent with the disabled/draft branches.
