### PR TITLE
Rename feed Active badge to Enabled

### DIFF
--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -39,7 +39,7 @@ module FeedHelper
     case feed.state.to_sym
     when :draft    then BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge")
     when :disabled then BadgeComponent.new(text: "Disabled", color: :yellow, key: "feed.#{feed.id}.disabled_badge")
-    when :enabled  then BadgeComponent.new(text: "Active", color: :green, key: "feed.#{feed.id}.enabled_badge")
+    when :enabled  then BadgeComponent.new(text: "Enabled", color: :green, key: "feed.#{feed.id}.enabled_badge")
     end
   end
 

--- a/test/components/feed_card_component_test.rb
+++ b/test/components/feed_card_component_test.rb
@@ -41,13 +41,13 @@ class FeedCardComponentTest < ViewComponent::TestCase
     assert_equal "Disabled", badge.text.strip
   end
 
-  test "#render should show Active badge for enabled feeds" do
+  test "#render should show Enabled badge for enabled feeds" do
     enabled_feed = create(:feed, :enabled, user: user)
     result = render_inline FeedCardComponent.new(feed: enabled_feed)
 
     badge = result.css("[data-key='feed.#{enabled_feed.id}.enabled_badge']").first
     assert_not_nil badge
-    assert_equal "Active", badge.text.strip
+    assert_equal "Enabled", badge.text.strip
   end
 
   test "#render should show @group label when target_group present" do

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -111,11 +111,11 @@ class FeedHelperTest < ActionView::TestCase
     assert_nil feed_summary_line(active_count: 0, inactive_count: 0, draft_count: 0)
   end
 
-  test "#feed_status_badge should render active badge for enabled feed" do
+  test "#feed_status_badge should render enabled badge for enabled feed" do
     feed = build(:feed, :enabled)
     result = feed_status_badge(feed)
 
-    assert_equal "Active", result.instance_variable_get(:@text)
+    assert_equal "Enabled", result.instance_variable_get(:@text)
     assert_equal :green, result.instance_variable_get(:@color)
   end
 


### PR DESCRIPTION
Changes:

- Updated `feed_status_badge` helper to display "Enabled" instead of "Active" for enabled feeds
