### PR TITLE
Add Postgres size and host OS metrics

### DIFF
--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -51,6 +51,13 @@ module Metrics
       gauges << [name.to_s, normalize_labels(labels), block]
     end
 
+    # Register a labeled gauge family sampled at push time; the block returns a
+    # hash mapping label sets to values, e.g. { { table: "users" } => 123 }.
+    # Use when the label values themselves are only known at sample time.
+    def gauge_set(name, &block)
+      gauge_sets << [name.to_s, block]
+    end
+
     # Everything currently known, as Prometheus exposition text.
     def render
       lines = []
@@ -60,6 +67,11 @@ module Metrics
       gauges.each do |name, labels, block|
         value = sample(block)
         lines << line(name, labels, value) unless value.nil?
+      end
+      gauge_sets.each do |name, block|
+        (sample(block) || {}).each do |labels, value|
+          lines << line(name, normalize_labels(labels), value)
+        end
       end
       "#{lines.join("\n")}\n"
     end
@@ -98,6 +110,7 @@ module Metrics
     def reset!
       mutex.synchronize { counters.clear }
       gauges.clear
+      gauge_sets.clear
       @instance_label = nil
     end
 
@@ -109,6 +122,10 @@ module Metrics
 
     def gauges
       @gauges ||= []
+    end
+
+    def gauge_sets
+      @gauge_sets ||= []
     end
 
     def mutex

--- a/app/services/postgres_metrics.rb
+++ b/app/services/postgres_metrics.rb
@@ -1,0 +1,20 @@
+# Samples Postgres size statistics for the metrics gauges. Queries run at
+# metrics push time on the flusher thread, never at boot, so the app can
+# start without a database; with_connection returns the connection to the
+# pool between samples.
+module PostgresMetrics
+  module_function
+
+  def database_size
+    ApplicationRecord.with_connection do |connection|
+      connection.select_value("SELECT pg_database_size(current_database())")
+    end
+  end
+
+  def table_sizes
+    rows = ApplicationRecord.with_connection do |connection|
+      connection.select_rows("SELECT relname, pg_total_relation_size(relid) FROM pg_stat_user_tables")
+    end
+    rows.to_h { |table, size| [{ table: table }, size] }
+  end
+end

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -36,9 +36,21 @@ accessories:
     image: victoriametrics/victoria-metrics:latest
     host: dev.fffeeder.com
     port: "127.0.0.1:8428:8428"
-    cmd: "-retentionPeriod=1"
+    cmd: "-retentionPeriod=1 -promscrape.config=/etc/victoriametrics/scrape.yml"
+    files:
+      - config/victoriametrics/scrape.yml:/etc/victoriametrics/scrape.yml
     directories:
       - vmdata:/victoria-metrics-data
+
+  # Host-level OS metrics (disk space, RAM, CPU). Reads the host root through
+  # a read-only mount; scraped by VictoriaMetrics over the Kamal network
+  # (see config/victoriametrics/scrape.yml), so no published port.
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:latest
+    host: dev.fffeeder.com
+    cmd: "--path.rootfs=/host"
+    volumes:
+      - "/:/host:ro,rslave"
 
 # Environment variables.
 env:

--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -8,6 +8,8 @@ Rails.application.config.after_initialize do
   Metrics.gauge("feeds_enabled") { Feed.where(state: :enabled).count }
   Metrics.gauge("posts_enqueued") { Post.enqueued.count }
   Metrics.gauge("jobs_ready") { SolidQueue::ReadyExecution.count }
+  Metrics.gauge("pg_database_size_bytes") { PostgresMetrics.database_size }
+  Metrics.gauge_set("pg_table_size_bytes") { PostgresMetrics.table_sizes }
 
   Metrics.start!
 end

--- a/config/victoriametrics/scrape.yml
+++ b/config/victoriametrics/scrape.yml
@@ -1,0 +1,7 @@
+# Scrape targets for the VictoriaMetrics accessory (-promscrape.config).
+# Targets are reached by container name over the Kamal docker network,
+# so no exporter needs a published port.
+scrape_configs:
+  - job_name: node
+    static_configs:
+      - targets: ["f2-node-exporter:9100"]

--- a/test/services/metrics_test.rb
+++ b/test/services/metrics_test.rb
@@ -54,6 +54,30 @@ class MetricsTest < ActiveSupport::TestCase
     assert_includes Metrics.render, "feeder_feeds_enabled 9"
   end
 
+  test "#gauge_set should render a line per label set sampled at render time" do
+    enable!
+    sizes = { { table: "users" } => 100, { table: "feeds" } => 200 }
+    Metrics.gauge_set("pg_table_size_bytes") { sizes }
+
+    out = Metrics.render
+    assert_includes out, %(feeder_pg_table_size_bytes{table="users"} 100)
+    assert_includes out, %(feeder_pg_table_size_bytes{table="feeds"} 200)
+
+    sizes = { { table: "users" } => 150 }
+    assert_includes Metrics.render, %(feeder_pg_table_size_bytes{table="users"} 150)
+  end
+
+  test "#gauge_set should report sampling errors and emit nothing for that set" do
+    enable!
+    Metrics.gauge_set("pg_table_size_bytes") { raise "db down" }
+
+    reported = []
+    out = Rails.error.stub(:report, ->(err, **) { reported << err }) { Metrics.render }
+
+    refute_includes out, "pg_table_size_bytes"
+    assert_equal 1, reported.size
+  end
+
   test "#render should escape quotes in label values" do
     enable!
     Metrics.increment("job_executions_total", job: 'a"b')

--- a/test/services/postgres_metrics_test.rb
+++ b/test/services/postgres_metrics_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class PostgresMetricsTest < ActiveSupport::TestCase
+  test "#database_size should return a positive byte count" do
+    assert_operator PostgresMetrics.database_size, :>, 0
+  end
+
+  test "#table_sizes should map table label sets to positive byte counts" do
+    sizes = PostgresMetrics.table_sizes
+
+    assert_operator sizes.fetch({ table: "users" }), :>, 0
+    assert_operator sizes.fetch({ table: "feeds" }), :>, 0
+  end
+end


### PR DESCRIPTION
Changes:

- Add `Metrics.gauge_set` for gauge families whose label values are only known at sample time
- Export Postgres database size and per-table sizes (`pg_database_size_bytes`, `pg_table_size_bytes{table=...}`)
- Run node_exporter as a staging accessory and let the VictoriaMetrics accessory scrape it for host-level disk and RAM metrics

All Postgres queries run on the metrics flusher thread at push time, never at boot, so builds and CI work without a database. The node_exporter has no published port — VictoriaMetrics reaches it over the internal Kamal network via a `-promscrape.config` file. Rolling out requires booting the new accessory and rebooting VictoriaMetrics once, in addition to a regular deploy.