### PR TITLE
Add configuration checklist to System Health page

### DIFF
--- a/app/controllers/admin/system_stats_controller.rb
+++ b/app/controllers/admin/system_stats_controller.rb
@@ -1,6 +1,7 @@
 class Admin::SystemStatsController < ApplicationController
   def show
     authorize :access, :dev?
+    @config_checks = config_checks
     @release_info = release_info
     @disk_usage = Rails.cache.fetch("admin/system_stats/v3", expires_in: 5.minutes) do
       DiskUsageService.new.call
@@ -8,6 +9,16 @@ class Admin::SystemStatsController < ApplicationController
   end
 
   private
+
+  def config_checks
+    [
+      {
+        key: "resend_key",
+        label: "Resend key present",
+        ok: Rails.application.credentials.dig(:resend_api_token).present?
+      }
+    ]
+  end
 
   def release_info
     revision = ENV.fetch("APP_REVISION", nil)

--- a/app/controllers/admin/system_stats_controller.rb
+++ b/app/controllers/admin/system_stats_controller.rb
@@ -12,12 +12,28 @@ class Admin::SystemStatsController < ApplicationController
 
   def config_checks
     [
-      {
-        key: "resend_key",
-        label: "Resend key present",
-        ok: Rails.application.credentials.dig(:resend_api_token).present?
-      }
+      credential_check("resend_key", "Resend key present", :resend_api_token),
+      credential_check("resend_signing_secret", "Resend signing secret present", :resend_signing_secret),
+      credential_check("honeybadger_key", "Honeybadger API key present", :honeybadger, :api_key),
+      background_jobs_check
     ]
+  end
+
+  # Presence checks for optional credentials. A missing key isn't an error —
+  # it just means that integration is off — so it shows as neutral, not red.
+  def credential_check(key, label, *path)
+    status = Rails.application.credentials.dig(*path).present? ? :ok : :neutral
+    { key: key, label: label, status: status }
+  end
+
+  # Jobs queue up silently when no worker is running, so confirm a SolidQueue
+  # process has sent a heartbeat recently.
+  def background_jobs_check
+    alive = SolidQueue::Process.where(last_heartbeat_at: SolidQueue.process_alive_threshold.ago..).exists?
+    { key: "background_jobs", label: "Background jobs are processing", status: alive ? :ok : :error }
+  rescue StandardError => e
+    Rails.error.report(e)
+    { key: "background_jobs", label: "Background jobs are processing", status: :error }
   end
 
   def release_info

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,6 +103,17 @@ module ApplicationHelper
     end
   end
 
+  def system_check_icon(status)
+    case status.to_sym
+    when :ok
+      icon("square-check-big", css_class: "size-5 text-green-600", aria_label: "OK")
+    when :error
+      icon("square", css_class: "size-5 text-red-600", aria_label: "Problem")
+    else
+      icon("square", css_class: "size-5 text-slate-400", aria_label: "Not set")
+    end
+  end
+
   def highlight_json(json_hash)
     json_string = JSON.pretty_generate(json_hash)
     formatter = Rouge::Formatters::HTML.new(wrap: false)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,6 +34,8 @@ module ApplicationHelper
     # Status & indicators
     "circle-check"   => '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>',
     "circle-x"       => '<circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/>',
+    "square"         => '<rect width="18" height="18" x="3" y="3" rx="2"/>',
+    "square-check-big" => '<path d="M21 10.656V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h12.344"/><path d="m9 11 3 3L22 4"/>',
     "clock"          => '<circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>',
     "file"           => '<path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/>',
     "file-image"     => '<path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><circle cx="10" cy="12" r="2"/><path d="m20 17-1.296-1.296a2.41 2.41 0 0 0-3.408 0L9 22"/>',

--- a/app/views/admin/system_stats/show.html.erb
+++ b/app/views/admin/system_stats/show.html.erb
@@ -21,12 +21,8 @@
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Configuration</h2>
     <ul class="space-y-2">
       <% @config_checks.each do |check| %>
