### PR TITLE
Add generalized RateLimit service

### DIFF
--- a/app/models/rate_limit/bucket.rb
+++ b/app/models/rate_limit/bucket.rb
@@ -1,0 +1,10 @@
+module RateLimit
+  # Persisted token-bucket state for one (policy, subject) pair.
+  #
+  # `data` holds every per-(dimension, window) bucket for the subject as
+  # `{ "dimension/window" => { "t" => tokens, "r" => refilled_at_epoch } }`.
+  # `blocked_until` is a server-imposed cooldown set by RateLimit.penalize.
+  class Bucket < ApplicationRecord
+    self.table_name = "rate_limit_buckets"
+  end
+end

--- a/app/models/rate_limit/bucket.rb
+++ b/app/models/rate_limit/bucket.rb
@@ -2,7 +2,7 @@ module RateLimit
   # Persisted token-bucket state for one (policy, subject) pair.
   #
   # `data` holds every per-(dimension, window) bucket for the subject as
-  # `{ "dimension/window" => { "t" => tokens, "r" => refilled_at_epoch } }`.
+  # `{ "dimension/window" => { "tokens" => Float, "refilled_at" => epoch } }`.
   # `blocked_until` is a server-imposed cooldown set by RateLimit.penalize.
   class Bucket < ApplicationRecord
     self.table_name = "rate_limit_buckets"

--- a/app/services/rate_limit.rb
+++ b/app/services/rate_limit.rb
@@ -20,15 +20,21 @@ module RateLimit
 
   # Outcome of an acquire attempt.
   Result = Data.define(:allowed, :retry_after) do
-    def allowed? = allowed
+    def allowed?
+      allowed
+    end
   end
 
   # A single token-bucket rule on one dimension over one window (seconds).
   # `burst` is the bucket capacity; it defaults to the per-window rate.
   Limit = Data.define(:dimension, :window, :rate, :burst) do
-    def rate_per_sec = rate.to_f / window
+    def rate_per_sec
+      rate.to_f / window
+    end
 
-    def bucket_key = "#{dimension}/#{window}"
+    def bucket_key
+      "#{dimension}/#{window}"
+    end
   end
 
   # A named provider profile: its limits (grouped by dimension) and how it
@@ -50,9 +56,13 @@ module RateLimit
     end
 
     # DSL: fail open (allow) or closed (throttle) on a limiter storage error.
-    def fail_open(value = true) = @fail_open = value
+    def fail_open(value = true)
+      @fail_open = value
+    end
 
-    def fail_open? = @fail_open
+    def fail_open?
+      @fail_open
+    end
 
     # All limits touched by the given cost, as [limit, amount] pairs. Dimensions
     # without a declared limit are unlimited and contribute nothing.

