### PR TITLE
Drop FreeFeed post id after withdrawal

### DIFF
--- a/app/components/post_delete_modal_component.html.erb
+++ b/app/components/post_delete_modal_component.html.erb
@@ -14,7 +14,7 @@
       <div class="space-y-4">
         <% if freefeed_option? %>
           <label class="flex gap-3">
-            <%= check_box_tag "delete_freefeed", "1", true,
+            <%= check_box_tag "delete_freefeed_post", "1", true,
                   data: { post_delete_target: "checkbox", action: "post-delete#update" },
                   class: "mt-1 size-4 shrink-0 rounded border-slate-300 text-sky-600 focus:ring-sky-500" %>
             <span>

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -58,7 +58,7 @@ class PostsController < ApplicationController
     end
 
     if @delete_freefeed && @post.freefeed_post_id.present?
-      PostWithdrawalJob.perform_later(@post.feed_id, @post.freefeed_post_id)
+      PostWithdrawalJob.perform_later(@post.feed_id, @post.freefeed_post_id, @post.id)
     end
 
     if @delete_record

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -47,17 +47,17 @@ class PostsController < ApplicationController
     @post = load_post
     authorize @post
 
-    @delete_freefeed = boolean_param(:delete_freefeed)
+    @delete_freefeed_post = boolean_param(:delete_freefeed_post)
     @delete_record = boolean_param(:delete_record)
 
-    unless @delete_freefeed || @delete_record
+    unless @delete_freefeed_post || @delete_record
       return respond_to do |format|
         format.html { redirect_to posts_path, alert: "Pick at least one thing to delete." }
         format.turbo_stream { head :no_content }
       end
     end
 
-    if @delete_freefeed && @post.freefeed_post_id.present?
+    if @delete_freefeed_post && @post.freefeed_post_id.present?
       PostWithdrawalJob.perform_later(@post.feed_id, @post.freefeed_post_id, @post.id)
     end
 
@@ -112,7 +112,7 @@ class PostsController < ApplicationController
   end
 
   def destroy_notice
-    if @delete_record && @delete_freefeed
+    if @delete_record && @delete_freefeed_post
       "Post removed from FreeFeed and Feeder. It may be imported again the next time the feed updates."
     elsif @delete_record
       "Post record deleted. It may be imported again the next time the feed updates."

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -71,12 +71,19 @@ class PostsController < ApplicationController
     @notice = destroy_notice
 
     respond_to do |format|
-      format.html { redirect_to posts_path, notice: @notice }
+      format.html { redirect_to destroy_redirect_path, notice: @notice }
       format.turbo_stream
     end
   end
 
   private
+
+  # After a withdrawal the post record stays, so send the user back to the post
+  # page to see its updated status. Once the record itself is gone there is
+  # nothing left to show, so fall back to the index.
+  def destroy_redirect_path
+    @delete_record ? posts_path : post_path(@post)
+  end
 
   def boolean_param(key)
     ActiveModel::Type::Boolean.new.cast(params[key])

--- a/app/jobs/post_withdrawal_job.rb
+++ b/app/jobs/post_withdrawal_job.rb
@@ -1,7 +1,7 @@
 class PostWithdrawalJob < ApplicationJob
   queue_as :default
 
-  def perform(feed_id, freefeed_post_id)
+  def perform(feed_id, freefeed_post_id, post_id = nil)
     return if freefeed_post_id.blank?
 
     feed = Feed.find_by(id: feed_id)
@@ -12,6 +12,8 @@ class PostWithdrawalJob < ApplicationJob
 
     client = access_token.build_client
     client.delete_post(freefeed_post_id)
+
+    Post.where(id: post_id).update_all(freefeed_post_id: nil)
   rescue FreefeedClient::Error => e
     Rails.logger.error("Failed to withdraw FreeFeed post #{freefeed_post_id}: #{e.message}")
   end

--- a/test/components/post_delete_modal_component_test.rb
+++ b/test/components/post_delete_modal_component_test.rb
@@ -17,7 +17,7 @@ class PostDeleteModalComponentTest < ViewComponent::TestCase
   test "#render should check Freefeed deletion by default and leave the record off" do
     result = render_inline PostDeleteModalComponent.new(post: post)
 
-    assert result.at_css("input[name='delete_freefeed']")[:checked]
+    assert result.at_css("input[name='delete_freefeed_post']")[:checked]
     assert_nil result.at_css("input[name='delete_record']")[:checked]
   end
 
@@ -39,7 +39,7 @@ class PostDeleteModalComponentTest < ViewComponent::TestCase
     withdrawn_post = create(:post, feed: feed, status: :withdrawn)
     result = render_inline PostDeleteModalComponent.new(post: withdrawn_post)
 
