### PR TITLE
Track posts imported by a feed refresh

### DIFF
--- a/app/components/recent_events_entry_component.rb
+++ b/app/components/recent_events_entry_component.rb
@@ -30,7 +30,7 @@ class RecentEventsEntryComponent < ViewComponent::Base
   def posts_count_tag
     return unless event.type == "feed_refresh"
 
-    count = event.event_references.size
+    count = event.event_references.count { |reference| reference.reference_type == "Post" }
     return if count.zero?
 
     content_tag(:span, helpers.pluralize(count, "post"),

--- a/app/components/recent_events_entry_component.rb
+++ b/app/components/recent_events_entry_component.rb
@@ -34,7 +34,7 @@ class RecentEventsEntryComponent < ViewComponent::Base
     return if count.zero?
 
     content_tag(:span, helpers.pluralize(count, "post"),
-                class: "shrink-0 text-xs font-medium text-slate-400",
+                class: "shrink-0 font-medium text-slate-400",
                 data: { key: "recent_events.posts_count" })
   end
 

--- a/app/components/recent_events_entry_component.rb
+++ b/app/components/recent_events_entry_component.rb
@@ -34,7 +34,7 @@ class RecentEventsEntryComponent < ViewComponent::Base
     return if count.zero?
 
     content_tag(:span, helpers.pluralize(count, "post"),
-                class: "shrink-0 font-medium text-slate-400",
+                class: "shrink-0 text-slate-400",
                 data: { key: "recent_events.posts_count" })
   end
 

--- a/app/components/recent_events_entry_component.rb
+++ b/app/components/recent_events_entry_component.rb
@@ -9,7 +9,7 @@ class RecentEventsEntryComponent < ViewComponent::Base
   def call
     content_tag(:li, class: "flex items-center gap-3 px-4 py-2.5",
                      data: { key: "recent_events.#{event.id}" }) do
-      safe_join([badge_tag, description_tag, time_tag])
+      safe_join([badge_tag, description_tag, posts_count_tag, time_tag].compact)
     end
   end
 
@@ -25,6 +25,17 @@ class RecentEventsEntryComponent < ViewComponent::Base
     content_tag(:span, render(EventDescriptionComponent.new(event: event)),
                 class: "flex-1 truncate text-sm text-slate-700",
                 data: { key: "recent_events.description" })
+  end
+
+  def posts_count_tag
+    return unless event.type == "feed_refresh"
+
+    count = event.imported_posts_count
+    return if count.zero?
+
+    content_tag(:span, helpers.pluralize(count, "post"),
+                class: "shrink-0 text-xs font-medium text-slate-400",
+                data: { key: "recent_events.posts_count" })
   end
 
   def time_tag

--- a/app/components/recent_events_entry_component.rb
+++ b/app/components/recent_events_entry_component.rb
@@ -30,6 +30,8 @@ class RecentEventsEntryComponent < ViewComponent::Base
   def posts_count_tag
     return unless event.type == "feed_refresh"
 
+    # Filter in Ruby, not with .where: event_references is preloaded for the
+    # list, so counting in memory avoids a COUNT query per event row.
     count = event.event_references.count { |reference| reference.reference_type == "Post" }
     return if count.zero?
 

--- a/app/components/recent_events_entry_component.rb
+++ b/app/components/recent_events_entry_component.rb
@@ -30,7 +30,7 @@ class RecentEventsEntryComponent < ViewComponent::Base
   def posts_count_tag
     return unless event.type == "feed_refresh"
 
-    count = event.imported_posts_count
+    count = event.event_references.size
     return if count.zero?
 
     content_tag(:span, helpers.pluralize(count, "post"),

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -16,7 +16,9 @@ class Admin::EventsController < ApplicationController
   def show
     authorize Event
     @event = Event.find(params[:id])
-    @referenced_posts = @event.referenced_posts
+    @referenced_posts = Post.where(id: @event.event_references.where(reference_type: "Post").select(:reference_id))
+                            .includes(:feed)
+                            .order(created_at: :desc)
     @previous_event = previous_event(@event)
     @next_event = next_event(@event)
   end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -16,6 +16,7 @@ class Admin::EventsController < ApplicationController
   def show
     authorize Event
     @event = Event.find(params[:id])
+    @referenced_posts = @event.event_references.includes(:reference).filter_map(&:reference)
     @previous_event = previous_event(@event)
     @next_event = next_event(@event)
   end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -16,7 +16,7 @@ class Admin::EventsController < ApplicationController
   def show
     authorize Event
     @event = Event.find(params[:id])
-    @referenced_posts = @event.event_references.referenced_records
+    @referenced_posts = @event.references
     @previous_event = previous_event(@event)
     @next_event = next_event(@event)
   end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,6 +1,7 @@
 class Admin::EventsController < ApplicationController
   include EventFiltering
   include EventCursorPagination
+  include EventReferencedPosts
 
   def index
     authorize Event
@@ -16,9 +17,7 @@ class Admin::EventsController < ApplicationController
   def show
     authorize Event
     @event = Event.find(params[:id])
-    @referenced_posts = Post.where(id: @event.event_references.where(reference_type: "Post").select(:reference_id))
-                            .includes(:feed)
-                            .order(created_at: :desc)
+    @referenced_posts = referenced_posts(@event)
     @previous_event = previous_event(@event)
     @next_event = next_event(@event)
   end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -16,7 +16,7 @@ class Admin::EventsController < ApplicationController
   def show
     authorize Event
     @event = Event.find(params[:id])
-    @referenced_posts = @event.references
+    @referenced_posts = @event.referenced_posts
     @previous_event = previous_event(@event)
     @next_event = next_event(@event)
   end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -16,7 +16,7 @@ class Admin::EventsController < ApplicationController
   def show
     authorize Event
     @event = Event.find(params[:id])
-    @referenced_posts = @event.event_references.includes(:reference).filter_map(&:reference)
+    @referenced_posts = @event.event_references.referenced_records
     @previous_event = previous_event(@event)
     @next_event = next_event(@event)
   end

--- a/app/controllers/concerns/event_referenced_posts.rb
+++ b/app/controllers/concerns/event_referenced_posts.rb
@@ -1,0 +1,12 @@
+module EventReferencedPosts
+  extend ActiveSupport::Concern
+
+  private
+
+  # Posts imported by the event, newest first, with feeds preloaded for cards.
+  def referenced_posts(event)
+    Post.where(id: event.event_references.where(reference_type: "Post").select(:reference_id))
+        .includes(:feed)
+        .order(created_at: :desc)
+  end
+end

--- a/app/controllers/concerns/event_streaming.rb
+++ b/app/controllers/concerns/event_streaming.rb
@@ -37,7 +37,7 @@ module EventStreaming
   end
 
   def render_brief_events_stream
-    @events = events_scope.includes(:user, :subject).order(created_at: :desc, id: :desc).limit(brief_events_limit)
+    @events = events_scope.includes(:user, :subject, :event_references).order(created_at: :desc, id: :desc).limit(brief_events_limit)
     body = helpers.render(RecentEventsListComponent.new(events: @events, endpoint: brief_polling_endpoint))
     render turbo_stream: turbo_stream.replace(RecentEventsListComponent::DOM_ID, body)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
 
   def show
     @event = owned_events.find(params[:id])
-    @referenced_posts = @event.event_references.includes(:reference).filter_map(&:reference)
+    @referenced_posts = @event.event_references.referenced_records
     @previous_event = adjacent_event(:newer)
     @next_event = adjacent_event(:older)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,9 @@ class EventsController < ApplicationController
 
   def show
     @event = owned_events.find(params[:id])
-    @referenced_posts = @event.referenced_posts
+    @referenced_posts = Post.where(id: @event.event_references.where(reference_type: "Post").select(:reference_id))
+                            .includes(:feed)
+                            .order(created_at: :desc)
     @previous_event = adjacent_event(:newer)
     @next_event = adjacent_event(:older)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,7 @@
 class EventsController < ApplicationController
   include EventFiltering
   include EventCursorPagination
+  include EventReferencedPosts
 
   def index
     respond_to do |format|
@@ -11,9 +12,7 @@ class EventsController < ApplicationController
 
   def show
     @event = owned_events.find(params[:id])
-    @referenced_posts = Post.where(id: @event.event_references.where(reference_type: "Post").select(:reference_id))
-                            .includes(:feed)
-                            .order(created_at: :desc)
+    @referenced_posts = referenced_posts(@event)
     @previous_event = adjacent_event(:newer)
     @next_event = adjacent_event(:older)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
 
   def show
     @event = owned_events.find(params[:id])
-    @referenced_posts = @event.references
+    @referenced_posts = @event.referenced_posts
     @previous_event = adjacent_event(:newer)
     @next_event = adjacent_event(:older)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
 
   def show
     @event = owned_events.find(params[:id])
-    @referenced_posts = @event.event_references.referenced_records
+    @referenced_posts = @event.references
     @previous_event = adjacent_event(:newer)
     @next_event = adjacent_event(:older)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,6 +11,7 @@ class EventsController < ApplicationController
 
   def show
     @event = owned_events.find(params[:id])
+    @referenced_posts = @event.event_references.includes(:reference).filter_map(&:reference)
     @previous_event = adjacent_event(:newer)
     @next_event = adjacent_event(:older)
   end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -13,7 +13,7 @@ class StatusesController < ApplicationController
 
   def recent_events
     apply_filters(Event.where(user: @user).user_relevant)
-      .includes(:user, :subject)
+      .includes(:user, :subject, :event_references)
       .order(created_at: :desc, id: :desc)
       .limit(initial_events_limit)
   end

--- a/app/jobs/purge_expired_events_job.rb
+++ b/app/jobs/purge_expired_events_job.rb
@@ -12,6 +12,7 @@ class PurgeExpiredEventsJob < ApplicationJob
     deleted_count = 0
 
     Event.expired.in_batches(of: BATCH_SIZE) do |events|
+      EventReference.where(event_id: events.select(:id)).delete_all
       deleted_count += events.delete_all
       sleep BATCH_PAUSE
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -35,10 +35,4 @@ class Event < ApplicationRecord
     update!(expires_at: duration.from_now)
     self
   end
-
-  def self.purge_expired
-    ids = expired.ids
-    EventReference.where(event_id: ids).delete_all
-    where(id: ids).delete_all
-  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,6 +27,14 @@ class Event < ApplicationRecord
     event_references.includes(:reference).filter_map(&:reference)
   end
 
+  # Posts this event imported, newest first. A use-case-specific companion to
+  # #references: it deliberately re-runs the lookup so the generic resolver
+  # above stays free of Post-specific concerns.
+  def referenced_posts
+    Post.where(id: event_references.where(reference_type: "Post").select(:reference_id))
+        .order(created_at: :desc)
+  end
+
   def expired?
     expires_at.present? && expires_at < Time.current
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,6 +21,19 @@ class Event < ApplicationRecord
     level == "debug" ? :info : level.to_sym
   end
 
+  # Posts this event references that still exist. References intentionally
+  # outlive the posts they point at, so deleted posts simply drop out here.
+  def imported_posts
+    Post.where(id: event_references.where(reference_type: "Post").select(:reference_id))
+        .order(published_at: :desc)
+  end
+
+  # Count of referenced posts, including ones the user later deleted. Uses the
+  # loaded association when preloaded to stay cheap inside event lists.
+  def imported_posts_count
+    event_references.count { |reference| reference.reference_type == "Post" }
+  end
+
   def expired?
     expires_at.present? && expires_at < Time.current
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,6 +32,7 @@ class Event < ApplicationRecord
   # above stays free of Post-specific concerns.
   def referenced_posts
     Post.where(id: event_references.where(reference_type: "Post").select(:reference_id))
+        .includes(:feed)
         .order(created_at: :desc)
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,6 +21,12 @@ class Event < ApplicationRecord
     level == "debug" ? :info : level.to_sym
   end
 
+  # Records this event points at, with deleted ones dropped. Distinct from
+  # #event_references, which are the join rows themselves.
+  def references
+    event_references.referenced_records
+  end
+
   def expired?
     expires_at.present? && expires_at < Time.current
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,6 +4,8 @@ class Event < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :subject, polymorphic: true, optional: true
 
+  has_many :event_references, dependent: :delete_all
+
   enum :level, { debug: 0, info: 1, warning: 2, error: 3 }
 
   validates :type, presence: true
@@ -29,6 +31,8 @@ class Event < ApplicationRecord
   end
 
   def self.purge_expired
-    expired.delete_all
+    ids = expired.ids
+    EventReference.where(event_id: ids).delete_all
+    where(id: ids).delete_all
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,19 +21,6 @@ class Event < ApplicationRecord
     level == "debug" ? :info : level.to_sym
   end
 
-  # Posts this event references that still exist. References intentionally
-  # outlive the posts they point at, so deleted posts simply drop out here.
-  def imported_posts
-    Post.where(id: event_references.where(reference_type: "Post").select(:reference_id))
-        .order(published_at: :desc)
-  end
-
-  # Count of referenced posts, including ones the user later deleted. Uses the
-  # loaded association when preloaded to stay cheap inside event lists.
-  def imported_posts_count
-    event_references.count { |reference| reference.reference_type == "Post" }
-  end
-
   def expired?
     expires_at.present? && expires_at < Time.current
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,7 +24,7 @@ class Event < ApplicationRecord
   # Records this event points at, with deleted ones dropped. Distinct from
   # #event_references, which are the join rows themselves.
   def references
-    event_references.referenced_records
+    event_references.includes(:reference).filter_map(&:reference)
   end
 
   def expired?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,15 +27,6 @@ class Event < ApplicationRecord
     event_references.includes(:reference).filter_map(&:reference)
   end
 
-  # Posts this event imported, newest first. A use-case-specific companion to
-  # #references: it deliberately re-runs the lookup so the generic resolver
-  # above stays free of Post-specific concerns.
-  def referenced_posts
-    Post.where(id: event_references.where(reference_type: "Post").select(:reference_id))
-        .includes(:feed)
-        .order(created_at: :desc)
-  end
-
   def expired?
     expires_at.present? && expires_at < Time.current
   end

--- a/app/models/event_reference.rb
+++ b/app/models/event_reference.rb
@@ -1,4 +1,10 @@
 class EventReference < ApplicationRecord
   belongs_to :event
   belongs_to :reference, polymorphic: true
+
+  # Resolves the referenced records for a set of references, eager-loading the
+  # polymorphic targets and dropping any that have since been deleted.
+  def self.referenced_records
+    includes(:reference).filter_map(&:reference)
+  end
 end

--- a/app/models/event_reference.rb
+++ b/app/models/event_reference.rb
@@ -1,0 +1,4 @@
+class EventReference < ApplicationRecord
+  belongs_to :event
+  belongs_to :reference, polymorphic: true
+end

--- a/app/models/event_reference.rb
+++ b/app/models/event_reference.rb
@@ -1,10 +1,4 @@
 class EventReference < ApplicationRecord
   belongs_to :event
   belongs_to :reference, polymorphic: true
-
-  # Resolves the referenced records for a set of references, eager-loading the
-  # polymorphic targets and dropping any that have since been deleted.
-  def self.referenced_records
-    includes(:reference).filter_map(&:reference)
-  end
 end

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -208,15 +208,14 @@ class FeedRefreshWorkflow
 
   def reference_posts(event, posts)
     return if posts.empty?
-    current_time = Time.current
 
     references_data = posts.map do |post|
       {
         event_id: event.id,
         reference_type: "Post",
         reference_id: post.id,
-        created_at: current_time,
-        updated_at: current_time
+        created_at: event.created_at,
+        updated_at: event.created_at
       }
     end
 

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -167,7 +167,7 @@ class FeedRefreshWorkflow
     rejected_posts_count = posts.count(&:rejected?)
 
     record_completed_at
-    create_feed_refresh_stats_event
+    create_feed_refresh_stats_event(posts)
 
     # Record daily metrics (sparse data - only if there's activity)
     posts_count = posts.count { |p| p.enqueued? || p.published? }
@@ -192,8 +192,8 @@ class FeedRefreshWorkflow
     record_stats(stats_key => duration)
   end
 
-  def create_feed_refresh_stats_event
-    Event.create!(
+  def create_feed_refresh_stats_event(posts)
+    event = Event.create!(
       type: "feed_refresh",
       level: :info,
       subject: feed,
@@ -201,6 +201,26 @@ class FeedRefreshWorkflow
       message: "",
       metadata: { stats: stats }
     )
+
+    reference_posts(event, posts)
+    event
+  end
+
+  def reference_posts(event, posts)
+    return if posts.empty?
+    current_time = Time.current
+
+    references_data = posts.map do |post|
+      {
+        event_id: event.id,
+        reference_type: "Post",
+        reference_id: post.id,
+        created_at: current_time,
+        updated_at: current_time
+      }
+    end
+
+    EventReference.insert_all(references_data)
   end
 
   def disable_credential_on_auth_error(error)

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -31,11 +31,11 @@
 
   <%= render(EventDetailsComponent.new(event: @event)) %>
 
-  <% imported_posts = @event.imported_posts.to_a %>
-  <% if imported_posts.any? %>
+  <% referenced_posts = @event.event_references.includes(:reference).filter_map(&:reference) %>
+  <% if referenced_posts.any? %>
     <section class="space-y-4" data-key="events.imported_posts">
       <h2 class="text-2xl font-semibold mb-3 text-slate-900">Imported Posts</h2>
-      <%= render PostsListComponent.new(posts: imported_posts, show_feed: true) %>
+      <%= render PostsListComponent.new(posts: referenced_posts, show_feed: true) %>
     </section>
   <% end %>
 

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -31,6 +31,14 @@
 
   <%= render(EventDetailsComponent.new(event: @event)) %>
 
+  <% imported_posts = @event.imported_posts.to_a %>
+  <% if imported_posts.any? %>
+    <section class="space-y-4" data-key="events.imported_posts">
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Imported Posts</h2>
+      <%= render PostsListComponent.new(posts: imported_posts, show_feed: true) %>
+    </section>
+  <% end %>
+
   <% if @event.metadata.present? && @event.metadata != {} %>
     <section class="space-y-4">
       <h2 class="text-2xl font-semibold mb-3 text-slate-900">Metadata</h2>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -31,11 +31,10 @@
 
   <%= render(EventDetailsComponent.new(event: @event)) %>
 
-  <% referenced_posts = @event.event_references.includes(:reference).filter_map(&:reference) %>
-  <% if referenced_posts.any? %>
+  <% if @referenced_posts.any? %>
     <section class="space-y-4" data-key="events.imported_posts">
       <h2 class="text-2xl font-semibold mb-3 text-slate-900">Imported Posts</h2>
-      <%= render PostsListComponent.new(posts: referenced_posts, show_feed: true) %>
+      <%= render PostsListComponent.new(posts: @referenced_posts, show_feed: true) %>
     </section>
   <% end %>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -48,11 +48,11 @@
     )) %>
   <% end %>
 
-  <% imported_posts = @event.imported_posts.to_a %>
-  <% if imported_posts.any? %>
+  <% referenced_posts = @event.event_references.includes(:reference).filter_map(&:reference) %>
+  <% if referenced_posts.any? %>
     <section class="space-y-4" data-key="events.imported_posts">
       <h2 class="text-2xl font-semibold mb-3 text-slate-900">Imported Posts</h2>
-      <%= render PostsListComponent.new(posts: imported_posts) %>
+      <%= render PostsListComponent.new(posts: referenced_posts) %>
     </section>
   <% end %>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -48,6 +48,14 @@
     )) %>
   <% end %>
 
