### PR TITLE
Fix metrics not reaching VictoriaMetrics from job workers

### DIFF
--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -74,6 +74,9 @@ module Metrics
 
       post(body)
     rescue SocketError, SystemCallError, Timeout::Error, EOFError => e
+      # Transport failures are logged, not reported: a metrics outage is an
+      # infrastructure event, not a bug. Reporting every flush attempt (every
+      # 15s) while VM is down would flood the error tracker with noise.
       Rails.logger.warn { "Metrics: transport error: #{e.message}" }
     rescue => e
       Rails.error.report(e, context: { component: "metrics" })

--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -10,4 +10,8 @@ Rails.application.config.after_initialize do
   Metrics.gauge("jobs_ready") { SolidQueue::ReadyExecution.count }
 
   Metrics.start!
+
+  # SolidQueue forks worker processes; threads don't survive fork, so the flush
+  # thread must be restarted inside each worker after the fork.
+  SolidQueue.on_worker_start { Metrics.start! }
 end


### PR DESCRIPTION
Changes:

- Log metrics transport errors (DNS, connection refused, timeouts) with `Rails.logger.warn` instead of reporting them to Honeybadger — a metrics outage shouldn't create error tracker noise
- Restart the metrics flush thread in each SolidQueue worker process via `SolidQueue.on_worker_start`, fixing counters silently accumulating in forked workers and never being pushed to VictoriaMetrics

SolidQueue forks worker processes, and Ruby threads don't survive `fork()`. The flush thread started during Rails initialization only exists in the supervisor process, so job counters (`feeder_job_executions_total`, `feeder_feed_refresh_total`, etc.) were incremented in workers but never sent to VM. The gauges appeared fine because they're flushed from the web container and the supervisor process, neither of which forks.

References:

- Related PR: #639