--- a/app/services/rate_limit.rb
+++ b/app/services/rate_limit.rb
@@ -1,0 +1,188 @@
+# Generalized token-bucket rate limiter.
+#
+# Policies are declared up front (see RateLimit.define); each policy holds one or
+# more limits, and a limit is a token bucket on a (dimension, window). A call
+# spends `cost` tokens per dimension; it's allowed only if every bucket it
+# touches has room. State lives in a single PostgreSQL table, one row per
+# (policy, subject), with all of that subject's buckets in a JSONB column.
+#
+# See docs/rate-limiting.md for the design.
+module RateLimit
+  # Raised by acquire! / throttle when a call can't proceed.
+  class Throttled < StandardError
+    attr_reader :retry_after
+
+    def initialize(retry_after:)
+      @retry_after = retry_after
+      super("Rate limited; retry after #{retry_after.round(2)}s")
+    end
+  end
+
+  # Outcome of an acquire attempt.
+  Result = Data.define(:allowed, :retry_after) do
+    def allowed? = allowed
+  end
+
+  # A single token-bucket rule on one dimension over one window (seconds).
+  # `burst` is the bucket capacity; it defaults to the per-window rate.
+  Limit = Data.define(:dimension, :window, :rate, :burst) do
+    def rate_per_sec = rate.to_f / window
+
+    def bucket_key = "#{dimension}/#{window}"
+  end
+
+  # A named provider profile: its limits (grouped by dimension) and how it
+  # behaves when the limiter's own storage is unavailable.
+  class Policy
+    attr_reader :name
+
+    def initialize(name)
+      @name = name
+      @limits = Hash.new { |h, k| h[k] = [] }
+      @fail_open = true
+    end
+
+    # DSL: declare a limit. Called multiple times for the same dimension to add
+    # extra windows (e.g. per-minute and per-day).
+    def limit(dimension, rate, per:, burst: nil)
+      dimension = dimension.to_sym
+      @limits[dimension] << Limit.new(dimension: dimension, window: per.to_i, rate: rate, burst: burst || rate)
+    end
+
+    # DSL: fail open (allow) or closed (throttle) on a limiter storage error.
+    def fail_open(value = true) = @fail_open = value
+
+    def fail_open? = @fail_open
+
+    # All limits touched by the given cost, as [limit, amount] pairs. Dimensions
+    # without a declared limit are unlimited and contribute nothing.
+    def buckets_for(cost)
+      cost.flat_map do |dimension, amount|
+        @limits.fetch(dimension.to_sym, []).map { |limit| [limit, amount] }
+      end
+    end
+  end
+
+  # Cooldown applied when failing closed on a storage error.
+  FAIL_CLOSED_COOLDOWN = 60.0
+
+  class << self
+    def define(name, &block)
+      policy = Policy.new(name.to_sym)
+      policy.instance_eval(&block)
+      registry[name.to_sym] = policy
+    end
+
+    def policy(name)
+      registry.fetch(name.to_sym) { raise ArgumentError, "Unknown rate limit policy: #{name}" }
+    end
+
+    # Test/boot helper: drop all registered policies.
+    def reset!
+      @registry = {}
+    end
+
+    # Try to reserve `cost`. Returns a Result; never raises for being over limit.
+    def acquire(name, subject:, cost:)
+      policy = policy(name)
+      buckets = policy.buckets_for(cost)
+      with_locked_row(name, subject) { |row, now| consume(row, buckets, now) }
+    rescue ActiveRecord::ActiveRecordError => e
+      Rails.error.report(e, context: { rate_limit_policy: name, subject: subject })
+      policy.fail_open? ? Result.new(allowed: true, retry_after: 0.0) : Result.new(allowed: false, retry_after: FAIL_CLOSED_COOLDOWN)
+    end
+
+    # Like acquire, but raises Throttled when not allowed.
+    def acquire!(name, subject:, cost:)
+      result = acquire(name, subject: subject, cost: cost)
+      raise Throttled.new(retry_after: result.retry_after) unless result.allowed?
+
+      result
+    end
+
+    # Reserve `cost` and run the block, raising Throttled if there's no room.
+    def throttle(name, subject:, cost:)
+      acquire!(name, subject: subject, cost: cost)
+      yield
+    end
+
+    # Adjust buckets after the fact, when the real cost differs from the
+    # estimate (LLM output tokens, actual bytes). A positive amount consumes
+    # more; a negative amount credits tokens back (capped at burst).
+    def reconcile(name, subject:, cost:)
+      policy = policy(name)
+      buckets = policy.buckets_for(cost)
+      with_locked_row(name, subject, create: false) do |row, _now|
+        next unless row
+
+        data = row.data
+        buckets.each do |limit, amount|
+          state = data[limit.bucket_key]
+          next unless state
+
+          data[limit.bucket_key] = { "t" => [state["t"] - amount, limit.burst.to_f].min, "r" => state["r"] }
+        end
+        row.update!(data: data)
+      end
+    end
+
+    # Record a server-imposed cooldown (e.g. on a real 429). Until it passes,
+    # acquire short-circuits to throttled for this subject.
+    def penalize(name, subject:, retry_after:)
+      with_locked_row(name, subject) do |row, _now|
+        row.update!(blocked_until: retry_after.seconds.from_now)
+      end
+    end
+
+    private
+
+    def registry
+      @registry ||= {}
+    end
+
+    def with_locked_row(name, subject, create: true)
+      key = "#{name}:#{subject}"
+      # Ensure the row exists before locking. Doing find-or-create inside the
+      # locking transaction would abort it on a concurrent insert (Postgres),
+      # surfacing as a StatementInvalid that fail-open would wrongly admit.
+      # create_or_find_by handles the race in its own savepoint.
+      Bucket.create_or_find_by!(key: key) if create
+      Bucket.transaction do
+        row = Bucket.lock.find_by(key: key)
+        yield(row, Time.current.to_f)
+      end
+    end
+
+    def consume(row, buckets, now)
+      return Result.new(allowed: false, retry_after: row.blocked_until.to_f - now) if blocked?(row, now)
+
+      data = row.data
+      new_states = {}
+      shortfalls = []
+
+      buckets.each do |limit, amount|
+        available = available_tokens(data[limit.bucket_key], limit, now)
+        if available >= amount
+          new_states[limit.bucket_key] = { "t" => available - amount, "r" => now }
+        else
+          shortfalls << (amount - available) / limit.rate_per_sec
+        end
+      end
+
+      return Result.new(allowed: false, retry_after: shortfalls.max) if shortfalls.any?
+
+      row.update!(data: data.merge(new_states))
+      Result.new(allowed: true, retry_after: 0.0)
+    end
+
+    def blocked?(row, now)
+      row.blocked_until.present? && row.blocked_until.to_f > now
+    end
+
+    def available_tokens(state, limit, now)
+      state ||= { "t" => limit.burst.to_f, "r" => now }
+      elapsed = now - state["r"]
+      [limit.burst.to_f, state["t"] + (elapsed * limit.rate_per_sec)].min
+    end
+  end
+end

