### PR TITLE
Add email preview admin interface for dev users

### DIFF
--- a/app/controllers/admin/email_previews_controller.rb
+++ b/app/controllers/admin/email_previews_controller.rb
@@ -61,7 +61,7 @@ class Admin::EmailPreviewsController < ApplicationController
   def sample_user
     user = User.new(
       email_address: "preview@example.com",
-      name: "Alex Preview",
+      name: "Sam Preview",
       password: "previewpassword",
       unconfirmed_email: "new.preview@example.com"
     )

--- a/app/controllers/admin/email_previews_controller.rb
+++ b/app/controllers/admin/email_previews_controller.rb
@@ -1,0 +1,71 @@
+class Admin::EmailPreviewsController < ApplicationController
+  CATALOG = [
+    {
+      id: "passwords_mailer-reset",
+      label: "Password Reset",
+      description: "Sent when someone requests a password reset"
+    },
+    {
+      id: "profile_mailer-account_confirmation",
+      label: "Account Confirmation",
+      description: "Sent during signup to verify the email address"
+    },
+    {
+      id: "profile_mailer-email_change_confirmation",
+      label: "Email Change Confirmation",
+      description: "Sent when a user requests an email address change"
+    },
+    {
+      id: "test_mailer-ping",
+      label: "Test Ping",
+      description: "A minimal test email to verify delivery is working"
+    }
+  ].freeze
+
+  def index
+    authorize [:admin, :email_preview], :index?
+    @previews = CATALOG
+  end
+
+  def show
+    authorize [:admin, :email_preview], :show?
+    @preview = CATALOG.find { _1[:id] == params[:id] }
+    redirect_to(admin_email_previews_path, alert: "Unknown email type.") and return unless @preview
+
+    message = build_message(params[:id])
+    @subject = message.subject
+    @html_body = message.html_part&.decoded
+    @text_body = message.text_part&.decoded
+  end
+
+  private
+
+  def build_message(id)
+    ApplicationMailer.preview_mode = true
+    user = sample_user
+
+    case id
+    when "passwords_mailer-reset"
+      PasswordsMailer.reset(user).message
+    when "profile_mailer-account_confirmation"
+      ProfileMailer.account_confirmation(user).message
+    when "profile_mailer-email_change_confirmation"
+      ProfileMailer.email_change_confirmation(user).message
+    when "test_mailer-ping"
+      TestMailer.ping("preview@example.com").message
+    end
+  ensure
+    ApplicationMailer.preview_mode = false
+  end
+
+  def sample_user
+    user = User.new(
+      email_address: "preview@example.com",
+      name: "Alex Preview",
+      password: "previewpassword",
+      unconfirmed_email: "new.preview@example.com"
+    )
+    user.id = 0
+    user
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,6 +2,14 @@ class ApplicationMailer < ActionMailer::Base
   default from: ENV.fetch("MAILER_FROM", "noreply@frf.im")
   layout "mailer"
 
+  def self.preview_mode=(value)
+    Thread.current[:mailer_preview_mode] = value
+  end
+
+  def self.preview_mode?
+    Thread.current[:mailer_preview_mode]
+  end
+
   private
 
   def set_event_context(level: nil, user_id: nil, subject: nil, details: nil)
