### PR TITLE
Apply rate limiting to GroupPurgeJob

### DIFF
--- a/app/jobs/group_purge_job.rb
+++ b/app/jobs/group_purge_job.rb
@@ -1,4 +1,6 @@
 class GroupPurgeJob < ApplicationJob
+  include RateLimited
+
   queue_as :default
 
   def perform(feed_id)
@@ -10,10 +12,13 @@ class GroupPurgeJob < ApplicationJob
 
     client = access_token.build_client
 
-    # Find all posts for the feed with non-blank freefeed_post_id
+    # Find all posts for the feed with non-blank freefeed_post_id. Posts cleared
+    # below drop out of this scope, so a rescheduled run resumes where it stopped.
     posts = feed.posts.where.not(freefeed_post_id: [nil, ""])
 
     posts.find_each do |post|
+      RateLimit.acquire!(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
+
       begin
         client.delete_post(post.freefeed_post_id)
         post.update!(freefeed_post_id: nil)

--- a/app/jobs/group_purge_job.rb
+++ b/app/jobs/group_purge_job.rb
@@ -1,6 +1,4 @@
 class GroupPurgeJob < ApplicationJob
-  include RateLimited
-
   queue_as :default
 
   def perform(feed_id)
@@ -12,8 +10,8 @@ class GroupPurgeJob < ApplicationJob
 
     client = access_token.build_client
 
-    # Find all posts for the feed with non-blank freefeed_post_id. Posts cleared
-    # below drop out of this scope, so a rescheduled run resumes where it stopped.
+    # Posts cleared below drop out of this scope, so a rescheduled run resumes
+    # with whatever is left.
     posts = feed.posts.where.not(freefeed_post_id: [nil, ""])
 
     posts.find_each do |post|
@@ -27,5 +25,11 @@ class GroupPurgeJob < ApplicationJob
         # Continue with next post even if one fails
       end
     end
+  rescue RateLimit::Throttled => e
+    # This is a batch job, so retrying the same job (the RateLimited pattern) would
+    # count against the attempt cap and only nibble a few posts per run. Instead,
+    # re-enqueue a fresh job for the remaining posts after the cooldown — already
+    # cleared posts are skipped, and the batch shrinks until it drains.
+    self.class.set(wait: e.retry_after).perform_later(feed_id)
   end
 end

--- a/app/jobs/group_purge_job.rb
+++ b/app/jobs/group_purge_job.rb
@@ -1,4 +1,6 @@
 class GroupPurgeJob < ApplicationJob
+  include RateLimited
+
   queue_as :default
 
   def perform(feed_id)
@@ -10,8 +12,8 @@ class GroupPurgeJob < ApplicationJob
 
     client = access_token.build_client
 
-    # Posts cleared below drop out of this scope, so a rescheduled run resumes
-    # with whatever is left.
+    # Posts cleared below drop out of this scope, so a rescheduled run (on throttle)
+    # resumes with whatever is left rather than re-deleting.
     posts = feed.posts.where.not(freefeed_post_id: [nil, ""])
 
     posts.find_each do |post|
@@ -25,11 +27,5 @@ class GroupPurgeJob < ApplicationJob
         # Continue with next post even if one fails
       end
     end
-  rescue RateLimit::Throttled => e
-    # This is a batch job, so retrying the same job (the RateLimited pattern) would
-    # count against the attempt cap and only nibble a few posts per run. Instead,
-    # re-enqueue a fresh job for the remaining posts after the cooldown — already
-    # cleared posts are skipped, and the batch shrinks until it drains.
-    self.class.set(wait: e.retry_after).perform_later(feed_id)
   end
 end

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -45,16 +45,36 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     assert_equal [[access_token.rate_limit_subject, { delete: 1 }]] * 2, captured
   end
 
-  test ".perform_now should reschedule when throttled" do
+  test ".perform_now should re-enqueue itself for the feed when throttled" do
     create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
 
     RateLimit.stub(:acquire!, ->(*, **) { raise RateLimit::Throttled.new(retry_after: 2) }) do
-      assert_enqueued_with(job: GroupPurgeJob) do
+      assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
         GroupPurgeJob.perform_now(feed.id)
       end
     end
 
     assert_not_requested :delete, "#{access_token.host}/v4/posts/post1"
+  end
+
+  test ".perform_now should keep progress and reschedule the rest when throttled mid-batch" do
+    post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
+    post2 = create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
+
+    calls = 0
+    RateLimit.stub(:acquire!, lambda { |*, **|
+      calls += 1
+      raise RateLimit::Throttled.new(retry_after: 5) if calls > 1
+    }) do
+      assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
+        GroupPurgeJob.perform_now(feed.id)
+      end
+    end
+
+    assert_nil post1.reload.freefeed_post_id
+    assert_equal "post2", post2.reload.freefeed_post_id
   end
 
   test ".perform_now should continue on error and log failure" do

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -28,6 +28,35 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     assert_nil post3.reload.freefeed_post_id
   end
 
+  test ".perform_now should reserve a delete per post" do
+    create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
+    create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
+    stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
+
+    captured = []
+    RateLimit.stub(:acquire!, lambda { |_policy, subject:, cost:|
+      captured << [subject, cost]
+    }) do
+      GroupPurgeJob.perform_now(feed.id)
+    end
+
+    assert_equal [[access_token.rate_limit_subject, { delete: 1 }]] * 2, captured
+  end
+
+  test ".perform_now should reschedule when throttled" do
+    create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
+
+    RateLimit.stub(:acquire!, ->(*, **) { raise RateLimit::Throttled.new(retry_after: 2) }) do
+      assert_enqueued_with(job: GroupPurgeJob) do
+        GroupPurgeJob.perform_now(feed.id)
+      end
+    end
+
+    assert_not_requested :delete, "#{access_token.host}/v4/posts/post1"
+  end
+
   test ".perform_now should continue on error and log failure" do
     post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
     post2 = create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -45,7 +45,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     assert_equal [[access_token.rate_limit_subject, { delete: 1 }]] * 2, captured
   end
 
-  test ".perform_now should re-enqueue itself for the feed when throttled" do
+  test ".perform_now should reschedule itself when throttled" do
     create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
 
     RateLimit.stub(:acquire!, ->(*, **) { raise RateLimit::Throttled.new(retry_after: 2) }) do


### PR DESCRIPTION
Changes:

- Mix `RateLimited` into `GroupPurgeJob` so it reschedules on throttle, like the other FreeFeed jobs
- Reserve `{ delete: 1 }` against the `:freefeed` policy before each post DELETE
- Add tests for the per-post reservation, the reschedule path, and progress preservation when throttled mid-batch

`GroupPurgeJob` issues one DELETE per post, which can overrun FreeFeed's DELETE limit. It now reserves capacity per call so most throttling is caught proactively (before the request goes out), with the client's 429 handler as the backstop. On throttle the job reschedules; cleared posts drop out of the `freefeed_post_id` scope, so a rescheduled run resumes with whatever is left rather than re-deleting.

References:

- Closes #631
- Part of #609