+  <% imported_posts = @event.imported_posts.to_a %>
+  <% if imported_posts.any? %>
+    <section class="space-y-4" data-key="events.imported_posts">
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Imported Posts</h2>
+      <%= render PostsListComponent.new(posts: imported_posts) %>
+    </section>
+  <% end %>
+
   <% if @event.metadata.present? && @event.metadata != {} %>
     <section class="space-y-4">
       <h2 class="text-2xl font-semibold mb-3 text-slate-900">Metadata</h2>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -48,11 +48,10 @@
     )) %>
   <% end %>
 
-  <% referenced_posts = @event.event_references.includes(:reference).filter_map(&:reference) %>
-  <% if referenced_posts.any? %>
+  <% if @referenced_posts.any? %>
     <section class="space-y-4" data-key="events.imported_posts">
       <h2 class="text-2xl font-semibold mb-3 text-slate-900">Imported Posts</h2>
-      <%= render PostsListComponent.new(posts: referenced_posts) %>
+      <%= render PostsListComponent.new(posts: @referenced_posts) %>
     </section>
   <% end %>
 

--- a/db/migrate/20260606120000_create_event_references.rb
+++ b/db/migrate/20260606120000_create_event_references.rb
@@ -1,0 +1,15 @@
+class CreateEventReferences < ActiveRecord::Migration[8.2]
+  def change
+    create_table :event_references do |t|
+      t.references :event, null: false, index: false
+      t.references :reference, polymorphic: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :event_references,
+              [:event_id, :reference_type, :reference_id],
+              unique: true,
+              name: "index_event_references_on_event_and_reference"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_04_103046) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_06_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -34,6 +34,16 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_04_103046) do
     t.bigint "user_id", null: false
     t.index ["user_id", "name"], name: "index_access_tokens_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_access_tokens_on_user_id"
