### PR TITLE
Handle FreeFeed 429 with penalize and Retry-After

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -60,7 +60,7 @@ class AccessToken < ApplicationRecord
   end
 
   def build_client
-    FreefeedClient.new(host: host, token: encrypted_token)
+    FreefeedClient.new(host: host, token: encrypted_token, rate_limit_subject: rate_limit_subject)
   end
 
   # Identity used for rate limiting FreeFeed API calls. Keyed per token: FreeFeed

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -21,9 +21,13 @@ class FreefeedPublisher
     attachment_ids = upload_attachments
     freefeed_post = create_freefeed_post(attachment_ids)
     freefeed_post_id = freefeed_post[:id]
+
+    # Persist the id before creating comments so a later failure (e.g. a 429 on
+    # a comment) can't make a retry re-create the post. Comments are
+    # best-effort once the post exists.
+    update_post_with_freefeed_id(freefeed_post_id)
     create_comments(freefeed_post_id)
 
-    update_post_with_freefeed_id(freefeed_post_id)
     freefeed_post_id
   rescue FreefeedClient::UnauthorizedError
     raise # propagate so the workflow can disable the token and related feeds

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -58,6 +58,8 @@ class FreefeedPublisher
       attachment = client.create_attachment_from_io(io, content_type: content_type)
       attachment[:id]
     end
+  rescue RateLimit::Throttled
+    raise # let the job reschedule; don't bury it as a publish failure
   rescue FreefeedClient::UnauthorizedError
     raise
   rescue FileBuffer::Error => e
@@ -72,6 +74,8 @@ class FreefeedPublisher
       feeds: [post.feed.target_group],
       attachment_ids: attachment_ids
     )
+  rescue RateLimit::Throttled
+    raise
   rescue FreefeedClient::UnauthorizedError
     raise
   rescue => e
@@ -89,6 +93,8 @@ class FreefeedPublisher
         body: comment_text
       )
     end
+  rescue RateLimit::Throttled
+    raise
   rescue FreefeedClient::UnauthorizedError
     raise
   rescue => e

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -16,6 +16,9 @@ class FreefeedPublisher
   # Publish the post to FreeFeed
   # @return [String] the FreeFeed post ID
   def publish
+    # Idempotency guard: if the post already has a FreeFeed id it was created on a
+    # previous run, so skip it. This is what stops a 429 raised *after* the post
+    # was created (e.g. on a comment) from re-creating the post when the job retries.
     return post.freefeed_post_id if already_published?
 
     attachment_ids = upload_attachments

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -18,9 +18,13 @@ class FreefeedClient
 
   attr_reader :host, :http_client
 
-  def initialize(host:, token:, http_client: nil, options: {})
+  # Used as the cooldown when a 429 response carries no usable Retry-After.
+  DEFAULT_RETRY_AFTER = 60
+
+  def initialize(host:, token:, http_client: nil, rate_limit_subject: nil, options: {})
     @host = host.chomp("/")
     @token = token
+    @rate_limit_subject = rate_limit_subject
     @http_client = http_client || HttpClient.build(DEFAULT_OPTIONS.merge(options))
   end
 
@@ -174,9 +178,24 @@ class FreefeedClient
       end
     when 404
       raise NotFoundError, "Resource not found"
+    when 429
+      handle_too_many_requests(response)
     else
       raise Error, "HTTP #{response.status}: #{response.body}"
     end
+  end
+
+  # FreeFeed throttled us. Record the cooldown so later acquires short-circuit,
+  # then raise Throttled so the job reschedules (handled by RateLimited).
+  def handle_too_many_requests(response)
+    retry_after = retry_after_seconds(response)
+    RateLimit.penalize(:freefeed, subject: @rate_limit_subject, retry_after: retry_after) if @rate_limit_subject
+    raise RateLimit::Throttled.new(retry_after: retry_after)
+  end
+
+  def retry_after_seconds(response)
+    seconds = response.headers["retry-after"].to_i
+    seconds.positive? ? seconds : DEFAULT_RETRY_AFTER
   end
 
   # TBD: Consider simplifying response processing. Probably keep the keys

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -322,4 +322,39 @@ class FreefeedClientTest < ActiveSupport::TestCase
     assert_includes error.message, "Failed to delete post"
     assert_includes error.message, "Connection failed"
   end
+
+  # 429 handling
+  test "429 raises Throttled and penalizes the subject using Retry-After" do
+    client = FreefeedClient.new(host: @host, token: @token, rate_limit_subject: "freefeed:1")
+    stub_request(:post, "#{@host}/v4/posts").to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    penalized = nil
+    RateLimit.stub(:penalize, ->(name, subject:, retry_after:) { penalized = [name, subject, retry_after] }) do
+      error = assert_raises(RateLimit::Throttled) { client.create_post(body: "hi", feeds: ["g"]) }
+      assert_equal 30, error.retry_after
+    end
+
+    assert_equal [:freefeed, "freefeed:1", 30], penalized
+  end
+
+  test "429 without Retry-After uses the default cooldown" do
+    client = FreefeedClient.new(host: @host, token: @token, rate_limit_subject: "freefeed:1")
+    stub_request(:post, "#{@host}/v4/posts").to_return(status: 429)
+
+    RateLimit.stub(:penalize, ->(*, **) { }) do
+      error = assert_raises(RateLimit::Throttled) { client.create_post(body: "hi", feeds: ["g"]) }
+      assert_equal FreefeedClient::DEFAULT_RETRY_AFTER, error.retry_after
+    end
+  end
+
+  test "429 without a rate_limit_subject raises Throttled but does not penalize" do
+    stub_request(:post, "#{@host}/v4/posts").to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    penalized = false
+    RateLimit.stub(:penalize, ->(*, **) { penalized = true }) do
+      assert_raises(RateLimit::Throttled) { @client.create_post(body: "hi", feeds: ["g"]) }
+    end
+
+    refute penalized
+  end
 end

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -357,4 +357,27 @@ class FreefeedClientTest < ActiveSupport::TestCase
 
     refute penalized
   end
