### PR TITLE
Add FreeFeed rate limit policy and token subject

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -63,6 +63,14 @@ class AccessToken < ApplicationRecord
     FreefeedClient.new(host: host, token: encrypted_token)
   end
 
+  # Identity used for rate limiting FreeFeed API calls. Keyed per token: FreeFeed
+  # actually meters per account, so multiple tokens for the same FreeFeed user
+  # share its real bucket, but that rare over-count is covered by the 429
+  # backstop. A token id is stable and always present. See docs/rate-limiting.md.
+  def rate_limit_subject
+    "freefeed:#{id}"
+  end
+
   def host_domain
     URI.parse(host).host
   end

--- a/config/initializers/rate_limits.rb
+++ b/config/initializers/rate_limits.rb
@@ -3,13 +3,21 @@
 # Wrapped in to_prepare so RateLimit (an autoloaded app constant) is available
 # and policies are re-registered on code reload in development.
 #
-# FreeFeed meters per HTTP method (see docs/rate-limiting-freefeed.md), so every
-# POST a publish makes — the post itself, each comment, AND each attachment
-# upload (POST /v1/attachments) — counts against the same POST bucket. We use a
-# single :post dimension set below FreeFeed's 60 POST/min ceiling. (The 1000/min
-# attachments limit FreeFeed documents is for GET downloads, not uploads.)
+# FreeFeed meters per HTTP method, per authenticated user. Limits below sit under
+# FreeFeed's ceilings (freefeed-server config/default.js, authenticated.maxRequests;
+# keyed by method in app/support/rateLimiter.ts — see docs/rate-limiting-freefeed.md):
+#
+#   POST            60/min  — every POST a publish makes: the post itself, each
+#                             comment, and each attachment upload (POST /v1/attachments)
+#   GET            200/min  — whoami, managedGroups (token validation)
+#   DELETE (`all`)  30/min  — post withdrawal / group purge (1 DELETE per post)
+#
+# FreeFeed also allows GET /vN/attachments/:attId/:type 1000/min, but that's the
+# attachment-download route, which Feeder never calls — so it gets no bucket.
 Rails.application.config.to_prepare do
   RateLimit.define :freefeed do
-    limit :post, 50, per: 1.minute # under FreeFeed's 60 POST/min
+    limit :post, 50, per: 1.minute   # under FreeFeed POST 60/min
+    limit :get, 150, per: 1.minute   # under FreeFeed GET 200/min
+    limit :delete, 25, per: 1.minute # under FreeFeed `all` fallback 30/min
   end
 end

--- a/config/initializers/rate_limits.rb
+++ b/config/initializers/rate_limits.rb
@@ -3,13 +3,13 @@
 # Wrapped in to_prepare so RateLimit (an autoloaded app constant) is available
 # and policies are re-registered on code reload in development.
 #
-# FreeFeed meters per HTTP method (see docs/rate-limiting-freefeed.md). We set
-# our limits below FreeFeed's defaults to keep a safety margin, and give
-# attachment uploads their own (higher) bucket so a media-heavy post isn't
-# throttled by the tighter post limit.
+# FreeFeed meters per HTTP method (see docs/rate-limiting-freefeed.md), so every
+# POST a publish makes — the post itself, each comment, AND each attachment
+# upload (POST /v1/attachments) — counts against the same POST bucket. We use a
+# single :post dimension set below FreeFeed's 60 POST/min ceiling. (The 1000/min
+# attachments limit FreeFeed documents is for GET downloads, not uploads.)
 Rails.application.config.to_prepare do
   RateLimit.define :freefeed do
-    limit :post, 50, per: 1.minute        # under FreeFeed's 60 POST/min
-    limit :attachment, 500, per: 1.minute # under the 1000/min attachments-route bucket
+    limit :post, 50, per: 1.minute # under FreeFeed's 60 POST/min
   end
 end

--- a/config/initializers/rate_limits.rb
+++ b/config/initializers/rate_limits.rb
@@ -1,0 +1,15 @@
+# Rate limit policies for external APIs. See docs/rate-limiting.md.
+#
+# Wrapped in to_prepare so RateLimit (an autoloaded app constant) is available
+# and policies are re-registered on code reload in development.
+#
+# FreeFeed meters per HTTP method (see docs/rate-limiting-freefeed.md). We set
+# our limits below FreeFeed's defaults to keep a safety margin, and give
+# attachment uploads their own (higher) bucket so a media-heavy post isn't
+# throttled by the tighter post limit.
+Rails.application.config.to_prepare do
+  RateLimit.define :freefeed do
+    limit :post, 50, per: 1.minute        # under FreeFeed's 60 POST/min
+    limit :attachment, 500, per: 1.minute # under the 1000/min attachments-route bucket
+  end
+end

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -59,7 +59,7 @@ behalf of a subject. That single shape covers every use case:
 
 | Use case            | Policy       | Subject              | Dimensions (cost)               |
 |---------------------|--------------|----------------------|---------------------------------|
