### PR TITLE
Decouple FreeFeed publishing from feed refresh

### DIFF
--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -15,6 +15,10 @@ class PostPublishJob < ApplicationJob
     feed = Feed.find_by(id: feed_id)
     return unless feed
 
+    # Stop the chain if the feed was disabled after it was kicked. Disabling a
+    # feed pauses publishing, including posts already enqueued.
+    return unless feed.enabled?
+
     Feed.with_advisory_lock("post_publish_#{feed_id}", timeout_seconds: 0) do
       publish_next(feed)
     end

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -26,7 +26,7 @@ class PostPublishJob < ApplicationJob
   private
 
   def publish_next(feed)
-    post = feed.posts.where(status: :enqueued).order(:published_at, :id).first
+    post = feed.posts.enqueued.order(:published_at, :id).first
     return unless post
 
     publish(feed, post)

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -6,8 +6,9 @@
 # original order and are never published concurrently.
 #
 # The chain is self-healing: if a run dies before scheduling the next one, the
-# feed's next refresh kicks it off again and it resumes from the earliest
-# remaining post.
+# recurring PublicationSchedulerJob (the primary watchdog, every minute) kicks it
+# off again and it resumes from the earliest remaining post. It also recovers
+# feeds that were disabled and later re-enabled.
 class PostPublishJob < ApplicationJob
   queue_as :default
 

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -1,0 +1,52 @@
+# Publishes enqueued posts to FreeFeed one at a time, in order.
+#
+# It works as a self-chaining FIFO queue: each run publishes the earliest
+# enqueued post for the feed, then schedules itself again for the next one. A
+# per-feed advisory lock guarantees a single active chain, so posts keep their
+# original order and are never published concurrently.
+#
+# The chain is self-healing: if a run dies before scheduling the next one, the
+# feed's next refresh kicks it off again and it resumes from the earliest
+# remaining post.
+class PostPublishJob < ApplicationJob
+  queue_as :default
+
+  def perform(feed_id)
+    feed = Feed.find_by(id: feed_id)
+    return unless feed
+
+    Feed.with_advisory_lock("post_publish_#{feed_id}", timeout_seconds: 0) do
+      publish_next(feed)
+    end
+  rescue WithAdvisoryLock::FailedToAcquireLock
+    # A chain is already running for this feed; it will pick up remaining posts.
+    Rails.logger.info "Publish chain already running for feed #{feed_id}, skipping"
+  end
+
+  private
+
+  def publish_next(feed)
+    post = feed.posts.where(status: :enqueued).order(:published_at, :id).first
+    return unless post
+
+    publish(feed, post)
+  end
+
+  def publish(feed, post)
+    FreefeedPublisher.new(post).publish
+    schedule_next(feed)
+  rescue FreefeedClient::UnauthorizedError
+    # Token is no longer valid: disable it and stop the chain.
+    feed.access_token&.disable_token_and_feeds
+  rescue => e
+    # Poison post: mark it failed and move on so the queue isn't blocked.
+    post.update!(status: :failed)
+    Rails.logger.error "Failed to publish post #{post.id}: #{e.message}"
+    Rails.error.report(e, context: { post: post.attributes, feed: feed.attributes })
+    schedule_next(feed)
+  end
+
+  def schedule_next(feed)
+    self.class.perform_later(feed.id)
+  end
+end

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -19,7 +19,7 @@ class PostPublishJob < ApplicationJob
     # feed pauses publishing, including posts already enqueued.
     return unless feed.enabled?
 
-    Feed.with_advisory_lock("post_publish_#{feed_id}", timeout_seconds: 0) do
+    Feed.with_advisory_lock!("post_publish_#{feed_id}", timeout_seconds: 0) do
       publish_next(feed)
     end
   rescue WithAdvisoryLock::FailedToAcquireLock

--- a/app/jobs/publication_scheduler_job.rb
+++ b/app/jobs/publication_scheduler_job.rb
@@ -1,0 +1,22 @@
+# Recurring scheduler that drives publishing, decoupled from feed refresh.
+#
+# Refresh produces and persists posts on each feed's own cron; this job runs
+# frequently and kicks a publish chain (PostPublishJob) for every enabled feed
+# that has enqueued posts waiting. It is also the chain's watchdog: a stalled or
+# never-started chain is picked up on the next run, including for feeds that were
+# disabled and re-enabled.
+class PublicationSchedulerJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Feed.where(state: :enabled, id: feeds_with_enqueued_posts).find_each do |feed|
+      PostPublishJob.perform_later(feed.id)
+    end
+  end
+
+  private
+
+  def feeds_with_enqueued_posts
+    Post.where(status: :enqueued).select(:feed_id).distinct
+  end
+end

