### PR TITLE
Reorganize feed card menu and add actions

### DIFF
--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -31,7 +31,7 @@
       <button type="button"
               id="<%= menu_id %>-button"
               data-dropdown-toggle="<%= menu_id %>"
-              data-dropdown-placement="top-end"
+              data-dropdown-placement="bottom-end"
               class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
               aria-haspopup="true"
               aria-expanded="false">

--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -27,38 +27,74 @@
       </span>
     </div>
 
-    <% if draft? %>
-      <div class="relative shrink-0">
-        <button type="button"
-                id="<%= menu_id %>-button"
-                data-dropdown-toggle="<%= menu_id %>"
-                data-dropdown-placement="top-end"
-                class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
-                aria-haspopup="true"
-                aria-expanded="false">
-          <%= helpers.icon("ellipsis", css_class: "size-4") %>
-          <span class="sr-only">More options</span>
-        </button>
-        <div id="<%= menu_id %>"
-             class="z-20 hidden w-44 rounded-lg border border-slate-200 bg-white shadow-sm"
-             role="menu"
-             aria-labelledby="<%= menu_id %>-button">
-          <ul class="py-1">
+    <div class="relative shrink-0">
+      <button type="button"
+              id="<%= menu_id %>-button"
+              data-dropdown-toggle="<%= menu_id %>"
+              data-dropdown-placement="top-end"
+              class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+              aria-haspopup="true"
+              aria-expanded="false">
+        <%= helpers.icon("ellipsis", css_class: "size-4") %>
+        <span class="sr-only">More options</span>
+      </button>
+      <div id="<%= menu_id %>"
+           class="z-20 hidden w-44 rounded-lg border border-slate-200 bg-white shadow-sm"
+           role="menu"
+           aria-labelledby="<%= menu_id %>-button">
+        <ul class="py-1">
+          <li>
+            <%= link_to "Details", feed_url,
+                  class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                  role: "menuitem",
+                  data: { key: "feed.#{feed.id}.details" } %>
+          </li>
+          <% if draft? %>
             <li>
-              <%= link_to "Continue setup", helpers.edit_feed_path(feed),
+              <%= link_to "Continue setup", edit_url,
                     class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
                     role: "menuitem",
                     data: { key: "feed.#{feed.id}.continue_setup" } %>
             </li>
+          <% else %>
             <li>
-              <%= link_to "Discard", helpers.feed_path(feed),
-                    class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
+              <%= link_to "Edit", edit_url,
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem",
+                    data: { key: "feed.#{feed.id}.edit" } %>
+            </li>
+            <% if enabled? %>
+              <li>
+                <%= button_to "Disable", status_url,
+                      method: :patch,
+                      params: { status: "disabled" },
+                      class: "block w-full px-4 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50",
+                      role: "menuitem",
+                      data: { key: "feed.#{feed.id}.disable", turbo_confirm: DISABLE_CONFIRM },
+                      form: { class: "block" } %>
+              </li>
+            <% elsif can_be_enabled? %>
+              <li>
+                <%= button_to "Enable", status_url,
+                      method: :patch,
+                      params: { status: "enabled" },
+                      class: "block w-full px-4 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50",
+                      role: "menuitem",
+                      data: { key: "feed.#{feed.id}.enable", turbo_confirm: ENABLE_CONFIRM },
+                      form: { class: "block" } %>
+              </li>
+            <% end %>
+          <% end %>
+          <% if draft? %>
+            <li>
+              <%= link_to "Discard…", feed_url,
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
                     role: "menuitem",
                     data: { key: "feed.#{feed.id}.discard", turbo_method: :delete, turbo_confirm: DISCARD_CONFIRM } %>
             </li>
-          </ul>
-        </div>
+          <% end %>
+        </ul>
       </div>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -1,9 +1,30 @@
 <div id="<%= helpers.dom_id(feed) %>" class="w-full rounded-lg border border-slate-200 bg-white shadow-xs">
-  <div class="flex items-start justify-between gap-4 px-5 py-4">
+  <div class="flex items-start gap-4 px-5 py-4">
     <div class="flex min-w-0 items-center gap-2">
       <%= link_to title, feed_url,
             class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
       <%= render status_badge %>
+    </div>
+  </div>
+
+  <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
+    <div class="flex items-center gap-3 text-sm text-slate-400">
+      <% if target_group_label %>
+        <% if target_group_url %>
+          <%= link_to target_group_label, target_group_url, target: "_blank", rel: "noopener",
+                class: "transition hover:text-slate-600" %>
+        <% else %>
+          <span><%= target_group_label %></span>
+        <% end %>
+      <% end %>
+      <span class="flex items-center gap-1">
+        <span class="text-slate-500">Updated:</span>
+        <%= last_refreshed_tag %>
+      </span>
+      <span class="flex items-center gap-1">
+        <span class="text-slate-500">Post:</span>
+        <%= most_recent_post_tag %>
+      </span>
     </div>
 
     <% if draft? %>
@@ -11,7 +32,7 @@
         <button type="button"
                 id="<%= menu_id %>-button"
                 data-dropdown-toggle="<%= menu_id %>"
-                data-dropdown-placement="bottom-end"
+                data-dropdown-placement="top-end"
                 class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
                 aria-haspopup="true"
                 aria-expanded="false">
