### PR TITLE
Refine post card and event log presentation

### DIFF
--- a/app/components/event_log_entry_presentation.rb
+++ b/app/components/event_log_entry_presentation.rb
@@ -14,22 +14,17 @@ module EventLogEntryPresentation
     end
   end
 
-  # A small colored dot flags entries that need attention. Routine "info"
-  # events carry no dot — the text alone is enough, and a badge saying "Info"
-  # tells the reader nothing.
-  def severity_dot
-    color = case event.level
-    when "warning" then "bg-amber-400"
-    when "error" then "bg-red-500"
+  # An icon flags entries that need attention: a warning triangle or an error
+  # cross. Routine "info" events carry nothing — the text alone is enough, and a
+  # badge saying "Info" tells the reader nothing.
+  def severity_icon
+    name, color = case event.level
+    when "warning" then ["triangle-alert", "text-amber-500"]
+    when "error" then ["circle-x", "text-red-500"]
     end
-    return unless color
+    return unless name
 
-    helpers.tag.span(
-      "",
-      class: "inline-block h-2 w-2 shrink-0 rounded-full #{color}",
-      aria: { hidden: true },
-      data: { key: "events.severity" }
-    )
+    helpers.icon(name, css_class: "size-4 #{color}", aria_label: event.level.capitalize)
   end
 
   def subject_label

--- a/app/components/events_list_entry_component.rb
+++ b/app/components/events_list_entry_component.rb
@@ -9,7 +9,7 @@ class EventsListEntryComponent < ViewComponent::Base
   def call
     content_tag(:li, class: "flex items-center gap-3 px-4 py-2.5",
                      data: { key: "events.entry", event_type: event.type, event_id: event.id }) do
-      safe_join([time_tag, severity_dot, description_tag, subject_tag].compact)
+      safe_join([time_tag, severity_dot, description_tag].compact)
     end
   end
 
@@ -19,21 +19,14 @@ class EventsListEntryComponent < ViewComponent::Base
 
   def time_tag
     link_to(helpers.short_time_ago(event.created_at), href,
-            class: "w-10 shrink-0 text-xs font-medium tabular-nums text-slate-400 hover:text-slate-700",
+            class: "w-10 shrink-0 text-sm font-medium tabular-nums text-slate-400 hover:text-slate-700",
             title: event.created_at.rfc3339,
             data: { key: "events.timestamp" })
   end
 
   def description_tag
     content_tag(:span, render(EventDescriptionComponent.for(event)),
-                class: "flex-1 truncate text-sm text-slate-700",
+                class: "flex-1 truncate text-slate-700",
                 data: { key: "events.description" })
-  end
-
-  def subject_tag
-    label = subject_label
-    return unless label
-
-    content_tag(:span, label, class: "shrink-0 text-xs text-slate-400")
   end
 end

--- a/app/components/events_list_entry_component.rb
+++ b/app/components/events_list_entry_component.rb
@@ -18,9 +18,11 @@ class EventsListEntryComponent < ViewComponent::Base
   attr_reader :event, :href
 
   # A fixed-width gutter keeps the message left edge aligned whether or not the
-  # entry carries a severity dot.
+  # entry carries a severity icon.
   def severity_tag
-    content_tag(:span, severity_dot, class: "flex w-2 shrink-0 justify-center")
+    icon = severity_icon
+    content_tag(:span, icon, class: "flex w-4 shrink-0 items-center justify-center",
+                             data: icon ? { key: "events.severity" } : {})
   end
 
   def description_tag

--- a/app/components/events_list_entry_component.rb
+++ b/app/components/events_list_entry_component.rb
@@ -9,7 +9,7 @@ class EventsListEntryComponent < ViewComponent::Base
   def call
     content_tag(:li, class: "flex items-center gap-3 px-4 py-2.5",
                      data: { key: "events.entry", event_type: event.type, event_id: event.id }) do
-      safe_join([time_tag, severity_dot, description_tag].compact)
+      safe_join([severity_tag, description_tag, time_tag])
     end
   end
 
@@ -17,16 +17,22 @@ class EventsListEntryComponent < ViewComponent::Base
 
   attr_reader :event, :href
 