--- a/app/services/rate_limit.rb
+++ b/app/services/rate_limit.rb
@@ -77,12 +77,19 @@ module RateLimit
   FAIL_CLOSED_COOLDOWN = 60.0
 
   class << self
+    # Register a policy from a configuration block (see Policy DSL).
+    # @param name [Symbol, String] the policy name (e.g. :freefeed)
+    # @yield evaluated in the Policy instance to declare `limit`s and `fail_open`
     def define(name, &block)
       policy = Policy.new(name.to_sym)
       policy.instance_eval(&block)
       registry[name.to_sym] = policy
     end
 
+    # Look up a registered policy.
+    # @param name [Symbol, String] the policy name
+    # @return [Policy]
+    # @raise [ArgumentError] if the policy is not registered
     def policy(name)
       registry.fetch(name.to_sym) { raise ArgumentError, "Unknown rate limit policy: #{name}" }
     end
@@ -92,7 +99,11 @@ module RateLimit
       @registry = {}
     end
 
-    # Try to reserve `cost`. Returns a Result; never raises for being over limit.
+    # Try to reserve `cost`. Never raises for being over limit.
+    # @param name [Symbol, String] the policy name
+    # @param subject [String] identity that owns the allowance (e.g. "freefeed:7")
+    # @param cost [Hash{Symbol=>Numeric}] tokens to spend per dimension
+    # @return [Result] allowed? and retry_after (seconds) when not allowed
     def acquire(name, subject:, cost:)
       policy = policy(name)
       buckets = policy.buckets_for(cost)
@@ -102,7 +113,12 @@ module RateLimit
       policy.fail_open? ? Result.new(allowed: true, retry_after: 0.0) : Result.new(allowed: false, retry_after: FAIL_CLOSED_COOLDOWN)
     end
 
-    # Like acquire, but raises Throttled when not allowed.
+    # Like acquire, but raises when not allowed.
+    # @param name [Symbol, String] the policy name
+    # @param subject [String] identity that owns the allowance
+    # @param cost [Hash{Symbol=>Numeric}] tokens to spend per dimension
+    # @return [Result]
+    # @raise [Throttled] with retry_after (seconds) when over limit
     def acquire!(name, subject:, cost:)
       result = acquire(name, subject: subject, cost: cost)
       raise Throttled.new(retry_after: result.retry_after) unless result.allowed?
