### PR TITLE
Merge post timestamps into source and repost links

### DIFF
--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -31,12 +31,12 @@
       </div>
 
       <div class="flex items-center gap-3">
-        <% if origin_content %>
+        <% if source_content %>
           <% if source_url %>
-            <%= link_to origin_content, source_url, target: "_blank", rel: "noopener",
+            <%= link_to source_content, source_url, target: "_blank", rel: "noopener",
                   class: "text-sm text-slate-400 transition hover:text-slate-600" %>
           <% else %>
-            <span class="text-sm text-slate-400"><%= origin_content %></span>
+            <span class="text-sm text-slate-400"><%= source_content %></span>
           <% end %>
         <% end %>
 

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -30,21 +30,15 @@
     </div>
 
     <div class="flex items-center gap-3">
-      <% if source_content %>
-        <% if source_url %>
-          <%= link_to source_content, source_url, target: "_blank", rel: "noopener",
-                class: "text-sm text-slate-400 transition hover:text-slate-600" %>
-        <% else %>
-          <span class="text-sm text-slate-400"><%= source_content %></span>
-        <% end %>
-      <% end %>
+      <%= link_to source_label, source_url, target: "_blank", rel: "noopener",
+            class: "text-sm text-slate-400 transition hover:text-slate-600" %>
 
-      <% if repost_content %>
+      <% if repost_label %>
         <% if freefeed_url %>
-          <%= link_to repost_content, freefeed_url, target: "_blank", rel: "noopener",
+          <%= link_to repost_label, freefeed_url, target: "_blank", rel: "noopener",
                 class: "text-sm text-slate-400 transition hover:text-slate-600" %>
         <% else %>
-          <span class="text-sm text-slate-400"><%= repost_content %></span>
+          <span class="text-sm text-slate-400"><%= repost_label %></span>
         <% end %>
       <% end %>
 

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -12,18 +12,6 @@
   <% if footer? %>
     <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
       <div class="flex items-center gap-3 text-sm text-slate-400">
-        <% if published_time_tag %>
-          <span class="flex shrink-0 items-center gap-1">
-            <span class="text-slate-500">Published:</span>
-            <%= published_time_tag %>
-          </span>
-        <% end %>
-        <% if reposted_time_tag %>
-          <span class="flex shrink-0 items-center gap-1">
-            <span class="text-slate-500">Reposted:</span>
-            <%= reposted_time_tag %>
-          </span>
-        <% end %>
         <% if group_label %>
           <%= link_to group_label, group_url, title: group_hint,
                 class: "transition hover:text-slate-600" %>
@@ -43,14 +31,22 @@
       </div>
 
       <div class="flex items-center gap-3">
-        <% if source_url %>
-          <%= link_to "Source", source_url, target: "_blank", rel: "noopener",
-                class: "text-sm text-slate-400 transition hover:text-slate-600" %>
+        <% if origin_content %>
+          <% if source_url %>
+            <%= link_to origin_content, source_url, target: "_blank", rel: "noopener",
+                  class: "text-sm text-slate-400 transition hover:text-slate-600" %>
+          <% else %>
+            <span class="text-sm text-slate-400"><%= origin_content %></span>
+          <% end %>
         <% end %>
 
-        <% if freefeed_url %>
-          <%= link_to "FreeFeed", freefeed_url, target: "_blank", rel: "noopener",
-                class: "text-sm text-slate-400 transition hover:text-slate-600" %>
+        <% if repost_content %>
+          <% if freefeed_url %>
+            <%= link_to repost_content, freefeed_url, target: "_blank", rel: "noopener",
+                  class: "text-sm text-slate-400 transition hover:text-slate-600" %>
+          <% else %>
+            <span class="text-sm text-slate-400"><%= repost_content %></span>
+          <% end %>
         <% end %>
 
         <% if withdraw_allowed? %>

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -9,74 +9,72 @@
     </div>
   </div>
 