-  def time_tag
-    link_to(helpers.short_time_ago(event.created_at), href,
-            class: "w-10 shrink-0 text-sm font-medium tabular-nums text-slate-400 hover:text-slate-700",
-            title: event.created_at.rfc3339,
-            data: { key: "events.timestamp" })
+  # A fixed-width gutter keeps the message left edge aligned whether or not the
+  # entry carries a severity dot.
+  def severity_tag
+    content_tag(:span, severity_dot, class: "flex w-2 shrink-0 justify-center")
   end
 
   def description_tag
     content_tag(:span, render(EventDescriptionComponent.for(event)),
-                class: "flex-1 truncate text-slate-700",
+                class: "min-w-0 flex-1 truncate text-slate-700",
                 data: { key: "events.description" })
+  end
+
+  def time_tag
+    link_to(helpers.short_time_ago(event.created_at), href,
+            class: "shrink-0 text-sm font-medium tabular-nums text-slate-400 hover:text-slate-700",
+            title: event.created_at.rfc3339,
+            data: { key: "events.timestamp" })
   end
 end

--- a/app/components/feed_refresh_description_component.rb
+++ b/app/components/feed_refresh_description_component.rb
@@ -1,5 +1,5 @@
 # Appends the imported posts count to a feed refresh description, e.g.
-# "My Feed refreshed (+2)". Refreshes that imported nothing render plain.
+# "My Feed refreshed (+2 posts)". Refreshes that imported nothing render plain.
 class FeedRefreshDescriptionComponent < EventDescriptionComponent
   def call
     suffix = posts_count_tag
@@ -12,6 +12,6 @@ class FeedRefreshDescriptionComponent < EventDescriptionComponent
     count = event.event_references.count { |reference| reference.reference_type == "Post" }
     return if count.zero?
 
-    helpers.tag.span("(+#{count})", class: "text-slate-400", data: { key: "events.posts_count" })
+    helpers.tag.span("(+#{helpers.pluralize(count, "post")})", class: "text-slate-400", data: { key: "events.posts_count" })
   end
 end

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -10,34 +10,34 @@
   </div>
 
   <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
-    <div class="flex items-center gap-3 text-sm text-slate-400">
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-400">
       <% if group_label %>
         <%= link_to group_label, group_url, title: group_hint,
               class: "transition hover:text-slate-600" %>
       <% end %>
-      <% if attachment_count > 0 %>
-        <span class="flex items-center gap-1">
-          <%= helpers.icon("paperclip", css_class: "size-3.5") %>
-          <%= attachment_count %>
-        </span>
-      <% end %>
-      <% if comment_count > 0 %>
-        <span class="flex items-center gap-1">
-          <%= helpers.icon("message-circle", css_class: "size-3.5") %>
-          <%= comment_count %>
-        </span>
-      <% end %>
 
-      <%= link_to source_label, source_url, target: "_blank", rel: "noopener",
-            class: "transition hover:text-slate-600" %>
-
-      <% if repost_label %>
-        <% if freefeed_url %>
-          <%= link_to repost_label, freefeed_url, target: "_blank", rel: "noopener",
-                class: "transition hover:text-slate-600" %>
-        <% else %>
-          <span><%= repost_label %></span>
+      <% if status_links_to_freefeed? %>
+        <%= link_to freefeed_url, target: "_blank", rel: "noopener",
+              class: "flex items-center gap-1.5 transition hover:text-slate-600",
+              data: { key: "post.status" } do %>
+          <%= status_icon %><%= status_label_with_time %>
         <% end %>
+      <% else %>
+        <span class="flex items-center gap-1.5" data-key="post.status">
+          <%= status_icon %><%= status_label_with_time %>
+        </span>
+      <% end %>
+
+      <% if source_url %>
+        <%= link_to "Source", source_url, target: "_blank", rel: "noopener",
+              class: "transition hover:text-slate-600", data: { key: "post.source" } %>
+      <% end %>
+
+      <% if show_attachment_count? %>
+        <span data-key="post.attachments"><%= attachment_label %></span>
+      <% end %>
+      <% if show_comment_count? %>
+        <span data-key="post.comments"><%= comment_label %></span>
       <% end %>
     </div>
 

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -1,4 +1,13 @@
 class PostCardComponent < ViewComponent::Base
