### PR TITLE
Fix email preview crash without Resend API key

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,6 +10,15 @@ class ApplicationMailer < ActionMailer::Base
     Thread.current[:mailer_preview_mode]
   end
 
+  # Building a message instantiates the configured delivery backend, and the
+  # Resend backend raises when no API key is set. Previews only render the
+  # message and never deliver it, so swap in the no-op :test backend.
+  def wrap_delivery_behavior!(*)
+    return super unless self.class.preview_mode?
+
+    super(:test)
+  end
+
   private
 
   def set_event_context(level: nil, user_id: nil, subject: nil, details: nil)

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class ApplicationMailerTest < ActionMailer::TestCase
+  def user
+    @user ||= build(:user)
+  end
+
+  test "#wrap_delivery_behavior! should use the test backend in preview mode" do
+    with_delivery_method(:resend) do
+      original_api_key = Resend.api_key
+      Resend.api_key = nil
+      ApplicationMailer.preview_mode = true
+
+      message = nil
+      assert_nothing_raised do
+        message = ProfileMailer.account_confirmation(user).message
+      end
+
+      assert_kind_of Mail::TestMailer, message.delivery_method
+    ensure
+      ApplicationMailer.preview_mode = false
+      Resend.api_key = original_api_key
+    end
+  end
+
+  test "#wrap_delivery_behavior! should use the configured backend otherwise" do
+    with_delivery_method(:resend) do
+      original_api_key = Resend.api_key
+      Resend.api_key = "test"
+
+      message = ProfileMailer.account_confirmation(user).message
+
+      assert_kind_of Resend::Mailer, message.delivery_method
+    ensure
+      Resend.api_key = original_api_key
+    end
+  end
+
+  private
+
+  def with_delivery_method(method)
+    original = ActionMailer::Base.delivery_method
+    ActionMailer::Base.delivery_method = method
+    yield
+  ensure
+    ActionMailer::Base.delivery_method = original
+  end
+end


### PR DESCRIPTION
Changes:

- Force the no-op `:test` delivery backend while rendering email previews
- Add mailer coverage for preview vs. configured delivery backends

Opening an email preview crashed with `Resend::Error: Make sure your API Key is set`. Building a message instantiates the configured delivery backend, and the Resend backend raises immediately when no API key is present — which is the case on staging. Previews only render messages and never deliver them, so swapping in the `:test` backend during preview mode sidesteps the backend entirely.
