### PR TITLE
Log metrics transport errors instead of reporting to Honeybadger

### DIFF
--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -64,8 +64,8 @@ module Metrics
       "#{lines.join("\n")}\n"
     end
 
-    # Push the current snapshot. Best-effort: errors are reported, never raised,
-    # so a metrics outage can't take down the app.
+    # Push the current snapshot. Best-effort: transport errors are logged,
+    # never raised, so a metrics outage can't take down the app.
     def flush!
       return unless enabled?
 
@@ -73,6 +73,8 @@ module Metrics
       return if body.strip.empty?
 
       post(body)
+    rescue SocketError, SystemCallError, Timeout::Error, EOFError => e
+      Rails.logger.warn { "Metrics: transport error: #{e.message}" }
     rescue => e
       Rails.error.report(e, context: { component: "metrics" })
     end

--- a/test/services/metrics_test.rb
+++ b/test/services/metrics_test.rb
@@ -76,12 +76,16 @@ class MetricsTest < ActiveSupport::TestCase
     end
   end
 
-  test "#flush! should swallow transport errors" do
+  test "#flush! should log transport errors without reporting to error tracker" do
     enable!
     stub_request(:post, "https://vm.test/api/v1/import/prometheus").to_raise(Errno::ECONNREFUSED)
     Metrics.increment("job_executions_total", status: "ok")
 
-    assert_nothing_raised { Metrics.flush! }
+    reported = []
+    Rails.error.stub(:report, ->(err, **) { reported << err }) do
+      assert_nothing_raised { Metrics.flush! }
+    end
+    assert_empty reported, "transport errors must not reach the error tracker"
   end
 
   test "ApplicationJob should record job runs by outcome" do


### PR DESCRIPTION
DNS and connection failures to the VictoriaMetrics endpoint are
expected during outages and should not create noise in error tracking.
Rescue SocketError, SystemCallError, Timeout::Error, and EOFError with
a local logger warn; only unexpected errors reach Rails.error.report.