+  STATUS_DISPLAY = {
+    "draft"     => { icon: "file",         color: "text-slate-400",  label: "Draft" },
+    "enqueued"  => { icon: "clock",        color: "text-blue-500",   label: "Enqueued" },
+    "rejected"  => { icon: "circle-x",     color: "text-orange-500", label: "Rejected" },
+    "published" => { icon: "circle-check", color: "text-green-600",  label: "Reposted" },
+    "failed"    => { icon: "circle-x",     color: "text-red-600",    label: "Failed" },
+    "withdrawn" => { icon: "trash-2",      color: "text-slate-400",  label: "Withdrawn" }
+  }.freeze
+
   def initialize(post:, show_feed: false)
     @post = post
     @show_feed = show_feed
@@ -31,18 +40,46 @@ class PostCardComponent < ViewComponent::Base
     post.feed&.display_name
   end
 
-  def source_label
-    return unless post.published_at
-    label_with_time("Source", post.published_at)
+  def status_display
+    STATUS_DISPLAY[post.status.to_s] ||
+      { icon: "file", color: "text-slate-400", label: post.status.to_s.capitalize }
   end
 
-  def repost_label
-    return unless post.reposted_at
-    label_with_time("Repost", post.reposted_at)
+  def status_icon
+    helpers.icon(status_display[:icon], css_class: "size-3.5 #{status_display[:color]}")
   end
 
-  def label_with_time(label, time)
-    helpers.safe_join([label, " (", helpers.short_time_ago_tag(time), ")"])
+  def status_label_with_time
+    helpers.safe_join([status_display[:label], " (", helpers.short_time_ago_tag(status_time), ")"])
+  end
+
+  # The status badge reports when the post reached its current state. For a
+  # published post that is the repost moment (see Post#reposted_at); for every
+  # other state it is the last transition, which updated_at tracks.
+  def status_time
+    post.reposted_at || post.updated_at
+  end
+
+  def reposted?
+    post.published?
+  end
+
+  # Attachment and comment counts describe what made it onto FreeFeed, so they
+  # only make sense once the post is actually reposted.
+  def show_attachment_count?
+    reposted? && attachment_count.positive?
+  end
+
+  def show_comment_count?
+    reposted? && comment_count.positive?
+  end
+
+  def attachment_label
+    helpers.pluralize(attachment_count, "attachment")
+  end
+
+  def comment_label
+    helpers.pluralize(comment_count, "comment")
   end
 
   def attachment_count
@@ -59,6 +96,10 @@ class PostCardComponent < ViewComponent::Base
 
   def freefeed_url
     post.freefeed_url
+  end
+
+  def status_links_to_freefeed?
+    reposted? && freefeed_url.present?
   end
 
   def delete_allowed?

--- a/test/components/events_list_entry_component_test.rb
+++ b/test/components/events_list_entry_component_test.rb
@@ -66,17 +66,27 @@ class EventsListEntryComponentTest < ViewComponent::TestCase
     assert_operator keys.index("events.description"), :<, keys.index("events.timestamp")
   end
 
-  test "#call should flag warning and error events with a severity dot" do
+  test "#call should flag error events with a red cross icon" do
     event = create(:event, type: "error_event", level: :error, user: user)
 
     result = render_inline(EventsListEntryComponent.new(event: event, href: "/events/#{event.id}"))
 
-    dot = result.css("[data-key='events.severity']").first
-    assert_not_nil dot
-    assert_includes dot["class"], "bg-red-500"
+    icon = result.at_css("[data-key='events.severity'] svg")
+    assert_not_nil icon
+    assert_includes icon["class"], "text-red-500"
   end
 
-  test "#call should not flag routine info events with a severity dot" do
+  test "#call should flag warning events with an amber triangle icon" do
+    event = create(:event, type: "warning_event", level: :warning, user: user)
+
+    result = render_inline(EventsListEntryComponent.new(event: event, href: "/events/#{event.id}"))
+
+    icon = result.at_css("[data-key='events.severity'] svg")
+    assert_not_nil icon
+    assert_includes icon["class"], "text-amber-500"
+  end
+
+  test "#call should not flag routine info events with a severity icon" do
     event = create(:event, type: "feed_refresh", level: :info, user: user)
 
     result = render_inline(EventsListEntryComponent.new(event: event, href: "/events/#{event.id}"))

