### PR TITLE
Update feed enable/disable in place via Turbo Stream

### DIFF
--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -2,17 +2,17 @@ class FeedStatusesController < ApplicationController
   include FeedHelper
 
   def update
-    feed = load_feed
+    @feed = load_feed
 
     case status
-    when "enabled" then enable(feed)
-    when "disabled" then disable(feed)
+    when "enabled" then enable(@feed)
+    when "disabled" then disable(@feed)
     else raise "Unsupported status: #{status.inspect}"
     end
   rescue ActiveRecord::RecordNotFound
     redirect_to feeds_path, alert: "Feed not found."
   rescue ActiveRecord::StaleObjectError
-    redirect_to feed, alert: "Feed was modified by another user. Please try again."
+    redirect_to @feed, alert: "Feed was modified by another user. Please try again."
   end
 
   private
@@ -21,10 +21,10 @@ class FeedStatusesController < ApplicationController
     feed.with_lock do
       if feed.can_be_enabled?
         feed.enabled!
-        redirect_to feed, success: "Feed enabled."
+        respond_with_status(feed, success: "Feed enabled.")
       else
         missing_parts = feed_missing_enablement_parts(feed)
-        redirect_to feed, alert: "Cannot enable feed: missing #{missing_parts.join(' and ')}."
+        respond_with_status(feed, alert: "Cannot enable feed: missing #{missing_parts.join(' and ')}.")
       end
     end
   end
@@ -32,7 +32,21 @@ class FeedStatusesController < ApplicationController
   def disable(feed)
     feed.with_lock do
       feed.disabled!
-      redirect_to feed, success: "Feed disabled."
+      respond_with_status(feed, success: "Feed disabled.")
+    end
+  end
+
+  # HTML clients get a redirect to the feed page; Turbo clients get a stream
+  # that re-renders the feed heading (feed page) or the feed card (feeds index)
+  # in place, with the flash surfaced as a toast.
+  def respond_with_status(feed, success: nil, alert: nil)
+    respond_to do |format|
+      format.html { redirect_to feed, success: success, alert: alert }
+      format.turbo_stream do
+        flash.now[:success] = success if success
+        flash.now[:alert] = alert if alert
+        render :update
+      end
     end
   end
 

--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -36,9 +36,8 @@ class FeedStatusesController < ApplicationController
     end
   end
 
-  # HTML clients get a redirect to the feed page; Turbo clients get a stream
-  # that re-renders the feed heading (feed page) or the feed card (feeds index)
-  # in place, with the flash surfaced as a toast.
+  # HTML clients redirect to the feed page; Turbo clients get a stream that
+  # re-renders the feed heading (feed page) or the feed card (feeds index).
   def respond_with_status(feed, success: nil, alert: nil)
     respond_to do |format|
       format.html { redirect_to feed, success: success, alert: alert }

--- a/app/views/feed_statuses/update.turbo_stream.erb
+++ b/app/views/feed_statuses/update.turbo_stream.erb
@@ -9,6 +9,6 @@
   <%= render FeedCardComponent.new(feed: @feed) %>
 <% end %>
 
-<%# Replace (not append) so repeated toggles don't stack alerts. The partial
-    renders its own #flash-messages wrapper, so this swaps in the current flash. %>
+<%# Replace so repeated toggles don't stack alerts; the partial renders its
+    own #flash-messages wrapper. %>
 <%= turbo_stream.replace "flash-messages", partial: "layouts/flash" %>

--- a/app/views/feed_statuses/update.turbo_stream.erb
+++ b/app/views/feed_statuses/update.turbo_stream.erb
@@ -9,15 +9,6 @@
   <%= render FeedCardComponent.new(feed: @feed) %>
 <% end %>
 
