### PR TITLE
Refine post card footer and assorted UI tweaks

### DIFF
--- a/REVIEW.yml
+++ b/REVIEW.yml
@@ -46,8 +46,8 @@ reviewed:
   app/views/onboarding/feeds/show.html.erb: ef841f73c86c1517f85521aa70aaf0b41a643cfc
   test/controllers/onboarding/access_token_validations_controller_test.rb: 8120d0d50c8b624100e711265df81b1560cfd695
   test/controllers/onboarding/access_tokens_controller_test.rb: 7c3fba894ca329bf58615e2a599f6724517a19f3
-  app/controllers/admin/system_stats_controller.rb: f5f1ea0666ea35b29925eaa0e353bd385d1c2257
+  app/controllers/admin/system_status_controller.rb: f5f1ea0666ea35b29925eaa0e353bd385d1c2257
   app/helpers/time_helper.rb: c88da2961eea22381bfbc506eb2e024de40184a4
   app/services/disk_usage_service.rb: 4e7162e70f8ab4601323af0207f3db5cc9790eff
-  app/views/admin/system_stats/show.html.erb: 0a7bbc1d0aa01a8530f656fdef261e713cb997f4
+  app/views/admin/system_status/show.html.erb: 0a7bbc1d0aa01a8530f656fdef261e713cb997f4
   app/views/admins/show.html.erb: 5b79fdff9f4fd1a85d46fc225fb4f8f6be570e15

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -10,12 +10,15 @@
   </div>
 
   <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-4 py-2">
-    <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-400">
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-400">
       <% if group_label %>
         <%= link_to group_label, group_url, title: group_hint,
               class: "transition hover:text-slate-600" %>
+        <%= middot %>
       <% end %>
 
+      <%# The status is always present, so every item after it leads with a
+          middot and the optional group label trails one. %>
       <% if status_links_to_freefeed? %>
         <%= link_to freefeed_url, target: "_blank", rel: "noopener",
               class: "flex items-center gap-1.5 transition hover:text-slate-600",
@@ -29,14 +32,17 @@
       <% end %>
 
       <% if source_url %>
+        <%= middot %>
         <%= link_to "Source", source_url, target: "_blank", rel: "noopener",
               class: "transition hover:text-slate-600", data: { key: "post.source" } %>
       <% end %>
 
       <% if show_attachment_count? %>
+        <%= middot %>
         <span data-key="post.attachments"><%= attachment_label %></span>
       <% end %>
       <% if show_comment_count? %>
+        <%= middot %>
         <span data-key="post.comments"><%= comment_label %></span>
       <% end %>
     </div>

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= helpers.dom_id(post) %>" class="<%= card_classes %>">
-  <div class="flex items-start justify-between gap-4 px-5 py-4">
+  <div class="flex items-start justify-between gap-4 px-4 py-4">
     <div class="flex min-w-0 items-center gap-2">
       <%= link_to title, post_url,
             class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
+  <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-4 py-2">
     <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-400">
       <% if group_label %>
         <%= link_to group_label, group_url, title: group_hint,

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -11,14 +11,8 @@
 
   <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-4 py-2">
     <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-400">
-      <% if show_group_chip? %>
-        <%= link_to group_label, group_url, title: group_hint,
-              class: "transition hover:text-slate-600" %>
-        <%= middot %>
-      <% end %>
-
-      <%# The status is always present, so every item after it leads with a
-          middot and the optional group label trails one. %>
+      <%# The status sits leftmost and is always present, so every following
+          item (group, source, counts) leads with a middot. %>
       <% if status_links_to_freefeed? %>
         <%= link_to freefeed_url, target: "_blank", rel: "noopener",
               class: "flex items-center gap-1.5 transition hover:text-slate-600",
@@ -28,6 +22,14 @@
       <% else %>
         <span class="flex items-center gap-1.5" data-key="post.status">
           <%= status_icon %><%= status_label_with_time %>