@@ -110,15 +126,25 @@ module RateLimit
       result
     end
 
-    # Reserve `cost` and run the block, raising Throttled if there's no room.
+    # Reserve `cost`, then run the block. Raises if there's no room.
+    # @param name [Symbol, String] the policy name
+    # @param subject [String] identity that owns the allowance
+    # @param cost [Hash{Symbol=>Numeric}] tokens to spend per dimension
+    # @yield runs only when the reservation succeeds
+    # @raise [Throttled] when over limit (the block does not run)
     def throttle(name, subject:, cost:)
       acquire!(name, subject: subject, cost: cost)
       yield
     end
 
     # Adjust buckets after the fact, when the real cost differs from the
-    # estimate (LLM output tokens, actual bytes). A positive amount consumes
-    # more; a negative amount credits tokens back (capped at burst).
+    # estimate (LLM output tokens, actual bytes). No-op if the subject has no
+    # state yet.
+    # @param name [Symbol, String] the policy name
+    # @param subject [String] identity that owns the allowance
+    # @param cost [Hash{Symbol=>Numeric}] per-dimension adjustment; positive
+    #   consumes more, negative credits tokens back (capped at burst)
+    # @return [void]
     def reconcile(name, subject:, cost:)
       policy = policy(name)
       buckets = policy.buckets_for(cost)
@@ -140,6 +166,10 @@ module RateLimit
 
     # Record a server-imposed cooldown (e.g. on a real 429). Until it passes,
     # acquire short-circuits to throttled for this subject.
+    # @param name [Symbol, String] the policy name
+    # @param subject [String] identity that owns the allowance
+    # @param retry_after [Numeric] seconds to block the subject for
+    # @return [void]
     def penalize(name, subject:, retry_after:)
       with_locked_row(name, subject) do |row, _now|
         row.update!(blocked_until: retry_after.seconds.from_now)

--- a/app/services/rate_limit.rb
+++ b/app/services/rate_limit.rb
@@ -122,15 +122,17 @@ module RateLimit
     def reconcile(name, subject:, cost:)
       policy = policy(name)
       buckets = policy.buckets_for(cost)
-      with_locked_row(name, subject, create: false) do |row, _now|
+      with_locked_row(name, subject, create: false) do |row, now|
         next unless row
 
         data = row.data
         buckets.each do |limit, amount|
-          state = data[limit.bucket_key]
-          next unless state
+          next unless data.key?(limit.bucket_key)
 
-          data[limit.bucket_key] = { "tokens" => [state["tokens"] - amount, limit.burst.to_f].min, "refilled_at" => state["refilled_at"] }
+          # Refill to `now` first (same as acquire) so the delta isn't applied
+          # against a stale base or swallowed by the burst cap.
+          available = available_tokens(data[limit.bucket_key], limit, now)
+          data[limit.bucket_key] = { "tokens" => [available - amount, limit.burst.to_f].min, "refilled_at" => now }
         end
         row.update!(data: data)
       end

--- a/app/services/rate_limit.rb
+++ b/app/services/rate_limit.rb
@@ -120,7 +120,7 @@ module RateLimit
           state = data[limit.bucket_key]
           next unless state
 
-          data[limit.bucket_key] = { "t" => [state["t"] - amount, limit.burst.to_f].min, "r" => state["r"] }
+          data[limit.bucket_key] = { "tokens" => [state["tokens"] - amount, limit.burst.to_f].min, "refilled_at" => state["refilled_at"] }
         end
         row.update!(data: data)
       end
@@ -163,7 +163,7 @@ module RateLimit
       buckets.each do |limit, amount|
         available = available_tokens(data[limit.bucket_key], limit, now)
         if available >= amount
-          new_states[limit.bucket_key] = { "t" => available - amount, "r" => now }
+          new_states[limit.bucket_key] = { "tokens" => available - amount, "refilled_at" => now }
         else
           shortfalls << (amount - available) / limit.rate_per_sec
         end