-<%= turbo_stream.prepend "flash-messages" do %>
-  <% if flash[:success] %>
-    <%= render AlertComponent.new(variant: :success) do %>
-      <span><%= sanitize(flash[:success]) %></span>
-    <% end %>
-  <% end %>
-  <% if flash[:alert] %>
-    <%= render AlertComponent.new(variant: :error) do %>
-      <span><%= sanitize(flash[:alert]) %></span>
-    <% end %>
-  <% end %>
-<% end %>
+<%# Replace (not append) so repeated toggles don't stack alerts. The partial
+    renders its own #flash-messages wrapper, so this swaps in the current flash. %>
+<%= turbo_stream.replace "flash-messages", partial: "layouts/flash" %>

--- a/app/views/feed_statuses/update.turbo_stream.erb
+++ b/app/views/feed_statuses/update.turbo_stream.erb
@@ -1,0 +1,23 @@
+<%# Re-render the feed page heading (feed show) and/or the feed card (feeds
+    index). Targets absent from the current page are ignored by Turbo, so this
+    one template serves both pages. %>
+<%= turbo_stream.replace dom_id(@feed, :header) do %>
+  <%= render "feeds/header", feed: @feed %>
+<% end %>
+
+<%= turbo_stream.replace dom_id(@feed) do %>
+  <%= render FeedCardComponent.new(feed: @feed) %>
+<% end %>
+
+<%= turbo_stream.prepend "flash-messages" do %>
+  <% if flash[:success] %>
+    <%= render AlertComponent.new(variant: :success) do %>
+      <span><%= sanitize(flash[:success]) %></span>
+    <% end %>
+  <% end %>
+  <% if flash[:alert] %>
+    <%= render AlertComponent.new(variant: :error) do %>
+      <span><%= sanitize(flash[:alert]) %></span>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/feeds/_header.html.erb
+++ b/app/views/feeds/_header.html.erb
@@ -1,0 +1,53 @@
+<%# locals: (feed:) %>
+<div id="<%= dom_id(feed, :header) %>">
+  <%= render PageHeaderComponent.new(title: feed.display_name) do |header| %>
+    <% header.with_context_paragraph do %>
+      <%= render feed_status_badge(feed) %>
+    <% end %>
+    <% if feed.target_group_url.present? %>
+      <% header.with_context_paragraph do %>
+        Target group:
+        <%= link_to "#{feed.access_token.host_domain}/#{feed.target_group}",
+                    feed.target_group_url,
+                    class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
+                    target: "_blank", rel: "noopener" %>
+      <% end %>
+    <% end %>
+    <% header.with_action_button do %>
+      <%= form_with url: feed_refresh_path(feed), method: :post, class: "inline-block", data: {
+            controller: "loading-button",
+            action: "turbo:submit-start->loading-button#start turbo:submit-end->loading-button#end"
+          } do %>
+        <%= render RefreshButtonComponent.new(title: "Refresh now", type: "submit") %>
+      <% end %>
+    <% end %>
+    <% header.with_action_button do %>
+      <%= link_to "Edit", edit_feed_path(feed), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
+    <% end %>
+    <% if feed.enabled? %>
+      <% header.with_action_button do %>
+        <%= button_to "Disable",
+                      feed_status_path(feed),
+                      method: :patch,
+                      params: { status: "disabled" },
+                      data: { turbo_confirm: "Disable this feed?" },
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
+                      form: { class: "inline-block" } %>
+      <% end %>
+    <% elsif feed.disabled? && feed.can_be_enabled? %>
+      <% header.with_action_button do %>
+        <%= button_to "Enable",
+                      feed_status_path(feed),
+                      method: :patch,
+                      params: { status: "enabled" },
+                      data: { turbo_confirm: "Enable this feed?" },
+                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
+                      form: { class: "inline-block" } %>
+      <% end %>
+    <% else %>
+      <% header.with_action_button do %>
+        <button type="button" disabled title="Complete setup to enable this feed" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">Enable</button>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -1,56 +1,7 @@
 <% content_for :title, @feed.display_name %>
 
 <div class="space-y-10">
