### PR TITLE
Truncate card footer on narrow screens

### DIFF
--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -8,20 +8,20 @@
   </div>
 
   <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
-    <div class="flex items-center gap-3 text-sm text-slate-400">
+    <div class="min-w-0 flex-1 truncate text-sm text-slate-400">
       <% if target_group_label %>
         <% if target_group_url %>
           <%= link_to target_group_label, target_group_url, target: "_blank", rel: "noopener",
-                class: "transition hover:text-slate-600" %>
+                class: "mr-3 transition hover:text-slate-600" %>
         <% else %>
-          <span><%= target_group_label %></span>
+          <span class="mr-3"><%= target_group_label %></span>
         <% end %>
       <% end %>
-      <span class="flex items-center gap-1">
+      <span class="inline-flex items-center gap-1 mr-3">
         Updated:
         <%= last_refreshed_tag %>
       </span>
-      <span class="flex items-center gap-1">
+      <span class="inline-flex items-center gap-1">
         Post:
         <%= most_recent_post_tag %>
       </span>

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -10,17 +10,17 @@
   </div>
 
   <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-4 py-2">
-    <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-400">
+    <div class="min-w-0 flex-1 truncate text-sm text-slate-400">
       <%# The status sits leftmost and is always present, so every following
           item (group, counts) leads with a middot. %>
       <% if status_links_to_freefeed? %>
         <%= link_to freefeed_url, target: "_blank", rel: "noopener",
-              class: "flex items-center gap-1.5 transition hover:text-slate-600",
+              class: "inline-flex items-center gap-1.5 transition hover:text-slate-600",
               data: { key: "post.status" } do %>
           <%= status_icon %><%= status_label_with_time %>
         <% end %>
       <% else %>
-        <span class="flex items-center gap-1.5" data-key="post.status">
+        <span class="inline-flex items-center gap-1.5" data-key="post.status">
           <%= status_icon %><%= status_label_with_time %>
         </span>
       <% end %>
@@ -43,7 +43,7 @@
       <% end %>
     </div>
 
-    <div class="flex items-center gap-3">
+    <div class="flex shrink-0 items-center gap-3">
       <div class="relative">
         <button type="button"
                 id="<%= menu_id %>-button"

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -140,6 +140,6 @@ class PostCardComponent < ViewComponent::Base
   # Decorative separator between footer items. Hidden from assistive tech so the
   # status, group and counts read as distinct items rather than "dot".
   def middot
-    helpers.content_tag(:span, "·", class: "text-slate-300", aria: { hidden: true })
+    helpers.content_tag(:span, "·", class: "mx-1 text-slate-300", aria: { hidden: true })
   end
 end


### PR DESCRIPTION
Changes:

- Switch post and feed card footers from `flex-wrap` to a block container with `truncate` so long content clips with `…` rather than wrapping
- Status icon+text spans changed to `inline-flex` to flow correctly inside the truncating block
- Add `mx-1` to the middot separator (replaces flex `gap-x-2` spacing)
- Add `shrink-0` to the post card menu button wrapper so it stays visible

The menu button is always visible; the info text truncates before it on narrow viewports — e.g. `Reposted (28m) · Group: @a-lis… [···]`.