### PR TITLE
Move source links into post and feed card menus

### DIFF
--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -49,6 +49,14 @@
                   role: "menuitem",
                   data: { key: "feed.#{feed.id}.details" } %>
           </li>
+          <% if source_url %>
+            <li>
+              <%= link_to "Source", source_url, target: "_blank", rel: "noopener",
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem",
+                    data: { key: "feed.#{feed.id}.source" } %>
+            </li>
+          <% end %>
           <% if draft? %>
             <li>
               <%= link_to "Continue setup", edit_url,

--- a/app/components/feed_card_component.rb
+++ b/app/components/feed_card_component.rb
@@ -47,6 +47,12 @@ class FeedCardComponent < ViewComponent::Base
     "feed-menu-#{feed.id}"
   end
 
+  # Query-shaped profiles (AI search) have no URL to open, so the menu only
+  # offers a source link when the feed's input is an actual URL.
+  def source_url
+    feed.source_input.presence if feed.source_input_shape == "url"
+  end
+
   def target_group_label
     "@#{feed.target_group}" if feed.target_group.present?
   end

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -12,7 +12,7 @@
   <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-4 py-2">
     <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-400">
       <%# The status sits leftmost and is always present, so every following
-          item (group, source, counts) leads with a middot. %>
+          item (group, counts) leads with a middot. %>
       <% if status_links_to_freefeed? %>
         <%= link_to freefeed_url, target: "_blank", rel: "noopener",
               class: "flex items-center gap-1.5 transition hover:text-slate-600",
@@ -31,12 +31,6 @@
           <%= link_to group_label, group_url, title: group_hint,
                 class: "transition hover:text-slate-600" %>
         </span>
-      <% end %>
-
-      <% if source_url %>
-        <%= middot %>
-        <%= link_to "Source", source_url, target: "_blank", rel: "noopener",
-              class: "transition hover:text-slate-600", data: { key: "post.source" } %>
       <% end %>
 
       <% if show_attachment_count? %>
@@ -71,6 +65,14 @@
                     class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
                     role: "menuitem" %>
             </li>
+            <% if source_url %>
+              <li>
+                <%= link_to "Source", source_url, target: "_blank", rel: "noopener",
+                      class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                      role: "menuitem",
+                      data: { key: "post.source" } %>
+              </li>
+            <% end %>
             <% if delete_allowed? %>
               <li>
                 <%= link_to "Delete…", "#",

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -138,7 +138,7 @@ class PostCardComponent < ViewComponent::Base
   end
 
   # Decorative separator between footer items. Hidden from assistive tech so the
-  # status, source and counts read as distinct items rather than "dot".
+  # status, group and counts read as distinct items rather than "dot".
   def middot
     helpers.content_tag(:span, "·", class: "text-slate-300", aria: { hidden: true })
   end

--- a/test/components/feed_card_component_test.rb
+++ b/test/components/feed_card_component_test.rb
@@ -87,6 +87,29 @@ class FeedCardComponentTest < ViewComponent::TestCase
     end
   end
 
+  test "#render should show Source action opening the feed source in a new tab" do
+    with_request_url("/feeds") do
+      result = render_inline FeedCardComponent.new(feed: feed)
+
+      source = result.css("[data-key='feed.#{feed.id}.source']").first
+      assert_not_nil source
+      assert_equal "Source", source.text.strip
+      assert_equal "https://example.com/feed.xml", source["href"]
+      assert_equal "_blank", source["target"]
+    end
+  end
+
+  test "#render should not show Source for query-shaped feeds" do
+    query_feed = create(:feed, user: user, feed_profile_key: "llm_web_search",
+      params: { "query" => "ruby news" })
+
+    with_request_url("/feeds") do
+      result = render_inline FeedCardComponent.new(feed: query_feed)
+
+      assert_empty result.css("[data-key='feed.#{query_feed.id}.source']")
+    end
+  end
+
   test "#render should show Edit action for non-draft feeds" do
     with_request_url("/feeds") do
       result = render_inline FeedCardComponent.new(feed: feed)

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -73,11 +73,10 @@ class PostCardComponentTest < ViewComponent::TestCase
   end
 
   test "#render should separate footer items with middots" do
-    post_with_attachments = create(:post, :published, :with_attachments, feed: feed,
-      source_url: "https://xkcd.com/3250/")
+    post_with_attachments = create(:post, :published, :with_attachments, :with_comments, feed: feed)
     result = render_inline PostCardComponent.new(post: post_with_attachments)
 
-    # status · Source · attachments => two separators, hidden from assistive tech.
+    # status · attachments · comments => two separators, hidden from assistive tech.
     middots = result.css("span").select { |span| span.text.strip == "·" }
     assert_equal 2, middots.size
     assert(middots.all? { |middot| middot["aria-hidden"] == "true" })
@@ -111,12 +110,13 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_not_empty result.css("##{ActionView::RecordIdentifier.dom_id(withdrawn_post)}.bg-slate-50")
   end
 
-  test "#render should offer Details and Delete actions for a published post" do
+  test "#render should offer Details, Source and Delete actions for a published post" do
     Current.session = build(:session, user: user)
     result = render_inline PostCardComponent.new(post: post)
 
     menu_items = result.css('[role="menuitem"]').map { |item| item.text.strip }
     assert_includes menu_items, "Details"
+    assert_includes menu_items, "Source"
     assert_includes menu_items, "Delete…"
   end
 
@@ -146,20 +146,28 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_not_includes menu_items, "Delete…"
   end
 
-  test "#render should show footer when post has a source url" do
+  test "#render should render the status footer" do
     result = render_inline PostCardComponent.new(post: post)
 
     assert_not_empty result.css(".border-t.border-slate-200")
   end
 
-  test "#render should link the source without a timestamp" do
-    published_post = create(:post, :published, feed: feed, source_url: "https://xkcd.com/3250/",
-      published_at: 11.hours.ago, updated_at: 10.hours.ago)
-    result = render_inline PostCardComponent.new(post: published_post)
+  test "#render should offer the source as a menu item opening in a new tab" do
+    result = render_inline PostCardComponent.new(post: post)
 
-    source_link = result.at_css("a[href='https://xkcd.com/3250/']")
+    source_link = result.at_css('[data-key="post.source"]')
     assert_not_nil source_link
     assert_equal "Source", source_link.text.strip
+    assert_equal "menuitem", source_link["role"]
+    assert_equal "https://xkcd.com/3250/", source_link["href"]
+    assert_equal "_blank", source_link["target"]
+  end
+
+  test "#render should keep the source link out of the footer metadata" do
+    result = render_inline PostCardComponent.new(post: post)
+
+    source_links = result.css("a[href='https://xkcd.com/3250/']")
+    assert(source_links.all? { |link| link["role"] == "menuitem" })
   end
 
   test "#render should label published posts as reposted and link to the freefeed post" do


### PR DESCRIPTION
Changes:

- Post card: moved the Source link from the footer metadata row into the [...] menu
- Feed card: added a Source item to the [...] menu, opening the feed's source URL in a new tab

The source link now reads as an action instead of footer metadata, so card footers stay focused on status and counts. Feed cards only offer the link for URL-based profiles — query-shaped feeds (AI search) have no URL to open.