### PR TITLE
Forget rate-limit state when access token is deleted

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -11,6 +11,7 @@ class AccessToken < ApplicationRecord
 
   before_validation :generate_default_name, if: -> { name.blank? }
   before_destroy :disable_associated_feeds
+  after_destroy :forget_rate_limit_state
 
   encrypts :encrypted_token
 
@@ -82,6 +83,10 @@ class AccessToken < ApplicationRecord
 
   def disable_associated_feeds
     feeds.update_all(state: :disabled, access_token_id: nil)
+  end
+
+  def forget_rate_limit_state
+    RateLimit.forget(:freefeed, subject: rate_limit_subject)
   end
 
   def disable_token_and_feeds

--- a/app/services/rate_limit.rb
+++ b/app/services/rate_limit.rb
@@ -186,6 +186,16 @@ module RateLimit
       policy(name).buckets_for(dimension => 1).map { |limit, _amount| limit.burst }.min
     end
 
+    # Drop a subject's stored state for a policy. Call this when the subject is
+    # gone for good (e.g. its access token is deleted) — the only definite signal
+    # that a row will never be used again. A later acquire would recreate it.
+    # @param name [Symbol, String] the policy name
+    # @param subject [String] identity whose allowance to forget
+    # @return [void]
+    def forget(name, subject:)
+      Bucket.where(key: "#{name}:#{subject}").delete_all
+    end
+
     private
 
     def registry

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -185,6 +185,16 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert_equal "https://beta.freefeed.net", AccessToken::FREEFEED_HOSTS[:beta][:url]
   end
 
+  test "destroying access token forgets its rate limit state" do
+    token = create(:access_token, :active)
+    RateLimit.acquire(:freefeed, subject: token.rate_limit_subject, cost: { get: 1 })
+    assert RateLimit::Bucket.exists?(key: "freefeed:#{token.rate_limit_subject}")
+
+    token.destroy!
+
+    assert_not RateLimit::Bucket.exists?(key: "freefeed:#{token.rate_limit_subject}")
+  end
+
   test "destroying access token disables enabled feeds and nullifies their access_token_id" do
     user = create(:user)
     token = create(:access_token, :active, user: user)

--- a/test/services/rate_limit_test.rb
+++ b/test/services/rate_limit_test.rb
@@ -13,6 +13,17 @@ class RateLimitTest < ActiveSupport::TestCase
     dims
   end
 
+  test ".forget should delete only the named subject's stored state" do
+    RateLimit.define(:t) { limit :requests, 5, per: 60 }
+    RateLimit.acquire(:t, subject: "a", cost: cost(requests: 1))
+    RateLimit.acquire(:t, subject: "b", cost: cost(requests: 1))
+
+    RateLimit.forget(:t, subject: "a")
+
+    assert_not RateLimit::Bucket.exists?(key: "t:a")
+    assert RateLimit::Bucket.exists?(key: "t:b")
+  end
+
   test ".acquire should allow up to burst then throttle" do
     RateLimit.define(:t) { limit :requests, 5, per: 60 }
 


### PR DESCRIPTION
Changes:

- Add `RateLimit.forget(name, subject:)` to drop a subject's stored bucket row
- Call it from an `AccessToken` `after_destroy` callback, so deleting a token clears its rate-limit state (cascade deletes like user removal included)

A bucket row holds only transient token state and has no definite end-of-life — staleness can't distinguish an abandoned subject from a merely idle one. Deleting the access token is that definite signal, so we clean up exactly then rather than guessing with a periodic prune.

References:

- Closes #623