+  end
+
+  create_table "event_references", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.string "reference_type", null: false
+    t.bigint "reference_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id", "reference_type", "reference_id"], name: "index_event_references_on_event_and_reference", unique: true
+    t.index ["reference_type", "reference_id"], name: "index_event_references_on_reference"
   end
 
   create_table "events", force: :cascade do |t|

--- a/test/components/recent_events_entry_component_test.rb
+++ b/test/components/recent_events_entry_component_test.rb
@@ -34,6 +34,17 @@ class RecentEventsEntryComponentTest < ViewComponent::TestCase
     assert_equal "2 posts", result.css("[data-key='recent_events.posts_count']").first&.text
   end
 
+  test "#call should count only post references" do
+    feed = create(:feed, user: user)
+    event = create(:event, type: "feed_refresh", level: :info, user: user, subject: feed)
+    create(:event_reference, event: event, reference: create(:post, feed: feed))
+    create(:event_reference, event: event, reference: user)
+
+    result = render_inline(RecentEventsEntryComponent.new(event: event, href: "/events/#{event.id}"))
+
+    assert_equal "1 post", result.css("[data-key='recent_events.posts_count']").first&.text
+  end
+
   test "#call should not show a posts count when there are no references" do
     event = create(:event, type: "feed_refresh", level: :info, user: user)
 

