### PR TITLE
Show feed state as a badge on the feed page

### DIFF
--- a/app/components/feed_card_component.rb
+++ b/app/components/feed_card_component.rb
@@ -22,11 +22,7 @@ class FeedCardComponent < ViewComponent::Base
   end
 
   def status_badge
-    case feed.state.to_sym
-    when :draft    then BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge")
-    when :disabled then BadgeComponent.new(text: "Disabled", color: :yellow, key: "feed.#{feed.id}.disabled_badge")
-    when :enabled  then BadgeComponent.new(text: "Active", color: :green, key: "feed.#{feed.id}.enabled_badge")
-    end
+    helpers.feed_status_badge(feed)
   end
 
   def menu_id

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -35,17 +35,11 @@ module FeedHelper
     end
   end
 
-  def feed_status_summary(feed)
-    missing_parts = feed_missing_enablement_parts(feed)
-
-    if feed.enabled?
-      "This feed is enabled and will continue to import items on its schedule."
-    elsif feed.can_be_enabled?
-      "This feed is ready to enable. Turn it on to start importing posts."
-    elsif missing_parts.any?
-      "This feed is currently disabled. Add #{missing_parts.to_sentence} to finish setup."
-    else
-      "This feed is currently disabled."
+  def feed_status_badge(feed)
+    case feed.state.to_sym
+    when :draft    then BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge")
+    when :disabled then BadgeComponent.new(text: "Disabled", color: :yellow, key: "feed.#{feed.id}.disabled_badge")
+    when :enabled  then BadgeComponent.new(text: "Active", color: :green, key: "feed.#{feed.id}.enabled_badge")
     end
   end
 

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -2,13 +2,8 @@
 
 <div class="space-y-10">
   <%= render PageHeaderComponent.new(title: @feed.display_name) do |header| %>
-    <% if @feed.enabled? %>
-      <% header.with_title_icon { icon("play", css_class: "size-9 text-green-600") } %>
-    <% else %>
-      <% header.with_title_icon { icon("pause", css_class: "size-9 text-slate-400") } %>
-    <% end %>
-    <% if (status_summary = feed_status_summary(@feed)).present? %>
-      <% header.with_context_paragraph(status_summary) %>
+    <% header.with_context_paragraph do %>
+      <%= render feed_status_badge(@feed) %>
     <% end %>
     <% if @feed.target_group_url.present? %>
       <% header.with_context_paragraph do %>

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -111,36 +111,28 @@ class FeedHelperTest < ActionView::TestCase
     assert_nil feed_summary_line(active_count: 0, inactive_count: 0, draft_count: 0)
   end
 
-  test "#feed_status_summary should describe enabled feed" do
+  test "#feed_status_badge should render active badge for enabled feed" do
     feed = build(:feed, :enabled)
-    expected = "This feed is enabled and will continue to import items on its schedule."
+    result = feed_status_badge(feed)
 
-    assert_equal expected, feed_status_summary(feed)
+    assert_equal "Active", result.instance_variable_get(:@text)
+    assert_equal :green, result.instance_variable_get(:@color)
   end
 
-  test "#feed_status_summary should describe ready feed" do
-    feed = build(:feed)
-    expected = "This feed is ready to enable. Turn it on to start importing posts."
-
-    assert_equal expected, feed_status_summary(feed)
-  end
-
-  test "#feed_status_summary should list missing parts" do
-    feed = build(:feed, :without_access_token)
-    expected = "This feed is currently disabled. Add active access token and target group to finish setup."
-
-    assert_equal expected, feed_status_summary(feed)
-  end
-
-  test "#feed_status_summary should handle disabled feed without missing parts" do
+  test "#feed_status_badge should render disabled badge for disabled feed" do
     feed = build(:feed, :disabled)
-    feed.define_singleton_method(:can_be_enabled?) { false }
+    result = feed_status_badge(feed)
 
-    expected = "This feed is currently disabled."
+    assert_equal "Disabled", result.instance_variable_get(:@text)
+    assert_equal :yellow, result.instance_variable_get(:@color)
+  end
 
-    self.stub(:feed_missing_enablement_parts, ->(_feed) { [] }) do
-      assert_equal expected, feed_status_summary(feed)
-    end
+  test "#feed_status_badge should render draft badge for draft feed" do
+    feed = build(:feed, :draft)
+    result = feed_status_badge(feed)
+
+    assert_equal "Draft", result.instance_variable_get(:@text)
+    assert_equal :gray, result.instance_variable_get(:@color)
   end
 
   test "#feed_missing_enablement_parts should not report source missing for query-type feed with query" do


### PR DESCRIPTION
Changes:

- Drop the enable/disable title icon from the `/feeds/:id` heading
- Show the feed state as a badge under the title, replacing the longer status summary text
- Extract a shared `feed_status_badge` helper so the feed page and feeds list render the same badge

The feed page now mirrors the state indicator already used on the feeds list, keeping the two views visually consistent.