### PR TITLE
Reserve rate limit capacity in FreeFeed jobs

### DIFF
--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -10,6 +10,8 @@
 # off again and it resumes from the earliest remaining post. It also recovers
 # feeds that were disabled and later re-enabled.
 class PostPublishJob < ApplicationJob
+  include RateLimited
+
   queue_as :default
 
   def perform(feed_id)
@@ -38,8 +40,13 @@ class PostPublishJob < ApplicationJob
   end
 
   def publish(feed, post)
+    reserve(feed, post)
     FreefeedPublisher.new(post).publish
     schedule_next(feed)
+  rescue RateLimit::Throttled
+    # No capacity: reschedule the whole job (RateLimited) for the same post.
+    # Must precede the generic rescue so it isn't recorded as a failure.
+    raise
   rescue FreefeedClient::UnauthorizedError
     # Token is no longer valid: disable it and stop the chain.
     feed.access_token&.disable_token_and_feeds
@@ -49,6 +56,13 @@ class PostPublishJob < ApplicationJob
     Rails.logger.error "Failed to publish post #{post.id}: #{e.message}"
     Rails.error.report(e, context: { post: post.attributes, feed: feed.attributes })
     schedule_next(feed)
+  end
+
+  # Reserve every POST the publish will make (the post, each comment, and each
+  # attachment upload) against the FreeFeed POST bucket, up front and atomically.
+  def reserve(feed, post)
+    posts = 1 + post.comments.to_a.count(&:present?) + post.attachment_urls.to_a.size
+    RateLimit.acquire!(:freefeed, subject: feed.access_token.rate_limit_subject, cost: { post: posts })
   end
 
   def schedule_next(feed)

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -40,12 +40,15 @@ class PostPublishJob < ApplicationJob
   end
 
   def publish(feed, post)
-    reserve(feed, post)
+    posts = post_cost(post)
+    return reject_oversized(feed, post, posts) unless within_capacity?(posts)
+
+    RateLimit.acquire!(:freefeed, subject: feed.access_token.rate_limit_subject, cost: { post: posts })
     FreefeedPublisher.new(post).publish
     schedule_next(feed)
   rescue RateLimit::Throttled
-    # No capacity: reschedule the whole job (RateLimited) for the same post.
-    # Must precede the generic rescue so it isn't recorded as a failure.
+    # No capacity right now: reschedule the whole job (RateLimited) for the same
+    # post. Must precede the generic rescue so it isn't recorded as a failure.
     raise
   rescue FreefeedClient::UnauthorizedError
     # Token is no longer valid: disable it and stop the chain.
@@ -58,11 +61,23 @@ class PostPublishJob < ApplicationJob
     schedule_next(feed)
   end
 
-  # Reserve every POST the publish will make (the post, each comment, and each
-  # attachment upload) against the FreeFeed POST bucket, up front and atomically.
-  def reserve(feed, post)
-    posts = 1 + post.comments.to_a.count(&:present?) + post.attachment_urls.to_a.size
-    RateLimit.acquire!(:freefeed, subject: feed.access_token.rate_limit_subject, cost: { post: posts })
+  # Every POST the publish will make: the post, each comment, and each
+  # attachment upload (all hit FreeFeed's POST bucket).
+  def post_cost(post)
+    1 + post.comments.to_a.count(&:present?) + post.attachment_urls.to_a.size
+  end
+
+  def within_capacity?(posts)
+    capacity = RateLimit.capacity(:freefeed, :post)
+    capacity.nil? || posts <= capacity
+  end
+
+  # A post needing more POSTs than the bucket can ever hold would throttle
+  # forever and block the queue, so fail it and move on.
+  def reject_oversized(feed, post, posts)
+    post.update!(status: :failed)
+    Rails.logger.error "Post #{post.id} needs #{posts} POSTs, over the FreeFeed limit; marking failed"
+    schedule_next(feed)
   end
 
   def schedule_next(feed)

--- a/app/jobs/post_withdrawal_job.rb
+++ b/app/jobs/post_withdrawal_job.rb
@@ -1,4 +1,6 @@
 class PostWithdrawalJob < ApplicationJob
+  include RateLimited
+
   queue_as :default
 
   def perform(feed_id, freefeed_post_id, post_id = nil)
@@ -9,6 +11,8 @@ class PostWithdrawalJob < ApplicationJob
 
     access_token = feed.access_token
     return unless access_token&.active?
