### PR TITLE
Encode non-ASCII characters in attachment URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development do
   gem "web-console"
 end
 
+gem "addressable"
 gem "dotenv"
 gem "faraday"
 gem "faraday-follow_redirects"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -522,6 +522,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  addressable
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman

--- a/app/services/file_buffer.rb
+++ b/app/services/file_buffer.rb
@@ -48,7 +48,8 @@ class FileBuffer
   end
 
   def url_to_io(url)
-    response = http_client.get(url)
+    normalized_url = normalize_url(url)
+    response = http_client.get(normalized_url)
 
     unless response.success?
       raise Error, "Failed to download attachment from #{url}: HTTP #{response.status}"
@@ -57,9 +58,18 @@ class FileBuffer
     io = StringIO.new(response.body)
     io.set_encoding(Encoding::BINARY)
 
-    content_type = url_content_type(url, response.body)
+    content_type = url_content_type(normalized_url, response.body)
 
     [io, content_type]
+  end
+
+  # Percent-encode any non-ASCII characters so the URL can be handled by
+  # Ruby's URI/Net::HTTP, which reject non-ASCII input. Existing percent-encoded
+  # sequences and ASCII reserved characters are left untouched.
+  def normalize_url(url)
+    url.gsub(/[^[:ascii:]]+/) do |chunk|
+      chunk.b.bytes.map { |byte| format("%%%02X", byte) }.join
+    end
   end
 
   def local_file_content_type(path)

--- a/app/services/file_buffer.rb
+++ b/app/services/file_buffer.rb
@@ -63,13 +63,11 @@ class FileBuffer
     [io, content_type]
   end
 
-  # Percent-encode any non-ASCII characters so the URL can be handled by
-  # Ruby's URI/Net::HTTP, which reject non-ASCII input. Existing percent-encoded
-  # sequences and ASCII reserved characters are left untouched.
+  # Normalize the URL so it can be handled by Ruby's URI/Net::HTTP, which reject
+  # non-ASCII input. Addressable percent-encodes non-ASCII characters in the path
+  # and query and converts non-ASCII hosts to punycode, leaving valid URLs intact.
   def normalize_url(url)
-    url.gsub(/[^[:ascii:]]+/) do |chunk|
-      chunk.b.bytes.map { |byte| format("%%%02X", byte) }.join
-    end
+    Addressable::URI.parse(url).normalize.to_s
   end
 
   def local_file_content_type(path)

--- a/test/services/file_buffer_test.rb
+++ b/test/services/file_buffer_test.rb
@@ -46,6 +46,19 @@ class FileBufferTest < ActiveSupport::TestCase
     assert_equal response_body, io.string
   end
 
+  test "#load should convert a non-ASCII host to punycode before downloading" do
+    url = "https://café.com/image.jpg"
+    encoded_url = "https://xn--caf-dma.com/image.jpg"
+    response_body = file_fixture("test_image.jpg").binread
+
+    stub_request(:get, encoded_url).to_return(status: 200, body: response_body)
+
+    io, content_type = FileBuffer.new.load(url)
+
+    assert_equal "image/jpeg", content_type
+    assert_equal response_body, io.string
+  end
+
   test "#load should detect content type from file content when URL has no extension" do
     url = "https://example.com/unknown"
     response_body = file_fixture("test_image.jpg").binread

--- a/test/services/file_buffer_test.rb
+++ b/test/services/file_buffer_test.rb
@@ -32,6 +32,20 @@ class FileBufferTest < ActiveSupport::TestCase
     assert_equal Encoding::BINARY, io.string.encoding
   end
 
+  test "#load should percent-encode non-ASCII characters in URL before downloading" do
+    url = "https://example.com/thailand’s-coast/image.jpg"
+    encoded_url = "https://example.com/thailand%E2%80%99s-coast/image.jpg"
+    response_body = file_fixture("test_image.jpg").binread
+
+    stub_request(:get, encoded_url).to_return(status: 200, body: response_body)
+
+    io, content_type = FileBuffer.new.load(url)
+
+    assert_instance_of StringIO, io
+    assert_equal "image/jpeg", content_type
+    assert_equal response_body, io.string
+  end
+
   test "#load should detect content type from file content when URL has no extension" do
     url = "https://example.com/unknown"
     response_body = file_fixture("test_image.jpg").binread


### PR DESCRIPTION
Changes:

- Normalize attachment URLs with `Addressable::URI` before downloading them in `FileBuffer`
- Promote `addressable` from a transitive to a direct dependency
- Add regression tests for a non-ASCII path and a non-ASCII host

Some source feeds expose image URLs containing non-ASCII characters (for example a U+2019 right single quote in a NASA "image of the day" path). Ruby's `URI`/`Net::HTTP` reject such input with "URI must be ascii only", which surfaced as a `FreefeedPublisher::PublishError: Failed to upload attachments` and blocked publishing. The fix normalizes the URL at the download boundary — where the ASCII constraint actually applies — so the stored URL stays untouched. `Addressable::URI#normalize` percent-encodes non-ASCII path and query characters and converts non-ASCII hosts to punycode, leaving valid URLs intact.