### PR TITLE
Rate limit feed refresh endpoint

### DIFF
--- a/app/controllers/feeds/refreshes_controller.rb
+++ b/app/controllers/feeds/refreshes_controller.rb
@@ -1,4 +1,11 @@
 class Feeds::RefreshesController < ApplicationController
+  THROTTLED_MESSAGE = "This feed was just refreshed. Give it a moment before refreshing again.".freeze
+
+  rate_limit to: 10, within: 1.minute,
+             by: -> { "#{Current.user.id}:#{params[:feed_id]}" },
+             only: :create,
+             with: :refresh_throttled
+
   def create
     @feed = Current.user.feeds.find(params[:feed_id])
     authorize @feed, :refresh?
@@ -8,6 +15,19 @@ class Feeds::RefreshesController < ApplicationController
     respond_to do |format|
       format.turbo_stream { render turbo_stream: "" }
       format.html { redirect_to feed_path(@feed), notice: "Feed refresh started" }
+    end
+  end
+
+  private
+
+  def refresh_throttled
+    respond_to do |format|
+      format.turbo_stream do
+        flash.now[:alert] = THROTTLED_MESSAGE
+        render turbo_stream: turbo_stream.replace("flash-messages", partial: "layouts/flash"),
+               status: :too_many_requests
+      end
+      format.html { redirect_to feed_path(params[:feed_id]), alert: THROTTLED_MESSAGE }
     end
   end
 end

--- a/test/controllers/feeds/refreshes_controller_test.rb
+++ b/test/controllers/feeds/refreshes_controller_test.rb
@@ -45,4 +45,28 @@ class Feeds::RefreshesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "text/vnd.turbo-stream.html", response.media_type
   end
+
+  test "create throttles repeated refreshes for the same feed" do
+    sign_in_as(user)
+
+    with_rate_limit_cache do
+      10.times do
+        post feed_refresh_path(feed), as: :turbo_stream
+        assert_response :success
+      end
+
+      assert_no_enqueued_jobs do
+        post feed_refresh_path(feed), as: :turbo_stream
+      end
+      assert_response :too_many_requests
+    end
+  end
+
+  # rate_limit counts in Rails.cache, which is the no-op :null_store in tests.
+  # Delegate the captured store's increment to a real MemoryStore so the limit
+  # actually engages for the duration of the block.
+  def with_rate_limit_cache(&block)
+    store = ActiveSupport::Cache::MemoryStore.new
+    ActionController::Base.cache_store.stub(:increment, ->(*args, **kwargs) { store.increment(*args, **kwargs) }, &block)
+  end
 end


### PR DESCRIPTION
Changes:

- Rate-limit `Feeds::RefreshesController#create` per user+feed (10/min) using Rails' native `rate_limit`
- Over the limit, respond with a 429 and a friendly flash (Turbo) or a redirect (HTML) — no refresh job is enqueued

Repeated clicks on "Refresh now" could enqueue a `FeedRefreshJob` on every request. The per-feed advisory lock already prevents concurrent runs, but nothing capped the queue churn from rapid requests. This adds the backend guard from #602 (preferred over a client-side throttle, which can't be trusted) so the endpoint can't flood the job queue.

References:

- Closes #602