--- a/app/jobs/publication_scheduler_job.rb
+++ b/app/jobs/publication_scheduler_job.rb
@@ -9,7 +9,7 @@ class PublicationSchedulerJob < ApplicationJob
   queue_as :default
 
   def perform
-    Feed.where(state: :enabled, id: feeds_with_enqueued_posts).find_each do |feed|
+    Feed.enabled.where(id: feeds_with_enqueued_posts).find_each do |feed|
       PostPublishJob.perform_later(feed.id)
     end
   end
@@ -17,6 +17,6 @@ class PublicationSchedulerJob < ApplicationJob
   private
 
   def feeds_with_enqueued_posts
-    Post.where(status: :enqueued).select(:feed_id).distinct
+    Post.enqueued.select(:feed_id).distinct
   end
 end

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -9,7 +9,7 @@ class FeedRefreshWorkflow
   step :persist_entries
   step :normalize_entries
   step :persist_posts
-  step :publish_posts
+  step :enqueue_publication
   step :finalize_workflow
 
   attr_reader :feed
@@ -130,41 +130,16 @@ class FeedRefreshWorkflow
     persisted_posts
   end
 
-  def publish_posts(persisted_posts)
-    enqueued_posts = persisted_posts.select(&:enqueued?).sort_by(&:published_at)
-    return persisted_posts if enqueued_posts.empty?
-
-    published_count = 0
-    failed_count = 0
-
-    enqueued_posts.each do |post|
-      begin
-        publisher = FreefeedPublisher.new(post)
-        freefeed_post_id = publisher.publish
-        post.update!(status: :published, freefeed_post_id: freefeed_post_id)
-        published_count += 1
-      rescue FreefeedClient::UnauthorizedError
-        feed.access_token&.disable_token_and_feeds
-        break
-      rescue => e
-        post.update!(status: :failed)
-        failed_count += 1
-        Rails.logger.error "Failed to publish post #{post.id}: #{e.message}"
-        Rails.error.report(e, context: { post: post.attributes, feed: feed.attributes })
-      end
-    end
-
-    record_stats(
-      published_posts: published_count,
-      failed_posts: failed_count
-    )
-
+  # Hands publishing off to the async FIFO chain (see PostPublishJob) instead of
+  # publishing inline. Kicking it on every refresh also restarts a chain that
+  # may have stalled, so it doubles as the chain's watchdog.
+  def enqueue_publication(persisted_posts)
+    PostPublishJob.perform_later(feed.id) if persisted_posts.any?(&:enqueued?)
     persisted_posts
   end
 
   def finalize_workflow(posts)
-    published_posts_count = posts.count(&:published?)
-    failed_posts_count = posts.count(&:failed?)
+    enqueued_posts_count = posts.count(&:enqueued?)
     rejected_posts_count = posts.count(&:rejected?)
 
     record_completed_at
@@ -180,8 +155,7 @@ class FeedRefreshWorkflow
     )
 
     Rails.logger.info "Feed refresh completed for feed #{feed.id}: " \
-                      "#{published_posts_count} published, " \
-                      "#{failed_posts_count} failed, " \
+                      "#{enqueued_posts_count} queued for publishing, " \
                       "#{rejected_posts_count} rejected"
 
     posts

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -15,6 +15,11 @@ development:
     queue: default
     schedule: every minute
 
+  publication_scheduler:
+    class: PublicationSchedulerJob
+    queue: default
+    schedule: every minute
+
   prune_feed_previews:
     class: PruneFeedPreviewsJob
     queue: default
@@ -23,6 +28,11 @@ development:
 staging:
   feed_scheduler:
     class: FeedSchedulerJob
+    queue: default
+    schedule: every minute
+
+  publication_scheduler:
+    class: PublicationSchedulerJob
     queue: default
     schedule: every minute
 
@@ -38,6 +48,11 @@ staging:
 production:
   feed_scheduler:
     class: FeedSchedulerJob