+        </span>
+      <% end %>
+
+      <% if show_group? %>
+        <%= middot %>
+        <span data-key="post.group">Group:
+          <%= link_to group_label, group_url, title: group_hint,
+                class: "transition hover:text-slate-600" %>
         </span>
       <% end %>
 

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -11,7 +11,7 @@
 
   <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-4 py-2">
     <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-400">
-      <% if group_label %>
+      <% if show_group_chip? %>
         <%= link_to group_label, group_url, title: group_hint,
               class: "transition hover:text-slate-600" %>
         <%= middot %>

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -49,8 +49,12 @@ class PostCardComponent < ViewComponent::Base
     helpers.icon(status_display[:icon], css_class: "size-3.5 #{status_display[:color]}")
   end
 
+  # Group the label, parens and the time tag inside a single inline wrapper so
+  # the surrounding flex gap only spaces the icon from the text. Without the
+  # wrapper the parens become separate flex items and the duration drifts away
+  # from them, e.g. "Reposted ( 1d )" instead of "Reposted (1d)".
   def status_label_with_time
-    helpers.safe_join([status_display[:label], " (", helpers.short_time_ago_tag(status_time), ")"])
+    helpers.content_tag(:span, helpers.safe_join([status_display[:label], " (", helpers.short_time_ago_tag(status_time), ")"]))
   end
 
   # The status badge reports when the post reached its current state. For a

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -49,12 +49,16 @@ class PostCardComponent < ViewComponent::Base
     helpers.icon(status_display[:icon], css_class: "size-3.5 #{status_display[:color]}")
   end
 
-  # Group the label, parens and the time tag inside a single inline wrapper so
-  # the surrounding flex gap only spaces the icon from the text. Without the
-  # wrapper the parens become separate flex items and the duration drifts away
-  # from them, e.g. "Reposted ( 1d )" instead of "Reposted (1d)".
+  # On the posts list a reposted card weaves its target group into the status
+  # ("Reposted to @group (16m)"). The label, group, parens and time tag share a
+  # single inline wrapper so the surrounding flex gap only spaces the icon from
+  # the text; otherwise the parens become separate flex items and the duration
+  # drifts away from them, e.g. "Reposted ( 1d )" instead of "Reposted (1d)".
   def status_label_with_time
-    helpers.content_tag(:span, helpers.safe_join([status_display[:label], " (", helpers.short_time_ago_tag(status_time), ")"]))
+    parts = [status_display[:label]]
+    parts << " to #{group_label}" if reposted_to_group?
+    parts.push(" (", helpers.short_time_ago_tag(status_time), ")")
+    helpers.content_tag(:span, helpers.safe_join(parts))
   end
 
   # The status badge reports when the post reached its current state. For a
@@ -66,6 +70,17 @@ class PostCardComponent < ViewComponent::Base
 
   def reposted?
     post.published?
+  end
+
+  # A reposted card folds the group into its status line, so the standalone
+  # "@group" chip is only shown for the other statuses (and only when the list
+  # spans feeds), where "Failed to @group" would read awkwardly.
+  def reposted_to_group?
+    reposted? && group_label.present?
+  end
+
+  def show_group_chip?
+    group_label.present? && !reposted?
   end
 
   # Attachment and comment counts describe what made it onto FreeFeed, so they

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -129,4 +129,10 @@ class PostCardComponent < ViewComponent::Base
   def menu_id
     "post-menu-#{post.id}"
   end
+
+  # Decorative separator between footer items. Hidden from assistive tech so the
+  # status, source and counts read as distinct items rather than "dot".
+  def middot
+    helpers.content_tag(:span, "·", class: "text-slate-300", aria: { hidden: true })
+  end
 end

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -49,16 +49,12 @@ class PostCardComponent < ViewComponent::Base
     helpers.icon(status_display[:icon], css_class: "size-3.5 #{status_display[:color]}")
   end
 
