### PR TITLE
Move attachments and comments to post body

### DIFF
--- a/app/components/post_attachments_component.html.erb
+++ b/app/components/post_attachments_component.html.erb
@@ -1,0 +1,12 @@
+<div class="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm p-4" data-key="post.attachments">
+  <h2 class="text-lg font-semibold text-slate-900 mb-3">Attachments (<%= attachment_urls.length %>)</h2>
+  <div class="flex flex-wrap gap-3">
+    <% attachment_urls.each do |url| %>
+      <%= link_to url, target: "_blank", rel: "noopener",
+            class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center" do %>
+        <%= helpers.icon("file-image", css_class: "size-4") %>
+        <span class="sr-only"><%= extract_filename(url) %></span>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/post_attachments_component.rb
+++ b/app/components/post_attachments_component.rb
@@ -1,37 +1,14 @@
 class PostAttachmentsComponent < ViewComponent::Base
-  CARD_CLASSES = "overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm p-4".freeze
-
   def initialize(post:)
     @post = post
   end
 
   def render?
-    @post.attachment_urls.present?
+    attachment_urls.present?
   end
 
-  def call
-    content_tag(:div, class: CARD_CLASSES, data: { key: "post.attachments" }) do
-      safe_join([
-        content_tag(:h2, "Attachments (#{@post.attachment_urls.length})", class: "text-lg font-semibold text-slate-900 mb-3"),
-        content_tag(:div, attachments_html, class: "flex flex-wrap gap-3")
-      ])
-    end
-  end
-
-  private
-
-  def attachments_html
-    safe_join(
-      @post.attachment_urls.map do |url|
-        filename = extract_filename(url)
-        helpers.link_to(url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center") do
-          safe_join([
-            helpers.icon("file-image", css_class: "size-4"),
-            content_tag(:span, filename, class: "sr-only")
-          ])
-        end
-      end
-    )
+  def attachment_urls
+    @post.attachment_urls
   end
 
   def extract_filename(url)

--- a/app/components/post_attachments_component.rb
+++ b/app/components/post_attachments_component.rb
@@ -1,0 +1,44 @@
+class PostAttachmentsComponent < ViewComponent::Base
+  CARD_CLASSES = "overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm p-4".freeze
+
+  def initialize(post:)
+    @post = post
+  end
+
+  def render?
+    @post.attachment_urls.present?
+  end
+
+  def call
+    content_tag(:div, class: CARD_CLASSES, data: { key: "post.attachments" }) do
+      safe_join([
+        content_tag(:h2, "Attachments (#{@post.attachment_urls.length})", class: "text-lg font-semibold text-slate-900 mb-3"),
+        content_tag(:div, attachments_html, class: "flex flex-wrap gap-3")
+      ])
+    end
+  end
+
+  private
+
+  def attachments_html
+    safe_join(
+      @post.attachment_urls.map do |url|
+        filename = extract_filename(url)
+        helpers.link_to(url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center") do
+          safe_join([
+            helpers.icon("file-image", css_class: "size-4"),
+            content_tag(:span, filename, class: "sr-only")
+          ])
+        end
+      end
+    )
+  end
+
+  def extract_filename(url)
+    uri = URI.parse(url)
+    filename = File.basename(uri.path)
+    filename.presence || "Attachment"
+  rescue URI::InvalidURIError
+    "Attachment"
+  end
+end

--- a/app/components/post_comments_component.html.erb
+++ b/app/components/post_comments_component.html.erb
@@ -1,0 +1,6 @@
+<div class="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm p-4" data-key="post.comments">
+  <h2 class="text-lg font-semibold text-slate-900 mb-3">Comments (<%= comments.length %>)</h2>
+  <% comments.each do |comment| %>
+    <div class="border-l-4 border-slate-300 pl-3 mb-3 last:mb-0"><%= simple_format(comment) %></div>
+  <% end %>
+</div>

--- a/app/components/post_comments_component.rb
+++ b/app/components/post_comments_component.rb
@@ -1,0 +1,30 @@
+class PostCommentsComponent < ViewComponent::Base
+  CARD_CLASSES = "overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm p-4".freeze
+
+  def initialize(post:)
+    @post = post
+  end
+
+  def render?
+    @post.comments.present?
+  end
+
+  def call
+    content_tag(:div, class: CARD_CLASSES, data: { key: "post.comments" }) do
+      safe_join([
+        content_tag(:h2, "Comments (#{@post.comments.length})", class: "text-lg font-semibold text-slate-900 mb-3"),
+        comments_html
+      ])
+    end
+  end
+
+  private
+
+  def comments_html
+    safe_join(
+      @post.comments.map do |comment|
+        content_tag(:div, helpers.simple_format(comment), class: "border-l-4 border-slate-300 pl-3 mb-3 last:mb-0")
+      end
+    )
+  end
+end

--- a/app/components/post_comments_component.rb
+++ b/app/components/post_comments_component.rb
@@ -1,30 +1,13 @@
 class PostCommentsComponent < ViewComponent::Base
-  CARD_CLASSES = "overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm p-4".freeze
-
   def initialize(post:)
     @post = post
   end
 
   def render?
-    @post.comments.present?
+    comments.present?
   end
 
-  def call
-    content_tag(:div, class: CARD_CLASSES, data: { key: "post.comments" }) do
-      safe_join([
-        content_tag(:h2, "Comments (#{@post.comments.length})", class: "text-lg font-semibold text-slate-900 mb-3"),
-        comments_html
-      ])
-    end
-  end
-
-  private
-
-  def comments_html
-    safe_join(
-      @post.comments.map do |comment|
-        content_tag(:div, helpers.simple_format(comment), class: "border-l-4 border-slate-300 pl-3 mb-3 last:mb-0")
-      end
-    )
+  def comments
+    @post.comments
   end
 end

--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -8,8 +8,6 @@ class PostDetailsComponent < ViewComponent::Base
       add_feed_item(list)
       add_published_item(list)
       add_reposted_item(list) if @post.reposted_at
-      add_attachments_item(list) if @post.attachment_urls.present?
-      add_comments_item(list) if @post.comments.present?
       add_source_url_item(list)
       add_validation_errors_item(list) if @post.validation_errors.present?
       add_uid_item(list)
@@ -41,49 +39,6 @@ class PostDetailsComponent < ViewComponent::Base
       label: "Reposted",
       value: helpers.datetime_with_duration_tag(@post.reposted_at),
       key: "post.reposted"
-    ))
-  end
-
-  def add_attachments_item(component)
-    attachments_html = safe_join(
-      @post.attachment_urls.map do |url|
-        filename = extract_filename(url)
-        helpers.link_to(url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center") do
-          safe_join([
-            helpers.icon("file-image", css_class: "size-4"),
-            content_tag(:span, filename, class: "sr-only")
-          ])
-        end
-      end,
-      " "
-    )
-
-    component.with_item(ListComponent::StatItemComponent.new(
-      label: "Attachments (#{@post.attachment_urls.length})",
-      value: attachments_html,
-      key: "post.attachments"
-    ))
-  end
-
-  def extract_filename(url)
-    uri = URI.parse(url)
-    filename = File.basename(uri.path)
-    filename.presence || "Attachment"
-  rescue URI::InvalidURIError
-    "Attachment"
-  end
-
-  def add_comments_item(component)
-    comments_html = safe_join(
-      @post.comments.map do |comment|
-        content_tag(:div, helpers.simple_format(comment), class: "border-l-4 border-slate-300 pl-3 mb-3 last:mb-0")
-      end
-    )
-
-    component.with_item(ListComponent::StatItemComponent.new(
-      label: "Comments (#{@post.comments.length})",
-      value: comments_html,
-      key: "post.comments"
     ))
   end
 

--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -84,18 +84,18 @@ module TimeHelper
     )
   end
 
