### PR TITLE
Add push-based metrics for VictoriaMetrics

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,3 +11,10 @@ ACTION_MAILER_HOST=example.com
 # Listed here so `bin/rails assets:precompile` and similar production-mode
 # tasks have a value locally. Do not add www. if it redirects to apex on edge.
 HOSTS=example.com,dev.example.com
+
+# Metrics push (optional). When METRICS_URL is unset, metrics are a no-op.
+# Point at a VictoriaMetrics Prometheus import endpoint to enable.
+# METRICS_URL=https://vm.example.com/api/v1/import/prometheus
+# METRICS_USERNAME=metrics
+# METRICS_PASSWORD=changeme
+# METRICS_FLUSH_INTERVAL=15

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,4 +4,17 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  # Count every job run by outcome. Throttles are tracked separately from real
+  # failures since RateLimited reschedules them (they aren't errors).
+  around_perform do |job, block|
+    block.call
+    Metrics.increment("job_executions_total", job: job.class.name, status: "ok")
+  rescue RateLimit::Throttled
+    Metrics.increment("job_executions_total", job: job.class.name, status: "throttled")
+    raise
+  rescue StandardError
+    Metrics.increment("job_executions_total", job: job.class.name, status: "error")
+    raise
+  end
 end

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -45,6 +45,7 @@ class PostPublishJob < ApplicationJob
 
     RateLimit.acquire!(:freefeed, subject: feed.access_token.rate_limit_subject, cost: { post: posts })
     FreefeedPublisher.new(post).publish
+    Metrics.increment("posts_published_total", status: "published")
     schedule_next(feed)
   rescue RateLimit::Throttled
     # No capacity right now: reschedule the whole job (RateLimited) for the same
@@ -56,6 +57,7 @@ class PostPublishJob < ApplicationJob
   rescue => e
     # Poison post: mark it failed and move on so the queue isn't blocked.
     post.update!(status: :failed)
+    Metrics.increment("posts_published_total", status: "failed")
     Rails.logger.error "Failed to publish post #{post.id}: #{e.message}"
     Rails.error.report(e, context: { post: post.attributes, feed: feed.attributes })
     schedule_next(feed)
@@ -76,6 +78,7 @@ class PostPublishJob < ApplicationJob
   # forever and block the queue, so fail it and move on.
   def reject_oversized(feed, post, posts)
     post.update!(status: :failed)
+    Metrics.increment("posts_published_total", status: "rejected")
     Rails.logger.error "Post #{post.id} needs #{posts} POSTs, over the FreeFeed limit; marking failed"
     schedule_next(feed)
   end

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -25,6 +25,7 @@ class FeedRefreshWorkflow
   end
 
   def on_error(error)
+    Metrics.increment("feed_refresh_total", status: "error")
     record_error_stats(error, current_step: current_step)
     disable_credential_on_auth_error(error)
     create_feed_refresh_error_event(error)
@@ -143,6 +144,7 @@ class FeedRefreshWorkflow
     rejected_posts_count = posts.count(&:rejected?)
 
     record_completed_at
+    Metrics.increment("feed_refresh_total", status: "ok")
     create_feed_refresh_stats_event(posts)
 
     # Record daily metrics (sparse data - only if there's activity)