--- a/test/components/events_list_entry_component_test.rb
+++ b/test/components/events_list_entry_component_test.rb
@@ -57,6 +57,15 @@ class EventsListEntryComponentTest < ViewComponent::TestCase
     assert_not_includes description["class"], "text-sm"
   end
 
+  test "#call should place the timestamp after the message" do
+    event = create(:event, type: "feed_refresh", level: :info, user: user)
+
+    result = render_inline(EventsListEntryComponent.new(event: event, href: "/events/#{event.id}"))
+
+    keys = result.css("[data-key='events.entry'] > *").map { |node| node["data-key"] }
+    assert_operator keys.index("events.description"), :<, keys.index("events.timestamp")
+  end
+
   test "#call should flag warning and error events with a severity dot" do
     event = create(:event, type: "error_event", level: :error, user: user)
 

--- a/test/components/events_list_entry_component_test.rb
+++ b/test/components/events_list_entry_component_test.rb
@@ -39,18 +39,22 @@ class EventsListEntryComponentTest < ViewComponent::TestCase
     assert_empty result.css("a[href='/events/#{event.id}'] a")
   end
 
-  test "#call should render the subject filter chip when a subject is present" do
+  test "#call should not repeat the subject reference, which the description already links" do
     feed = create(:feed, user: user)
     event = create(:event, type: "feed_refresh", subject: feed, user: user)
 
     result = render_inline(EventsListEntryComponent.new(event: event, href: "/events/#{event.id}"))
 
-    link = result.css("a[data-key='events.subject']").first
-    assert_not_nil link
-    assert_equal "Feed ##{feed.id}", link.text
-    assert_includes link["href"], "filter%5Bsubject_type%5D=Feed"
-    assert_includes link["href"], "filter%5Bsubject_id%5D=#{feed.id}"
-    assert_not_includes link["href"], "/admin/"
+    assert_nil result.css("[data-key='events.subject']").first
+  end
+
+  test "#call should render the description at the default text size" do
+    event = create(:event, type: "feed_refresh", level: :info, user: user)
+
+    result = render_inline(EventsListEntryComponent.new(event: event, href: "/events/#{event.id}"))
+
+    description = result.css("[data-key='events.description']").first
+    assert_not_includes description["class"], "text-sm"
   end
 
   test "#call should flag warning and error events with a severity dot" do

--- a/test/components/feed_refresh_description_component_test.rb
+++ b/test/components/feed_refresh_description_component_test.rb
@@ -21,7 +21,7 @@ class FeedRefreshDescriptionComponentTest < ViewComponent::TestCase
     result = render_inline(FeedRefreshDescriptionComponent.new(event: refresh_event))
 
     assert_includes result.to_html, "refreshed"
-    assert_equal "(+2)", result.css("[data-key='events.posts_count']").first&.text
+    assert_equal "(+2 posts)", result.css("[data-key='events.posts_count']").first&.text
   end
 
   test "#call should count only post references" do
@@ -30,7 +30,7 @@ class FeedRefreshDescriptionComponentTest < ViewComponent::TestCase
 
     result = render_inline(FeedRefreshDescriptionComponent.new(event: refresh_event))
 
-    assert_equal "(+1)", result.css("[data-key='events.posts_count']").first&.text
+    assert_equal "(+1 post)", result.css("[data-key='events.posts_count']").first&.text
   end
 
   test "#call should omit the count when the refresh imported nothing" do

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -43,11 +43,32 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_nil result.at_css("a[href*='/feeds/']")
   end
 
-  test "#render should show attachment count icon when attachments present" do
-    post_with_attachments = create(:post, :with_attachments, feed: feed)
+  test "#render should show attachment count for reposted posts with attachments" do
+    post_with_attachments = create(:post, :published, :with_attachments, feed: feed)
     result = render_inline PostCardComponent.new(post: post_with_attachments)
 