-  def datetime_with_duration(time)
-    return nil unless time
-
-    "#{long_time_format(time)} (#{short_time_ago(time)})"
-  end
-
   def datetime_with_duration_tag(time)
     return nil unless time
 
+    content = safe_join([
+      long_time_format(time),
+      " ",
+      content_tag(:span, "(#{short_time_ago(time)})", class: "text-slate-500")
+    ])
+
     content_tag(
       :time,
-      datetime_with_duration(time),
+      content,
       datetime: time.rfc3339,
       title: "#{time_ago(time)} ago"
     )

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -35,4 +35,8 @@
       <%= format_post_content(@post.content) %>
     </div>
   </div>
+
+  <%= render PostAttachmentsComponent.new(post: @post) %>
+
+  <%= render PostCommentsComponent.new(post: @post) %>
 </div>

--- a/test/components/post_attachments_component_test.rb
+++ b/test/components/post_attachments_component_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+require "view_component/test_case"
+
+class PostAttachmentsComponentTest < ViewComponent::TestCase
+  def feed
+    @feed ||= create(:feed)
+  end
+
+  test "#render should show attachments with accessible filenames" do
+    post = create(:post, :with_attachments, feed: feed)
+
+    result = render_inline(PostAttachmentsComponent.new(post: post))
+
+    assert_not_nil result.css('[data-key="post.attachments"]').first
+    assert_equal "image1.jpg", result.css('a[href*="image1.jpg"] span.sr-only').first.text
+    assert_equal "image2.png", result.css('a[href*="image2.png"] span.sr-only').first.text
+  end
+
+  test "#render should not render when there are no attachments" do
+    post = create(:post, feed: feed)
+
+    result = render_inline(PostAttachmentsComponent.new(post: post))
+
+    assert_empty result.css('[data-key="post.attachments"]')
+  end
+end

