### PR TITLE
Use green success flash for entity mutations

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -50,7 +50,7 @@ class AccessTokensController < ApplicationController
 
     if @access_token.update(attrs)
       @access_token.validate_token_async if new_token
-      redirect_to access_token_path(@access_token), notice: "Changes saved."
+      redirect_to access_token_path(@access_token), success: "Changes saved."
     else
       render :edit, status: :unprocessable_entity
     end
@@ -60,7 +60,7 @@ class AccessTokensController < ApplicationController
     access_token = find_access_token
     authorize access_token
     access_token.destroy!
-    redirect_to access_tokens_path, notice: "Access token '#{access_token.name}' deleted."
+    redirect_to access_tokens_path, success: "Access token '#{access_token.name}' deleted."
   end
 
   private

--- a/app/controllers/admin/available_invites_controller.rb
+++ b/app/controllers/admin/available_invites_controller.rb
@@ -4,7 +4,7 @@ class Admin::AvailableInvitesController < ApplicationController
     authorize user
 
     if user.update(available_invites_params)
-      flash.now[:notice] = "Available invites updated successfully."
+      flash.now[:success] = "Available invites updated successfully."
       render turbo_stream: [
         turbo_stream.replace(
           "available-invites-value",

--- a/app/controllers/admin/email_reactivations_controller.rb
+++ b/app/controllers/admin/email_reactivations_controller.rb
@@ -3,6 +3,6 @@ class Admin::EmailReactivationsController < ApplicationController
     @user = User.find(params[:user_id])
     authorize @user, :reactivate_email?
     @user.reactivate_email!
-    redirect_to admin_user_path(@user), notice: "Email reactivated."
+    redirect_to admin_user_path(@user), success: "Email reactivated."
   end
 end

--- a/app/controllers/admin/email_updates_controller.rb
+++ b/app/controllers/admin/email_updates_controller.rb
@@ -27,7 +27,7 @@ class Admin::EmailUpdatesController < ApplicationController
       ProfileMailer.email_change_confirmation(user, new_email).deliver_later
       redirect_to admin_user_path(user), notice: "Confirmation email sent to #{new_email}. User must confirm before change takes effect."
     elsif user.update(email_address: new_email)
-      redirect_to admin_user_path(user), notice: "Email address updated."
+      redirect_to admin_user_path(user), success: "Email address updated."
     else
       redirect_to edit_admin_user_email_update_path(user), alert: "Failed to update email address."
     end

--- a/app/controllers/admin/permissions_controller.rb
+++ b/app/controllers/admin/permissions_controller.rb
@@ -15,7 +15,7 @@ class Admin::PermissionsController < ApplicationController
     if error
       redirect_to admin_user_path(user), alert: error
     else
-      redirect_to admin_user_path(user), notice: "Permissions updated."
+      redirect_to admin_user_path(user), success: "Permissions updated."
     end
   end
 

--- a/app/controllers/admin/suspensions_controller.rb
+++ b/app/controllers/admin/suspensions_controller.rb
@@ -3,14 +3,14 @@ class Admin::SuspensionsController < ApplicationController
     authorize User, :suspend?
     user = find_user
     suspend_user_and_record_event(user)
-    redirect_to admin_user_path(user), notice: "User suspended."
+    redirect_to admin_user_path(user), success: "User suspended."
   end
 
   def destroy
     authorize User, :unsuspend?
     user = find_user
     unsuspend_user_and_record_event(user)
-    redirect_to admin_user_path(user), notice: "User unsuspended."
+    redirect_to admin_user_path(user), success: "User unsuspended."
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,9 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  # Adds a green "success" flash alongside the default neutral :notice and :alert.
+  add_flash_types :success
+
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private

--- a/app/controllers/development/sent_emails_controller.rb
+++ b/app/controllers/development/sent_emails_controller.rb
@@ -31,7 +31,7 @@ class Development::SentEmailsController < ApplicationController
   def purge
     authorize :access, :dev?
     email_storage.purge
-    redirect_to development_sent_emails_path, notice: "All emails purged"
+    redirect_to development_sent_emails_path, success: "All emails purged"
   rescue => e
     redirect_to development_sent_emails_path, alert: "Failed to purge emails: #{e.message}"
   end

--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -21,7 +21,7 @@ class FeedStatusesController < ApplicationController
     feed.with_lock do
       if feed.can_be_enabled?
         feed.enabled!
-        redirect_to feed, notice: "Feed enabled."
+        redirect_to feed, success: "Feed enabled."
       else
         missing_parts = feed_missing_enablement_parts(feed)
         redirect_to feed, alert: "Cannot enable feed: missing #{missing_parts.join(' and ')}."
@@ -32,7 +32,7 @@ class FeedStatusesController < ApplicationController
   def disable(feed)
     feed.with_lock do
       feed.disabled!
-      redirect_to feed, notice: "Feed disabled."
+      redirect_to feed, success: "Feed disabled."
     end
   end
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -61,7 +61,7 @@ class FeedsController < ApplicationController
       elsif enable_feed?
         enable_and_respond(@feed)
       else
-        redirect_to feed_path(@feed), notice: success_message_for(@feed)
+        redirect_to feed_path(@feed), success: success_message_for(@feed)
       end
     else
       render :new, status: :unprocessable_entity
@@ -108,7 +108,7 @@ class FeedsController < ApplicationController
         promote_and_redirect(@feed, interval_changed)
       else
         @feed.reset_schedule! if interval_changed && @feed.feed_schedule.present?
-        redirect_to feed_path(@feed), notice: update_message_for(@feed)
+        redirect_to feed_path(@feed), success: update_message_for(@feed)
       end
     else
       render :edit, status: :unprocessable_entity
@@ -119,7 +119,7 @@ class FeedsController < ApplicationController
     @feed = load_feed
     authorize @feed
     @feed.destroy!
-    redirect_to feeds_path, notice: "Feed deleted."
+    redirect_to feeds_path, success: "Feed deleted."
   end
 
   private
@@ -138,7 +138,7 @@ class FeedsController < ApplicationController
 
   def enable_and_respond(feed)
     if feed.enable
-      redirect_to feed_path(feed), notice: success_message_for(feed)
+      redirect_to feed_path(feed), success: success_message_for(feed)
     else
       flash.now[:alert] = "Couldn't enable. See issues below."
       render :new, status: :unprocessable_entity
@@ -153,7 +153,7 @@ class FeedsController < ApplicationController
     end
 
     if feed.enabled?
-      redirect_to feed_path(feed), notice: update_message_for(feed)
+      redirect_to feed_path(feed), success: update_message_for(feed)
     else
       flash.now[:alert] = "Couldn't enable. See issues below."
       render :edit, status: :unprocessable_entity

--- a/app/controllers/llm_credentials/defaults_controller.rb
+++ b/app/controllers/llm_credentials/defaults_controller.rb
@@ -4,7 +4,7 @@ class LlmCredentials::DefaultsController < ApplicationController
 
     credential.make_default!
     message = "'#{credential.display_name}' is now the default for #{provider_name}."
-    redirect_to llm_credentials_path, notice: message
+    redirect_to llm_credentials_path, success: message
   end
 
   private

--- a/app/controllers/llm_credentials_controller.rb
+++ b/app/controllers/llm_credentials_controller.rb
@@ -51,7 +51,7 @@ class LlmCredentialsController < ApplicationController
     credential = find_credential
     authorize credential
     credential.destroy!
-    redirect_to llm_credentials_path, notice: "AI credential '#{credential.display_name}' deleted."
+    redirect_to llm_credentials_path, success: "AI credential '#{credential.display_name}' deleted."
   end
 
   private

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -14,7 +14,7 @@ class PasswordsController < ApplicationController
 
   def update
     if @user.update(params.permit(:password, :password_confirmation))
-      redirect_to new_session_path, notice: "Password reset."
+      redirect_to new_session_path, success: "Password reset."
     else
       redirect_to edit_password_path(params[:token]), alert: "Passwords did not match."
     end

--- a/app/controllers/registration/email_confirmations_controller.rb
+++ b/app/controllers/registration/email_confirmations_controller.rb
@@ -4,7 +4,7 @@ class Registration::EmailConfirmationsController < ApplicationController
   def show
     user = find_user_by_token
     activate_user(user)
-    redirect_to new_session_path, notice: "Your email is now confirmed. Please sign in to get started."
+    redirect_to new_session_path, success: "Your email is now confirmed. Please sign in to get started."
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     redirect_to new_session_path, alert: "Email confirmation link is invalid or has expired."
   end

--- a/app/controllers/settings/email_confirmations_controller.rb
+++ b/app/controllers/settings/email_confirmations_controller.rb
@@ -44,7 +44,7 @@ class Settings::EmailConfirmationsController < ApplicationController
 
   def redirect_with_success
     redirect_path = authenticated? ? settings_path : new_session_path
-    redirect_to redirect_path, notice: "Email address updated."
+    redirect_to redirect_path, success: "Email address updated."
   end
 
   def redirect_with_failure

--- a/app/controllers/settings/password_updates_controller.rb
+++ b/app/controllers/settings/password_updates_controller.rb
@@ -34,7 +34,7 @@ class Settings::PasswordUpdatesController < ApplicationController
   end
 
   def redirect_with_success
-    redirect_to settings_path, notice: "Password updated."
+    redirect_to settings_path, success: "Password updated."
   end
 
   def redirect_with_validation_errors

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,8 +1,8 @@
 <%# locals: () %>
-<div class="<%= 'space-y-3 mb-4' if notice || alert || flash[:success] %>" id="flash-messages">
-  <% if flash[:success] %>
+<div class="<%= 'space-y-3 mb-4' if notice || alert || success %>" id="flash-messages">
+  <% if success %>
     <%= render AlertComponent.new(variant: :success) do %>
-      <span><%= sanitize(flash[:success]) %></span>
+      <span><%= sanitize(success) %></span>
     <% end %>
   <% end %>
 

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,11 @@
 <%# locals: () %>
-<div class="<%= 'space-y-3 mb-4' if notice || alert %>" id="flash-messages">
+<div class="<%= 'space-y-3 mb-4' if notice || alert || flash[:success] %>" id="flash-messages">
+  <% if flash[:success] %>
+    <%= render AlertComponent.new(variant: :success) do %>
+      <span><%= sanitize(flash[:success]) %></span>
+    <% end %>
+  <% end %>
+
   <% if notice %>
     <%= render AlertComponent.new(variant: :info) do %>
       <span><%= sanitize(notice) %></span>

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -311,7 +311,7 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to access_token_path(access_token)
     assert_equal "Updated Name", access_token.reload.name
-    assert_equal "Changes saved.", flash[:notice]
+    assert_equal "Changes saved.", flash[:success]
   end
 
   test "#update should not re-validate when only name changes" do
@@ -364,7 +364,7 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to access_tokens_path
-    assert_equal "Access token '#{access_token.name}' deleted.", flash[:notice]
+    assert_equal "Access token '#{access_token.name}' deleted.", flash[:success]
   end
 
   test "cannot delete other user's token" do

--- a/test/controllers/admin/available_invites_controller_test.rb
+++ b/test/controllers/admin/available_invites_controller_test.rb
@@ -24,7 +24,7 @@ class Admin::AvailableInvitesControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-stream[action='replace'][target='available-invites-input-wrapper-#{target_user.id}']"
     assert_select "turbo-stream[action='replace'][target='flash-messages']" do
       assert_select "div[id='flash-messages']"
-      assert_select ".bg-sky-100", text: /Available invites updated successfully/
+      assert_select ".bg-emerald-100", text: /Available invites updated successfully/
     end
 
     target_user.reload
@@ -86,7 +86,7 @@ class Admin::AvailableInvitesControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-stream[action='replace'][target='available-invites-input-wrapper-#{target_user.id}']"
     assert_select "turbo-stream[action='replace'][target='flash-messages']" do
       assert_select "div[id='flash-messages']"
-      assert_select ".bg-sky-100", text: /Available invites updated successfully/
+      assert_select ".bg-emerald-100", text: /Available invites updated successfully/
     end
 
     target_user.reload

--- a/test/controllers/admin/email_updates_controller_test.rb
+++ b/test/controllers/admin/email_updates_controller_test.rb
@@ -36,7 +36,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
     patch admin_user_email_update_path(user), params: { user: { email_address: "new@example.com" }, require_confirmation: "0" }
 
     assert_redirected_to admin_user_path(user)
-    assert_equal "Email address updated.", flash[:notice]
+    assert_equal "Email address updated.", flash[:success]
     assert_equal "new@example.com", user.reload.email_address
   end
 

--- a/test/controllers/admin/permissions_controller_test.rb
+++ b/test/controllers/admin/permissions_controller_test.rb
@@ -31,7 +31,7 @@ class Admin::PermissionsControllerTest < ActionDispatch::IntegrationTest
     patch admin_user_permissions_path(target_user), params: { permissions: [Permission::DEV] }
 
     assert_redirected_to admin_user_path(target_user)
-    assert_equal "Permissions updated.", flash[:notice]
+    assert_equal "Permissions updated.", flash[:success]
     assert target_user.reload.permission?(Permission::DEV)
   end
 
@@ -86,7 +86,7 @@ class Admin::PermissionsControllerTest < ActionDispatch::IntegrationTest
     patch admin_user_permissions_path(admin_user), params: { permissions: [Permission::ADMIN] }
 
     assert_redirected_to admin_user_path(admin_user)
-    assert_equal "Permissions updated.", flash[:notice]
+    assert_equal "Permissions updated.", flash[:success]
     assert admin_user.reload.permission?(Permission::ADMIN)
   end
 
@@ -97,7 +97,7 @@ class Admin::PermissionsControllerTest < ActionDispatch::IntegrationTest
     patch admin_user_permissions_path(second_admin), params: { permissions: [] }
 
     assert_redirected_to admin_user_path(second_admin)
-    assert_equal "Permissions updated.", flash[:notice]
+    assert_equal "Permissions updated.", flash[:success]
     assert_not second_admin.reload.permission?(Permission::ADMIN)
   end
 

--- a/test/controllers/development/sent_emails_controller_test.rb
+++ b/test/controllers/development/sent_emails_controller_test.rb
@@ -93,7 +93,7 @@ class Development::SentEmailsControllerTest < ActionDispatch::IntegrationTest
 
     delete purge_development_sent_emails_path
     assert_redirected_to development_sent_emails_path
-    assert_equal "All emails purged", flash[:notice]
+    assert_equal "All emails purged", flash[:success]
     assert_equal 0, email_storage.list.count
   end
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -87,7 +87,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil feed.feed_schedule.next_run_at
     assert_not_nil feed.feed_schedule.last_run_at
     assert_redirected_to feed_path(feed)
-    assert_match "Feed created and enabled.", flash[:notice]
+    assert_match "Feed created and enabled.", flash[:success]
   end
 
   test "#create should save as draft with blank name" do
@@ -133,7 +133,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     feed = Feed.last
     assert_predicate feed, :draft?
     assert_redirected_to feed_path(feed)
-    assert_match "Feed saved as draft", flash[:notice]
+    assert_match "Feed saved as draft", flash[:success]
   end
 
   test "#create should enable a feed without any preview" do

--- a/test/controllers/registration/email_confirmations_controller_test.rb
+++ b/test/controllers/registration/email_confirmations_controller_test.rb
@@ -8,7 +8,7 @@ class Registration::EmailConfirmationsControllerTest < ActionDispatch::Integrati
     get registration_email_confirmation_url(token)
 
     assert_redirected_to new_session_path
-    assert_equal "Your email is now confirmed. Please sign in to get started.", flash[:notice]
+    assert_equal "Your email is now confirmed. Please sign in to get started.", flash[:success]
     assert inactive_user.reload.onboarding?
   end
 

--- a/test/controllers/settings/email_confirmations_controller_test.rb
+++ b/test/controllers/settings/email_confirmations_controller_test.rb
@@ -23,7 +23,7 @@ class Settings::EmailConfirmationsControllerTest < ActionDispatch::IntegrationTe
     get settings_email_confirmation_url(token)
 
     assert_redirected_to settings_path
-    assert_equal "Email address updated.", flash[:notice]
+    assert_equal "Email address updated.", flash[:success]
     assert_equal new_email, user.reload.email_address
     assert_nil user.unconfirmed_email
   end

--- a/test/controllers/settings/password_updates_controller_test.rb
+++ b/test/controllers/settings/password_updates_controller_test.rb
@@ -30,7 +30,7 @@ class Settings::PasswordUpdatesControllerTest < ActionDispatch::IntegrationTest
       }
     }
     assert_redirected_to settings_path
-    assert_equal "Password updated.", flash[:notice]
+    assert_equal "Password updated.", flash[:success]
   end
 
   test "should not update password with incorrect current password" do


### PR DESCRIPTION
Changes:

- Add a registered `:success` flash type, rendered with the green alert variant
- Switch create/update/delete confirmations across the app to `success:`
- Keep neutral, pending, and async messages (emails sent, jobs started) on the blue `notice`/info style

Flash messages previously used a single blue `notice` style for everything. This distinguishes "the thing you asked for is done" (green) from informational or still-pending messages (blue), while errors stay red.