--- a/test/components/recent_events_entry_component_test.rb
+++ b/test/components/recent_events_entry_component_test.rb
@@ -23,6 +23,25 @@ class RecentEventsEntryComponentTest < ViewComponent::TestCase
     assert_not_nil result.css("li[data-key='recent_events.#{event.id}']").first
   end
 
+  test "#call should show the imported posts count for feed_refresh events" do
+    feed = create(:feed, user: user)
+    event = create(:event, type: "feed_refresh", level: :info, user: user, subject: feed)
+    create(:event_reference, event: event, reference: create(:post, feed: feed))
+    create(:event_reference, event: event, reference: create(:post, feed: feed))
+
+    result = render_inline(RecentEventsEntryComponent.new(event: event, href: "/events/#{event.id}"))
+
+    assert_equal "2 posts", result.css("[data-key='recent_events.posts_count']").first&.text
+  end
+
+  test "#call should not show a posts count when there are no references" do
+    event = create(:event, type: "feed_refresh", level: :info, user: user)
+
+    result = render_inline(RecentEventsEntryComponent.new(event: event, href: "/events/#{event.id}"))
+
+    assert_nil result.css("[data-key='recent_events.posts_count']").first
+  end
+
   test "#call should use the correct badge color for each level" do
     error_event = create(:event, type: "error_event", level: :error, user: user)
 

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -53,6 +53,20 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[data-key='admin.event.user']", "User ##{event.user_id}"
   end
 