+
+    RateLimit.acquire!(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
 
     client = access_token.build_client
     client.delete_post(freefeed_post_id)

--- a/app/jobs/rate_limited.rb
+++ b/app/jobs/rate_limited.rb
@@ -1,0 +1,22 @@
+# Shared throttle handling for jobs that reserve RateLimit capacity.
+#
+# On RateLimit::Throttled, reschedules the job after the limiter's retry_after
+# (plus a little jitter to avoid stampedes), up to MAX_ATTEMPTS. After that it
+# reports and gives up — the recurring schedulers re-kick work later, so giving
+# up is not permanent.
+module RateLimited
+  extend ActiveSupport::Concern
+
+  MAX_ATTEMPTS = 10
+  JITTER_SECONDS = 5
+
+  included do
+    rescue_from(RateLimit::Throttled) do |error|
+      if executions < MAX_ATTEMPTS
+        retry_job(wait: error.retry_after + rand(0.0..JITTER_SECONDS))
+      else
+        Rails.error.report(error, context: { job: self.class.name, arguments: arguments })
+      end
+    end
+  end
+end

--- a/app/jobs/token_validation_job.rb
+++ b/app/jobs/token_validation_job.rb
@@ -1,7 +1,12 @@
 class TokenValidationJob < ApplicationJob
+  include RateLimited
+
   queue_as :default
 
   def perform(access_token)
+    # Validation makes two GETs: whoami and managedGroups.
+    RateLimit.acquire!(:freefeed, subject: access_token.rate_limit_subject, cost: { get: 2 })
+
     AccessTokenValidationService.new(access_token).call
   end
 end

--- a/app/services/rate_limit.rb
+++ b/app/services/rate_limit.rb
@@ -176,6 +176,16 @@ module RateLimit
       end
     end
 
+    # Largest cost a single acquire could ever satisfy for a dimension — the
+    # smallest bucket capacity (burst) across its windows. A cost above this can
+    # never be granted, so callers can reject it instead of throttling forever.
+    # @param name [Symbol, String] the policy name
+    # @param dimension [Symbol, String] the dimension to check
+    # @return [Numeric, nil] the capacity, or nil if the dimension is unlimited
+    def capacity(name, dimension)
+      policy(name).buckets_for(dimension => 1).map { |limit, _amount| limit.burst }.min
+    end
+
     private
 
     def registry

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -124,6 +124,22 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_equal [:freefeed, access_token.rate_limit_subject, { post: 6 }], captured
   end
 
+  test ".perform_now should fail an oversized post and advance the chain" do
+    oversized = create(:post, :enqueued, feed: feed, published_at: 2.hours.ago,
+                                         attachment_urls: Array.new(60) { |i| "https://example.com/#{i}.jpg" })
+
+    # No acquire and no publish happen for an impossible post; the chain advances.
+    captured_acquire = false
+    RateLimit.stub(:acquire!, ->(*, **) { captured_acquire = true }) do
+      assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
+        PostPublishJob.perform_now(feed.id)
+      end
+    end
+
+    assert_equal "failed", oversized.reload.status
+    refute captured_acquire, "should not try to reserve capacity it can never get"
+  end
+
   test ".perform_now should reschedule and keep the post enqueued when throttled" do
     post = create(:post, :enqueued, feed: feed)
 

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -110,6 +110,32 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_no_enqueued_jobs(only: PostPublishJob)
   end
 
+  test ".perform_now should reserve one POST per post, comment, and attachment" do
+    create(:post, :enqueued, feed: feed, comments: ["a", "b"], attachment_urls: ["u1", "u2", "u3"])
+
+    captured = nil
+    RateLimit.stub(:acquire!, lambda { |policy, subject:, cost:|
+      captured = [policy, subject, cost]
+      raise RateLimit::Throttled.new(retry_after: 1)
+    }) do
+      PostPublishJob.perform_now(feed.id)
+    end
+
+    assert_equal [:freefeed, access_token.rate_limit_subject, { post: 6 }], captured
+  end
+
+  test ".perform_now should reschedule and keep the post enqueued when throttled" do
+    post = create(:post, :enqueued, feed: feed)
+
+    RateLimit.stub(:acquire!, ->(*, **) { raise RateLimit::Throttled.new(retry_after: 2) }) do
+      assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
+        PostPublishJob.perform_now(feed.id)
+      end
+    end
+
+    assert_equal "enqueued", post.reload.status
+  end
+
   test ".perform_now should do nothing when there are no enqueued posts" do
     assert_no_enqueued_jobs(only: PostPublishJob) do
       PostPublishJob.perform_now(feed.id)

--- a/test/jobs/post_withdrawal_job_test.rb
+++ b/test/jobs/post_withdrawal_job_test.rb
@@ -13,6 +13,23 @@ class PostWithdrawalJobTest < ActiveJob::TestCase
     @feed ||= create(:feed, user: user, access_token: access_token)
   end
 
+  test ".perform_now should reserve a delete and reschedule when throttled" do
+    post = create(:post, :published, feed: feed, freefeed_post_id: "test_post_123")
+
+    captured = nil
+    RateLimit.stub(:acquire!, lambda { |_policy, subject:, cost:|
+      captured = [subject, cost]
+      raise RateLimit::Throttled.new(retry_after: 2)
+    }) do
+      assert_enqueued_with(job: PostWithdrawalJob) do
+        PostWithdrawalJob.perform_now(feed.id, "test_post_123", post.id)
+      end
+    end
+
+    assert_equal [access_token.rate_limit_subject, { delete: 1 }], captured
+    assert_not_requested :delete, "#{access_token.host}/v4/posts/test_post_123"
+  end
+
   test ".perform_now should delete post from FreeFeed" do
     stub_request(:delete, "#{access_token.host}/v4/posts/test_post_123")
       .to_return(status: 200)

--- a/test/jobs/rate_limited_test.rb
+++ b/test/jobs/rate_limited_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class RateLimitedTest < ActiveJob::TestCase
+  class ThrottledJob < ApplicationJob
+    include RateLimited
+
+    def perform
+      raise RateLimit::Throttled.new(retry_after: 3)
+    end
+  end
+
+  test "reschedules the job when throttled within the attempt cap" do
+    assert_enqueued_with(job: ThrottledJob) do
+      ThrottledJob.perform_now
+    end
+  end
+
+  test "gives up and reports once the attempt cap is reached" do
+    job = ThrottledJob.new
+    job.executions = RateLimited::MAX_ATTEMPTS
+
+    reported = []
+    Rails.error.stub(:report, ->(error, **) { reported << error }) do
+      assert_no_enqueued_jobs { job.perform_now }
+    end
+
+    assert_equal 1, reported.size
+    assert_instance_of RateLimit::Throttled, reported.first
+  end
+end

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -9,6 +9,20 @@ class TokenValidationJobTest < ActiveJob::TestCase
     @access_token ||= create(:access_token, user: user)
   end
 
+  test ".perform_now should reserve two GETs and reschedule when throttled" do
+    captured = nil
+    RateLimit.stub(:acquire!, lambda { |_policy, subject:, cost:|
+      captured = [subject, cost]
+      raise RateLimit::Throttled.new(retry_after: 2)
+    }) do
+      assert_enqueued_with(job: TokenValidationJob) do
+        TokenValidationJob.perform_now(access_token)
+      end
+    end
+
+    assert_equal [access_token.rate_limit_subject, { get: 2 }], captured
+  end
+
   test ".perform_now should mark token as active when validation succeeds" do
     stub_successful_freefeed_response
 

--- a/test/services/rate_limit_test.rb
+++ b/test/services/rate_limit_test.rb
@@ -171,6 +171,21 @@ class RateLimitTest < ActiveSupport::TestCase
     end
   end
 
+  test ".capacity should return the smallest bucket capacity for a dimension" do
+    RateLimit.define(:t) do
+      limit :requests, 100, per: 60
+      limit :requests, 5, per: 3600
+    end
+
+    assert_equal 5, RateLimit.capacity(:t, :requests)
+  end
+
+  test ".capacity should be nil for a dimension with no declared limit" do
+    RateLimit.define(:t) { limit :requests, 1, per: 60 }
+
+    assert_nil RateLimit.capacity(:t, :other)
+  end
+
   test ".acquire should fail open by default on a storage error" do
     RateLimit.define(:t) { limit :requests, 1, per: 60 }
 


### PR DESCRIPTION
Changes:

- Add a `RateLimited` job concern: on `RateLimit::Throttled`, reschedule with `retry_after` + jitter up to an attempt cap, then report and give up (the recurring schedulers re-kick later).
- `PostPublishJob` reserves the whole post's POST cost up front (`{ post: 1 + comments + attachments }`) before publishing; a throttle reschedules the job for the same post (FIFO order preserved) instead of failing it.
- `PostWithdrawalJob` reserves `{ delete: 1 }`; `TokenValidationJob` reserves `{ get: 2 }`.

Wires the `RateLimit` service into FreeFeed API jobs so publishing/withdrawal/validation stay under FreeFeed's per-method limits. Capacity is reserved atomically before any API call (no partial-then-throttled work), and `RateLimit::Throttled` is kept out of the publish failure path so a throttled post isn't marked failed.

References:

- Part of #609.
- Closes #615.