+    queue: default
+    schedule: every minute
+
+  publication_scheduler:
+    class: PublicationSchedulerJob
     queue: default
     schedule: every minute
 

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -96,17 +96,18 @@ class PostPublishJobTest < ActiveJob::TestCase
     second = create(:post, :enqueued, feed: feed, published_at: 1.hour.ago)
     stub_publish_success
 
+    # Publish the first post; this enqueues the chained job for the next one.
     PostPublishJob.perform_now(feed.id)
     assert_equal "published", first.reload.status
+    assert_enqueued_jobs 1, only: PostPublishJob
 
+    # Disable the feed, then let the already-enqueued chained job run.
     feed.update!(state: :disabled)
-
-    assert_no_enqueued_jobs(only: PostPublishJob) do
-      PostPublishJob.perform_now(feed.id)
-    end
+    perform_enqueued_jobs(only: PostPublishJob)
 
     assert_equal "enqueued", second.reload.status
     assert_requested :post, "#{access_token.host}/v4/posts", times: 1
+    assert_no_enqueued_jobs(only: PostPublishJob)
   end
 
   test ".perform_now should do nothing when there are no enqueued posts" do

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class PostPublishJobTest < ActiveJob::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def access_token
+    @access_token ||= create(:access_token, :active, user: user)
+  end
+
+  def feed
+    @feed ||= create(:feed, user: user, access_token: access_token, target_group: "group")
+  end
+
+  def stub_publish_success
+    stub_request(:post, "#{access_token.host}/v4/posts")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { posts: { id: "freefeed-#{SecureRandom.hex(8)}" } }.to_json
+      )
+  end
+
+  test ".perform_now should publish the earliest enqueued post first" do
+    older = create(:post, :enqueued, feed: feed, published_at: 2.hours.ago)
+    newer = create(:post, :enqueued, feed: feed, published_at: 1.hour.ago)
+    stub_publish_success
+
+    assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
+      PostPublishJob.perform_now(feed.id)
+    end
+
+    assert_equal "published", older.reload.status
+    assert_equal "enqueued", newer.reload.status
+  end
+
+  test ".perform_now should publish all enqueued posts through the chain" do
+    create(:post, :enqueued, feed: feed, published_at: 3.hours.ago)
+    create(:post, :enqueued, feed: feed, published_at: 2.hours.ago)
+    create(:post, :enqueued, feed: feed, published_at: 1.hour.ago)
+    stub_publish_success
+
+    perform_enqueued_jobs { PostPublishJob.perform_now(feed.id) }
+
+    assert_equal 3, feed.posts.where(status: :published).count
+    assert_equal 0, feed.posts.where(status: :enqueued).count
+  end
+
+  test ".perform_now should mark a failing post as failed, report it, and continue" do
+    post = create(:post, :enqueued, feed: feed)
+    stub_request(:post, "#{access_token.host}/v4/posts").to_return(status: 500)
+
+    reported = []
+    assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
+      Rails.error.stub(:report, ->(err, **kwargs) { reported << [err, kwargs] }) do
+        PostPublishJob.perform_now(feed.id)
+      end
+    end
+
+    assert_equal "failed", post.reload.status
+    assert_equal 1, reported.size
+    _error, kwargs = reported.first
+    assert_equal post.id, kwargs.dig(:context, :post)["id"]
+    assert_equal feed.id, kwargs.dig(:context, :feed)["id"]
+  end
+
+  test ".perform_now should disable the token and stop the chain on UnauthorizedError" do
+    post = create(:post, :enqueued, feed: feed)
+    stub_request(:post, "#{access_token.host}/v4/posts").to_return(status: 401)
+
+    assert_no_enqueued_jobs(only: PostPublishJob) do
+      PostPublishJob.perform_now(feed.id)
+    end
+
+    assert_equal "inactive", access_token.reload.status
+    assert_equal "enqueued", post.reload.status
+  end
+
+  test ".perform_now should do nothing when there are no enqueued posts" do
+    assert_no_enqueued_jobs(only: PostPublishJob) do
+      PostPublishJob.perform_now(feed.id)
+    end
+  end
+
+  test ".perform_now should return when the feed does not exist" do
+    assert_nothing_raised { PostPublishJob.perform_now(-1) }
+  end
+end

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -77,6 +77,20 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_equal "enqueued", post.reload.status
   end
 