+  test "should list imported posts referenced by the event" do
+    login_as(admin_user)
+    feed = create(:feed)
+    event = create(:event, type: "feed_refresh", subject: feed, user: feed.user)
+    post = create(:post, feed: feed)
+    create(:event_reference, event: event, reference: post)
+
+    get admin_event_path(event)
+
+    assert_response :success
+    assert_select "[data-key='events.imported_posts']"
+    assert_select "##{ActionView::RecordIdentifier.dom_id(post)}"
+  end
+
   test "should link user subject to filter by that subject" do
     login_as(admin_user)
     subject_user = create(:user)

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -233,6 +233,24 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "##{ActionView::RecordIdentifier.dom_id(post)}"
   end
 
+  test "#show should list imported posts newest first and skip non-post references" do
+    sign_in_as user
+    feed = create(:feed, user: user)
+    event = create(:event, type: "feed_refresh", user: user, subject: feed)
+    older = create(:post, feed: feed, created_at: 2.days.ago)
+    newer = create(:post, feed: feed, created_at: 1.hour.ago)
+    create(:event_reference, event: event, reference: older)
+    create(:event_reference, event: event, reference: newer)
+    create(:event_reference, event: event, reference: user)
+
+    get event_path(event)
+
+    assert_response :success
+    newer_dom = ActionView::RecordIdentifier.dom_id(newer)
+    older_dom = ActionView::RecordIdentifier.dom_id(older)
+    assert_operator response.body.index(newer_dom), :<, response.body.index(older_dom)
+  end
+
   test "#show should not render the imported posts section without references" do
     sign_in_as user
     event = create(:event, type: "feed_refresh", user: user)

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -219,6 +219,30 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='events.type']", "owned_event"
   end
 
