### PR TITLE
Replace post Withdraw with a Delete action

### DIFF
--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= helpers.dom_id(post) %>" class="w-full rounded-lg border border-slate-200 bg-white shadow-xs">
+<div id="<%= helpers.dom_id(post) %>" class="<%= card_classes %>">
   <div class="flex items-start justify-between gap-4 px-5 py-4">
     <div class="flex min-w-0 items-center gap-2">
       <%= link_to title, post_url,
@@ -42,33 +42,42 @@
     </div>
 
     <div class="flex items-center gap-3">
-      <% if withdraw_allowed? %>
-        <div class="relative">
-          <button type="button"
-                  id="<%= menu_id %>-button"
-                  data-dropdown-toggle="<%= menu_id %>"
-                  data-dropdown-placement="bottom-end"
-                  class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
-                  aria-haspopup="true"
-                  aria-expanded="false">
-            <%= helpers.icon("ellipsis", css_class: "size-4") %>
-            <span class="sr-only">More options</span>
-          </button>
-          <div id="<%= menu_id %>"
-               class="z-20 hidden w-40 rounded-lg border border-slate-200 bg-white shadow-sm"
-               role="menu"
-               aria-labelledby="<%= menu_id %>-button">
-            <ul class="py-1">
+      <div class="relative">
+        <button type="button"
+                id="<%= menu_id %>-button"
+                data-dropdown-toggle="<%= menu_id %>"
+                data-dropdown-placement="bottom-end"
+                class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+                aria-haspopup="true"
+                aria-expanded="false">
+          <%= helpers.icon("ellipsis", css_class: "size-4") %>
+          <span class="sr-only">More options</span>
+        </button>
+        <div id="<%= menu_id %>"
+             class="z-20 hidden w-40 rounded-lg border border-slate-200 bg-white shadow-sm"
+             role="menu"
+             aria-labelledby="<%= menu_id %>-button">
+          <ul class="py-1">
+            <li>
+              <%= link_to "Details", post_url,
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem" %>
+            </li>
+            <% if delete_allowed? %>
               <li>