-| Post to FreeFeed    | `:freefeed`  | `freefeed:<token id>`| `post: N`, `attachment: M`      |
+| Post to FreeFeed    | `:freefeed`  | `freefeed:<token id>`| `post: N` (post + comments + uploads) |
 | LLM fetch/processing| `:openai`    | api-key id           | `requests: 1`, `tokens: ~1500`  |
 | Web fetch (loader)  | `:web_fetch` | domain               | `requests: 1`                   |
 
@@ -176,7 +176,7 @@ subject's buckets live in one **JSONB** column; only mutable state is persisted
 
 ```
 key          text   -- "policy:subject", e.g. "freefeed:7"
-data         jsonb  -- { "post/1m": {tokens, refilled_at}, "attachment/1m": {...} }
+data         jsonb  -- { "post/1m": {tokens, refilled_at}, ... }
 blocked_until timestamptz  -- set by penalize() on a real 429; short-circuits acquire
 ```
 
@@ -221,7 +221,7 @@ reschedule rather than a blocked worker. The flow:
 
 1. **Reserve the whole job's cost up front**, in one `acquire!`, *before* any
    API call. A job computes its total cost ahead of time (for FreeFeed publish:
-   `{ post: 1 + comments, attachment: attachments }`).
+   `{ post: 1 + comments + attachments }` — attachment uploads are POSTs too).
 2. **Throttled → reschedule** the job with `wait: retry_after` (+ jitter).
    Nothing was sent, so there's no partial work.
 3. **Granted → run all calls straight through** without re-consulting the
@@ -286,7 +286,7 @@ buckets keyed per `(dimension, window)`:
 
 | Provider    | Buckets                                                    |
 |-------------|-----------------------------------------------------------|
-| FreeFeed    | `post/1m`, `attachment/1m` (per-method)                    |
+| FreeFeed    | `post/1m` (post + comments + attachment uploads are all POSTs) |
 | Anthropic   | `requests/1m`, `input_tokens/1m`, `output_tokens/1m`      |
 | OpenAI      | `requests/1m`, `requests/1d`, `tokens/1m`, `tokens/1d`    |
 | OpenRouter  | `requests/1m`, `requests/1d`                              |

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,8 +1,9 @@
 # Generalized Request Rate Limiting (Working Draft)
 
