### PR TITLE
Decode HTML entities in Twitter text

### DIFF
--- a/app/services/processor/twitter_processor.rb
+++ b/app/services/processor/twitter_processor.rb
@@ -50,15 +50,16 @@ module Processor
       permalink.presence || "https://twitter.com/i/web/status/#{tweet['id_str']}"
     end
 
-    # Rebuilds readable text: expand t.co links to their targets and drop the
-    # trailing t.co link that points to attached media.
+    # Rebuilds readable text: expand t.co links to their targets, drop the
+    # trailing t.co link that points to attached media, and decode the HTML
+    # entities (&amp;, &lt;, &gt;) that the syndication API encodes.
     def tweet_text(tweet)
       text = tweet["full_text"].to_s
       Array(tweet.dig("entities", "urls")).each do |url|
         text = text.gsub(url["url"], url["expanded_url"]) if url["url"].present? && url["expanded_url"].present?
       end
       media(tweet).each { |item| text = text.gsub(item["url"], "") if item["url"].present? }
-      text.strip
+      CGI.unescapeHTML(text).strip
     end
 
     def media_urls(tweet)

--- a/test/fixtures/files/feeds/twitter/normalized.json
+++ b/test/fixtures/files/feeds/twitter/normalized.json
@@ -2,7 +2,7 @@
   {
     "attachment_urls": [],
     "comments": [],
-    "content": "Check our docs https://developer.x.com/docs and more - https://twitter.com/testuser/status/1001",
+    "content": "Agency > Intelligence. Check our docs https://developer.x.com/docs and more - https://twitter.com/testuser/status/1001",
     "published_at": "2026-06-04T18:00:00.000Z",
     "source_url": "https://twitter.com/testuser/status/1001",
     "status": "enqueued",

--- a/test/fixtures/files/feeds/twitter/timeline.html
+++ b/test/fixtures/files/feeds/twitter/timeline.html
@@ -16,7 +16,7 @@
           { "content": { "tweet": {
             "id_str": "1001",
             "created_at": "Wed Jun 04 18:00:00 +0000 2026",
-            "full_text": "Check our docs https://t.co/abc and more",
+            "full_text": "Agency &gt; Intelligence. Check our docs https://t.co/abc and more",
             "permalink": "/testuser/status/1001",
             "entities": { "urls": [ { "url": "https://t.co/abc", "expanded_url": "https://developer.x.com/docs" } ] }
           } } },

--- a/test/services/processor/twitter_processor_test.rb
+++ b/test/services/processor/twitter_processor_test.rb
@@ -29,7 +29,11 @@ class Processor::TwitterProcessorTest < ActiveSupport::TestCase
   end
 
   test "#process should expand t.co links in the text" do
-    assert_equal "Check our docs https://developer.x.com/docs and more", entries.first.raw_data["text"]
+    assert_equal "Agency > Intelligence. Check our docs https://developer.x.com/docs and more", entries.first.raw_data["text"]
+  end
+
+  test "#process should decode HTML entities in the text" do
+    assert_includes entries.first.raw_data["text"], "Agency > Intelligence"
   end
 
   test "#process should drop the trailing media link from the text" do


### PR DESCRIPTION
Changes:

- Decode HTML entities (`&amp;`, `&lt;`, `&gt;`) in tweet text so content like "Agency &gt; Intelligence" renders as "Agency > Intelligence"

The X/Twitter syndication API HTML-encodes characters in the tweet `full_text`. The processor now runs the text through `CGI.unescapeHTML` after expanding links, so imported posts read naturally.