+  test "#show should list imported posts referenced by the event" do
+    sign_in_as user
+    feed = create(:feed, user: user)
+    event = create(:event, type: "feed_refresh", user: user, subject: feed)
+    post = create(:post, feed: feed)
+    create(:event_reference, event: event, reference: post)
+
+    get event_path(event)
+
+    assert_response :success
+    assert_select "[data-key='events.imported_posts']"
+    assert_select "##{ActionView::RecordIdentifier.dom_id(post)}"
+  end
+
+  test "#show should not render the imported posts section without references" do
+    sign_in_as user
+    event = create(:event, type: "feed_refresh", user: user)
+
+    get event_path(event)
+
+    assert_response :success
+    assert_select "[data-key='events.imported_posts']", false
+  end
+
   test "#show should render an owned event even with list filter params" do
     sign_in_as user
     event = create(:event, type: "feed_refresh", user: user)

--- a/test/factories/event_references.rb
+++ b/test/factories/event_references.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :event_reference do
+    event
+    reference { association(:post) }
+  end
+end

--- a/test/jobs/purge_expired_events_job_test.rb
+++ b/test/jobs/purge_expired_events_job_test.rb
@@ -13,4 +13,16 @@ class PurgeExpiredEventsJobTest < ActiveJob::TestCase
     assert Event.exists?(active.id)
     assert Event.exists?(permanent.id)
   end
+
+  test "#perform should delete references of purged events" do
+    expired = create(:event, expires_at: 1.hour.ago)
+    active = create(:event, expires_at: 1.hour.from_now)
+    expired_reference = create(:event_reference, event: expired)
+    active_reference = create(:event_reference, event: active)
+
+    PurgeExpiredEventsJob.perform_now
+
+    assert_not EventReference.exists?(expired_reference.id)
+    assert EventReference.exists?(active_reference.id)
+  end
 end

--- a/test/models/event_reference_test.rb
+++ b/test/models/event_reference_test.rb
@@ -41,4 +41,14 @@ class EventReferenceTest < ActiveSupport::TestCase
     assert_equal "Post", reference.reference_type
     assert_nil reference.reference
   end
+
+  test ".referenced_records should resolve the referenced records, skipping deleted ones" do
+    kept = create(:post)
+    deleted = create(:post)
+    EventReference.create!(event: event, reference: kept)
+    EventReference.create!(event: event, reference: deleted)
+    deleted.destroy!
+
+    assert_equal [kept], event.event_references.referenced_records
+  end
 end

--- a/test/models/event_reference_test.rb
+++ b/test/models/event_reference_test.rb
@@ -41,14 +41,4 @@ class EventReferenceTest < ActiveSupport::TestCase
     assert_equal "Post", reference.reference_type
     assert_nil reference.reference
   end
-
-  test ".referenced_records should resolve the referenced records, skipping deleted ones" do
-    kept = create(:post)
-    deleted = create(:post)
-    EventReference.create!(event: event, reference: kept)
-    EventReference.create!(event: event, reference: deleted)
-    deleted.destroy!
-
-    assert_equal [kept], event.event_references.referenced_records
-  end
 end

--- a/test/models/event_reference_test.rb
+++ b/test/models/event_reference_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class EventReferenceTest < ActiveSupport::TestCase
+  def event
+    @event ||= create(:event)
+  end
+
+  def post
+    @post ||= create(:post)
+  end
+
+  test "should create reference linking an event to a record" do
+    reference = EventReference.create!(event: event, reference: post)
+
+    assert_equal event, reference.event
+    assert_equal post, reference.reference
+    assert_equal "Post", reference.reference_type
+    assert_equal post.id, reference.reference_id
+  end
+
+  test "should require an event" do
+    reference = EventReference.new(reference: post)
+
+    assert_not reference.valid?
+    assert reference.errors.of_kind?(:event, :blank)
+  end
+
+  test "should require a reference" do
+    reference = EventReference.new(event: event)
+
+    assert_not reference.valid?
+    assert reference.errors.of_kind?(:reference, :blank)
+  end
+
+  test "should survive deletion of the referenced record" do
+    reference = EventReference.create!(event: event, reference: post)
+    post.destroy!
+
+    reference.reload
+
+    assert_equal "Post", reference.reference_type
+    assert_nil reference.reference
+  end
+end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -132,6 +132,17 @@ class EventTest < ActiveSupport::TestCase
     assert Event.exists?(permanent_event.id)
   end
 
