### PR TITLE
Reset token to pending when throttle retries exhausted

### DIFF
--- a/app/jobs/rate_limited.rb
+++ b/app/jobs/rate_limited.rb
@@ -16,7 +16,15 @@ module RateLimited
         retry_job(wait: error.retry_after + rand(0.0..JITTER_SECONDS))
       else
         Rails.error.report(error, context: { job: self.class.name, arguments: arguments })
+        on_rate_limit_exhausted(error)
       end
     end
+  end
+
+  private
+
+  # Hook for jobs to clean up any in-progress state left behind when the
+  # throttle retries are exhausted. Default is a no-op.
+  def on_rate_limit_exhausted(error)
   end
 end

--- a/app/jobs/token_validation_job.rb
+++ b/app/jobs/token_validation_job.rb
@@ -9,4 +9,14 @@ class TokenValidationJob < ApplicationJob
 
     AccessTokenValidationService.new(access_token).call
   end
+
+  private
+
+  # Validation flips the token to `validating` before enqueuing. If we exhaust
+  # the throttle retries, reset it to `pending` so it doesn't stay stuck — the
+  # recurring schedulers can pick it up again later.
+  def on_rate_limit_exhausted(_error)
+    access_token = arguments.first
+    access_token.pending! if access_token.validating?
+  end
 end

--- a/test/jobs/rate_limited_test.rb
+++ b/test/jobs/rate_limited_test.rb
@@ -9,6 +9,22 @@ class RateLimitedTest < ActiveJob::TestCase
     end
   end
 
+  class HookJob < ApplicationJob
+    include RateLimited
+
+    cattr_accessor :exhausted_with
+
+    def perform
+      raise RateLimit::Throttled.new(retry_after: 3)
+    end
+
+    private
+
+    def on_rate_limit_exhausted(error)
+      self.class.exhausted_with = error
+    end
+  end
+
   test "reschedules the job when throttled within the attempt cap" do
     assert_enqueued_with(job: ThrottledJob) do
       ThrottledJob.perform_now
@@ -26,5 +42,17 @@ class RateLimitedTest < ActiveJob::TestCase
 
     assert_equal 1, reported.size
     assert_instance_of RateLimit::Throttled, reported.first
+  end
+
+  test "invokes on_rate_limit_exhausted once the attempt cap is reached" do
+    HookJob.exhausted_with = nil
+    job = HookJob.new
+    job.executions = RateLimited::MAX_ATTEMPTS
+
+    Rails.error.stub(:report, ->(*, **) { }) do
+      assert_no_enqueued_jobs { job.perform_now }
+    end
+
+    assert_instance_of RateLimit::Throttled, HookJob.exhausted_with
   end
 end

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -23,6 +23,22 @@ class TokenValidationJobTest < ActiveJob::TestCase
     assert_equal [access_token.rate_limit_subject, { get: 2 }], captured
   end
 
+  test ".perform_now should reset token to pending when throttle retries are exhausted" do
+    access_token.validating!
+
+    job = TokenValidationJob.new(access_token)
+    job.executions = RateLimited::MAX_ATTEMPTS
+
+    RateLimit.stub(:acquire!, ->(*, **) { raise RateLimit::Throttled.new(retry_after: 2) }) do
+      Rails.error.stub(:report, ->(*, **) { }) do
+        assert_no_enqueued_jobs { job.perform_now }
+      end
+    end
+
+    access_token.reload
+    assert access_token.pending?
+  end
+
   test ".perform_now should mark token as active when validation succeeds" do
     stub_successful_freefeed_response
 


### PR DESCRIPTION
Changes:

- Add an `on_rate_limit_exhausted` hook to `RateLimited` that jobs can override to clean up in-progress state when throttle retries are exhausted
- Reset access tokens from `validating` back to `pending` in `TokenValidationJob` when retries run out, so the recurring scheduler can pick them up again
- Add test coverage for the hook and the token reset behavior

`AccessToken#validate_token_async` flips a token to `validating` before enqueuing the job. Since `TokenValidationJob` gives up after the throttle retry cap, the token would otherwise be stuck in `validating` indefinitely. The new hook lets the job reset that state cleanly.

References:

- Closes #633
- Part of #609