-    assert_nil result.at_css("input[name='delete_freefeed']")
+    assert_nil result.at_css("input[name='delete_freefeed_post']")
     assert result.at_css("input[name='delete_record']")[:checked]
   end
 

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -148,7 +148,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
     assert_enqueued_with(job: PostWithdrawalJob, args: [feed.id, "test-123", published_post.id]) do
       assert_difference("Event.count", 1) do
-        delete post_url(published_post), params: { delete_freefeed: "1" },
+        delete post_url(published_post), params: { delete_freefeed_post: "1" },
                                          headers: { "Accept" => "text/vnd.turbo-stream.html" }
       end
     end
@@ -172,7 +172,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")
 
-    delete post_url(published_post), params: { delete_freefeed: "1" }
+    delete post_url(published_post), params: { delete_freefeed_post: "1" }
 
     assert_redirected_to post_path(published_post)
     assert_equal "withdrawn", published_post.reload.status
@@ -182,7 +182,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")
 
-    delete post_url(published_post), params: { delete_freefeed: "1", delete_record: "1" }
+    delete post_url(published_post), params: { delete_freefeed_post: "1", delete_record: "1" }
 
     assert_redirected_to posts_path
     assert_nil Post.find_by(id: published_post.id)
@@ -197,7 +197,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
     assert_difference(["Post.count", "FeedEntry.count", "FeedEntryUid.count"], -1) do
       assert_difference("Event.count", 1) do
-        delete post_url(published_post), params: { delete_freefeed: "1", delete_record: "1" },
+        delete post_url(published_post), params: { delete_freefeed_post: "1", delete_record: "1" },
                                          headers: { "Accept" => "text/vnd.turbo-stream.html" }
       end
     end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -168,6 +168,26 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "info", event.level
   end
 
+  test "#destroy should reload the post page after withdrawing it" do
+    sign_in_as(user)
+    published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")
+
+    delete post_url(published_post), params: { delete_freefeed: "1" }
+
+    assert_redirected_to post_path(published_post)
+    assert_equal "withdrawn", published_post.reload.status
+  end
+
+  test "#destroy should redirect to the index after deleting the record" do
+    sign_in_as(user)
+    published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")
+
+    delete post_url(published_post), params: { delete_freefeed: "1", delete_record: "1" }
+
+    assert_redirected_to posts_path
+    assert_nil Post.find_by(id: published_post.id)
+  end
+
   test "#destroy should delete the post record and let it be imported again" do
     sign_in_as(user)
     feed_entry = create(:feed_entry, feed: feed, uid: "entry-1")

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -146,7 +146,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")
 
-    assert_enqueued_with(job: PostWithdrawalJob, args: [feed.id, "test-123"]) do
+    assert_enqueued_with(job: PostWithdrawalJob, args: [feed.id, "test-123", published_post.id]) do
       assert_difference("Event.count", 1) do
         delete post_url(published_post), params: { delete_freefeed: "1" },
                                          headers: { "Accept" => "text/vnd.turbo-stream.html" }

--- a/test/jobs/post_withdrawal_job_test.rb
+++ b/test/jobs/post_withdrawal_job_test.rb
@@ -22,6 +22,26 @@ class PostWithdrawalJobTest < ActiveJob::TestCase
     assert_requested :delete, "#{access_token.host}/v4/posts/test_post_123"
   end
 
+  test ".perform_now should drop the FreeFeed post id after deletion" do
+    post = create(:post, :published, feed: feed, freefeed_post_id: "test_post_123")
+    stub_request(:delete, "#{access_token.host}/v4/posts/test_post_123")
+      .to_return(status: 200)
+
+    PostWithdrawalJob.perform_now(feed.id, "test_post_123", post.id)
+
+    assert_nil post.reload.freefeed_post_id
+  end
+
+  test ".perform_now should keep the FreeFeed post id when deletion fails" do
+    post = create(:post, :published, feed: feed, freefeed_post_id: "test_post_123")
+    stub_request(:delete, "#{access_token.host}/v4/posts/test_post_123")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    PostWithdrawalJob.perform_now(feed.id, "test_post_123", post.id)
+
+    assert_equal "test_post_123", post.reload.freefeed_post_id
+  end
+
   test ".perform_now should handle FreeFeed API errors gracefully" do
     stub_request(:delete, "#{access_token.host}/v4/posts/test_post_123")
       .to_return(status: 500, body: "Internal Server Error")


### PR DESCRIPTION
Changes:

- Clear a post's `freefeed_post_id` once it's been withdrawn from FreeFeed, so the stale id no longer lingers on the local record
- Keep the user on the post page (reloading it to show the new status) after a withdrawal, and only send them to the posts index once the record itself is deleted
- Leave the index page's Turbo Stream update in place so a deleted card disappears and a withdrawn one re-renders with its new status

When a post is withdrawn the Feeder record stays around, so its FreeFeed reference should be tidied up and the user should land back where they were instead of being bounced to the index.