+  test "#references should resolve referenced records, skipping deleted ones" do
+    event = Event.create!(type: "feed_refresh", subject: feed)
+    kept = create(:post, feed: feed)
+    deleted = create(:post, feed: feed)
+    create(:event_reference, event: event, reference: kept)
+    create(:event_reference, event: event, reference: deleted)
+    deleted.destroy!
+
+    assert_equal [kept], event.references
+  end
+
   test "#purge_expired should drop references of purged events" do
     expired_event = Event.create!(type: "expired_event", expires_at: 1.hour.ago)
     active_event = Event.create!(type: "active_event", expires_at: 1.hour.from_now)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -150,6 +150,13 @@ class EventTest < ActiveSupport::TestCase
     assert_equal [post], event.referenced_posts.to_a
   end
 
+  test "#referenced_posts should eager-load feeds" do
+    event = Event.create!(type: "feed_refresh", subject: feed)
+    create(:event_reference, event: event, reference: create(:post, feed: feed))
+
+    assert event.referenced_posts.first.association(:feed).loaded?
+  end
+
   test "#destroy should delete associated references" do
     event = Event.create!(type: "feed_event", subject: feed)
     reference = create(:event_reference, event: event)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -131,32 +131,6 @@ class EventTest < ActiveSupport::TestCase
     assert_equal [kept], event.references
   end
 
-  test "#referenced_posts should return imported posts newest first" do
-    event = Event.create!(type: "feed_refresh", subject: feed)
-    older = create(:post, feed: feed, created_at: 2.days.ago)
-    newer = create(:post, feed: feed, created_at: 1.hour.ago)
-    create(:event_reference, event: event, reference: older)
-    create(:event_reference, event: event, reference: newer)
-
-    assert_equal [newer, older], event.referenced_posts.to_a
-  end
-
-  test "#referenced_posts should ignore non-post references" do
-    event = Event.create!(type: "feed_refresh", subject: feed)
-    post = create(:post, feed: feed)
-    create(:event_reference, event: event, reference: post)
-    create(:event_reference, event: event, reference: user)
-
-    assert_equal [post], event.referenced_posts.to_a
-  end
-
-  test "#referenced_posts should eager-load feeds" do
-    event = Event.create!(type: "feed_refresh", subject: feed)
-    create(:event_reference, event: event, reference: create(:post, feed: feed))
-
-    assert event.referenced_posts.first.association(:feed).loaded?
-  end
-
   test "#destroy should delete associated references" do
     event = Event.create!(type: "feed_event", subject: feed)
     reference = create(:event_reference, event: event)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -132,38 +132,6 @@ class EventTest < ActiveSupport::TestCase
     assert Event.exists?(permanent_event.id)
   end
 
-  test "#imported_posts should return referenced posts newest first" do
-    event = Event.create!(type: "feed_refresh", subject: feed)
-    older = create(:post, feed: feed, published_at: 2.days.ago)
-    newer = create(:post, feed: feed, published_at: 1.hour.ago)
-    create(:event_reference, event: event, reference: older)
-    create(:event_reference, event: event, reference: newer)
-
-    assert_equal [newer, older], event.imported_posts.to_a
-  end
-
-  test "#imported_posts should exclude posts that were deleted" do
-    event = Event.create!(type: "feed_refresh", subject: feed)
-    kept = create(:post, feed: feed)
-    deleted = create(:post, feed: feed)
-    create(:event_reference, event: event, reference: kept)
-    create(:event_reference, event: event, reference: deleted)
-    deleted.destroy!
-
-    assert_equal [kept], event.imported_posts.to_a
-  end
-
-  test "#imported_posts_count should count references including deleted posts" do
-    event = Event.create!(type: "feed_refresh", subject: feed)
-    kept = create(:post, feed: feed)
-    deleted = create(:post, feed: feed)
-    create(:event_reference, event: event, reference: kept)
-    create(:event_reference, event: event, reference: deleted)
-    deleted.destroy!
-
-    assert_equal 2, event.imported_posts_count
-  end
-
   test "#purge_expired should drop references of purged events" do
     expired_event = Event.create!(type: "expired_event", expires_at: 1.hour.ago)
     active_event = Event.create!(type: "active_event", expires_at: 1.hour.from_now)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -120,18 +120,6 @@ class EventTest < ActiveSupport::TestCase
     assert event.expires_at < 2.weeks.from_now
   end
 
-  test "should purge expired events" do
-    expired_event = Event.create!(type: "expired_event", expires_at: 1.hour.ago)
-    active_event = Event.create!(type: "active_event", expires_at: 1.hour.from_now)
-    permanent_event = Event.create!(type: "permanent_event")
-
-    Event.purge_expired
-
-    assert_not Event.exists?(expired_event.id)
-    assert Event.exists?(active_event.id)
-    assert Event.exists?(permanent_event.id)
-  end
-
   test "#references should resolve referenced records, skipping deleted ones" do
     event = Event.create!(type: "feed_refresh", subject: feed)
     kept = create(:post, feed: feed)
@@ -141,18 +129,6 @@ class EventTest < ActiveSupport::TestCase
     deleted.destroy!
 
     assert_equal [kept], event.references
