### PR TITLE
Refine feed and post stats layout

### DIFF
--- a/app/components/feed_stats_component.rb
+++ b/app/components/feed_stats_component.rb
@@ -24,18 +24,6 @@ class FeedStatsComponent < ViewComponent::Base
   def layout_items
     @layout_items ||= [
       {
-        key: "last_refresh",
-        label: "Last refresh",
-        label_short: "Refreshed",
-        value: last_refresh_value
-      },
-      {
-        key: "most_recent_repost",
-        label: "Most recent repost",
-        label_short: "Recent",
-        value: most_recent_repost_value
-      },
-      {
         key: "imported_posts",
         label: "Imported posts",
         label_short: "Imported",
@@ -46,6 +34,24 @@ class FeedStatsComponent < ViewComponent::Base
         label: "Published posts",
         label_short: "Published",
         value: helpers.number_with_delimiter(published_posts_count)
+      },
+      {
+        key: "posts_last_week",
+        label: "Posts published last week",
+        label_short: "Last week",
+        value: helpers.number_with_delimiter(posts_last_week_count)
+      },
+      {
+        key: "last_refresh",
+        label: "Last refresh",
+        label_short: "Refreshed",
+        value: last_refresh_value
+      },
+      {
+        key: "most_recent_repost",
+        label: "Most recent repost",
+        label_short: "Recent",
+        value: most_recent_repost_value
       }
     ]
   end
@@ -76,7 +82,7 @@ class FeedStatsComponent < ViewComponent::Base
 
   def most_recent_repost_value
     if @feed.most_recent_repost_at
-      helpers.short_time_ago_tag(@feed.most_recent_repost_at)
+      safe_join([helpers.short_time_ago_tag(@feed.most_recent_repost_at), " ago"])
     else
       content_tag(:span, "No reposts yet", class: "text-slate-500")
     end
@@ -88,5 +94,9 @@ class FeedStatsComponent < ViewComponent::Base
 
   def published_posts_count
     @published_posts_count ||= @feed.posts.published.count
+  end
+
+  def posts_last_week_count
+    @posts_last_week_count ||= @feed.posts_published_last_week_count
   end
 end

--- a/app/components/post_attachments_component.html.erb
+++ b/app/components/post_attachments_component.html.erb
@@ -1,5 +1,4 @@
 <div class="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm p-4" data-key="post.attachments">
-  <h2 class="text-lg font-semibold text-slate-900 mb-3">Attachments (<%= attachment_urls.length %>)</h2>
   <div class="flex flex-wrap gap-3">
     <% attachment_urls.each do |url| %>
       <%= link_to url, target: "_blank", rel: "noopener",

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -27,21 +27,21 @@
           <%= comment_count %>
         </span>
       <% end %>
-    </div>
 
-    <div class="flex items-center gap-3">
       <%= link_to source_label, source_url, target: "_blank", rel: "noopener",
-            class: "text-sm text-slate-400 transition hover:text-slate-600" %>
+            class: "transition hover:text-slate-600" %>
 
       <% if repost_label %>
         <% if freefeed_url %>
           <%= link_to repost_label, freefeed_url, target: "_blank", rel: "noopener",
-                class: "text-sm text-slate-400 transition hover:text-slate-600" %>
+                class: "transition hover:text-slate-600" %>
         <% else %>
-          <span class="text-sm text-slate-400"><%= repost_label %></span>
+          <span><%= repost_label %></span>
         <% end %>
       <% end %>
+    </div>
 
+    <div class="flex items-center gap-3">
       <% if withdraw_allowed? %>
         <div class="relative">
           <button type="button"

--- a/app/components/post_comments_component.html.erb
+++ b/app/components/post_comments_component.html.erb
@@ -1,6 +1,5 @@
-<div class="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm p-4" data-key="post.comments">
-  <h2 class="text-lg font-semibold text-slate-900 mb-3">Comments (<%= comments.length %>)</h2>
+<div class="space-y-4" data-key="post.comments">
   <% comments.each do |comment| %>
-    <div class="border-l-4 border-slate-300 pl-3 mb-3 last:mb-0"><%= simple_format(comment) %></div>
+    <div class="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm p-4 text-slate-900"><%= simple_format(comment) %></div>
   <% end %>
 </div>

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -235,6 +235,12 @@ class Feed < ApplicationRecord
     posts.published.maximum(:updated_at)
   end
 
