### PR TITLE
Report post publish failures to error tracker

### DIFF
--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -150,6 +150,7 @@ class FeedRefreshWorkflow
         post.update!(status: :failed)
         failed_count += 1
         Rails.logger.error "Failed to publish post #{post.id}: #{e.message}"
+        Rails.error.report(e, context: { post_id: post.id, feed_id: feed.id })
       end
     end
 

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -150,7 +150,7 @@ class FeedRefreshWorkflow
         post.update!(status: :failed)
         failed_count += 1
         Rails.logger.error "Failed to publish post #{post.id}: #{e.message}"
-        Rails.error.report(e, context: { post_id: post.id, feed_id: feed.id })
+        Rails.error.report(e, context: { post: post.attributes, feed: feed.attributes })
       end
     end
 

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -560,4 +560,26 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
     assert_equal "inactive", token.reload.status
   end
+
+  test "#publish_posts should report the error when a post fails to publish" do
+    pub_user = create(:user)
+    token = create(:access_token, :active, user: pub_user)
+    test_feed = create(:feed, user: pub_user, access_token: token,
+                               feed_profile_key: "rss", target_group: "group")
+    post = create(:post, :enqueued, feed: test_feed)
+
+    stub_request(:post, "#{token.host}/v4/posts").to_return(status: 500)
+
+    reported = []
+    workflow = FeedRefreshWorkflow.new(test_feed)
+    Rails.error.stub(:report, ->(err, **kwargs) { reported << [err, kwargs] }) do
+      workflow.send(:publish_posts, Post.where(id: post.id))
+    end
+
+    assert_equal "failed", post.reload.status
+    assert_equal 1, reported.size
+    _error, kwargs = reported.first
+    assert_equal post.id, kwargs.dig(:context, :post_id)
+    assert_equal test_feed.id, kwargs.dig(:context, :feed_id)
+  end
 end

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -579,7 +579,12 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal "failed", post.reload.status
     assert_equal 1, reported.size
     _error, kwargs = reported.first
-    assert_equal post.id, kwargs.dig(:context, :post_id)
-    assert_equal test_feed.id, kwargs.dig(:context, :feed_id)
+    post_context = kwargs.dig(:context, :post)
+    feed_context = kwargs.dig(:context, :feed)
+    assert_equal post.attributes.keys.sort, post_context.keys.sort
+    assert_equal post.id, post_context["id"]
+    assert_equal "failed", post_context["status"]
+    assert_equal test_feed.attributes.keys.sort, feed_context.keys.sort
+    assert_equal test_feed.id, feed_context["id"]
   end
 end


### PR DESCRIPTION
Changes:

- Report the exception to `Rails.error` when a post fails to publish in `FeedRefreshWorkflow#publish_posts`, with post and feed context

Previously a post that ended up in the `failed` state only produced a log line, so these failures never surfaced in Honeybadger. Routing them through the Rails error reporter (the project's convention for handled exceptions) makes them visible for monitoring. The expected `UnauthorizedError` path is left untouched, since it's an auth condition handled by disabling the token rather than an error worth paging on.
