### PR TITLE
Fix dead advisory-lock rescue in FeedRefreshJob

### DIFF
--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -6,7 +6,7 @@ class FeedRefreshJob < ApplicationJob
     feed = Feed.find_by(id: feed_id)
     return unless feed
 
-    Feed.with_advisory_lock("feed_refresh_#{feed.id}", timeout_seconds: 0) do
+    Feed.with_advisory_lock!("feed_refresh_#{feed.id}", timeout_seconds: 0) do
       FeedRefreshWorkflow.new(feed).execute
     end
   rescue WithAdvisoryLock::FailedToAcquireLock

--- a/test/jobs/feed_refresh_job_test.rb
+++ b/test/jobs/feed_refresh_job_test.rb
@@ -63,12 +63,11 @@ class FeedRefreshJobTest < ActiveJob::TestCase
     end
   end
 
-  test "handles advisory lock failure gracefully" do
+  test ".perform_now should skip without raising when the feed is already being refreshed" do
     feed = create(:feed, feed_profile_key: "rss")
 
-    # Mock the advisory lock to always fail
-    Feed.stub(:with_advisory_lock, ->(*args) { raise WithAdvisoryLock::FailedToAcquireLock.new("Could not acquire lock") }) do
-      # Should not raise an exception
+    # with_advisory_lock! raises on contention; the job rescues it and skips.
+    Feed.stub(:with_advisory_lock!, ->(*, **) { raise WithAdvisoryLock::FailedToAcquireLock.new("feed_refresh") }) do
       assert_nothing_raised do
         FeedRefreshJob.perform_now(feed.id)
       end


### PR DESCRIPTION
Changes:

- Switch `FeedRefreshJob` to `with_advisory_lock!` so a held lock raises `WithAdvisoryLock::FailedToAcquireLock` instead of silently returning `false`
- Update the test to stub the bang form, matching real runtime behavior

The non-bang `with_advisory_lock` never raises on contention, so the existing `FailedToAcquireLock` rescue and its "already being processed" log were dead code — a concurrent refresh was skipped but never logged or testable. Using the bang form (as `PostPublishJob` already does) makes the skip path live, logged, and verifiable. Runtime safety is unchanged: the block still doesn't run while the lock is held.

References:

- Closes #626
- Related PR: #625