-        <li class="flex items-center gap-2" data-key="config.<%= check[:key] %>">
-          <% if check[:ok] %>
-            <%= icon("square-check-big", css_class: "size-5 text-green-600", aria_label: "OK") %>
-          <% else %>
-            <%= icon("square", css_class: "size-5 text-red-600", aria_label: "Missing") %>
-          <% end %>
+        <li class="flex items-center gap-2" data-key="config.<%= check[:key] %>" data-status="<%= check[:status] %>">
+          <%= system_check_icon(check[:status]) %>
           <span class="text-slate-700"><%= check[:label] %></span>
         </li>
       <% end %>

--- a/app/views/admin/system_stats/show.html.erb
+++ b/app/views/admin/system_stats/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "System Stats" %>
+<% content_for :title, "System Health" %>
 
 <%
   postgres_size = @disk_usage[:postgres_usage]
@@ -11,11 +11,27 @@
 %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "System Stats") do |header| %>
+  <%= render PageHeaderComponent.new(title: "System Health") do |header| %>
     <% header.with_action_button do %>
       <%= link_to "Back to Admin", admin_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>
   <% end %>
+
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Configuration</h2>
+    <ul class="space-y-2">
+      <% @config_checks.each do |check| %>
+        <li class="flex items-center gap-2" data-key="config.<%= check[:key] %>">
+          <% if check[:ok] %>
+            <%= icon("square-check-big", css_class: "size-5 text-green-600", aria_label: "OK") %>
+          <% else %>
+            <%= icon("square", css_class: "size-5 text-red-600", aria_label: "Missing") %>
+          <% end %>
+          <span class="text-slate-700"><%= check[:label] %></span>
+        </li>
+      <% end %>
+    </ul>
+  </section>
 
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Deployed Version</h2>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -29,9 +29,9 @@
         <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
             <%= icon("hard-drive", css_class: "size-5") %>
-            <span>System Info</span>
+            <span>System Health</span>
           </h2>
-          <p class="text-slate-600">View disk usage and other system information</p>
+          <p class="text-slate-600">Check configuration, disk usage, and other system info</p>
         </div>
       <% end %>
 

--- a/test/controllers/admin/system_stats_controller_test.rb
+++ b/test/controllers/admin/system_stats_controller_test.rb
@@ -39,6 +39,29 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-key='config.resend_key']", text: /Resend key present/
+    assert_select "[data-key='config.resend_signing_secret']", text: /Resend signing secret/
+    assert_select "[data-key='config.honeybadger_key']", text: /Honeybadger/
+    assert_select "[data-key='config.background_jobs']", text: /Background jobs/
+  end
+
+  test "should flag background jobs as healthy when a process is heartbeating" do
+    SolidQueue::Process.create!(kind: "Worker", name: "worker-test", pid: 999, last_heartbeat_at: Time.current)
+    login_as(dev_user)
+
+    get admin_system_stats_path
+
+    assert_response :success
+    assert_select "[data-key='config.background_jobs'][data-status='ok']"
+  end
+
+  test "should flag background jobs as a problem when no process is heartbeating" do
+    SolidQueue::Process.delete_all
+    login_as(dev_user)
+
+    get admin_system_stats_path
+
+    assert_response :success
+    assert_select "[data-key='config.background_jobs'][data-status='error']"
   end
 
   test "should show deployed version details" do

--- a/test/controllers/admin/system_stats_controller_test.rb
+++ b/test/controllers/admin/system_stats_controller_test.rb
@@ -32,6 +32,15 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should show configuration checklist" do
+    login_as(dev_user)
+
+    get admin_system_stats_path
+
+    assert_response :success
+    assert_select "[data-key='config.resend_key']", text: /Resend key present/
+  end
+
   test "should show deployed version details" do
     with_release_env(
       "APP_REVISION" => "0123456789abcdef",


### PR DESCRIPTION
Changes:

- Rename the admin panel's "System Info" card (and the page) to "System Health"
- Add a configuration checklist to the top of the page, starting with a "Resend key present" check
- Show each check with a green square-check-big or red square icon (added both to the icon helper)

The checklist gives admins a quick visual read on essential setup at a glance. It's structured as a simple list of checks, so adding more is a one-liner.

Motivation: prevent non-critical misconfiguration issues, like a missing Resend API key that may cause an error in application runtime ("Resend::Error: Make sure your API Key is set"), but generally not required on all environments.