-                <%= link_to "Withdraw", helpers.post_path(post),
-                      data: { turbo_method: :delete, turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here." },
-                      class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
-                      role: "menuitem" %>
+                <%= link_to "Delete…", "#",
+                      class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                      role: "menuitem",
+                      data: { controller: "modal-trigger", modal_trigger_modal_id_value: delete_modal_id, action: "click->modal-trigger#open" } %>
               </li>
-            </ul>
-          </div>
+            <% end %>
+          </ul>
         </div>
-      <% end %>
+      </div>
     </div>
   </div>
+
+  <% if delete_allowed? %>
+    <%= render PostDeleteModalComponent.new(post: post) %>
+  <% end %>
 </div>

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -61,12 +61,21 @@ class PostCardComponent < ViewComponent::Base
     post.freefeed_url
   end
 
-  def withdraw_allowed?
+  def delete_allowed?
     helpers.policy(post).destroy?
   end
 
   def withdrawn?
     post.status.to_s == "withdrawn"
+  end
+
+  def card_classes
+    base = "w-full rounded-lg border border-slate-200 shadow-xs"
+    "#{base} #{withdrawn? ? 'bg-slate-50' : 'bg-white'}"
+  end
+
+  def delete_modal_id
+    PostDeleteModalComponent.modal_id(post)
   end
 
   def menu_id

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -70,8 +70,11 @@ class PostCardComponent < ViewComponent::Base
   end
 
   def card_classes
-    base = "w-full rounded-lg border border-slate-200 shadow-xs"
-    "#{base} #{withdrawn? ? 'bg-slate-50' : 'bg-white'}"
+    helpers.class_names(
+      "w-full rounded-lg border border-slate-200 shadow-xs",
+      "bg-slate-50" => withdrawn?,
+      "bg-white" => !withdrawn?
+    )
   end
 
   def delete_modal_id

--- a/app/components/post_delete_modal_component.html.erb
+++ b/app/components/post_delete_modal_component.html.erb
@@ -1,0 +1,41 @@
+<%= render ModalComponent.new(title: "Delete post", modal_id: modal_id) do %>
+  <%= form_with url: helpers.post_path(post), method: :delete, data: form_data do |form| %>
+    <div class="space-y-6">
+      <p class="text-base text-slate-600">
+        This post lives in two places: as a published post on FreeFeed, and as a record here in Feeder. Choose what you want to remove.
+      </p>
+
+      <div class="space-y-4">
+        <label class="flex gap-3">
+          <%= check_box_tag "delete_freefeed", "1", true,
+                data: { post_delete_target: "checkbox", action: "post-delete#update" },
+                class: "mt-1 size-4 shrink-0 rounded border-slate-300 text-sky-600 focus:ring-sky-500" %>
+          <span>
+            <span class="block text-base font-medium text-slate-900">Delete the post on FreeFeed</span>
+            <span class="block text-sm text-slate-500">Remove the published post from FreeFeed.</span>
+          </span>
+        </label>
+
+        <label class="flex gap-3">
+          <%= check_box_tag "delete_record", "1", false,
+                data: { post_delete_target: "checkbox", action: "post-delete#update" },
+                class: "mt-1 size-4 shrink-0 rounded border-slate-300 text-sky-600 focus:ring-sky-500" %>
+          <span>
+            <span class="block text-base font-medium text-slate-900">Forget this post was ever imported</span>
+            <span class="block text-sm text-slate-500">Delete the import record so the post can be imported again. Leave this off to keep the post from coming back.</span>
+          </span>
+        </label>
+      </div>
+
+      <div class="flex items-center gap-3 pt-2">
+        <%= form.submit "Delete",
+              data: { post_delete_target: "submit", action: "modal#confirm" },
+              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-600 bg-red-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
+        <%= tag.button "Cancel",
+              type: "button",
+              class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer",
+              data: { action: "modal#close" } %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/post_delete_modal_component.html.erb
+++ b/app/components/post_delete_modal_component.html.erb
@@ -1,23 +1,31 @@
 <%= render ModalComponent.new(title: "Delete post", modal_id: modal_id) do %>
   <%= form_with url: helpers.post_path(post), method: :delete, data: form_data do |form| %>
     <div class="space-y-6">
-      <p class="text-base text-slate-600">
-        This post lives in two places: as a published post on FreeFeed, and as a record here in Feeder. Choose what you want to remove.
-      </p>
+      <% if freefeed_option? %>
+        <p class="text-base text-slate-600">
+          This post lives in two places: as a published post on FreeFeed, and as a record here in Feeder. Choose what you want to remove.
+        </p>
+      <% else %>
+        <p class="text-base text-slate-600">
+          This post is already gone from FreeFeed. You can still remove Feeder's record of it.
+        </p>
+      <% end %>
 
       <div class="space-y-4">
-        <label class="flex gap-3">
-          <%= check_box_tag "delete_freefeed", "1", true,
-                data: { post_delete_target: "checkbox", action: "post-delete#update" },
-                class: "mt-1 size-4 shrink-0 rounded border-slate-300 text-sky-600 focus:ring-sky-500" %>
-          <span>
-            <span class="block text-base font-medium text-slate-900">Delete the post on FreeFeed</span>
-            <span class="block text-sm text-slate-500">Remove the published post from FreeFeed.</span>
-          </span>
-        </label>
+        <% if freefeed_option? %>
+          <label class="flex gap-3">
+            <%= check_box_tag "delete_freefeed", "1", true,
+                  data: { post_delete_target: "checkbox", action: "post-delete#update" },
+                  class: "mt-1 size-4 shrink-0 rounded border-slate-300 text-sky-600 focus:ring-sky-500" %>
+            <span>
+              <span class="block text-base font-medium text-slate-900">Delete the post on FreeFeed</span>
+              <span class="block text-sm text-slate-500">Remove the published post from FreeFeed.</span>
+            </span>
+          </label>
+        <% end %>
 
         <label class="flex gap-3">
-          <%= check_box_tag "delete_record", "1", false,
+          <%= check_box_tag "delete_record", "1", record_checked_by_default?,
                 data: { post_delete_target: "checkbox", action: "post-delete#update" },
                 class: "mt-1 size-4 shrink-0 rounded border-slate-300 text-sky-600 focus:ring-sky-500" %>
           <span>

--- a/app/components/post_delete_modal_component.rb
+++ b/app/components/post_delete_modal_component.rb
@@ -1,0 +1,24 @@
+class PostDeleteModalComponent < ViewComponent::Base
+  def initialize(post:, turbo: true)
+    @post = post
+    @turbo = turbo
+  end
+
+  def self.modal_id(post)
+    "delete-post-modal-#{post.id}"
+  end
+
+  private
+
+  attr_reader :post, :turbo
+
+  def modal_id
+    self.class.modal_id(post)
+  end
+
+  def form_data
+    data = { controller: "post-delete" }
+    data[:turbo] = false unless turbo
+    data
+  end
+end

--- a/app/components/post_delete_modal_component.rb
+++ b/app/components/post_delete_modal_component.rb
@@ -16,6 +16,16 @@ class PostDeleteModalComponent < ViewComponent::Base
     self.class.modal_id(post)
   end
 
+  # A withdrawn post is already gone from FreeFeed, so the only thing left to
+  # remove is Feeder's record of it.
+  def freefeed_option?
+    !post.withdrawn?
+  end
+
+  def record_checked_by_default?
+    !freefeed_option?
+  end
+
   def form_data
     data = { controller: "post-delete" }
     data[:turbo] = false unless turbo

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -47,23 +47,71 @@ class PostsController < ApplicationController
     @post = load_post
     authorize @post
 
-    @post.withdrawn!
-    PostWithdrawalJob.perform_later(@post.id)
+    @delete_freefeed = boolean_param(:delete_freefeed)
+    @delete_record = boolean_param(:delete_record)
 
-    Event.create!(
-      type: "post_withdrawn",
-      user: Current.user,
-      subject: @post,
-      level: :info
-    )
+    unless @delete_freefeed || @delete_record
+      return respond_to do |format|
+        format.html { redirect_to posts_path, alert: "Pick at least one thing to delete." }
+        format.turbo_stream { head :no_content }
+      end
+    end
+
+    if @delete_freefeed && @post.freefeed_post_id.present?
+      PostWithdrawalJob.perform_later(@post.feed_id, @post.freefeed_post_id)
+    end
+
+    if @delete_record
+      delete_post_record(@post)
+    else
+      @post.withdrawn!
+      log_post_event("post_withdrawn", @post)
+    end
 
     respond_to do |format|
-      format.html { redirect_to posts_path, notice: "Post withdrawal initiated. It remains visible in the app." }
+      format.html { redirect_to posts_path, notice: destroy_notice }
       format.turbo_stream
     end
   end
 
   private
+
+  def boolean_param(key)
+    ActiveModel::Type::Boolean.new.cast(params[key])
+  end
+
+  # Removes Feeder's record of the post, including the source entry and its
+  # import marker, so the item can be picked up again on the next feed refresh.
+  def delete_post_record(post)
+    feed = post.feed
+    feed_entry = post.feed_entry
+    uid = post.uid
+
+    log_post_event("post_deleted", post, subject: feed)
+
+    ActiveRecord::Base.transaction do
+      if feed_entry
+        feed_entry.destroy! # cascades to posts via dependent: :destroy
+      else
+        post.destroy!
+      end
+      FeedEntryUid.where(feed_id: feed.id, uid: uid).delete_all
+    end
+  end
+
+  def log_post_event(type, post, subject: post)
+    Event.create!(type: type, user: Current.user, subject: subject, level: :info)
+  end
+
+  def destroy_notice
+    if @delete_record && @delete_freefeed
+      "Post removed from FreeFeed and Feeder. It may be imported again later."
+    elsif @delete_record
+      "Post record deleted. It may be imported again later."
+    else
+      "Post withdrawal initiated. It remains visible in the app."
+    end
+  end
 
   def sortable_fields
     SORTABLE_FIELDS

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -68,8 +68,10 @@ class PostsController < ApplicationController
       log_post_event("post_withdrawn", @post)
     end
 
+    @notice = destroy_notice
+
     respond_to do |format|
-      format.html { redirect_to posts_path, notice: destroy_notice }
+      format.html { redirect_to posts_path, notice: @notice }
       format.turbo_stream
     end
   end
@@ -104,11 +106,11 @@ class PostsController < ApplicationController
 
   def destroy_notice
     if @delete_record && @delete_freefeed
-      "Post removed from FreeFeed and Feeder. It may be imported again later."
+      "Post removed from FreeFeed and Feeder. It may be imported again the next time the feed updates."
     elsif @delete_record
-      "Post record deleted. It may be imported again later."
+      "Post record deleted. It may be imported again the next time the feed updates."
     else
-      "Post withdrawal initiated. It remains visible in the app."
+      "The post will be withdrawn from FreeFeed but stays here so it won't be imported again."
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -87,15 +87,14 @@ class PostsController < ApplicationController
     feed_entry = post.feed_entry
     uid = post.uid
 
-    log_post_event("post_deleted", post, subject: feed)
-
     ActiveRecord::Base.transaction do
       if feed_entry
-        feed_entry.destroy! # cascades to posts via dependent: :destroy
+        feed_entry.destroy! # cascades to the post via dependent: :destroy
       else
         post.destroy!
       end
       FeedEntryUid.where(feed_id: feed.id, uid: uid).delete_all
+      log_post_event("post_deleted", post, subject: feed)
     end
   end
 

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -41,19 +41,6 @@ module PostHelper
     end
   end
 
-  # TBD: Refactor after metadata/list item description pattern stabilizes
-  def post_metadata_segments(post, show_feed: false, withdraw_allowed: false)
-    [
-      post_metadata_feed_link_segment(post, show_feed),
-      post_metadata_published_segment(post),
-      post_metadata_attachments_segment(post),
-      post_metadata_comments_segment(post),
-      post_metadata_source_link_segment(post),
-      post_metadata_freefeed_link_segment(post),
-      post_metadata_withdraw_link_segment(post, withdraw_allowed)
-    ].compact
-  end
-
   private
 
   # Convert URLs in text to clickable links and escape all content
@@ -87,61 +74,5 @@ module PostHelper
     result << ERB::Util.html_escape(text[last_end..])
 
     result.join
-  end
-
-  def post_metadata_feed_link_segment(post, show_feed)
-    return unless show_feed
-    return unless post.feed.present?
-
-    link_to(post.feed.name, feed_path(post.feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
-  end
-
-  def post_metadata_published_segment(post)
-    return unless post.published_at
-
-    safe_join(["Published", time_ago_tag(post.published_at)], " ")
-  end
-
-  def post_metadata_attachments_segment(post)
-    attachments_count = Array(post.attachment_urls).size
-    return if attachments_count.zero?
-
-    "Attachments: #{attachments_count}"
-  end
-
-  def post_metadata_comments_segment(post)
-    comments_count = Array(post.comments).size
-    return if comments_count.zero?
-
-    "Comments: #{comments_count}"
-  end
-
-  def post_metadata_source_link_segment(post)
-    return unless post.source_url.present?
-
-    link_to("Source post", post.source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
-  end
-
-  def post_metadata_freefeed_link_segment(post)
-    return unless post.freefeed_post_id.present?
-
-    feed = post.feed
-    access_token = feed&.access_token
-
-    return unless feed.present? && access_token.present? && feed.target_group.present?
-
-    freefeed_url = "#{access_token.host}/#{feed.target_group}/#{post.freefeed_post_id}"
-    link_to("FreeFeed post", freefeed_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
-  end
-
-  def post_metadata_withdraw_link_segment(post, withdraw_allowed)
-    return unless withdraw_allowed
-
-    link_to(
-      "Withdraw",
-      post_path(post),
-      data: { turbo_method: :delete, turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here." },
-      class: "font-medium underline underline-offset-4 transition text-red-600 hover:text-red-500"
-    )
   end
 end

--- a/app/javascript/controllers/post_delete_controller.js
+++ b/app/javascript/controllers/post_delete_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Enables the delete submit button only while at least one option is checked.
+export default class extends Controller {
+  static targets = ["checkbox", "submit"]
+
+  connect() {
+    this.update()
+  }
+
+  update() {
+    const anyChecked = this.checkboxTargets.some((checkbox) => checkbox.checked)
+    this.submitTarget.disabled = !anyChecked
+  }
+}

--- a/app/javascript/controllers/post_delete_controller.js
+++ b/app/javascript/controllers/post_delete_controller.js
@@ -9,6 +9,8 @@ export default class extends Controller {
   }
 
   update() {
+    if (!this.hasSubmitTarget) return
+
     const anyChecked = this.checkboxTargets.some((checkbox) => checkbox.checked)
     this.submitTarget.disabled = !anyChecked
   }

--- a/app/jobs/post_withdrawal_job.rb
+++ b/app/jobs/post_withdrawal_job.rb
@@ -1,16 +1,18 @@
 class PostWithdrawalJob < ApplicationJob
   queue_as :default
 
-  def perform(post_id)
-    post = Post.find_by(id: post_id)
-    return unless post
+  def perform(feed_id, freefeed_post_id)
+    return if freefeed_post_id.blank?
 
-    access_token = post.feed.access_token
+    feed = Feed.find_by(id: feed_id)
+    return unless feed
+
+    access_token = feed.access_token
     return unless access_token&.active?
 
     client = access_token.build_client
-    client.delete_post(post.freefeed_post_id)
+    client.delete_post(freefeed_post_id)
   rescue FreefeedClient::Error => e
-    Rails.logger.error("Failed to withdraw post #{post_id} from FreeFeed: #{e.message}")
+    Rails.logger.error("Failed to withdraw FreeFeed post #{freefeed_post_id}: #{e.message}")
   end
 end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -8,7 +8,7 @@ class PostPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (owner? || admin?) && record.published?
+    (owner? || admin?) && (record.published? || record.withdrawn?)
   end
 
   private

--- a/app/views/posts/destroy.turbo_stream.erb
+++ b/app/views/posts/destroy.turbo_stream.erb
@@ -1,19 +1,13 @@
 <% if @delete_record %>
   <%= turbo_stream.remove dom_id(@post) %>
-
-  <%= turbo_stream.prepend "flash-messages" do %>
-    <%= render AlertComponent.new(variant: :info) do %>
-      <span>Post record deleted. It may be imported again the next time the feed updates.</span>
-    <% end %>
-  <% end %>
 <% else %>
   <%= turbo_stream.replace dom_id(@post) do %>
     <%= render PostCardComponent.new(post: @post, show_feed: true) %>
   <% end %>
+<% end %>
 
-  <%= turbo_stream.prepend "flash-messages" do %>
-    <%= render AlertComponent.new(variant: :info) do %>
-      <span>The post will be withdrawn from FreeFeed but will remain here to prevent it from being imported again.</span>
-    <% end %>
+<%= turbo_stream.prepend "flash-messages" do %>
+  <%= render AlertComponent.new(variant: :info) do %>
+    <span><%= @notice %></span>
   <% end %>
 <% end %>

--- a/app/views/posts/destroy.turbo_stream.erb
+++ b/app/views/posts/destroy.turbo_stream.erb
@@ -1,9 +1,19 @@
-<%= turbo_stream.replace dom_id(@post) do %>
-  <%= render PostCardComponent.new(post: @post, show_feed: true) %>
-<% end %>
+<% if @delete_record %>
+  <%= turbo_stream.remove dom_id(@post) %>
 
-<%= turbo_stream.prepend "flash-messages" do %>
-  <%= render AlertComponent.new(variant: :info) do %>
-    <span>The post will be withdrawn from FreeFeed but will remain here to prevent it from being imported again.</span>
+  <%= turbo_stream.prepend "flash-messages" do %>
+    <%= render AlertComponent.new(variant: :info) do %>
+      <span>Post record deleted. It may be imported again the next time the feed updates.</span>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.replace dom_id(@post) do %>
+    <%= render PostCardComponent.new(post: @post, show_feed: true) %>
+  <% end %>
+
+  <%= turbo_stream.prepend "flash-messages" do %>
+    <%= render AlertComponent.new(variant: :info) do %>
+      <span>The post will be withdrawn from FreeFeed but will remain here to prevent it from being imported again.</span>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -17,15 +17,15 @@
     <% end %>
     <% if policy(@post).destroy? %>
       <% header.with_action_button do %>
-        <%= button_to "Withdraw", post_path(@post),
-                      method: :delete,
-                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-red-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
-                      data: {
-                        turbo_confirm: "Withdraw this post? It will be removed from FreeFeed but remain visible here."
-                      },
-                      form: { class: "inline-block" } %>
+        <%= link_to "Delete…", "#",
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-red-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer",
+                    data: { controller: "modal-trigger", modal_trigger_modal_id_value: PostDeleteModalComponent.modal_id(@post), action: "click->modal-trigger#open" } %>
       <% end %>
     <% end %>
+  <% end %>
+
+  <% if policy(@post).destroy? %>
+    <%= render PostDeleteModalComponent.new(post: @post, turbo: false) %>
   <% end %>
 
   <%= render PostDetailsComponent.new(post: @post) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,9 @@ en:
     post_withdrawn:
       name: "Post withdrawn"
       description_html: "Post withdrawn from FreeFeed"
+    post_deleted:
+      name: "Post deleted"
+      description_html: "Post record deleted from feed %{subject_link}"
     access_token_validation_failed:
       name: "Token validation failed"
       description_html: "Token validation failed. Feeds disabled: %{feed_links}"

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -57,6 +57,39 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_includes result.text, "Withdrawn"
   end
 
+  test "#render should use a gray background for withdrawn posts" do
+    withdrawn_post = create(:post, feed: feed, status: :withdrawn)
+    result = render_inline PostCardComponent.new(post: withdrawn_post)
+
+    assert_not_empty result.css("##{ActionView::RecordIdentifier.dom_id(withdrawn_post)}.bg-slate-50")
+  end
+
+  test "#render should offer Details and Delete actions for a published post" do
+    Current.session = build(:session, user: user)
+    result = render_inline PostCardComponent.new(post: post)
+
+    menu_items = result.css('[role="menuitem"]').map { |item| item.text.strip }
+    assert_includes menu_items, "Details"
+    assert_includes menu_items, "Delete…"
+  end
+
+  test "#render should render the delete modal for a published post" do
+    Current.session = build(:session, user: user)
+    result = render_inline PostCardComponent.new(post: post)
+
+    assert_not_empty result.css("##{PostDeleteModalComponent.modal_id(post)}")
+  end
+
+  test "#render should not offer Delete for an unpublished post" do
+    Current.session = build(:session, user: user)
+    draft_post = create(:post, feed: feed, status: :draft)
+    result = render_inline PostCardComponent.new(post: draft_post)
+
+    menu_items = result.css('[role="menuitem"]').map { |item| item.text.strip }
+    assert_includes menu_items, "Details"
+    assert_not_includes menu_items, "Delete…"
+  end
+
   test "#render should show footer when post has a source url" do
     result = render_inline PostCardComponent.new(post: post)
 

--- a/test/components/post_delete_modal_component_test.rb
+++ b/test/components/post_delete_modal_component_test.rb
@@ -35,6 +35,14 @@ class PostDeleteModalComponentTest < ViewComponent::TestCase
     assert_equal "false", result.at_css("form")["data-turbo"]
   end
 
+  test "#render should offer only the record option for a withdrawn post" do
+    withdrawn_post = create(:post, feed: feed, status: :withdrawn)
+    result = render_inline PostDeleteModalComponent.new(post: withdrawn_post)
+
+    assert_nil result.at_css("input[name='delete_freefeed']")
+    assert result.at_css("input[name='delete_record']")[:checked]
+  end
+
   test "#render should wire the submit button to the post-delete controller" do
     result = render_inline PostDeleteModalComponent.new(post: post)
 

--- a/test/components/post_delete_modal_component_test.rb
+++ b/test/components/post_delete_modal_component_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+require "view_component/test_case"
+
+class PostDeleteModalComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed
+    @feed ||= create(:feed, user: user)
+  end
+
+  def post
+    @post ||= create(:post, :published, feed: feed)
+  end
+
+  test "#render should check Freefeed deletion by default and leave the record off" do
+    result = render_inline PostDeleteModalComponent.new(post: post)
+
+    assert result.at_css("input[name='delete_freefeed']")[:checked]
+    assert_nil result.at_css("input[name='delete_record']")[:checked]
+  end
+
+  test "#render should post a delete request to the post path" do
+    result = render_inline PostDeleteModalComponent.new(post: post)
+
+    form = result.at_css("form")
+    assert_equal "/posts/#{post.id}", form[:action]
+    assert_not_nil form.at_css("input[name='_method'][value='delete']")
+  end
+
+  test "#render should disable turbo when requested" do
+    result = render_inline PostDeleteModalComponent.new(post: post, turbo: false)
+
+    assert_equal "false", result.at_css("form")["data-turbo"]
+  end
+
+  test "#render should wire the submit button to the post-delete controller" do
+    result = render_inline PostDeleteModalComponent.new(post: post)
+
+    submit = result.at_css("input[type='submit'][data-post-delete-target='submit']")
+    assert_not_nil submit
+  end
+end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -142,13 +142,14 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='post.freefeed_post_id']"
   end
 
-  test "#destroy should withdraw post and create event" do
+  test "#destroy should withdraw the FreeFeed post and create event" do
     sign_in_as(user)
     published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")
 
-    assert_enqueued_with(job: PostWithdrawalJob) do
+    assert_enqueued_with(job: PostWithdrawalJob, args: [feed.id, "test-123"]) do
       assert_difference("Event.count", 1) do
-        delete post_url(published_post), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        delete post_url(published_post), params: { delete_freefeed: "1" },
+                                         headers: { "Accept" => "text/vnd.turbo-stream.html" }
       end
     end
 
@@ -158,7 +159,6 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "id=\"#{dom_id(published_post)}\""
     assert_includes response.body, "Withdrawn"
     assert_includes response.body, "The post will be withdrawn from FreeFeed"
-    refute_includes response.body, "data-bs-toggle"
     assert_equal "withdrawn", published_post.reload.status
 
     event = Event.last
@@ -166,6 +166,58 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal user, event.user
     assert_equal published_post, event.subject
     assert_equal "info", event.level
+  end
+
+  test "#destroy should delete the post record and let it be imported again" do
+    sign_in_as(user)
+    feed_entry = create(:feed_entry, feed: feed, uid: "entry-1")
+    create(:feed_entry_uid, feed: feed, uid: "entry-1")
+    published_post = create(:post, :published, feed: feed, feed_entry: feed_entry,
+      uid: "entry-1", freefeed_post_id: "test-123")
+
+    assert_difference(["Post.count", "FeedEntry.count", "FeedEntryUid.count"], -1) do
+      assert_difference("Event.count", 1) do
+        delete post_url(published_post), params: { delete_freefeed: "1", delete_record: "1" },
+                                         headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      end
+    end
+
+    assert_response :success
+    assert_includes response.body, "turbo-stream"
+    assert_includes response.body, "remove"
+    assert_nil Post.find_by(id: published_post.id)
+    assert_empty FeedEntryUid.where(feed: feed, uid: "entry-1")
+
+    event = Event.last
+    assert_equal "post_deleted", event.type
+    assert_equal feed, event.subject
+  end
+
+  test "#destroy should not drop the FreeFeed post when only the record is deleted" do
+    sign_in_as(user)
+    published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")
+
+    assert_no_enqueued_jobs(only: PostWithdrawalJob) do
+      delete post_url(published_post), params: { delete_record: "1" },
+                                       headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_nil Post.find_by(id: published_post.id)
+  end
+
+  test "#destroy should do nothing when no option is selected" do
+    sign_in_as(user)
+    published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")
+
+    assert_no_enqueued_jobs(only: PostWithdrawalJob) do
+      assert_no_difference(["Post.count", "Event.count"]) do
+        delete post_url(published_post)
+      end
+    end
+
+    assert_redirected_to posts_path
+    assert_equal "published", published_post.reload.status
   end
 
   test "#destroy should require authentication" do

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -206,6 +206,21 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_nil Post.find_by(id: published_post.id)
   end
 
+  test "#destroy should let a withdrawn post's record be deleted" do
+    sign_in_as(user)
+    feed_entry = create(:feed_entry, feed: feed, uid: "entry-9")
+    create(:feed_entry_uid, feed: feed, uid: "entry-9")
+    withdrawn_post = create(:post, feed: feed, feed_entry: feed_entry, uid: "entry-9", status: :withdrawn)
+
+    assert_difference(["Post.count", "FeedEntryUid.count"], -1) do
+      delete post_url(withdrawn_post), params: { delete_record: "1" },
+                                       headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_nil Post.find_by(id: withdrawn_post.id)
+  end
+
   test "#destroy should do nothing when no option is selected" do
     sign_in_as(user)
     published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")

--- a/test/helpers/post_helper_test.rb
+++ b/test/helpers/post_helper_test.rb
@@ -2,61 +2,6 @@ require "test_helper"
 
 class PostHelperTest < ActionView::TestCase
   include PostHelper
-  include TimeHelper
-
-  test "#post_metadata_segments should include feed link when requested" do
-    feed = create(:feed, target_group: "testgroup")
-
-    post = create(
-      :post,
-      :published,
-      feed: feed,
-      attachment_urls: ["https://example.com/a.png"],
-      comments: ["Great post!"],
-      source_url: "https://example.com/source",
-      freefeed_post_id: "post-123"
-    )
-
-    segments = post_metadata_segments(post, show_feed: true, withdraw_allowed: false)
-
-    assert_includes segments.first, feed.name
-  end
-
-  test "#post_metadata_segments should build default segments" do
-    feed = create(:feed)
-
-    post = create(
-      :post,
-      :published,
-      feed: feed,
-      attachment_urls: ["https://example.com/a.png"],
-      comments: ["Great post!"],
-      source_url: "https://example.com/source"
-    )
-
-    segments = post_metadata_segments(post, withdraw_allowed: false)
-
-    assert_includes segments, "Attachments: #{post.attachment_urls.size}"
-    assert_includes segments, "Comments: #{post.comments.size}"
-    assert segments.any? { |segment| segment.include?("Published") }
-  end
-
-  test "#post_metadata_segments should include withdraw link when permitted" do
-    feed = create(:feed)
-
-    post = create(
-      :post,
-      :published,
-      feed: feed,
-      attachment_urls: ["https://example.com/a.png"],
-      comments: ["Great post!"],
-      source_url: "https://example.com/source"
-    )
-
-    segments = post_metadata_segments(post, withdraw_allowed: true)
-
-    assert segments.any? { |segment| segment.include?("Withdraw") }
-  end
 
   test "#format_post_content should return empty string for nil content" do
     assert_equal "", format_post_content(nil)

--- a/test/jobs/post_withdrawal_job_test.rb
+++ b/test/jobs/post_withdrawal_job_test.rb
@@ -13,15 +13,11 @@ class PostWithdrawalJobTest < ActiveJob::TestCase
     @feed ||= create(:feed, user: user, access_token: access_token)
   end
 
-  def post
-    @post ||= create(:post, feed: feed, freefeed_post_id: "test_post_123", status: :withdrawn)
-  end
-
   test ".perform_now should delete post from FreeFeed" do
     stub_request(:delete, "#{access_token.host}/v4/posts/test_post_123")
       .to_return(status: 200)
 
-    PostWithdrawalJob.perform_now(post.id)
+    PostWithdrawalJob.perform_now(feed.id, "test_post_123")
 
     assert_requested :delete, "#{access_token.host}/v4/posts/test_post_123"
   end
@@ -31,14 +27,20 @@ class PostWithdrawalJobTest < ActiveJob::TestCase
       .to_return(status: 500, body: "Internal Server Error")
 
     assert_nothing_raised do
-      PostWithdrawalJob.perform_now(post.id)
+      PostWithdrawalJob.perform_now(feed.id, "test_post_123")
     end
   end
 
-  test ".perform_now should handle missing post gracefully" do
+  test ".perform_now should handle missing feed gracefully" do
     assert_nothing_raised do
-      PostWithdrawalJob.perform_now(999999)
+      PostWithdrawalJob.perform_now(999999, "test_post_123")
     end
+  end
+
+  test ".perform_now should do nothing without a freefeed post id" do
+    PostWithdrawalJob.perform_now(feed.id, nil)
+
+    assert_not_requested :delete, "#{access_token.host}/v4/posts/test_post_123"
   end
 
   test ".perform_now should handle authorization errors gracefully" do
@@ -46,7 +48,7 @@ class PostWithdrawalJobTest < ActiveJob::TestCase
       .to_return(status: 401, body: "Unauthorized")
 
     assert_nothing_raised do
-      PostWithdrawalJob.perform_now(post.id)
+      PostWithdrawalJob.perform_now(feed.id, "test_post_123")
     end
   end
 end

--- a/test/policies/post_policy_test.rb
+++ b/test/policies/post_policy_test.rb
@@ -64,6 +64,11 @@ class PostPolicyTest < ActiveSupport::TestCase
     assert PostPolicy.new(user, published_post).destroy?
   end
 
+  test "#destroy? should allow owner for withdrawn post" do
+    withdrawn_post = create(:post, feed: feed, status: :withdrawn)
+    assert PostPolicy.new(user, withdrawn_post).destroy?
+  end
+
   test "#destroy? should deny owner for non-published post" do
     draft_post = create(:post, :draft, feed: feed)
     assert_not PostPolicy.new(user, draft_post).destroy?


### PR DESCRIPTION
Changes:

- Add a **Details** item to the post menu that opens the post page
- Replace **Withdraw** with **Delete**, opening a confirmation modal with two independent choices: remove the published post from FreeFeed, and/or forget the import record so the item can be picked up again
- Delete the import record (post, feed entry, and import marker) when the user opts to forget a post, which is what actually re-enables import on the next refresh
- Show withdrawn posts with a "Withdrawn" badge and a light-gray card background

The old "Withdraw" only dropped the FreeFeed post and kept the local record to block re-import. Pulling these apart lets people choose: hide a post from FreeFeed for good, give an item a clean slate so it can come back, or both. The modal copy spells out the trade-off in plain language, and the Delete button stays disabled until at least one option is selected.