--- a/test/components/post_comments_component_test.rb
+++ b/test/components/post_comments_component_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+require "view_component/test_case"
+
+class PostCommentsComponentTest < ViewComponent::TestCase
+  def feed
+    @feed ||= create(:feed)
+  end
+
+  test "#render should show comments when present" do
+    post = create(:post, :with_comments, feed: feed)
+
+    result = render_inline(PostCommentsComponent.new(post: post))
+
+    assert_not_nil result.css('[data-key="post.comments"]').first
+    assert_includes result.text, "Additional context about this post"
+  end
+
+  test "#render should not render when there are no comments" do
+    post = create(:post, feed: feed)
+
+    result = render_inline(PostCommentsComponent.new(post: post))
+
+    assert_empty result.css('[data-key="post.comments"]')
+  end
+end

--- a/test/helpers/time_helper_test.rb
+++ b/test/helpers/time_helper_test.rb
@@ -112,6 +112,20 @@ class TimeHelperTest < ActiveSupport::TestCase
     end
   end
 
+  test "#datetime_with_duration_tag should return nil for nil input" do
+    assert_nil datetime_with_duration_tag(nil)
+  end
+
+  test "#datetime_with_duration_tag should render the duration as muted text" do
+    time = Time.zone.parse("2025-01-15 15:45:30")
+
+    travel_to Time.zone.parse("2025-01-15 17:45:30") do
+      result = datetime_with_duration_tag(time)
+      expected = '<time datetime="2025-01-15T15:45:30Z" title="2 hours ago">15 Jan 2025, 15:45 <span class="text-slate-500">(2h)</span></time>'
+      assert_equal expected, result
+    end
+  end
+
   test "#time_distance should return nil for nil input" do
     assert_nil time_distance(nil)
   end


### PR DESCRIPTION
Changes:

- Move the Attachments and Comments sections out of the post metadata list and render them below the post content card on `/posts/:id`
- Add `PostAttachmentsComponent` and `PostCommentsComponent`, each shown only when there is something to display
- Add tests for both new components

On the post page, attachments and comments now read as standalone sections under the post content instead of being squeezed into the metadata list, and they disappear entirely when a post has none.