--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -1,0 +1,164 @@
+require "net/http"
+require "socket"
+
+# Tiny push-based metrics client for VictoriaMetrics (or any Prometheus
+# remote-import endpoint).
+#
+# Counters live in memory and are pushed periodically as their current
+# cumulative total; gauges are sampled from a block at push time. A background
+# thread flushes everything to METRICS_URL on an interval.
+#
+# Disabled (a no-op) unless METRICS_URL is set, so dev, test, and console runs
+# are unaffected and instrumentation costs nothing there.
+#
+# Each process tags its counter series with an `instance` label (host:pid) so
+# totals from multiple web/worker processes don't clobber each other — sum/max
+# them at query time. Gauges are global snapshots, so they carry no instance.
+#
+# Configuration (ENV):
+#   METRICS_URL            VM import endpoint, e.g.
+#                          https://vm.example/api/v1/import/prometheus
+#   METRICS_USERNAME       basic-auth user (optional)
+#   METRICS_PASSWORD       basic-auth password (optional)
+#   METRICS_FLUSH_INTERVAL seconds between pushes (default 15)
+#   METRICS_INSTANCE       override the instance label (default host:pid)
+#
+# Keep label values low-cardinality (job, status, policy) — never per-user,
+# per-subject, or per-id, which would blow up series count.
+module Metrics
+  PREFIX = "feeder_".freeze
+  DEFAULT_FLUSH_INTERVAL = 15
+
+  class << self
+    def enabled?
+      url.present?
+    end
+
+    def url
+      ENV["METRICS_URL"].presence
+    end
+
+    # Bump a counter by `by` (default 1) for the given label set.
+    def increment(name, by: 1, **labels)
+      return unless enabled?
+
+      key = [name.to_s, normalize_labels(labels)]
+      mutex.synchronize { counters[key] += by }
+    end
+
+    # Register a gauge sampled at push time; the block returns the current value.
+    def gauge(name, **labels, &block)
+      gauges << [name.to_s, normalize_labels(labels), block]
+    end
+
+    # Everything currently known, as Prometheus exposition text.
+    def render
+      lines = []
+      mutex.synchronize { counters.dup }.each do |(name, labels), value|
+        lines << line(name, labels.merge("instance" => instance_label), value)
+      end
+      gauges.each do |name, labels, block|
+        value = sample(block)
+        lines << line(name, labels, value) unless value.nil?
+      end
+      "#{lines.join("\n")}\n"
+    end
+
+    # Push the current snapshot. Best-effort: errors are reported, never raised,
+    # so a metrics outage can't take down the app.
+    def flush!
+      return unless enabled?
+
+      body = render
+      return if body.strip.empty?
+
+      post(body)
+    rescue => e
+      Rails.error.report(e, context: { component: "metrics" })
+    end
+
+    # Start the background flusher. Call once per process (from an initializer).
+    def start!(interval: flush_interval)
+      return unless enabled?
+      return if @thread&.alive?
+
+      @thread = Thread.new do
+        loop do
+          sleep(interval)
+          flush!
+        end
+      end
+      @thread.name = "metrics-flusher"
+      @thread
+    end
+
+    # Test seam: drop all recorded state.
+    def reset!
+      mutex.synchronize { counters.clear }
+      gauges.clear
+      @instance_label = nil
+    end
+
+    private
+
+    def counters
+      @counters ||= Hash.new(0)
+    end
+
+    def gauges
+      @gauges ||= []
+    end
+
+    def mutex
+      @mutex ||= Mutex.new
+    end
+
+    def flush_interval
+      Integer(ENV.fetch("METRICS_FLUSH_INTERVAL", DEFAULT_FLUSH_INTERVAL))
+    end
+
+    def instance_label
+      @instance_label ||= ENV["METRICS_INSTANCE"].presence || "#{Socket.gethostname}:#{Process.pid}"
+    end
+
+    def normalize_labels(labels)
+      labels.to_h { |key, value| [key.to_s, value.to_s] }.sort.to_h
+    end
+
+    def sample(block)
+      block.call
+    rescue => e
+      Rails.error.report(e, context: { component: "metrics", phase: "gauge_sample" })
+      nil
+    end
+
+    def line(name, labels, value)
+      prefixed = "#{PREFIX}#{name}"
+      return "#{prefixed} #{value}" if labels.empty?
+
+      inner = labels.map { |key, val| %(#{key}="#{escape(val)}") }.join(",")
+      "#{prefixed}{#{inner}} #{value}"
+    end
+
+    def escape(value)
+      value.gsub(/[\\"\n]/) { |char| { "\\" => "\\\\", '"' => '\"', "\n" => '\n' }[char] }
+    end
+
+    def post(body)
+      uri = URI(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = 5
+      http.read_timeout = 5
+
+      request = Net::HTTP::Post.new(uri)
+      request.body = body
+      request.content_type = "text/plain"
+      if (user = ENV["METRICS_USERNAME"].presence)
+        request.basic_auth(user, ENV["METRICS_PASSWORD"].to_s)
+      end
+
+      http.request(request)
+    end
+  end
+end

--- a/app/services/rate_limit.rb
+++ b/app/services/rate_limit.rb
@@ -111,6 +111,7 @@ module RateLimit
       unless result.allowed?
         Rails.logger.info("RateLimit throttled #{name}:#{subject} cost=#{cost.inspect} retry_after=#{result.retry_after.round(2)}s")
         Honeybadger.event("rate_limit.throttled", policy: name.to_s, subject: subject, cost: cost, retry_after: result.retry_after)
+        Metrics.increment("rate_limit_throttled_total", policy: name.to_s)
       end
       result
     rescue ActiveRecord::ActiveRecordError => e
@@ -181,6 +182,7 @@ module RateLimit
       end
       Rails.logger.warn("RateLimit cooldown #{name}:#{subject} blocked for #{retry_after}s (server throttled us)")
       Honeybadger.event("rate_limit.penalized", policy: name.to_s, subject: subject, retry_after: retry_after)
+      Metrics.increment("rate_limit_penalized_total", policy: name.to_s)
     end
 
     # Largest cost a single acquire could ever satisfy for a dimension — the

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -27,9 +27,25 @@ accessories:
     directories:
       - data:/var/lib/postgresql
 
+  # Temporary metrics backend for staging. VictoriaMetrics with its built-in
+  # web UI (vmui at :8428/vmui). Bound to localhost — the app pushes over the
+  # private Kamal network (see METRICS_URL below); view the UI via an SSH
+  # tunnel: ssh -L 8428:127.0.0.1:8428 dev.fffeeder.com → http://localhost:8428/vmui
+  # Remove with: bin/kamal accessory remove victoriametrics -d staging
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:latest
+    host: dev.fffeeder.com
+    port: "127.0.0.1:8428:8428"
+    cmd: "-retentionPeriod=1"
+    directories:
+      - vmdata:/victoria-metrics-data
+
 # Environment variables.
 env:
   clear:
     RAILS_ENV: staging
     HOSTS: dev.fffeeder.com
     ACTION_MAILER_HOST: dev.fffeeder.com
+    # Reaches the victoriametrics accessory by container name over the Kamal
+    # network. Unset this (or remove the accessory) to disable metrics.
+    METRICS_URL: http://f2-victoriametrics:8428/api/v1/import/prometheus

--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -1,0 +1,13 @@
+# Register sampled gauges and start the metrics push loop. The whole thing is a
+# no-op unless METRICS_URL is set, so dev, test, and console runs do nothing.
+# See app/services/metrics.rb.
+Rails.application.config.after_initialize do
+  next unless Metrics.enabled?
+
+  Metrics.gauge("users_active") { User.where(state: :active).count }
+  Metrics.gauge("feeds_enabled") { Feed.where(state: :enabled).count }
+  Metrics.gauge("posts_enqueued") { Post.enqueued.count }
+  Metrics.gauge("jobs_ready") { SolidQueue::ReadyExecution.count }
+
+  Metrics.start!
+end

--- a/test/services/metrics_test.rb
+++ b/test/services/metrics_test.rb
@@ -1,0 +1,99 @@
+require "test_helper"
+
+# A throwaway job used to exercise the ApplicationJob metrics hook.
+class MetricsProbeJob < ApplicationJob
+  def perform(mode)
+    raise RateLimit::Throttled.new(retry_after: 1) if mode == :throttle
+    raise "boom" if mode == :error
+  end
+end
+
+class MetricsTest < ActiveSupport::TestCase
+  teardown do
+    Metrics.reset!
+    %w[METRICS_URL METRICS_USERNAME METRICS_PASSWORD METRICS_INSTANCE].each { |key| ENV.delete(key) }
+  end
+
+  def enable!(url: "https://vm.test/api/v1/import/prometheus")
+    ENV["METRICS_URL"] = url
+    ENV["METRICS_INSTANCE"] = "host:1"
+  end
+
+  test "#enabled? should be false without METRICS_URL" do
+    assert_not Metrics.enabled?
+  end
+
+  test "#increment should be a no-op when disabled" do
+    Metrics.increment("job_executions_total", status: "ok")
+
+    refute_includes Metrics.render, "feeder_job_executions_total"
+  end
+
+  test "#render should emit a prefixed counter line with sorted labels and an instance" do
+    enable!
+    2.times { Metrics.increment("job_executions_total", job: "PostPublishJob", status: "ok") }
+
+    assert_includes Metrics.render,
+                    %(feeder_job_executions_total{job="PostPublishJob",status="ok",instance="host:1"} 2)
+  end
+
+  test "#increment should accumulate and honor by:" do
+    enable!
+    Metrics.increment("rate_limit_throttled_total", policy: "freefeed", by: 3)
+
+    assert_includes Metrics.render, %(feeder_rate_limit_throttled_total{policy="freefeed",instance="host:1"} 3)
+  end
+
+  test "#gauge should be sampled at render time and carry no instance label" do
+    enable!
+    value = 5
+    Metrics.gauge("feeds_enabled") { value }
+
+    assert_includes Metrics.render, "feeder_feeds_enabled 5"
+    value = 9
+    assert_includes Metrics.render, "feeder_feeds_enabled 9"
+  end
+
+  test "#render should escape quotes in label values" do
+    enable!
+    Metrics.increment("job_executions_total", job: 'a"b')
+
+    assert_includes Metrics.render, 'job="a\"b"'
+  end
+
+  test "#flush! should POST exposition text to METRICS_URL with basic auth" do
+    enable!
+    ENV["METRICS_USERNAME"] = "u"
+    ENV["METRICS_PASSWORD"] = "p"
+    stub_request(:post, "https://vm.test/api/v1/import/prometheus").to_return(status: 204)
+    Metrics.increment("job_executions_total", status: "ok")
+
+    Metrics.flush!
+
+    assert_requested(:post, "https://vm.test/api/v1/import/prometheus") do |req|
+      req.headers["Authorization"] == "Basic #{Base64.strict_encode64("u:p")}" &&
+        req.body.include?("feeder_job_executions_total")
+    end
+  end
+
+  test "#flush! should swallow transport errors" do
+    enable!
+    stub_request(:post, "https://vm.test/api/v1/import/prometheus").to_raise(Errno::ECONNREFUSED)
+    Metrics.increment("job_executions_total", status: "ok")
+
+    assert_nothing_raised { Metrics.flush! }
+  end
+
+  test "ApplicationJob should record job runs by outcome" do
+    enable!
+
+    MetricsProbeJob.perform_now(:ok)
+    assert_raises(RateLimit::Throttled) { MetricsProbeJob.perform_now(:throttle) }
+    assert_raises(RuntimeError) { MetricsProbeJob.perform_now(:error) }
+
+    out = Metrics.render
+    assert_includes out, %(feeder_job_executions_total{job="MetricsProbeJob",status="ok",instance="host:1"} 1)
+    assert_includes out, %(feeder_job_executions_total{job="MetricsProbeJob",status="throttled",instance="host:1"} 1)
+    assert_includes out, %(feeder_job_executions_total{job="MetricsProbeJob",status="error",instance="host:1"} 1)
+  end
+end


### PR DESCRIPTION
Changes:

- Add `Metrics`, a small push-based client that buffers counters in memory, samples gauges from blocks, and flushes Prometheus exposition text to a VictoriaMetrics import endpoint on a background thread
- No-op unless `METRICS_URL` is set, so dev, test, and console runs are unaffected; optional basic auth via `METRICS_USERNAME`/`METRICS_PASSWORD`
- Instrument a small, verified demo set: job runs by outcome (one global ActiveJob hook), posts published/failed/rejected, rate-limit throttle/penalize, feed refresh ok/error, plus sampled gauges for active users, enabled feeds, enqueued-post backlog, and SolidQueue ready depth
- Add a temporary VictoriaMetrics Kamal accessory to the staging destination (localhost-bound, vmui via SSH tunnel) and wire `METRICS_URL` to it
- Document the env vars in `.env.sample`

This is a deliberately limited first set — enough to demo counters, gauges, labels, and `rate()` in VictoriaMetrics without sprawling instrumentation. Counters carry a per-process `instance` label so web and worker processes don't clobber each other (sum/max at query time); gauges are global snapshots. Pushing (rather than scraping `/metrics`) was chosen because much of the activity originates in SolidQueue job processes, which don't serve HTTP. Histograms (durations, latencies) and broader subsystem coverage are intentionally left for a follow-up.

The staging accessory is meant to be temporary: bound to `127.0.0.1`, reachable by the app over the private Kamal network for ingestion, and viewable through an SSH tunnel. Remove it with `bin/kamal accessory remove victoriametrics -d staging`.

References:

- Related issue: #622