+  test ".perform_now should skip without publishing when a chain is already running" do
+    create(:post, :enqueued, feed: feed)
+    stub_publish_success
+
+    Feed.stub(:with_advisory_lock, ->(*, **) { raise WithAdvisoryLock::FailedToAcquireLock.new("post_publish") }) do
+      assert_no_enqueued_jobs(only: PostPublishJob) do
+        assert_nothing_raised { PostPublishJob.perform_now(feed.id) }
+      end
+    end
+
+    assert_equal "enqueued", feed.posts.first.reload.status
+    assert_not_requested :post, "#{access_token.host}/v4/posts"
+  end
+
   test ".perform_now should do nothing when there are no enqueued posts" do
     assert_no_enqueued_jobs(only: PostPublishJob) do
       PostPublishJob.perform_now(feed.id)

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -81,7 +81,7 @@ class PostPublishJobTest < ActiveJob::TestCase
     create(:post, :enqueued, feed: feed)
     stub_publish_success
 
-    Feed.stub(:with_advisory_lock, ->(*, **) { raise WithAdvisoryLock::FailedToAcquireLock.new("post_publish") }) do
+    Feed.stub(:with_advisory_lock!, ->(*, **) { raise WithAdvisoryLock::FailedToAcquireLock.new("post_publish") }) do
       assert_no_enqueued_jobs(only: PostPublishJob) do
         assert_nothing_raised { PostPublishJob.perform_now(feed.id) }
       end

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -10,7 +10,7 @@ class PostPublishJobTest < ActiveJob::TestCase
   end
 
   def feed
-    @feed ||= create(:feed, user: user, access_token: access_token, target_group: "group")
+    @feed ||= create(:feed, :enabled, user: user, access_token: access_token, target_group: "group")
   end
 
   def stub_publish_success
@@ -89,6 +89,24 @@ class PostPublishJobTest < ActiveJob::TestCase
 
     assert_equal "enqueued", feed.posts.first.reload.status
     assert_not_requested :post, "#{access_token.host}/v4/posts"
+  end
+
+  test ".perform_now should stop publishing when the feed was disabled mid-chain" do
+    first = create(:post, :enqueued, feed: feed, published_at: 2.hours.ago)
+    second = create(:post, :enqueued, feed: feed, published_at: 1.hour.ago)
+    stub_publish_success
+
+    PostPublishJob.perform_now(feed.id)
+    assert_equal "published", first.reload.status
+
+    feed.update!(state: :disabled)
+
+    assert_no_enqueued_jobs(only: PostPublishJob) do
+      PostPublishJob.perform_now(feed.id)
+    end
+
+    assert_equal "enqueued", second.reload.status
+    assert_requested :post, "#{access_token.host}/v4/posts", times: 1
   end
 
   test ".perform_now should do nothing when there are no enqueued posts" do

--- a/test/jobs/publication_scheduler_job_test.rb
+++ b/test/jobs/publication_scheduler_job_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class PublicationSchedulerJobTest < ActiveJob::TestCase
+  test ".perform_now should kick a publish chain for enabled feeds with enqueued posts" do
+    feed = create(:feed, :enabled)
+    create(:post, :enqueued, feed: feed)
+
+    assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
+      PublicationSchedulerJob.perform_now
+    end
+  end
+
+  test ".perform_now should skip enabled feeds without enqueued posts" do
+    feed = create(:feed, :enabled)
+    create(:post, :published, feed: feed)
+
+    assert_no_enqueued_jobs(only: PostPublishJob) do
+      PublicationSchedulerJob.perform_now
+    end
+  end
+
+  test ".perform_now should skip disabled feeds even with enqueued posts" do
+    feed = create(:feed, :disabled)
+    create(:post, :enqueued, feed: feed)
+
+    assert_no_enqueued_jobs(only: PostPublishJob) do
+      PublicationSchedulerJob.perform_now
+    end
+  end
+
+  test ".perform_now should enqueue one job per feed regardless of post count" do
+    feed = create(:feed, :enabled)
+    create_list(:post, 3, :enqueued, feed: feed)
+
+    assert_enqueued_jobs 1, only: PostPublishJob do
+      PublicationSchedulerJob.perform_now
+    end
+  end
+end

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -61,7 +61,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
   test "#execute should process real RSS data and create posts" do
     # Create feed with proper configuration