@@ -180,9 +180,9 @@ module RateLimit
     end
 
     def available_tokens(state, limit, now)
-      state ||= { "t" => limit.burst.to_f, "r" => now }
-      elapsed = now - state["r"]
-      [limit.burst.to_f, state["t"] + (elapsed * limit.rate_per_sec)].min
+      state ||= { "tokens" => limit.burst.to_f, "refilled_at" => now }
+      elapsed = now - state["refilled_at"]
+      [limit.burst.to_f, state["tokens"] + (elapsed * limit.rate_per_sec)].min
     end
   end
 end

--- a/db/migrate/20260607150000_create_rate_limit_buckets.rb
+++ b/db/migrate/20260607150000_create_rate_limit_buckets.rb
@@ -1,0 +1,13 @@
+class CreateRateLimitBuckets < ActiveRecord::Migration[8.2]
+  def change
+    create_table :rate_limit_buckets do |t|
+      t.string :key, null: false
+      t.jsonb :data, null: false, default: {}
+      t.datetime :blocked_until
+
+      t.timestamps
+    end
+
+    add_index :rate_limit_buckets, :key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_06_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_07_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -238,6 +238,15 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_06_120000) do
     t.index ["feed_entry_id"], name: "index_posts_on_feed_entry_id"
     t.index ["feed_id", "uid"], name: "index_posts_on_feed_id_and_uid", unique: true
     t.index ["feed_id"], name: "index_posts_on_feed_id"