@@ -14,6 +22,8 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def register_event
+    return if self.class.preview_mode?
+
     Event.create!(
       type: event_type,
       level: event_context[:level] || :info,

--- a/app/policies/admin/email_preview_policy.rb
+++ b/app/policies/admin/email_preview_policy.rb
@@ -1,0 +1,9 @@
+class Admin::EmailPreviewPolicy < ApplicationPolicy
+  def index?
+    dev?
+  end
+
+  def show?
+    dev?
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -66,4 +66,8 @@ class ApplicationPolicy
   def admin?
     user&.admin?
   end
+
+  def dev?
+    user&.dev?
+  end
 end

--- a/app/views/admin/email_previews/index.html.erb
+++ b/app/views/admin/email_previews/index.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, "Email Previews" %>
+
+<div class="space-y-8">
+  <%= render PageHeaderComponent.new(title: "Email Previews") %>
+
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+    <% @previews.each do |preview| %>
+      <%= render CardComponent.new(href: admin_email_preview_path(preview[:id])) do %>
+        <div class="space-y-2">
+          <h2 class="text-base font-semibold text-slate-900"><%= preview[:label] %></h2>
+          <p class="text-sm text-slate-500"><%= preview[:description] %></p>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/email_previews/show.html.erb
+++ b/app/views/admin/email_previews/show.html.erb
@@ -1,0 +1,36 @@
+<% content_for :title, @preview[:label] %>
+
+<div class="space-y-8">
+  <%= render PageHeaderComponent.new(title: @preview[:label]) %>
+
+  <div class="space-y-6">
+    <div class="rounded-lg border border-slate-200 bg-white p-4 space-y-1">
+      <p class="text-sm text-slate-500"><%= @preview[:description] %></p>
+      <p class="text-sm text-slate-500">
+        <span class="font-medium text-slate-700">Subject:</span>
+        <%= @subject %>
+      </p>
+    </div>
+
+    <% if @html_body.present? %>
+      <div class="space-y-2">
+        <h2 class="text-sm font-medium text-slate-700">HTML</h2>
+        <div class="overflow-hidden rounded-lg border border-slate-200 bg-white">
+          <iframe srcdoc="<%= h(@html_body) %>"
+                  class="w-full"
+                  style="height: 480px; border: none;"
+                  sandbox="allow-same-origin"></iframe>
+        </div>
+      </div>
+    <% end %>
+
+    <% if @text_body.present? %>
+      <div class="space-y-2">
+        <h2 class="text-sm font-medium text-slate-700">Plain text</h2>
+        <pre class="overflow-auto rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 whitespace-pre-wrap"><%= @text_body %></pre>
+      </div>
+    <% end %>
+
+    <%= link_to "← All email previews", admin_email_previews_path, class: "inline-block text-sm text-slate-500 hover:text-slate-700" %>
+  </div>
+</div>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -45,6 +45,16 @@
         </div>
       <% end %>
 
+      <%= render CardComponent.new(href: admin_email_previews_path) do %>
+        <div class="space-y-4">
+          <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+            <%= icon("mail", css_class: "size-5") %>
+            <span>Email Previews</span>
+          </h2>
+          <p class="text-slate-600">Browse rendered previews of all email templates</p>
+        </div>
+      <% end %>
+
       <%= render CardComponent.new(href: development_sent_emails_path, target: "_blank", rel: "noopener noreferrer") do %>
         <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
 
     resources :events, only: [:index, :show]
     resource :system_stats, only: :show
+    resources :email_previews, only: [:index, :show]
   end
 
   resource :settings, only: :show

--- a/test/controllers/admin/email_previews_controller_test.rb
+++ b/test/controllers/admin/email_previews_controller_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class Admin::EmailPreviewsControllerTest < ActionDispatch::IntegrationTest
+  def dev_user
+    @dev_user ||= create(:user, :dev)
+  end
+
+  def regular_user
+    @regular_user ||= create(:user)
+  end
+
+  test "#index should redirect unauthenticated users" do
+    get admin_email_previews_path
+
+    assert_redirected_to new_session_path
+  end
+
+  test "#index should deny users without dev permission" do
+    login_as(regular_user)
+
+    get admin_email_previews_path
+
+    assert_redirected_to root_path
+  end
+
+  test "#index should show email list for dev users" do
+    login_as(dev_user)
+
+    get admin_email_previews_path
+
+    assert_response :success
+    assert_select "h1", "Email Previews"
+  end
+
+  test "#show should redirect unauthenticated users" do
+    get admin_email_preview_path("passwords_mailer-reset")
+
+    assert_redirected_to new_session_path
+  end
+
+  test "#show should deny users without dev permission" do
+    login_as(regular_user)
+
+    get admin_email_preview_path("passwords_mailer-reset")
+
+    assert_redirected_to root_path
+  end
+
+  test "#show should redirect for unknown email type" do
+    login_as(dev_user)
+
+    get admin_email_preview_path("unknown-mailer")
+
+    assert_redirected_to admin_email_previews_path
+  end
+
+  %w[
+    passwords_mailer-reset
+    profile_mailer-account_confirmation
+    profile_mailer-email_change_confirmation
+    test_mailer-ping
+  ].each do |id|
+    test "#show should render preview for #{id}" do
+      login_as(dev_user)
+
+      get admin_email_preview_path(id)
+
+      assert_response :success
+    end
+  end
+
+  private
+
+  def login_as(user)
+    post session_path, params: { email_address: user.email_address, password: "password123" }
+  end
+end


### PR DESCRIPTION
Changes:

- Add `Admin::EmailPreviewsController` with index and show actions to preview rendered email templates
- Create email preview views (index and show) with HTML iframe and plain text rendering
- Add `Admin::EmailPreviewPolicy` to restrict access to users with dev permission
- Introduce `dev` permission type alongside existing `admin` permission
- Add `dev?` helper methods to `User` and `ApplicationPolicy` for permission checking
- Add `:dev` trait to user factory for testing
- Prevent event logging during email preview generation via `ApplicationMailer.preview_mode`
- Add email previews card to admin dashboard (visible only to dev users)
- Route email previews under `/admin/email_previews`

This provides a development tool for previewing all application emails in a browser before sending, helping catch rendering issues and verify email content during development.
