### PR TITLE
Close open dropdowns before Turbo caches the page

### DIFF
--- a/app/javascript/tailwind.js
+++ b/app/javascript/tailwind.js
@@ -5,3 +5,17 @@
 //
 import "application"
 import "flowbite"
+
+// Close any open Flowbite dropdowns before Turbo caches the page. Otherwise a
+// dropdown left open while navigating away (e.g. clicking "Details" in a post
+// menu) gets cached in its open state and reappears stuck open on back
+// navigation, with Flowbite's click-outside handler no longer wired up.
+document.addEventListener("turbo:before-cache", () => {
+  document.querySelectorAll("[data-dropdown-toggle]").forEach((toggle) => {
+    const menu = document.getElementById(toggle.getAttribute("data-dropdown-toggle"))
+    if (menu && !menu.classList.contains("hidden")) {
+      menu.classList.add("hidden")
+      toggle.setAttribute("aria-expanded", "false")
+    }
+  })
+})


### PR DESCRIPTION
Changes:

- Close any open Flowbite dropdown on `turbo:before-cache`

A dropdown left open while navigating away (e.g. clicking "Details" in a post menu) gets snapshotted by Turbo in its open state. On back navigation the cached page reappears with the menu stuck open, since Flowbite reinitializes thinking it's closed and never arms its click-outside handler. Hiding open dropdowns before the snapshot is taken avoids the mismatch, and applies to all Flowbite dropdowns in the app.