-    test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
+    test_feed = create(:feed, :enabled, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 
     workflow = FeedRefreshWorkflow.new(test_feed)
 

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class FeedRefreshWorkflowTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   def feed
     @feed ||= create(:feed, feed_profile_key: "rss")
   end
@@ -42,7 +44,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       :persist_entries,
       :normalize_entries,
       :persist_posts,
-      :publish_posts,
+      :enqueue_publication,
       :finalize_workflow
     ]
 
@@ -91,20 +93,20 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     # Use real HTTP loader with stubbed network call
     WebMock.stub_request(:get, test_feed.url).to_return(body: sample_rss, status: 200)
 
-    result = workflow.execute
+    result = perform_enqueued_jobs { workflow.execute }
 
     assert_equal 2, result.length, "Should return 2 posts"
 
-    published_posts = result.select(&:published?)
-    assert_equal 2, published_posts.length, "Should have 2 published posts"
+    # Publishing is async now; the chain runs within perform_enqueued_jobs.
+    published_posts = test_feed.posts.where(status: :published).order(:published_at)
+    assert_equal 2, published_posts.count, "Should have 2 published posts"
 
-    # Posts are ordered by published_at, so second entry comes first
+    # Posts are published in published_at order, so the older entry comes first
     first_post = published_posts.first
     assert_equal test_feed, first_post.feed
     assert_not_nil first_post.feed_entry
     assert_match(/Another test entry/, first_post.content)
     assert_equal "https://example.com/entry-456", first_post.source_url
-    assert_equal "published", first_post.status
     assert_not_nil first_post.freefeed_post_id
 
     assert_equal 2, FeedEntry.where(feed: test_feed).count
@@ -552,45 +554,23 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     end
   end
 
-  test "#publish_posts should disable the access token and stop publishing on UnauthorizedError" do
-    pub_user = create(:user)
-    token = create(:access_token, :active, user: pub_user)
-    test_feed = create(:feed, user: pub_user, access_token: token,
-                               feed_profile_key: "rss", target_group: "group")
+  test "#enqueue_publication should kick the publish chain when there are enqueued posts" do
+    test_feed = create(:feed, feed_profile_key: "rss")
     post = create(:post, :enqueued, feed: test_feed)
 
-    stub_request(:post, "#{token.host}/v4/posts").to_return(status: 401)
-
     workflow = FeedRefreshWorkflow.new(test_feed)
-    workflow.send(:publish_posts, Post.where(id: post.id))
-
-    assert_equal "inactive", token.reload.status
+    assert_enqueued_with(job: PostPublishJob, args: [test_feed.id]) do
+      workflow.send(:enqueue_publication, Post.where(id: post.id))
+    end
   end
 
-  test "#publish_posts should report the error when a post fails to publish" do
-    pub_user = create(:user)
-    token = create(:access_token, :active, user: pub_user)
-    test_feed = create(:feed, user: pub_user, access_token: token,
-                               feed_profile_key: "rss", target_group: "group")
-    post = create(:post, :enqueued, feed: test_feed)
+  test "#enqueue_publication should not kick the chain when nothing is enqueued" do
+    test_feed = create(:feed, feed_profile_key: "rss")
+    post = create(:post, :rejected, feed: test_feed)
 
-    stub_request(:post, "#{token.host}/v4/posts").to_return(status: 500)
-
-    reported = []
     workflow = FeedRefreshWorkflow.new(test_feed)
-    Rails.error.stub(:report, ->(err, **kwargs) { reported << [err, kwargs] }) do
-      workflow.send(:publish_posts, Post.where(id: post.id))
+    assert_no_enqueued_jobs(only: PostPublishJob) do
+      workflow.send(:enqueue_publication, Post.where(id: post.id))
     end
-
-    assert_equal "failed", post.reload.status
-    assert_equal 1, reported.size
-    _error, kwargs = reported.first
-    post_context = kwargs.dig(:context, :post)
-    feed_context = kwargs.dig(:context, :feed)
-    assert_equal post.attributes.keys.sort, post_context.keys.sort
-    assert_equal post.id, post_context["id"]
-    assert_equal "failed", post_context["status"]
-    assert_equal test_feed.attributes.keys.sort, feed_context.keys.sort
-    assert_equal test_feed.id, feed_context["id"]
   end
 end

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -250,7 +250,9 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     test_feed = create(:feed, :enabled, feed_profile_key: "rss", user: llm_user, llm_credential: credential)
 
     workflow = FeedRefreshWorkflow.new(test_feed)