+  end
+
+  create_table "rate_limit_buckets", force: :cascade do |t|
+    t.string "key", null: false
+    t.jsonb "data", default: {}, null: false
+    t.datetime "blocked_until"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_rate_limit_buckets_on_key", unique: true
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/test/services/rate_limit_test.rb
+++ b/test/services/rate_limit_test.rb
@@ -1,0 +1,200 @@
+require "test_helper"
+
+class RateLimitTest < ActiveSupport::TestCase
+  setup { RateLimit.reset! }
+  teardown { RateLimit.reset! }
+
+  def cost(**dims) = dims
+
+  test ".acquire should allow up to burst then throttle" do
+    RateLimit.define(:t) { limit :requests, 5, per: 60 }
+
+    5.times { assert RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed? }
+    refute RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+  end
+
+  test ".acquire should meter subjects independently" do
+    RateLimit.define(:t) { limit :requests, 1, per: 60 }
+
+    assert RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+    assert RateLimit.acquire(:t, subject: "b", cost: cost(requests: 1)).allowed?
+    refute RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+  end
+
+  test ".acquire should refill continuously over time" do
+    RateLimit.define(:t) { limit :requests, 60, per: 60 } # 1 token/sec
+
+    # travel_to truncates sub-second precision; a usec-zero base keeps elapsed exact
+    travel_to Time.current.change(usec: 0)
+    60.times { RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)) }
+    refute RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+
+    travel_to Time.current + 10.seconds
+    assert RateLimit.acquire(:t, subject: "a", cost: cost(requests: 10)).allowed?
+    refute RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+  end
+
+  test ".acquire should cap accumulation at burst, not rate times idle" do
+    RateLimit.define(:t) { limit :requests, 5, per: 60 }
+
+    travel_to Time.current.change(usec: 0)
+    5.times { RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)) }
+
+    travel_to Time.current + 1.hour
+    5.times { assert RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed? }
+    refute RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+  end
+
+  test ".acquire should support sub-second windows" do
+    RateLimit.define(:t) { limit :requests, 1, per: 1 }
+
+    travel_to Time.current.change(usec: 0)
+    assert RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+    refute RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+
+    travel_to Time.current + 1.second
+    assert RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+  end
+
+  test ".acquire should be all-or-nothing across dimensions" do
+    RateLimit.define(:llm) do
+      limit :requests, 10, per: 60
+      limit :tokens, 100, per: 60
+    end
+
+    assert RateLimit.acquire(:llm, subject: "a", cost: cost(requests: 1, tokens: 100)).allowed?
+    # tokens are exhausted; this call must be denied AND must not consume a request
+    refute RateLimit.acquire(:llm, subject: "a", cost: cost(requests: 1, tokens: 1)).allowed?
+    # proof the request token was not consumed by the denied call
+    assert RateLimit.acquire(:llm, subject: "a", cost: cost(requests: 1)).allowed?
+  end
+
+  test ".acquire should enforce multiple windows on the same dimension" do
+    RateLimit.define(:t) do
+      limit :requests, 100, per: 60   # generous per minute
+      limit :requests, 3, per: 3600   # tight per hour
+    end
+
+    3.times { assert RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed? }
+    refute RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+  end
+
+  test ".acquire should allow dimensions without a declared limit" do
+    RateLimit.define(:t) { limit :requests, 1, per: 60 }
+
+    assert RateLimit.acquire(:t, subject: "a", cost: cost(other: 999)).allowed?
+  end
+
+  test ".acquire should raise for an unknown policy" do
+    assert_raises(ArgumentError) do
+      RateLimit.acquire(:nope, subject: "a", cost: cost(requests: 1))
+    end
+  end
+
+  test ".acquire! should raise Throttled with a positive retry_after" do
+    RateLimit.define(:t) { limit :requests, 1, per: 60 }
+
+    RateLimit.acquire!(:t, subject: "a", cost: cost(requests: 1))
+    error = assert_raises(RateLimit::Throttled) do
+      RateLimit.acquire!(:t, subject: "a", cost: cost(requests: 1))
+    end
+    assert error.retry_after > 0
+  end
+
+  test ".throttle should yield when allowed and raise when not" do
+    RateLimit.define(:t) { limit :requests, 1, per: 60 }
+
+    ran = false
+    RateLimit.throttle(:t, subject: "a", cost: cost(requests: 1)) { ran = true }
+    assert ran
+
+    assert_raises(RateLimit::Throttled) do
+      RateLimit.throttle(:t, subject: "a", cost: cost(requests: 1)) { flunk "should not run" }
+    end
+  end
+
+  test ".reconcile should consume additional tokens for an under-estimate" do
+    RateLimit.define(:t) { limit :tokens, 100, per: 60 }
+
+    RateLimit.acquire!(:t, subject: "a", cost: cost(tokens: 10)) # estimated 10
+    RateLimit.reconcile(:t, subject: "a", cost: cost(tokens: 90)) # actual was 100
+
+    refute RateLimit.acquire(:t, subject: "a", cost: cost(tokens: 1)).allowed?
+  end
+
+  test ".reconcile should credit tokens back for an over-estimate" do
+    RateLimit.define(:t) { limit :tokens, 100, per: 60 }
+
+    RateLimit.acquire!(:t, subject: "a", cost: cost(tokens: 100)) # drains the bucket
+    RateLimit.reconcile(:t, subject: "a", cost: cost(tokens: -50)) # actual was only 50
+
+    assert RateLimit.acquire(:t, subject: "a", cost: cost(tokens: 50)).allowed?
+  end
+
+  test ".reconcile should do nothing when the subject has no row" do
+    RateLimit.define(:t) { limit :tokens, 100, per: 60 }
+
+    assert_nothing_raised { RateLimit.reconcile(:t, subject: "missing", cost: cost(tokens: 5)) }
+  end
+
+  test ".penalize should block acquire until the cooldown passes" do
+    RateLimit.define(:t) { limit :requests, 100, per: 60 }
+
+    RateLimit.penalize(:t, subject: "a", retry_after: 30)
+
+    result = RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1))
+    refute result.allowed?
+    assert_in_delta 30, result.retry_after, 2
+
+    travel 31.seconds do
+      assert RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+    end
+  end
+
+  test ".acquire should fail open by default on a storage error" do
+    RateLimit.define(:t) { limit :requests, 1, per: 60 }
+
+    RateLimit::Bucket.stub(:transaction, ->(*) { raise ActiveRecord::StatementInvalid, "boom" }) do
+      assert RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+    end
+  end
+
+  test ".acquire should fail closed when the policy is configured to" do
+    RateLimit.define(:t) do
+      limit :requests, 1, per: 60
+      fail_open false
+    end
+
+    RateLimit::Bucket.stub(:transaction, ->(*) { raise ActiveRecord::StatementInvalid, "boom" }) do
+      refute RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1)).allowed?
+    end
+  end
+end
+
+class RateLimitConcurrencyTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  setup do
+    RateLimit.reset!
+    RateLimit.define(:t) { limit :requests, 5, per: 60 }
+    RateLimit::Bucket.delete_all
+  end
+
+  teardown do
+    RateLimit::Bucket.delete_all
+    RateLimit.reset!
+  end
+
+  test "parallel acquire on the same subject does not over-admit" do
+    threads = 20.times.map do
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          RateLimit.acquire(:t, subject: "shared", cost: { requests: 1 }).allowed?
+        end
+      end
+    end
+
+    allowed = threads.map(&:value).count(true)
+    assert_equal 5, allowed, "burst is 5, so exactly 5 of 20 concurrent calls should be allowed"
+  end
+end