+
+  test "429 on a GET (whoami) raises Throttled rather than a generic Error" do
+    client = FreefeedClient.new(host: @host, token: @token, rate_limit_subject: "freefeed:1")
+    stub_request(:get, "#{@host}/v4/users/whoami").to_return(status: 429, headers: { "Retry-After" => "20" })
+
+    RateLimit.stub(:penalize, ->(*, **) { }) do
+      error = assert_raises(RateLimit::Throttled) { client.whoami }
+      assert_equal 20, error.retry_after
+    end
+  end
+
+  test "429 on a DELETE (delete_post) raises Throttled and penalizes" do
+    client = FreefeedClient.new(host: @host, token: @token, rate_limit_subject: "freefeed:1")
+    stub_request(:delete, "#{@host}/v4/posts/p1").to_return(status: 429, headers: { "Retry-After" => "15" })
+
+    penalized = nil
+    RateLimit.stub(:penalize, ->(_name, subject:, retry_after:) { penalized = [subject, retry_after] }) do
+      error = assert_raises(RateLimit::Throttled) { client.delete_post("p1") }
+      assert_equal 15, error.retry_after
+    end
+
+    assert_equal ["freefeed:1", 15], penalized
+  end
 end

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -89,6 +89,15 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     assert_equal "Post feed access token is inactive", error.message
   end
 
+  test "#publish should re-raise RateLimit::Throttled instead of wrapping it" do
+    post = post_with_content("Test post content")
+    stub_request(:post, "#{access_token.host}/v4/posts").to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    RateLimit.stub(:penalize, ->(*, **) { }) do
+      assert_raises(RateLimit::Throttled) { FreefeedPublisher.new(post).publish }
+    end
+  end
+
   test "#publish should create post without attachments or comments" do
     post = post_with_content("Test post content")
 

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -119,6 +119,25 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     end
   end
 
+  test "#publish should persist the post id before comments so a comment 429 can't duplicate the post" do
+    post = post_with_content("Post with comment", comments: ["hello"])
+    post_stub = stub_request(:post, "#{access_token.host}/v4/posts")
+      .to_return(status: 201, body: { posts: { id: "freefeed_post_123" } }.to_json)
+    stub_request(:post, "#{access_token.host}/v4/comments").to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    RateLimit.stub(:penalize, ->(*, **) { }) do
+      assert_raises(RateLimit::Throttled) { FreefeedPublisher.new(post).publish }
+    end
+
+    # The post was recorded despite the throttle, so it won't be re-created.
+    assert_equal "freefeed_post_123", post.reload.freefeed_post_id
+    assert_predicate post, :published?
+
+    # A retry (already published) makes no further create-post call.
+    assert_equal "freefeed_post_123", FreefeedPublisher.new(post).publish
+    assert_requested post_stub, times: 1
+  end
+
   test "#publish should create post without attachments or comments" do
     post = post_with_content("Test post content")
 

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -98,6 +98,27 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     end
   end
 
+  test "#publish should re-raise RateLimit::Throttled when an attachment upload is throttled" do
+    file_path = file_fixture("test_image.jpg")
+    post = post_with_content("Post with image", attachment_urls: [file_path.to_s])
+    stub_request(:post, "#{access_token.host}/v1/attachments").to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    RateLimit.stub(:penalize, ->(*, **) { }) do
+      assert_raises(RateLimit::Throttled) { FreefeedPublisher.new(post).publish }
+    end
+  end
+
+  test "#publish should re-raise RateLimit::Throttled when a comment is throttled" do
+    post = post_with_content("Post with comment", comments: ["hello"])
+    stub_request(:post, "#{access_token.host}/v4/posts")
+      .to_return(status: 201, body: { posts: { id: "freefeed_post_123" } }.to_json)
+    stub_request(:post, "#{access_token.host}/v4/comments").to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    RateLimit.stub(:penalize, ->(*, **) { }) do
+      assert_raises(RateLimit::Throttled) { FreefeedPublisher.new(post).publish }
+    end
+  end
+
   test "#publish should create post without attachments or comments" do
     post = post_with_content("Test post content")
 


### PR DESCRIPTION
Changes:

- `FreefeedClient` now handles HTTP `429`: it reads `Retry-After` (defaulting to 60s when absent), calls `RateLimit.penalize` for the token's subject, and raises `RateLimit::Throttled`.
- `AccessToken#build_client` passes the token's `rate_limit_subject` into the client.
- `FreefeedPublisher` re-raises `RateLimit::Throttled` instead of burying it in `PublishError`, so a throttled publish reschedules rather than failing.

This is the server-truth backstop for FreeFeed rate limiting: even when our local reservation (#615) under-counts, FreeFeed's own `429` records a cooldown (`blocked_until`) so subsequent `acquire`s short-circuit, and the job reschedules via the `RateLimited` concern. Honoring `Retry-After` keeps us out of FreeFeed's escalating-block spiral.

References:

- Part of #609.
- Closes #617.