-    workflow.stub(:load_feed_contents, ->(_) { raise LlmClient::AuthError, "Unauthorized" }) do
+    loader = Object.new
+    loader.define_singleton_method(:load) { raise LlmClient::AuthError, "Unauthorized" }
+    test_feed.stub(:loader_instance, loader) do
       assert_raises(LlmClient::AuthError) { workflow.execute }
     end
 
@@ -271,7 +273,9 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     test_feed = create(:feed, feed_profile_key: "rss", user: llm_user, llm_credential: credential)
 
     workflow = FeedRefreshWorkflow.new(test_feed)
-    workflow.stub(:load_feed_contents, ->(_) { raise LlmClient::ProviderError, "server error" }) do
+    loader = Object.new
+    loader.define_singleton_method(:load) { raise LlmClient::ProviderError, "server error" }
+    test_feed.stub(:loader_instance, loader) do
       assert_raises(LlmClient::ProviderError) { workflow.execute }
     end
 
@@ -299,13 +303,12 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
     WebMock.stub_request(:get, test_feed.url).to_return(body: sample_rss, status: 200)
 
-    # Override normalizer_instance to pass nil instead of the feed_entry
-    test_feed.define_singleton_method(:normalizer_instance) do |feed_entry|
-      normalizer_class.new(nil)  # Pass nil instead of feed_entry to trigger error
-    end
+    # Make normalization fail at the collaborator boundary
+    normalizer = Object.new
+    normalizer.define_singleton_method(:normalize) { raise "normalization failed" }
 
-    error = assert_raises(StandardError) do
-      workflow.execute
+    test_feed.stub(:normalizer_instance, normalizer) do
+      assert_raises(StandardError) { workflow.execute }
     end
 
     # Should fail during normalize step

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -379,7 +379,9 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
     WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
 
-    result = workflow.execute
+    # No enqueued posts means the publish chain must not be kicked
+    result = nil
+    assert_no_enqueued_jobs(only: PostPublishJob) { result = workflow.execute }
 
     # Should complete successfully with no posts
     assert_equal 0, result.length
@@ -551,26 +553,6 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
       metric.reload
       assert_equal 1, metric.posts_count, "Metric should reflect only new posts from second refresh"
-    end
-  end
-
-  test "#enqueue_publication should kick the publish chain when there are enqueued posts" do
-    test_feed = create(:feed, feed_profile_key: "rss")
-    post = create(:post, :enqueued, feed: test_feed)
-
-    workflow = FeedRefreshWorkflow.new(test_feed)
-    assert_enqueued_with(job: PostPublishJob, args: [test_feed.id]) do
-      workflow.send(:enqueue_publication, Post.where(id: post.id))
-    end
-  end
-
-  test "#enqueue_publication should not kick the chain when nothing is enqueued" do
-    test_feed = create(:feed, feed_profile_key: "rss")
-    post = create(:post, :rejected, feed: test_feed)
-
-    workflow = FeedRefreshWorkflow.new(test_feed)
-    assert_no_enqueued_jobs(only: PostPublishJob) do
-      workflow.send(:enqueue_publication, Post.where(id: post.id))
     end
   end
 end


### PR DESCRIPTION
Changes:

- Add `PostPublishJob` — a self-chaining FIFO job that publishes the earliest enqueued post for a feed, then schedules itself for the next one.
- Add `PublicationSchedulerJob` — a recurring job (every minute) that kicks a publish chain for every enabled feed with enqueued posts.
- `FeedRefreshWorkflow` now eagerly kicks the chain after persisting new posts instead of publishing inline.

Decouples publishing from feed refresh: refresh produces posts on each feed's own cron, while a separate frequent scheduler drives publishing. The scheduler doubles as the chain's watchdog — stalled or never-started chains (e.g. feeds disabled then re-enabled) are picked up automatically, and the post-persist kick keeps publishing prompt. A per-feed advisory lock keeps a single active chain so posts retain order and never publish concurrently; a permanently failing post is marked failed and the chain moves on. No user-facing change, and the existing token-disable-on-`UnauthorizedError` behavior is preserved.

This is the groundwork for reschedule-based rate limiting (#615), which will slot into `PostPublishJob` regardless of who kicks it.

References:

- Part of #609.
- Closes #610.