-> **Status:** working draft — design agreed, not yet implemented. Captures the
-> concepts, public API, storage, and integration plan for a shared
-> rate-limiting mechanism.
+> **Status:** being implemented (tracked in #609). The `RateLimit` service and
+> storage, the `:freefeed` policy, and async publishing have shipped; FreeFeed
+> call/job wiring is in progress. This doc captures the concepts, public API,
+> storage, and integration plan.
 
 ## Goal
 
@@ -122,8 +123,9 @@ Policies are declared up front, in plain, readable terms:
 
 ```ruby
 RateLimit.define :freefeed do
-  limit :requests, 25, per: 1.minute   # stay under the provider's ceiling
-  limit :posts,    50, per: 1.minute
+  limit :post,   50, per: 1.minute   # post + comments + attachment uploads (POSTs)
+  limit :get,   150, per: 1.minute   # whoami, managedGroups
+  limit :delete, 25, per: 1.minute   # withdrawal / group purge
 end
 
 RateLimit.define :openai do

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -286,7 +286,7 @@ buckets keyed per `(dimension, window)`:
 
 | Provider    | Buckets                                                    |
 |-------------|-----------------------------------------------------------|
-| FreeFeed    | `post/1m` (post + comments + attachment uploads are all POSTs) |
+| FreeFeed    | `post/1m` (post + comments + uploads), `get/1m`, `delete/1m` |
 | Anthropic   | `requests/1m`, `input_tokens/1m`, `output_tokens/1m`      |
 | OpenAI      | `requests/1m`, `requests/1d`, `tokens/1m`, `tokens/1d`    |
 | OpenRouter  | `requests/1m`, `requests/1d`                              |

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -11,6 +11,10 @@ class AccessTokenTest < ActiveSupport::TestCase
     @user ||= create(:user)
   end
 
+  test "#rate_limit_subject is keyed by the token id" do
+    assert_equal "freefeed:#{access_token.id}", access_token.rate_limit_subject
+  end
+
   test ".build_with_token stores encrypted token and sets pending status" do
     token = AccessToken.build_with_token(
       name: "Test Token",

--- a/test/services/rate_limit_freefeed_policy_test.rb
+++ b/test/services/rate_limit_freefeed_policy_test.rb
@@ -9,6 +9,20 @@ class RateLimitFreefeedPolicyTest < ActiveSupport::TestCase
     assert_equal 60, limit.window
   end
 
+  test "the :freefeed policy limits gets under FreeFeed's GET ceiling" do
+    limit = RateLimit.policy(:freefeed).buckets_for(get: 1).map(&:first).sole
+
+    assert_equal 150, limit.rate
+    assert_equal 60, limit.window
+  end
+
+  test "the :freefeed policy limits deletes under FreeFeed's fallback ceiling" do
+    limit = RateLimit.policy(:freefeed).buckets_for(delete: 1).map(&:first).sole
+
+    assert_equal 25, limit.rate
+    assert_equal 60, limit.window
+  end
+
   test "the :freefeed policy fails open" do
     assert RateLimit.policy(:freefeed).fail_open?
   end

--- a/test/services/rate_limit_freefeed_policy_test.rb
+++ b/test/services/rate_limit_freefeed_policy_test.rb
@@ -9,13 +9,6 @@ class RateLimitFreefeedPolicyTest < ActiveSupport::TestCase
     assert_equal 60, limit.window
   end
 
-  test "the :freefeed policy gives attachments their own higher bucket" do
-    limit = RateLimit.policy(:freefeed).buckets_for(attachment: 1).map(&:first).sole
-
-    assert_equal 500, limit.rate
-    assert_equal 60, limit.window
-  end
-
   test "the :freefeed policy fails open" do
     assert RateLimit.policy(:freefeed).fail_open?
   end

--- a/test/services/rate_limit_freefeed_policy_test.rb
+++ b/test/services/rate_limit_freefeed_policy_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+# Verifies the :freefeed policy registered by config/initializers/rate_limits.rb.
+class RateLimitFreefeedPolicyTest < ActiveSupport::TestCase
+  test "the :freefeed policy limits posts under FreeFeed's POST ceiling" do
+    limit = RateLimit.policy(:freefeed).buckets_for(post: 1).map(&:first).sole
+
+    assert_equal 50, limit.rate
+    assert_equal 60, limit.window
+  end
+
+  test "the :freefeed policy gives attachments their own higher bucket" do
+    limit = RateLimit.policy(:freefeed).buckets_for(attachment: 1).map(&:first).sole
+
+    assert_equal 500, limit.rate
+    assert_equal 60, limit.window
+  end
+
+  test "the :freefeed policy fails open" do
+    assert RateLimit.policy(:freefeed).fail_open?
+  end
+end

--- a/test/services/rate_limit_test.rb
+++ b/test/services/rate_limit_test.rb
@@ -1,8 +1,13 @@
 require "test_helper"
 
 class RateLimitTest < ActiveSupport::TestCase
-  setup { RateLimit.reset! }
-  teardown { RateLimit.reset! }
+  # Isolate the registry per test, but restore the app's real policies (defined
+  # in an initializer) afterward so other tests still see them.
+  setup do
+    @registry_backup = RateLimit.instance_variable_get(:@registry)
+    RateLimit.reset!
+  end
+  teardown { RateLimit.instance_variable_set(:@registry, @registry_backup) }
 
   def cost(**dims)
     dims
@@ -190,6 +195,7 @@ class RateLimitConcurrencyTest < ActiveSupport::TestCase
   self.use_transactional_tests = false
 
   setup do
+    @registry_backup = RateLimit.instance_variable_get(:@registry)
     RateLimit.reset!
     RateLimit.define(:t) { limit :requests, 5, per: 60 }
     RateLimit::Bucket.delete_all
@@ -197,7 +203,7 @@ class RateLimitConcurrencyTest < ActiveSupport::TestCase
 
   teardown do
     RateLimit::Bucket.delete_all
-    RateLimit.reset!
+    RateLimit.instance_variable_set(:@registry, @registry_backup)
   end
 
   test "parallel acquire on the same subject does not over-admit" do


### PR DESCRIPTION
Changes:

- Register a `:freefeed` rate limit policy (`config/initializers/rate_limits.rb`): `post` 50/min and `attachment` 500/min, set below FreeFeed's per-method ceilings.
- Add `AccessToken#rate_limit_subject` (`freefeed:<id>`) — the per-token identity used to key the limiter.

Configuration only; nothing calls the limiter yet (client/job wiring follows in #615 and #617). Limits and rationale follow `docs/rate-limiting.md` and `docs/rate-limiting-freefeed.md`. The policy is registered via `to_prepare` so it survives code reloads in development.

References:

- Part of #609
- Closes #613