@@ -39,26 +60,5 @@
         </div>
       </div>
     <% end %>
-  </div>
-
-  <div class="flex items-center gap-4 border-t border-slate-200 px-5 py-2">
-    <div class="flex items-center gap-3 text-sm text-slate-400">
-      <% if target_group_label %>
-        <% if target_group_url %>
-          <%= link_to target_group_label, target_group_url, target: "_blank", rel: "noopener",
-                class: "transition hover:text-slate-600" %>
-        <% else %>
-          <span><%= target_group_label %></span>
-        <% end %>
-      <% end %>
-      <span class="flex items-center gap-1">
-        <span class="text-slate-500">Updated:</span>
-        <%= last_refreshed_tag %>
-      </span>
-      <span class="flex items-center gap-1">
-        <span class="text-slate-500">Post:</span>
-        <%= most_recent_post_tag %>
-      </span>
-    </div>
   </div>
 </div>

--- a/app/components/feed_card_component.rb
+++ b/app/components/feed_card_component.rb
@@ -1,5 +1,7 @@
 class FeedCardComponent < ViewComponent::Base
   DISCARD_CONFIRM = "Discard this draft? No data will be lost since it hasn't been activated.".freeze
+  ENABLE_CONFIRM = "Enable this feed?".freeze
+  DISABLE_CONFIRM = "Disable this feed?".freeze
 
   def initialize(feed:)
     @feed = feed
@@ -17,8 +19,24 @@ class FeedCardComponent < ViewComponent::Base
     helpers.feed_path(feed)
   end
 
+  def edit_url
+    helpers.edit_feed_path(feed)
+  end
+
+  def status_url
+    helpers.feed_status_path(feed)
+  end
+
   def draft?
     feed.draft?
+  end
+
+  def enabled?
+    feed.enabled?
+  end
+
+  def can_be_enabled?
+    feed.can_be_enabled?
   end
 
   def status_badge

--- a/test/components/feed_card_component_test.rb
+++ b/test/components/feed_card_component_test.rb
@@ -76,6 +76,59 @@ class FeedCardComponentTest < ViewComponent::TestCase
     end
   end
 
+  test "#render should show Details action for every feed" do
+    with_request_url("/feeds") do
+      result = render_inline FeedCardComponent.new(feed: feed)
+
+      details = result.css("[data-key='feed.#{feed.id}.details']").first
+      assert_not_nil details
+      assert_equal "Details", details.text.strip
+      assert_includes details["href"], "/feeds/#{feed.id}"
+    end
+  end
+
+  test "#render should show Edit action for non-draft feeds" do
+    with_request_url("/feeds") do
+      result = render_inline FeedCardComponent.new(feed: feed)
+
+      edit = result.css("[data-key='feed.#{feed.id}.edit']").first
+      assert_not_nil edit
+      assert_includes edit["href"], "/feeds/#{feed.id}/edit"
+    end
+  end
+
+  test "#render should show Enable action for enableable disabled feeds" do
+    with_request_url("/feeds") do
+      result = render_inline FeedCardComponent.new(feed: feed)
+
+      assert_not_empty result.css("[data-key='feed.#{feed.id}.enable']")
+      assert_empty result.css("[data-key='feed.#{feed.id}.disable']")
+    end
+  end
+
+  test "#render should show Disable action for enabled feeds" do
+    enabled_feed = create(:feed, :enabled, user: user)
+
+    with_request_url("/feeds") do
+      result = render_inline FeedCardComponent.new(feed: enabled_feed)
+
+      assert_not_empty result.css("[data-key='feed.#{enabled_feed.id}.disable']")
+      assert_empty result.css("[data-key='feed.#{enabled_feed.id}.enable']")
+    end
+  end
+
+  test "#render should not show status toggle for draft feeds" do
+    draft_feed = create(:feed, :draft, user: user)
+
+    with_request_url("/feeds") do
+      result = render_inline FeedCardComponent.new(feed: draft_feed)
+
+      assert_empty result.css("[data-key='feed.#{draft_feed.id}.enable']")
+      assert_empty result.css("[data-key='feed.#{draft_feed.id}.disable']")
+      assert_empty result.css("[data-key='feed.#{draft_feed.id}.edit']")
+    end
+  end
+
   test "#render should show refresh and post time placeholders when never refreshed" do
     result = render_inline FeedCardComponent.new(feed: feed)
 

--- a/test/components/feeds_list_component_test.rb
+++ b/test/components/feeds_list_component_test.rb
@@ -73,7 +73,7 @@ class FeedsListComponentTest < ViewComponent::TestCase
 
       discard_link = result.css(%([data-key="feed.#{feed.id}.discard"])).first
       assert_not_nil discard_link, "Expected Discard link"
-      assert_equal "Discard", discard_link.text.strip
+      assert_equal "Discard…", discard_link.text.strip
       assert_equal Rails.application.routes.url_helpers.feed_path(feed), discard_link["href"]
       assert_equal "delete", discard_link["data-turbo-method"]
       assert_equal "Discard this draft? No data will be lost since it hasn't been activated.",


### PR DESCRIPTION
Changes:

- Move the feed card options menu from the header into the footer
- Show the menu on every card with a Details action (opens the feed page)
- Add Edit and Enable/Disable actions for non-draft feeds
- Keep Continue setup for drafts and soften Discard (neutral color, confirmation)