-  end
-
-  test "#purge_expired should drop references of purged events" do
-    expired_event = Event.create!(type: "expired_event", expires_at: 1.hour.ago)
-    active_event = Event.create!(type: "active_event", expires_at: 1.hour.from_now)
-    expired_reference = create(:event_reference, event: expired_event)
-    active_reference = create(:event_reference, event: active_event)
-
-    Event.purge_expired
-
-    assert_not EventReference.exists?(expired_reference.id)
-    assert EventReference.exists?(active_reference.id)
   end
 
   test "#destroy should delete associated references" do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -132,6 +132,38 @@ class EventTest < ActiveSupport::TestCase
     assert Event.exists?(permanent_event.id)
   end
 
+  test "#imported_posts should return referenced posts newest first" do
+    event = Event.create!(type: "feed_refresh", subject: feed)
+    older = create(:post, feed: feed, published_at: 2.days.ago)
+    newer = create(:post, feed: feed, published_at: 1.hour.ago)
+    create(:event_reference, event: event, reference: older)
+    create(:event_reference, event: event, reference: newer)
+
+    assert_equal [newer, older], event.imported_posts.to_a
+  end
+
+  test "#imported_posts should exclude posts that were deleted" do
+    event = Event.create!(type: "feed_refresh", subject: feed)
+    kept = create(:post, feed: feed)
+    deleted = create(:post, feed: feed)
+    create(:event_reference, event: event, reference: kept)
+    create(:event_reference, event: event, reference: deleted)
+    deleted.destroy!
+
+    assert_equal [kept], event.imported_posts.to_a
+  end
+
+  test "#imported_posts_count should count references including deleted posts" do
+    event = Event.create!(type: "feed_refresh", subject: feed)
+    kept = create(:post, feed: feed)
+    deleted = create(:post, feed: feed)
+    create(:event_reference, event: event, reference: kept)
+    create(:event_reference, event: event, reference: deleted)
+    deleted.destroy!
+
+    assert_equal 2, event.imported_posts_count
+  end
+
   test "#purge_expired should drop references of purged events" do
     expired_event = Event.create!(type: "expired_event", expires_at: 1.hour.ago)
     active_event = Event.create!(type: "active_event", expires_at: 1.hour.from_now)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -131,6 +131,25 @@ class EventTest < ActiveSupport::TestCase
     assert_equal [kept], event.references
   end
 
+  test "#referenced_posts should return imported posts newest first" do
+    event = Event.create!(type: "feed_refresh", subject: feed)
+    older = create(:post, feed: feed, created_at: 2.days.ago)
+    newer = create(:post, feed: feed, created_at: 1.hour.ago)
+    create(:event_reference, event: event, reference: older)
+    create(:event_reference, event: event, reference: newer)
+
+    assert_equal [newer, older], event.referenced_posts.to_a
+  end
+
+  test "#referenced_posts should ignore non-post references" do
+    event = Event.create!(type: "feed_refresh", subject: feed)
+    post = create(:post, feed: feed)
+    create(:event_reference, event: event, reference: post)
+    create(:event_reference, event: event, reference: user)
+
+    assert_equal [post], event.referenced_posts.to_a
+  end
+
   test "#destroy should delete associated references" do
     event = Event.create!(type: "feed_event", subject: feed)
     reference = create(:event_reference, event: event)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -132,6 +132,27 @@ class EventTest < ActiveSupport::TestCase
     assert Event.exists?(permanent_event.id)
   end
 
+  test "#purge_expired should drop references of purged events" do
+    expired_event = Event.create!(type: "expired_event", expires_at: 1.hour.ago)
+    active_event = Event.create!(type: "active_event", expires_at: 1.hour.from_now)
+    expired_reference = create(:event_reference, event: expired_event)
+    active_reference = create(:event_reference, event: active_event)
+
+    Event.purge_expired
+
+    assert_not EventReference.exists?(expired_reference.id)
+    assert EventReference.exists?(active_reference.id)
+  end
+
+  test "#destroy should delete associated references" do
+    event = Event.create!(type: "feed_event", subject: feed)
+    reference = create(:event_reference, event: event)
+
+    event.destroy!
+
+    assert_not EventReference.exists?(reference.id)
+  end
+
   test "should work with polymorphic subjects" do
     feed_event = Event.create!(type: "feed_event", subject: feed)
     user_event = Event.create!(type: "user_event", subject: user)

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -124,6 +124,12 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     events = Event.where(subject: test_feed, type: "feed_refresh")
     assert_equal 1, events.count
     assert_equal 2, events.first.metadata["stats"]["new_posts"]
+
+    # Verify each new post is referenced by the refresh event
+    references = events.first.event_references
+    assert_equal 2, references.count
+    assert_equal Post.where(feed: test_feed).order(:id).pluck(:id),
+                 references.where(reference_type: "Post").order(:reference_id).pluck(:reference_id).sort
   end
 
   test "#execute should skip duplicate entries on subsequent runs" do


### PR DESCRIPTION
Changes:

- Add an `EventReference` polymorphic join model so an event can reference any number of records
- Reference each new post from its `feed_refresh` event during a refresh

This makes it possible to look up the posts a specific feed refresh imported. References are removed when their event is destroyed or purged, but intentionally outlive their referenced posts. So they remain a durable record of how many posts a refresh brought in, even after the user deletes the posts themselves.