-  # On the posts list a reposted card weaves its target group into the status
-  # ("Reposted to @group (16m)"). The label, group, parens and time tag share a
-  # single inline wrapper so the surrounding flex gap only spaces the icon from
-  # the text; otherwise the parens become separate flex items and the duration
-  # drifts away from them, e.g. "Reposted ( 1d )" instead of "Reposted (1d)".
+  # Group the label, parens and the time tag inside a single inline wrapper so
+  # the surrounding flex gap only spaces the icon from the text. Without the
+  # wrapper the parens become separate flex items and the duration drifts away
+  # from them, e.g. "Reposted ( 1d )" instead of "Reposted (1d)".
   def status_label_with_time
-    parts = [status_display[:label]]
-    parts << " to #{group_label}" if reposted_to_group?
-    parts.push(" (", helpers.short_time_ago_tag(status_time), ")")
-    helpers.content_tag(:span, helpers.safe_join(parts))
+    helpers.content_tag(:span, helpers.safe_join([status_display[:label], " (", helpers.short_time_ago_tag(status_time), ")"]))
   end
 
   # The status badge reports when the post reached its current state. For a
@@ -72,15 +68,11 @@ class PostCardComponent < ViewComponent::Base
     post.published?
   end
 
-  # A reposted card folds the group into its status line, so the standalone
-  # "@group" chip is only shown for the other statuses (and only when the list
-  # spans feeds), where "Failed to @group" would read awkwardly.
-  def reposted_to_group?
-    reposted? && group_label.present?
-  end
-
-  def show_group_chip?
-    group_label.present? && !reposted?
+  # The target group rides alongside the status as its own labeled item
+  # ("Group: @name") whenever the list spans feeds, keeping the status itself
+  # uncluttered and reading the same for every status.
+  def show_group?
+    group_label.present?
   end
 
   # Attachment and comment counts describe what made it onto FreeFeed, so they

--- a/app/components/post_delete_modal_component.html.erb
+++ b/app/components/post_delete_modal_component.html.erb
@@ -1,15 +1,9 @@
 <%= render ModalComponent.new(title: "Delete post", modal_id: modal_id) do %>
   <%= form_with url: helpers.post_path(post), method: :delete, data: form_data do |form| %>
     <div class="space-y-6">
-      <% if freefeed_option? %>
-        <p class="text-base text-slate-600">
-          This post lives in two places: as a published post on FreeFeed, and as a record here in Feeder. Choose what you want to remove.
-        </p>
-      <% else %>
-        <p class="text-base text-slate-600">
-          This post is already gone from FreeFeed. You can still remove Feeder's record of it.
-        </p>
-      <% end %>
+      <p class="text-base text-slate-600">
+        <%= intro_message %>
+      </p>
 
       <div class="space-y-4">
         <% if freefeed_option? %>

--- a/app/components/post_delete_modal_component.rb
+++ b/app/components/post_delete_modal_component.rb
@@ -16,14 +16,26 @@ class PostDeleteModalComponent < ViewComponent::Base
     self.class.modal_id(post)
   end
 
-  # A withdrawn post is already gone from FreeFeed, so the only thing left to
-  # remove is Feeder's record of it.
+  # The FreeFeed deletion option only makes sense when the post is actually
+  # live on FreeFeed. A withdrawn post is already gone and a failed post never
+  # got there, so in both cases the only thing left to remove is Feeder's
+  # record of it.
   def freefeed_option?
-    !post.withdrawn?
+    post.published? && post.freefeed_post_id.present?
   end
 
   def record_checked_by_default?
     !freefeed_option?
+  end
+
+  def intro_message
+    if freefeed_option?
+      "This post lives in two places: as a published post on FreeFeed, and as a record here in Feeder. Choose what you want to remove."
+    elsif post.failed?
+      "This post never made it to FreeFeed. You can still remove Feeder's record of it."
+    else
+      "This post is already gone from FreeFeed. You can still remove Feeder's record of it."
+    end
   end
 
   def form_data

--- a/app/controllers/admin/system_status_controller.rb
+++ b/app/controllers/admin/system_status_controller.rb
@@ -1,9 +1,9 @@
-class Admin::SystemStatsController < ApplicationController
+class Admin::SystemStatusController < ApplicationController
   def show
     authorize :access, :dev?
     @config_checks = config_checks
     @release_info = release_info