-  <% if footer? %>
-    <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
-      <div class="flex items-center gap-3 text-sm text-slate-400">
-        <% if group_label %>
-          <%= link_to group_label, group_url, title: group_hint,
-                class: "transition hover:text-slate-600" %>
-        <% end %>
-        <% if attachment_count > 0 %>
-          <span class="flex items-center gap-1">
-            <%= helpers.icon("paperclip", css_class: "size-3.5") %>
-            <%= attachment_count %>
-          </span>
-        <% end %>
-        <% if comment_count > 0 %>
-          <span class="flex items-center gap-1">
-            <%= helpers.icon("message-circle", css_class: "size-3.5") %>
-            <%= comment_count %>
-          </span>
-        <% end %>
-      </div>
-
-      <div class="flex items-center gap-3">
-        <% if source_content %>
-          <% if source_url %>
-            <%= link_to source_content, source_url, target: "_blank", rel: "noopener",
-                  class: "text-sm text-slate-400 transition hover:text-slate-600" %>
-          <% else %>
-            <span class="text-sm text-slate-400"><%= source_content %></span>
-          <% end %>
-        <% end %>
-
-        <% if repost_content %>
-          <% if freefeed_url %>
-            <%= link_to repost_content, freefeed_url, target: "_blank", rel: "noopener",
-                  class: "text-sm text-slate-400 transition hover:text-slate-600" %>
-          <% else %>
-            <span class="text-sm text-slate-400"><%= repost_content %></span>
-          <% end %>
-        <% end %>
-
-        <% if withdraw_allowed? %>
-          <div class="relative">
-            <button type="button"
-                    id="<%= menu_id %>-button"
-                    data-dropdown-toggle="<%= menu_id %>"
-                    data-dropdown-placement="bottom-end"
-                    class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
-                    aria-haspopup="true"
-                    aria-expanded="false">
-              <%= helpers.icon("ellipsis", css_class: "size-4") %>
-              <span class="sr-only">More options</span>
-            </button>
-            <div id="<%= menu_id %>"
-                 class="z-20 hidden w-40 rounded-lg border border-slate-200 bg-white shadow-sm"
-                 role="menu"
-                 aria-labelledby="<%= menu_id %>-button">
-              <ul class="py-1">
-                <li>
-                  <%= link_to "Withdraw", helpers.post_path(post),
-                        data: { turbo_method: :delete, turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here." },
-                        class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
-                        role: "menuitem" %>
-                </li>
-              </ul>
-            </div>
-          </div>
-        <% end %>
-      </div>
+  <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
+    <div class="flex items-center gap-3 text-sm text-slate-400">
+      <% if group_label %>
+        <%= link_to group_label, group_url, title: group_hint,
+              class: "transition hover:text-slate-600" %>
+      <% end %>
+      <% if attachment_count > 0 %>
+        <span class="flex items-center gap-1">
+          <%= helpers.icon("paperclip", css_class: "size-3.5") %>
+          <%= attachment_count %>
+        </span>
+      <% end %>
+      <% if comment_count > 0 %>
+        <span class="flex items-center gap-1">
+          <%= helpers.icon("message-circle", css_class: "size-3.5") %>
+          <%= comment_count %>
+        </span>
+      <% end %>
     </div>
-  <% end %>
+
+    <div class="flex items-center gap-3">
+      <% if source_content %>
+        <% if source_url %>
+          <%= link_to source_content, source_url, target: "_blank", rel: "noopener",
+                class: "text-sm text-slate-400 transition hover:text-slate-600" %>
+        <% else %>
+          <span class="text-sm text-slate-400"><%= source_content %></span>
+        <% end %>
+      <% end %>
+
+      <% if repost_content %>
+        <% if freefeed_url %>
+          <%= link_to repost_content, freefeed_url, target: "_blank", rel: "noopener",
+                class: "text-sm text-slate-400 transition hover:text-slate-600" %>
+        <% else %>
+          <span class="text-sm text-slate-400"><%= repost_content %></span>
+        <% end %>
+      <% end %>
+
+      <% if withdraw_allowed? %>
+        <div class="relative">
+          <button type="button"
+                  id="<%= menu_id %>-button"
+                  data-dropdown-toggle="<%= menu_id %>"
+                  data-dropdown-placement="bottom-end"
+                  class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+                  aria-haspopup="true"
+                  aria-expanded="false">
+            <%= helpers.icon("ellipsis", css_class: "size-4") %>
+            <span class="sr-only">More options</span>
+          </button>
+          <div id="<%= menu_id %>"
+               class="z-20 hidden w-40 rounded-lg border border-slate-200 bg-white shadow-sm"
+               role="menu"
+               aria-labelledby="<%= menu_id %>-button">
+            <ul class="py-1">
+              <li>
+                <%= link_to "Withdraw", helpers.post_path(post),
+                      data: { turbo_method: :delete, turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here." },
+                      class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
+                      role: "menuitem" %>
+              </li>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -69,10 +69,6 @@ class PostCardComponent < ViewComponent::Base
     post.status.to_s == "withdrawn"
   end
 
-  def footer?
-    source_content || repost_content || group_label.present? || attachment_count > 0 || comment_count > 0 || withdraw_allowed?
-  end
-
   def menu_id
     "post-menu-#{post.id}"
   end

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -31,7 +31,7 @@ class PostCardComponent < ViewComponent::Base
     post.feed&.display_name
   end
 
-  def origin_content
+  def source_content
     return unless post.published_at
     label_with_time("Source", post.published_at)
   end
@@ -70,7 +70,7 @@ class PostCardComponent < ViewComponent::Base
   end
 
   def footer?
-    origin_content || repost_content || group_label.present? || attachment_count > 0 || comment_count > 0 || withdraw_allowed?
+    source_content || repost_content || group_label.present? || attachment_count > 0 || comment_count > 0 || withdraw_allowed?
   end
 
   def menu_id

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -33,7 +33,7 @@ class PostCardComponent < ViewComponent::Base
 
   def origin_content
     return unless post.published_at
-    label_with_time("Origin", post.published_at)
+    label_with_time("Source", post.published_at)
   end
 
   def repost_content

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -42,7 +42,7 @@ class PostCardComponent < ViewComponent::Base
   end
 
   def label_with_time(label, time)
-    helpers.safe_join(["#{label} (", helpers.short_time_ago_tag(time), ")"])
+    helpers.safe_join([label, " (", helpers.short_time_ago_tag(time), ")"])
   end
 
   def attachment_count

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -31,12 +31,12 @@ class PostCardComponent < ViewComponent::Base
     post.feed&.display_name
   end
 
-  def source_content
+  def source_label
     return unless post.published_at
     label_with_time("Source", post.published_at)
   end
 
-  def repost_content
+  def repost_label
     return unless post.reposted_at
     label_with_time("Repost", post.reposted_at)
   end

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -31,14 +31,18 @@ class PostCardComponent < ViewComponent::Base
     post.feed&.display_name
   end
 
-  def published_time_tag
+  def origin_content
     return unless post.published_at
-    helpers.short_time_ago_tag(post.published_at)
+    label_with_time("Origin", post.published_at)
   end
 
-  def reposted_time_tag
+  def repost_content
     return unless post.reposted_at
-    helpers.short_time_ago_tag(post.reposted_at)
+    label_with_time("Repost", post.reposted_at)
+  end
+
+  def label_with_time(label, time)
+    helpers.safe_join(["#{label} (", helpers.short_time_ago_tag(time), ")"])
   end
 
   def attachment_count
@@ -66,7 +70,7 @@ class PostCardComponent < ViewComponent::Base
   end
 
   def footer?
-    published_time_tag || group_label.present? || attachment_count > 0 || comment_count > 0 || source_url || freefeed_url || withdraw_allowed?
+    origin_content || repost_content || group_label.present? || attachment_count > 0 || comment_count > 0 || withdraw_allowed?
   end
 
   def menu_id

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -70,7 +70,7 @@ class PostCardComponentTest < ViewComponent::TestCase
 
     origin_link = result.at_css("a[href='https://xkcd.com/3250/']")
     assert_not_nil origin_link
-    assert_includes origin_link.text.gsub(/\s+/, " "), "Origin (11h)"
+    assert_includes origin_link.text.gsub(/\s+/, " "), "Source (11h)"
   end
 
   test "#render should link repost time to the freefeed post" do
@@ -88,7 +88,7 @@ class PostCardComponentTest < ViewComponent::TestCase
     result = render_inline PostCardComponent.new(post: draft_post)
 
     text = result.text.gsub(/\s+/, " ")
-    assert_includes text, "Origin (11h)"
+    assert_includes text, "Source (11h)"
     assert_not_includes text, "Repost"
   end
 end

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -63,14 +63,14 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_not_empty result.css(".border-t.border-slate-200")
   end
 
-  test "#render should link origin time to the source publication" do
+  test "#render should link source time to the original publication" do
     published_post = create(:post, :published, feed: feed, source_url: "https://xkcd.com/3250/",
       published_at: 11.hours.ago, updated_at: 10.hours.ago)
     result = render_inline PostCardComponent.new(post: published_post)
 
-    origin_link = result.at_css("a[href='https://xkcd.com/3250/']")
-    assert_not_nil origin_link
-    assert_includes origin_link.text.gsub(/\s+/, " "), "Source (11h)"
+    source_link = result.at_css("a[href='https://xkcd.com/3250/']")
+    assert_not_nil source_link
+    assert_includes source_link.text.gsub(/\s+/, " "), "Source (11h)"
   end
 
   test "#render should link repost time to the freefeed post" do
@@ -81,6 +81,17 @@ class PostCardComponentTest < ViewComponent::TestCase
     repost_link = result.at_css("a[href='#{published_post.freefeed_url}']")
     assert_not_nil repost_link
     assert_includes repost_link.text.gsub(/\s+/, " "), "Repost (10h)"
+  end
+
+  test "#render should show repost time as plain text when freefeed url is missing" do
+    # A purged post stays published but loses its freefeed_post_id (see GroupPurgeJob)
+    purged_post = create(:post, :published, feed: feed, freefeed_post_id: nil,
+      published_at: 11.hours.ago, updated_at: 10.hours.ago)
+    result = render_inline PostCardComponent.new(post: purged_post)
+
+    assert_nil purged_post.freefeed_url
+    assert_includes result.text.gsub(/\s+/, " "), "Repost (10h)"
+    assert_empty result.css("a").select { |a| a.text.include?("Repost") }
   end
 
   test "#render should not show a repost time for unpublished posts" do

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -63,24 +63,32 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_not_empty result.css(".border-t.border-slate-200")
   end
 
-  test "#render should show labeled published and reposted times for published posts" do
-    published_post = create(:post, :published, feed: feed, published_at: 11.hours.ago, updated_at: 10.hours.ago)
+  test "#render should link origin time to the source publication" do
+    published_post = create(:post, :published, feed: feed, source_url: "https://xkcd.com/3250/",
+      published_at: 11.hours.ago, updated_at: 10.hours.ago)
     result = render_inline PostCardComponent.new(post: published_post)
 
-    assert_includes result.text, "Published:"
-    assert_includes result.text, "Reposted:"
-    times = result.css("time").map { |t| t.text.strip }
-    assert_includes times, "11h"
-    assert_includes times, "10h"
+    origin_link = result.at_css("a[href='https://xkcd.com/3250/']")
+    assert_not_nil origin_link
+    assert_includes origin_link.text.gsub(/\s+/, " "), "Origin (11h)"
   end
 
-  test "#render should not show a reposted time for unpublished posts" do
+  test "#render should link repost time to the freefeed post" do
+    published_post = create(:post, :published, feed: feed,
+      published_at: 11.hours.ago, updated_at: 10.hours.ago)
+    result = render_inline PostCardComponent.new(post: published_post)
+
+    repost_link = result.at_css("a[href='#{published_post.freefeed_url}']")
+    assert_not_nil repost_link
+    assert_includes repost_link.text.gsub(/\s+/, " "), "Repost (10h)"
+  end
+
+  test "#render should not show a repost time for unpublished posts" do
     draft_post = create(:post, feed: feed, status: :draft, published_at: 11.hours.ago)
     result = render_inline PostCardComponent.new(post: draft_post)
 
-    assert_includes result.text, "Published:"
-    assert_not_includes result.text, "Reposted:"
-    times = result.css("time").map { |t| t.text.strip }
-    assert_equal ["11h"], times
+    text = result.text.gsub(/\s+/, " ")
+    assert_includes text, "Origin (11h)"
+    assert_not_includes text, "Repost"
   end
 end


### PR DESCRIPTION
Changes:

- Replace the post card footer's separate `Published:`/`Reposted:` timestamps and `Source`/`FreeFeed` links with two combined, linkable items
- `Origin (3h)` links to the original publication; `Repost (2h)` links to the FreeFeed post

This makes the footer more compact and gives each timestamp a meaningful destination, so readers can jump straight to the source or the repost. Affects every post card — the feed page and the posts index. The repost item only appears once a post is published, and either item falls back to plain text if its URL is missing.