-    assert_not_empty result.css("span.flex.items-center.gap-1")
+    assert_equal "2 attachments", result.at_css('[data-key="post.attachments"]').text.strip
+  end
+
+  test "#render should show comment count for reposted posts with comments" do
+    post_with_comments = create(:post, :published, :with_comments, feed: feed)
+    result = render_inline PostCardComponent.new(post: post_with_comments)
+
+    assert_equal "1 comment", result.at_css('[data-key="post.comments"]').text.strip
+  end
+
+  test "#render should not show attachment or comment counts when none" do
+    result = render_inline PostCardComponent.new(post: post)
+
+    assert_nil result.at_css('[data-key="post.attachments"]')
+    assert_nil result.at_css('[data-key="post.comments"]')
+  end
+
+  test "#render should not show counts for failed posts even with attachments" do
+    failed_post = create(:post, :failed, :with_attachments, feed: feed)
+    result = render_inline PostCardComponent.new(post: failed_post)
+
+    assert_nil result.at_css('[data-key="post.attachments"]')
   end
 
   test "#render should show Withdrawn badge for withdrawn posts" do
@@ -96,43 +117,45 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_not_empty result.css(".border-t.border-slate-200")
   end
 
-  test "#render should link source time to the original publication" do
+  test "#render should link the source without a timestamp" do
     published_post = create(:post, :published, feed: feed, source_url: "https://xkcd.com/3250/",
       published_at: 11.hours.ago, updated_at: 10.hours.ago)
     result = render_inline PostCardComponent.new(post: published_post)
 
     source_link = result.at_css("a[href='https://xkcd.com/3250/']")
     assert_not_nil source_link
-    assert_includes source_link.text.gsub(/\s+/, " "), "Source (11h)"
+    assert_equal "Source", source_link.text.strip
   end
 
-  test "#render should link repost time to the freefeed post" do
+  test "#render should label published posts as reposted and link to the freefeed post" do
     published_post = create(:post, :published, feed: feed,
       published_at: 11.hours.ago, updated_at: 10.hours.ago)
     result = render_inline PostCardComponent.new(post: published_post)
 
-    repost_link = result.at_css("a[href='#{published_post.freefeed_url}']")
-    assert_not_nil repost_link
-    assert_includes repost_link.text.gsub(/\s+/, " "), "Repost (10h)"
+    status_link = result.at_css("a[href='#{published_post.freefeed_url}']")
+    assert_not_nil status_link
+    assert_includes status_link.text.gsub(/\s+/, " "), "Reposted (10h)"
+    assert_not_empty status_link.css("svg.text-green-600")
   end
 
-  test "#render should show repost time as plain text when freefeed url is missing" do
+  test "#render should show the reposted status as plain text when freefeed url is missing" do
     # A purged post stays published but loses its freefeed_post_id (see GroupPurgeJob)
     purged_post = create(:post, :published, feed: feed, freefeed_post_id: nil,
       published_at: 11.hours.ago, updated_at: 10.hours.ago)
     result = render_inline PostCardComponent.new(post: purged_post)
 
     assert_nil purged_post.freefeed_url
-    assert_includes result.text.gsub(/\s+/, " "), "Repost (10h)"
-    assert_empty result.css("a").select { |a| a.text.include?("Repost") }
+    status = result.at_css('[data-key="post.status"]')
+    assert_includes status.text.gsub(/\s+/, " "), "Reposted (10h)"
+    assert_equal "span", status.name
   end
 
-  test "#render should not show a repost time for unpublished posts" do
-    draft_post = create(:post, feed: feed, status: :draft, published_at: 11.hours.ago)
-    result = render_inline PostCardComponent.new(post: draft_post)
+  test "#render should label failed posts as failed with a red icon" do
+    failed_post = create(:post, :failed, feed: feed, updated_at: 10.hours.ago)
+    result = render_inline PostCardComponent.new(post: failed_post)
 
-    text = result.text.gsub(/\s+/, " ")
-    assert_includes text, "Source (11h)"
-    assert_not_includes text, "Repost"
+    status = result.at_css('[data-key="post.status"]')
+    assert_includes status.text.gsub(/\s+/, " "), "Failed (10h)"
+    assert_not_empty status.css("svg.text-red-600")
   end
 end


### PR DESCRIPTION
Changes:

- Lead the post card footer with the repost outcome — green "Reposted" or red "Failed" with its time — and show attachment/comment counts only for reposted posts
- Reduce the source to a plain "Source" link without a timestamp
- Declutter the user event log: drop the redundant feed reference, right-align the timestamp, and let the message use the default text size
- Pluralize the feed refresh posts counter, e.g. "(+2 posts)" instead of "(+2)"

These are presentation-only refinements that make a post's repost status and a feed's recent activity easier to scan at a glance.