--- a/test/services/rate_limit_test.rb
+++ b/test/services/rate_limit_test.rb
@@ -4,7 +4,9 @@ class RateLimitTest < ActiveSupport::TestCase
   setup { RateLimit.reset! }
   teardown { RateLimit.reset! }
 
-  def cost(**dims) = dims
+  def cost(**dims)
+    dims
+  end
 
   test ".acquire should allow up to burst then throttle" do
     RateLimit.define(:t) { limit :requests, 5, per: 60 }

--- a/test/services/rate_limit_test.rb
+++ b/test/services/rate_limit_test.rb
@@ -133,6 +133,19 @@ class RateLimitTest < ActiveSupport::TestCase
     assert RateLimit.acquire(:t, subject: "a", cost: cost(tokens: 50)).allowed?
   end
 
+  test ".reconcile should refill before adjusting, so the delta isn't swallowed by the burst cap" do
+    RateLimit.define(:t) { limit :tokens, 60, per: 60, burst: 100 } # 1 token/sec, cap 100
+
+    travel_to Time.current.change(usec: 0)
+    RateLimit.acquire!(:t, subject: "a", cost: cost(tokens: 10)) # 90 left
+    travel_to Time.current + 60.seconds                          # refills, capped at 100
+    RateLimit.reconcile(:t, subject: "a", cost: cost(tokens: 5)) # actually used 5 more
+
+    # refill caps at 100, minus the 5 reconciled => exactly 95 available
+    assert RateLimit.acquire(:t, subject: "a", cost: cost(tokens: 95)).allowed?
+    refute RateLimit.acquire(:t, subject: "a", cost: cost(tokens: 1)).allowed?
+  end
+
   test ".reconcile should do nothing when the subject has no row" do
     RateLimit.define(:t) { limit :tokens, 100, per: 60 }
 


### PR DESCRIPTION
Changes:

- Add the generalized `RateLimit` service: token-bucket limiter with lazy continuous refill, policies declared up front, and a small API (`acquire`/`acquire!`/`throttle`/`reconcile`/`penalize`).
- Add the `rate_limit_buckets` table (migration) and `RateLimit::Bucket` model — one row per `(policy, subject)`, all of a subject's per-`(dimension, window)` buckets in one JSONB column.

The foundation for rate-limiting external API calls (see `docs/rate-limiting.md`). A call spends `cost` tokens per dimension and is allowed only if every bucket it touches has room (multi-dimension all-or-nothing; multi-window per dimension supported). State is mutated atomically per subject under a row lock, so concurrent jobs sharing a subject can't over-admit. `penalize` records a server-imposed cooldown (`blocked_until`) honored by later `acquire`s; `reconcile` trues up estimated costs after the fact. Storage errors fall open or closed per policy. Nothing consumes this service yet — FreeFeed wiring and the rest follow in sibling issues.

References:

- Part of #609
- Closes #611