-    @disk_usage = Rails.cache.fetch("admin/system_stats/v3", expires_in: 5.minutes) do
+    @disk_usage = Rails.cache.fetch("admin/system_status/v3", expires_in: 5.minutes) do
       DiskUsageService.new.call
     end
   end

--- a/app/javascript/controllers/preview_button_controller.js
+++ b/app/javascript/controllers/preview_button_controller.js
@@ -2,8 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 
 // Drives the manual feed preview:
 // - keeps the button enabled only when a profile is selected and a source is present
-// - on click, points the modal's feed-preview frame at the preview endpoint for
-//   the currently selected profile + source, then opens the modal
+// - on click, paints the loading spinner, points the modal's feed-preview frame
+//   at the preview endpoint for the selected profile + source, then opens the modal
 // - on modal close, clears the frame so the polling host unmounts (stops polling)
 export default class extends Controller {
   static targets = ["button", "frame"]
@@ -15,6 +15,10 @@ export default class extends Controller {
   }
 
   connect() {
+    // Snapshot the frame's initial loading markup so we can paint the spinner
+    // instantly on every open, instead of waiting for the first server response.
+    if (this.hasFrameTarget) this._loadingHTML = this.frameTarget.innerHTML
+
     this._onHide = this._clearFrame.bind(this)
     this._modal = document.getElementById(this.modalIdValue)
     this._modal?.addEventListener("modal:hide", this._onHide)
@@ -40,6 +44,10 @@ export default class extends Controller {
     const url = new URL(this.endpointValue, window.location.origin)
     url.searchParams.set("profile_key", profileKey)
     url.searchParams.set(`params[${shape}]`, this.sourceValue)
+
+    // Paint the spinner before kicking off the fetch so the modal never opens
+    // empty while the first response is in flight.
+    if (this._loadingHTML != null) this.frameTarget.innerHTML = this._loadingHTML
     this.frameTarget.setAttribute("src", url.toString())
 
     this._modal?.dispatchEvent(new CustomEvent("modal:show"))

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -8,7 +8,7 @@ class PostPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (owner? || admin?) && (record.published? || record.withdrawn?)
+    (owner? || admin?) && (record.published? || record.withdrawn? || record.failed?)
   end
 
   private

--- a/app/views/admin/system_status/show.html.erb
+++ b/app/views/admin/system_status/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "System Health" %>
+<% content_for :title, "System Status" %>
 
 <%
   postgres_size = @disk_usage[:postgres_usage]
@@ -11,7 +11,7 @@
 %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "System Health") do |header| %>
+  <%= render PageHeaderComponent.new(title: "System Status") do |header| %>
     <% header.with_action_button do %>
       <%= link_to "Back to Admin", admin_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -25,11 +25,11 @@
     <% end %>
 
     <% if policy(:access).dev? %>
-      <%= render CardComponent.new(href: admin_system_stats_path) do %>
+      <%= render CardComponent.new(href: admin_system_status_path) do %>
         <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
             <%= icon("hard-drive", css_class: "size-5") %>
-            <span>System Health</span>
+            <span>System Status</span>
           </h2>
           <p class="text-slate-600">Check configuration, disk usage, and other system info</p>
         </div>

--- a/app/views/feed_previews/_processing.html.erb
+++ b/app/views/feed_previews/_processing.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (preview:) %>
+<%# locals: (preview: nil) %>
 <div class="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 shadow-xs"
      role="status"
      aria-busy="true"

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -89,7 +89,10 @@
 
         <%= render ModalComponent.new(title: "Feed preview", modal_id: "feed-preview-modal") do %>
           <%= turbo_frame_tag "feed-preview", data: { preview_button_target: "frame" } do %>
-            <p class="text-slate-500">Your preview will show up here.</p>
+            <%# Shown right away when the modal opens so the spinner is visible
+                before the frame's first response lands (the JS controller
+                re-injects this markup on each open). %>
+            <%= render "feed_previews/processing" %>
           <% end %>
         <% end %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
     end
 
     resources :events, only: [:index, :show]
-    resource :system_stats, only: :show
+    resource :system_status, only: :show, controller: "system_status"
     resources :email_previews, only: [:index, :show]
   end
 

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -28,13 +28,23 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_includes link.text, "Flag Design"
   end
 
-  test "#render should show @group label with display name title when show_feed is true" do
-    result = render_inline PostCardComponent.new(post: post, show_feed: true)
+  test "#render should show @group chip for an unpublished post when show_feed is true" do
+    draft_post = create(:post, :draft, feed: feed)
+    result = render_inline PostCardComponent.new(post: draft_post, show_feed: true)
 
     group_link = result.at_css("a[href*='/feeds/']")
     assert_not_nil group_link
     assert_equal "@xkcd", group_link.text.strip
     assert_equal feed.display_name, group_link["title"]
+  end
+
+  test "#render should weave the group into a reposted status when show_feed is true" do
+    result = render_inline PostCardComponent.new(post: post, show_feed: true)
+
+    status = result.at_css('[data-key="post.status"]')
+    assert_includes status.text.gsub(/\s+/, " "), "Reposted to @xkcd"
+    # The group reads as plain text inside the status, not a separate feed link.
+    assert_nil result.at_css("a[href*='/feeds/']")
   end
 
   test "#render should hide group label when show_feed is false" do

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -138,6 +138,18 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_not_empty status_link.css("svg.text-green-600")
   end
 
+  test "#render should keep the duration tight against its parentheses" do
+    published_post = create(:post, :published, feed: feed,
+      published_at: 11.hours.ago, updated_at: 10.hours.ago)
+    result = render_inline PostCardComponent.new(post: published_post)
+
+    # The label, parens and time tag share one inline wrapper that carries no
+    # flex gap, so the duration cannot drift away from its parentheses.
+    wrapper = result.at_css('[data-key="post.status"] time').parent
+    assert_equal "Reposted (10h)", wrapper.text.strip
+    assert_not_includes wrapper["class"].to_s, "gap"
+  end
+
   test "#render should show the reposted status as plain text when freefeed url is missing" do
     # A purged post stays published but loses its freefeed_post_id (see GroupPurgeJob)
     purged_post = create(:post, :published, feed: feed, freefeed_post_id: nil,

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -28,28 +28,33 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_includes link.text, "Flag Design"
   end
 
-  test "#render should show @group chip for an unpublished post when show_feed is true" do
+  test "#render should show the group as a labeled item linking to the feed when show_feed is true" do
+    result = render_inline PostCardComponent.new(post: post, show_feed: true)
+
+    group = result.at_css('[data-key="post.group"]')
+    assert_not_nil group
+    assert_includes group.text.gsub(/\s+/, " "), "Group: @xkcd"
+    assert_includes group.at_css("a")["href"], "/feeds/"
+    assert_equal feed.display_name, group.at_css("a")["title"]
+  end
+
+  test "#render should label the group the same way for unpublished posts" do
     draft_post = create(:post, :draft, feed: feed)
     result = render_inline PostCardComponent.new(post: draft_post, show_feed: true)
 
-    group_link = result.at_css("a[href*='/feeds/']")
-    assert_not_nil group_link
-    assert_equal "@xkcd", group_link.text.strip
-    assert_equal feed.display_name, group_link["title"]
+    assert_includes result.at_css('[data-key="post.group"]').text.gsub(/\s+/, " "), "Group: @xkcd"
   end
 
-  test "#render should weave the group into a reposted status when show_feed is true" do
+  test "#render should keep the group out of the status label" do
     result = render_inline PostCardComponent.new(post: post, show_feed: true)
 
-    status = result.at_css('[data-key="post.status"]')
-    assert_includes status.text.gsub(/\s+/, " "), "Reposted to @xkcd"
-    # The group reads as plain text inside the status, not a separate feed link.
-    assert_nil result.at_css("a[href*='/feeds/']")
+    assert_not_includes result.at_css('[data-key="post.status"]').text, "@xkcd"
   end
 
-  test "#render should hide group label when show_feed is false" do
+  test "#render should hide the group when show_feed is false" do
     result = render_inline PostCardComponent.new(post: post, show_feed: false)
 
+    assert_nil result.at_css('[data-key="post.group"]')
     assert_nil result.at_css("a[href*='/feeds/']")
   end
 

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -101,6 +101,15 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_not_empty result.css("##{PostDeleteModalComponent.modal_id(post)}")
   end
 
+  test "#render should offer Delete for a failed post" do
+    Current.session = build(:session, user: user)
+    failed_post = create(:post, :failed, feed: feed)
+    result = render_inline PostCardComponent.new(post: failed_post)
+
+    menu_items = result.css('[role="menuitem"]').map { |item| item.text.strip }
+    assert_includes menu_items, "Delete…"
+  end
+
   test "#render should not offer Delete for an unpublished post" do
     Current.session = build(:session, user: user)
     draft_post = create(:post, feed: feed, status: :draft)

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -57,6 +57,17 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_equal "1 comment", result.at_css('[data-key="post.comments"]').text.strip
   end
 
+  test "#render should separate footer items with middots" do
+    post_with_attachments = create(:post, :published, :with_attachments, feed: feed,
+      source_url: "https://xkcd.com/3250/")
+    result = render_inline PostCardComponent.new(post: post_with_attachments)
+
+    # status · Source · attachments => two separators, hidden from assistive tech.
+    middots = result.css("span").select { |span| span.text.strip == "·" }
+    assert_equal 2, middots.size
+    assert(middots.all? { |middot| middot["aria-hidden"] == "true" })
+  end
+
   test "#render should not show attachment or comment counts when none" do
     result = render_inline PostCardComponent.new(post: post)
 

--- a/test/components/post_delete_modal_component_test.rb
+++ b/test/components/post_delete_modal_component_test.rb
@@ -43,6 +43,15 @@ class PostDeleteModalComponentTest < ViewComponent::TestCase
     assert result.at_css("input[name='delete_record']")[:checked]
   end
 
+  test "#render should offer only the record option for a failed post" do
+    failed_post = create(:post, :failed, feed: feed)
+    result = render_inline PostDeleteModalComponent.new(post: failed_post)
+
+    assert_nil result.at_css("input[name='delete_freefeed_post']")
+    assert result.at_css("input[name='delete_record']")[:checked]
+    assert_includes result.text, "never made it to FreeFeed"
+  end
+
   test "#render should wire the submit button to the post-delete controller" do
     result = render_inline PostDeleteModalComponent.new(post: post)
 

--- a/test/controllers/admin/system_status_controller_test.rb
+++ b/test/controllers/admin/system_status_controller_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
+class Admin::SystemStatusControllerTest < ActionDispatch::IntegrationTest
   def dev_user
     @dev_user ||= create(:user, :dev)
   end
@@ -12,22 +12,22 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
   test "should redirect non-dev users" do
     login_as(regular_user)
 
-    get admin_system_stats_path
+    get admin_system_status_path
 
     assert_redirected_to root_path
     assert_equal "Access denied. You don't have permission to perform this action.", flash[:alert]
   end
 
   test "should redirect unauthenticated users" do
-    get admin_system_stats_path
+    get admin_system_status_path
 
     assert_redirected_to new_session_path
   end
 
-  test "should show system stats for dev users" do
+  test "should show system status for dev users" do
     login_as(dev_user)
 
-    get admin_system_stats_path
+    get admin_system_status_path
 
     assert_response :success
   end
@@ -35,7 +35,7 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
   test "should show configuration checklist" do
     login_as(dev_user)
 
-    get admin_system_stats_path
+    get admin_system_status_path
 
     assert_response :success
     assert_select "[data-key='config.resend_key']", text: /Resend key present/
@@ -48,7 +48,7 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
     SolidQueue::Process.create!(kind: "Worker", name: "worker-test", pid: 999, last_heartbeat_at: Time.current)
     login_as(dev_user)
 
-    get admin_system_stats_path
+    get admin_system_status_path
 
     assert_response :success
     assert_select "[data-key='config.background_jobs'][data-status='ok']"
@@ -58,7 +58,7 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
     SolidQueue::Process.delete_all
     login_as(dev_user)
 
-    get admin_system_stats_path
+    get admin_system_status_path
 
     assert_response :success
     assert_select "[data-key='config.background_jobs'][data-status='error']"
@@ -72,7 +72,7 @@ class Admin::SystemStatsControllerTest < ActionDispatch::IntegrationTest
     ) do
       login_as(dev_user)
 
-      get admin_system_stats_path
+      get admin_system_status_path
     end
 
     assert_response :success

--- a/test/controllers/admins_controller_test.rb
+++ b/test/controllers/admins_controller_test.rb
@@ -21,7 +21,7 @@ class AdminsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Admin Panel"
     assert_select "a[href='#{admin_users_path}']", count: 1
     assert_select "a[href='#{admin_events_path}']", count: 1
-    assert_select "a[href='#{admin_system_stats_path}']", count: 0
+    assert_select "a[href='#{admin_system_status_path}']", count: 0
     assert_select "a[href='#{development_components_path}']", count: 0
   end
 
@@ -32,7 +32,7 @@ class AdminsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "a[href='#{admin_users_path}']", count: 1
     assert_select "a[href='#{admin_events_path}']", count: 1
-    assert_select "a[href='#{admin_system_stats_path}']", count: 1
+    assert_select "a[href='#{admin_system_status_path}']", count: 1
     assert_select "a[href='#{mission_control_jobs.root_path}']", count: 1
     assert_select "a[href='#{development_sent_emails_path}']", count: 1
     assert_select "a[href='#{development_components_path}']", count: 1

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -241,6 +241,23 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_nil Post.find_by(id: withdrawn_post.id)
   end
 
+  test "#destroy should let a failed post's record be deleted" do
+    sign_in_as(user)
+    feed_entry = create(:feed_entry, feed: feed, uid: "entry-fail")
+    create(:feed_entry_uid, feed: feed, uid: "entry-fail")
+    failed_post = create(:post, :failed, feed: feed, feed_entry: feed_entry, uid: "entry-fail")
+
+    assert_no_enqueued_jobs(only: PostWithdrawalJob) do
+      assert_difference(["Post.count", "FeedEntryUid.count"], -1) do
+        delete post_url(failed_post), params: { delete_record: "1" },
+                                      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      end
+    end
+
+    assert_response :success
+    assert_nil Post.find_by(id: failed_post.id)
+  end
+
   test "#destroy should do nothing when no option is selected" do
     sign_in_as(user)
     published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")

--- a/test/policies/post_policy_test.rb
+++ b/test/policies/post_policy_test.rb
@@ -69,6 +69,11 @@ class PostPolicyTest < ActiveSupport::TestCase
     assert PostPolicy.new(user, withdrawn_post).destroy?
   end
 
+  test "#destroy? should allow owner for failed post" do
+    failed_post = create(:post, :failed, feed: feed)
+    assert PostPolicy.new(user, failed_post).destroy?
+  end
+
   test "#destroy? should deny owner for non-published post" do
     draft_post = create(:post, :draft, feed: feed)
     assert_not PostPolicy.new(user, draft_post).destroy?


### PR DESCRIPTION
Changes:

- Tighten the reposted duration in post cards so "(1d)" hugs its parentheses
- Separate post card footer items with middots, surface the target group as a labeled "Group: @name" item (status stays leftmost), and trim the card sections to `px-4`
- Let failed posts be deleted from Feeder; the delete dialog drops the FreeFeed option since there's nothing published to withdraw
- Show the feed-preview spinner the moment the modal opens instead of waiting for the first server response
- Rename the admin "System Health" area to "System Status" and move it to `/admin/system_status`

These are mostly small presentation fixes on the posts list, plus two standalone tweaks (failed-post deletion and the System Status rename). The relative timestamp stays bound to its status ("Reposted (16m)") so it reads unambiguously in the middot-separated row.