+  # Returns the count of posts published in the last week (by source date)
+  # @return [Integer] number of posts published in the last week
+  def posts_published_last_week_count
+    posts.where(published_at: 1.week.ago.beginning_of_day..Time.current.end_of_day).count
+  end
+
   # Returns metrics for a date range, filling gaps with zeros
   # @param start_date [Date] start date of the range
   # @param end_date [Date] end date of the range (inclusive)

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,5 @@
 <%# locals: () %>
-<% flash_alerts = capture do %>
+<div class="space-y-3 mb-6 empty:hidden" id="flash-messages">
   <% if success %>
     <%= render AlertComponent.new(variant: :success) do %>
       <span><%= sanitize(success) %></span>
@@ -17,5 +17,4 @@
       <span><%= sanitize(alert) %></span>
     <% end %>
   <% end %>
-<% end %>
-<div class="space-y-3 mb-6 empty:hidden" id="flash-messages"><%= flash_alerts if flash_alerts.present? %></div>
+</div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,5 @@
 <%# locals: () %>
-<div class="<%= 'space-y-3 mb-4' if notice || alert || success %>" id="flash-messages">
+<% flash_alerts = capture do %>
   <% if success %>
     <%= render AlertComponent.new(variant: :success) do %>
       <span><%= sanitize(success) %></span>
@@ -17,4 +17,5 @@
       <span><%= sanitize(alert) %></span>
     <% end %>
   <% end %>
-</div>
+<% end %>
+<div class="space-y-3 mb-6 empty:hidden" id="flash-messages"><%= flash_alerts if flash_alerts.present? %></div>

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -26,7 +26,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
 
       most_recent = result.css('[data-key="stats.most_recent_repost"]').first
       assert_not_nil most_recent
-      assert_equal "1h", result.css('[data-key="stats.most_recent_repost.value"]').first.text.strip
+      assert_equal "1h ago", result.css('[data-key="stats.most_recent_repost.value"]').first.text.strip
 
       imported = result.css('[data-key="stats.imported_posts"]').first
       assert_not_nil imported
@@ -35,6 +35,10 @@ class FeedStatsComponentTest < ViewComponent::TestCase
       published = result.css('[data-key="stats.published_posts"]').first
       assert_not_nil published
       assert_equal "1", result.css('[data-key="stats.published_posts.value"]').first.text.strip
+
+      last_week = result.css('[data-key="stats.posts_last_week"]').first
+      assert_not_nil last_week
+      assert_equal "2", result.css('[data-key="stats.posts_last_week.value"]').first.text.strip
     end
   end
 
@@ -57,6 +61,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     assert_equal "Recent", result.css(".hidden.md\\:flex [data-key=\"stats.most_recent_repost.label\"]").first.text
     assert_equal "Imported", result.css(".hidden.md\\:flex [data-key=\"stats.imported_posts.label\"]").first.text
     assert_equal "Published", result.css(".hidden.md\\:flex [data-key=\"stats.published_posts.label\"]").first.text
+    assert_equal "Last week", result.css(".hidden.md\\:flex [data-key=\"stats.posts_last_week.label\"]").first.text
   end
 
   test "#render should display fallback values for missing data" do

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -838,4 +838,13 @@ class FeedTest < ActiveSupport::TestCase
 
     assert_nil feed.most_recent_repost_at
   end
+
+  test "#posts_published_last_week_count should count posts published within the last week" do
+    feed = create(:feed)
+    create(:post, feed: feed, published_at: 2.days.ago)
+    create(:post, feed: feed, published_at: 6.days.ago)
+    create(:post, feed: feed, published_at: 10.days.ago)
+
+    assert_equal 2, feed.posts_published_last_week_count
+  end
 end


### PR DESCRIPTION
Changes:

- Align the feed page stats with the Status page (Imported, Published, Last week, Refreshed, Recent), adding a "posts published last week" metric
- Move Source/Repost to the left of the post card footer, leaving only the actions menu on the right
- Keep consistent spacing below flash messages, including alerts injected via Turbo after page load
- Simplify the post detail comments and attachments: drop the section titles, and give each comment its own card

These are presentation tweaks to make the stats and post views more consistent across pages. The flash change also fixes alerts that landed flush against the page header when prepended via Turbo, since spacing was previously only applied at server-render time.