-  <%= render PageHeaderComponent.new(title: @feed.display_name) do |header| %>
-    <% header.with_context_paragraph do %>
-      <%= render feed_status_badge(@feed) %>
-    <% end %>
-    <% if @feed.target_group_url.present? %>
-      <% header.with_context_paragraph do %>
-        Target group:
-        <%= link_to "#{@feed.access_token.host_domain}/#{@feed.target_group}",
-                    @feed.target_group_url,
-                    class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
-                    target: "_blank", rel: "noopener" %>
-      <% end %>
-    <% end %>
-    <% header.with_action_button do %>
-      <%= form_with url: feed_refresh_path(@feed), method: :post, class: "inline-block", data: {
-            controller: "loading-button",
-            action: "turbo:submit-start->loading-button#start turbo:submit-end->loading-button#end"
-          } do %>
-        <%= render RefreshButtonComponent.new(title: "Refresh now", type: "submit") %>
-      <% end %>
-    <% end %>
-    <% header.with_action_button do %>
-      <%= link_to "Edit", edit_feed_path(@feed), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
-    <% end %>
-    <% if @feed.enabled? %>
-      <% header.with_action_button do %>
-        <%= button_to "Disable",
-                      feed_status_path(@feed),
-                      method: :patch,
-                      params: { status: "disabled" },
-                      data: { turbo_confirm: "Disable this feed?" },
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
-                      form: { class: "inline-block" } %>
-      <% end %>
-    <% elsif @feed.disabled? && @feed.can_be_enabled? %>
-      <% header.with_action_button do %>
-        <%= button_to "Enable",
-                      feed_status_path(@feed),
-                      method: :patch,
-                      params: { status: "enabled" },
-                      data: { turbo_confirm: "Enable this feed?" },
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
-                      form: { class: "inline-block" } %>
-      <% end %>
-    <% else %>
-      <% header.with_action_button do %>
-        <button type="button" disabled title="Complete setup to enable this feed" class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50">Enable</button>
-      <% end %>
-    <% end %>
-  <% end %>
+  <%= render "header", feed: @feed %>
 
   <% if @recent_posts.any? %>
     <section class="space-y-4">

--- a/test/controllers/feed_statuses_controller_test.rb
+++ b/test/controllers/feed_statuses_controller_test.rb
@@ -36,6 +36,49 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "disabled", feed.state
   end
 
+  test "#update should respond with turbo stream when enabling" do
+    sign_in_as(user)
+
+    patch feed_status_path(feed), params: { status: "enabled" }, as: :turbo_stream
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_includes response.body, ActionView::RecordIdentifier.dom_id(feed, :header)
+    assert_includes response.body, ActionView::RecordIdentifier.dom_id(feed)
+    assert_includes response.body, "Feed enabled"
+
+    feed.reload
+    assert_equal "enabled", feed.state
+  end
+
+  test "#update should respond with turbo stream when disabling" do
+    sign_in_as(user)
+    feed.update!(state: :enabled)
+
+    patch feed_status_path(feed), params: { status: "disabled" }, as: :turbo_stream
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_includes response.body, "Feed disabled"
+
+    feed.reload
+    assert_equal "disabled", feed.state
+  end
+
+  test "#update should respond with turbo stream when enablement fails" do
+    sign_in_as(user)
+    feed_without_token = create(:feed, :without_access_token, user: user)
+
+    patch feed_status_path(feed_without_token), params: { status: "enabled" }, as: :turbo_stream
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_includes response.body, "Cannot enable feed: missing"
+
+    feed_without_token.reload
+    assert_equal "disabled", feed_without_token.state
+  end
+
   test "#update should reject an unsupported status" do
     sign_in_as(user)
 


### PR DESCRIPTION
Changes:

- Respond to feed enable/disable with Turbo Stream, re-rendering the feed page heading or the feeds index card in place
- Keep the HTML fallback redirecting to the feed page
- Extract the feed page heading into a shared partial so it can be rendered both on the show page and in the stream response

Enabling or disabling a feed no longer triggers a full page reload for Turbo clients. A single stream template targets both the feed heading and the feed card, and Turbo ignores whichever target isn't present on the current page — so the same response serves both the feed page and the feeds index without the controller needing to know where the request came from.
