### PR TITLE
Improve admin event log presentation

### DIFF
--- a/app/components/admin/event_log_entry_component.html.erb
+++ b/app/components/admin/event_log_entry_component.html.erb
@@ -1,6 +1,6 @@
 <div class="w-full rounded-lg border border-slate-200 bg-white shadow-xs" data-key="events.<%= event.id %>">
   <div class="flex items-center gap-3 px-5 py-4">
-    <span class="flex w-4 shrink-0 items-center justify-center" data-key="events.severity"><%= severity_icon %></span>
+    <%= severity_link %>
     <div class="min-w-0 flex-1 truncate text-slate-700" data-key="events.description">
       <%= render EventDescriptionComponent.for(event) %>
     </div>

--- a/app/components/admin/event_log_entry_component.html.erb
+++ b/app/components/admin/event_log_entry_component.html.erb
@@ -1,11 +1,11 @@
-<div class="w-full rounded-lg border border-slate-200 bg-white shadow-xs" data-key="events.<%= event.id %>">
+<div class="<%= card_classes %>" data-key="events.<%= event.id %>">
   <div class="flex items-center gap-3 px-5 py-4">
     <%= severity_link %>
     <div class="min-w-0 flex-1 truncate text-slate-700" data-key="events.description">
       <%= render EventDescriptionComponent.for(event) %>
     </div>
   </div>
-  <div class="truncate border-t border-slate-200 px-5 py-2 text-sm text-slate-400">
+  <div class="truncate border-t <%= divider_border %> px-5 py-2 text-sm text-slate-400">
     <%= safe_join(footer_items, helpers.middot) %>
   </div>
 </div>

--- a/app/components/admin/event_log_entry_component.html.erb
+++ b/app/components/admin/event_log_entry_component.html.erb
@@ -1,21 +1,11 @@
 <div class="w-full rounded-lg border border-slate-200 bg-white shadow-xs" data-key="events.<%= event.id %>">
-  <div class="flex items-start justify-between gap-4 px-5 py-4">
-    <div class="flex min-w-0 flex-wrap items-center gap-2">
-      <%= render BadgeComponent.new(text: event.level.humanize, color: badge_color(event.level)) %>
-      <code class="text-sm font-semibold text-slate-800" data-key="events.type"><%= event.type %></code>
-    </div>
-    <%= link_to helpers.short_time_ago(event.created_at), href,
-                class: "shrink-0 text-sm font-medium text-slate-400 hover:text-slate-700",
-                title: event.created_at.rfc3339,
-                data: { key: "events.timestamp" } %>
-  </div>
-  <div class="flex items-center gap-3 border-t border-slate-200 px-5 py-2 text-sm text-slate-500">
-    <div class="min-w-0 truncate text-slate-600">
+  <div class="flex items-center gap-3 px-5 py-4">
+    <span class="flex w-4 shrink-0 items-center justify-center" data-key="events.severity"><%= severity_icon %></span>
+    <div class="min-w-0 flex-1 truncate text-slate-700" data-key="events.description">
       <%= render EventDescriptionComponent.for(event) %>
     </div>
-    <% meta = safe_join([user_label, subject_label].compact, " • ") %>
-    <% if meta.present? %>
-      <div class="shrink-0"><%= meta %></div>
-    <% end %>
+  </div>
+  <div class="truncate border-t border-slate-200 px-5 py-2 text-sm text-slate-400">
+    <%= safe_join(footer_items, helpers.middot) %>
   </div>
 </div>

--- a/app/components/admin/event_log_entry_component.rb
+++ b/app/components/admin/event_log_entry_component.rb
@@ -10,19 +10,52 @@ class Admin::EventLogEntryComponent < ViewComponent::Base
 
   attr_reader :event, :href
 
-  def subject_filter_path(filter_params)
-    helpers.admin_events_path(filter: filter_params)
+  # The timestamp sits leftmost so it survives the narrow-screen truncation;
+  # everything after it clips with an ellipsis.
+  def footer_items
+    [timestamp_link, type_link, user_label, target_label].compact
+  end
+
+  def timestamp_link
+    helpers.link_to(helpers.short_time_ago(event.created_at), href,
+                    class: "font-medium transition hover:text-slate-700",
+                    title: event.created_at.rfc3339,
+                    data: { key: "events.timestamp" })
+  end
+
+  def type_link
+    helpers.link_to(event.type,
+                    helpers.admin_events_path(filter: { type: [event.type] }),
+                    class: "font-mono transition hover:text-slate-700",
+                    data: { key: "events.type" })
   end
 
   # Admins see who an event belongs to; the user links to a filtered log.
   def user_label
-    return helpers.tag.em("System", data: { key: "events.user" }) if event.user_id.blank?
+    label = if event.user_id.blank?
+      helpers.tag.em("System", data: { key: "events.user" })
+    else
+      helpers.link_to("##{event.user_id}",
+                      helpers.admin_events_path(filter: { user_id: event.user_id }),
+                      class: "underline underline-offset-2 transition hover:text-slate-700",
+                      data: { key: "events.user" })
+    end
 
-    helpers.link_to(
-      "User ##{event.user_id}",
-      helpers.admin_events_path(filter: { user_id: event.user_id }),
-      class: "underline underline-offset-2 hover:text-slate-700",
-      data: { key: "events.user" }
-    )
+    safe_join(["User: ", label])
+  end
+
+  def target_label
+    return if event.subject_type.blank?
+
+    value = [event.subject_type, event.subject_id].compact.join("#")
+    filter_params = { subject_type: event.subject_type }
+    filter_params[:subject_id] = event.subject_id if event.subject_id.present?
+
+    link = helpers.link_to(value,
+                           helpers.admin_events_path(filter: filter_params),
+                           class: "underline underline-offset-2 transition hover:text-slate-700",
+                           data: { key: "events.subject" })
+
+    safe_join(["Target: ", link])
   end
 end

--- a/app/components/admin/event_log_entry_component.rb
+++ b/app/components/admin/event_log_entry_component.rb
@@ -38,6 +38,7 @@ class Admin::EventLogEntryComponent < ViewComponent::Base
       helpers.link_to("##{event.user_id}",
                       helpers.admin_events_path(filter: { user_id: event.user_id }),
                       class: "underline underline-offset-2 transition hover:text-slate-700",
+                      title: event.user&.email_address,
                       data: { key: "events.user" })
     end
 
@@ -54,8 +55,18 @@ class Admin::EventLogEntryComponent < ViewComponent::Base
     link = helpers.link_to(value,
                            helpers.admin_events_path(filter: filter_params),
                            class: "underline underline-offset-2 transition hover:text-slate-700",
+                           title: target_title,
                            data: { key: "events.subject" })
 
     safe_join(["Target: ", link])
+  end
+
+  # Resolves the subject to its human name so admins don't have to memorize
+  # ids; deleted subjects render without a hint.
+  def target_title
+    subject = event.subject
+    return unless subject
+
+    subject.try(:display_name) || subject.try(:name) || subject.try(:email_address)
   end
 end

--- a/app/components/admin/event_log_entry_component.rb
+++ b/app/components/admin/event_log_entry_component.rb
@@ -1,6 +1,16 @@
 class Admin::EventLogEntryComponent < ViewComponent::Base
   include EventLogEntryPresentation
 
+  # Warning and error cards reuse the alert palette so problems stand out
+  # while scanning the log; routine events stay neutral. The border picks a
+  # slightly darker shade of the background hue, like AlertComponent does.
+  LEVEL_TINTS = {
+    "warning" => { border: "border-amber-200", background: "bg-amber-100" },
+    "error" => { border: "border-red-200", background: "bg-red-100" }
+  }.freeze
+
+  DEFAULT_TINT = { border: "border-slate-200", background: "bg-white" }.freeze
+
   def initialize(event:, href:)
     @event = event
     @href = href
@@ -9,6 +19,18 @@ class Admin::EventLogEntryComponent < ViewComponent::Base
   private
 
   attr_reader :event, :href
+
+  def card_classes
+    helpers.class_names("w-full rounded-lg border shadow-xs", tint[:border], tint[:background])
+  end
+
+  def divider_border
+    tint[:border]
+  end
+
+  def tint
+    LEVEL_TINTS.fetch(event.level, DEFAULT_TINT)
+  end
 
   # The severity gutter doubles as a drill-down: clicking the icon narrows
   # the log to events of the same level.

--- a/app/components/admin/event_log_entry_component.rb
+++ b/app/components/admin/event_log_entry_component.rb
@@ -10,6 +10,16 @@ class Admin::EventLogEntryComponent < ViewComponent::Base
 
   attr_reader :event, :href
 
+  # The severity gutter doubles as a drill-down: clicking the icon narrows
+  # the log to events of the same level.
+  def severity_link
+    helpers.link_to(severity_icon,
+                    helpers.admin_events_path(filter: { level: event.level }),
+                    class: "flex w-4 shrink-0 items-center justify-center",
+                    title: "Show #{event.level} events",
+                    data: { key: "events.severity" })
+  end
+
   # The timestamp sits leftmost so it survives the narrow-screen truncation;
   # everything after it clips with an ellipsis.
   def footer_items

--- a/app/components/event_log_entry_presentation.rb
+++ b/app/components/event_log_entry_presentation.rb
@@ -4,16 +4,6 @@
 module EventLogEntryPresentation
   private
 
-  def badge_color(level)
-    case level
-    when "debug" then :gray
-    when "info" then :blue
-    when "warning" then :yellow
-    when "error" then :red
-    else :blue
-    end
-  end
-
   # Every entry carries a severity icon. Warnings and errors stand out in
   # amber and red; routine events get a muted info circle so the column reads
   # as a continuous gutter.
@@ -25,25 +15,5 @@ module EventLogEntryPresentation
     end
 
     helpers.icon(name, css_class: "size-4 #{color}", aria_label: event.level.capitalize)
-  end
-
-  def subject_label
-    return if event.subject_type.blank?
-
-    value = event.subject_id.present? ? "#{event.subject_type} ##{event.subject_id}" : event.subject_type
-
-    filter_params = { subject_type: event.subject_type }
-    filter_params[:subject_id] = event.subject_id if event.subject_id.present?
-
-    helpers.link_to(
-      value,
-      subject_filter_path(filter_params),
-      class: "underline underline-offset-2 hover:text-slate-700",
-      data: { key: "events.subject" }
-    )
-  end
-
-  def subject_filter_path(filter_params)
-    helpers.events_path(filter: filter_params)
   end
 end

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -26,7 +26,7 @@
       <% end %>
 
       <% if show_group? %>
-        <%= middot %>
+        <%= helpers.middot %>
         <span data-key="post.group">Group:
           <%= link_to group_label, group_url, title: group_hint,
                 class: "transition hover:text-slate-600" %>
@@ -34,11 +34,11 @@
       <% end %>
 
       <% if show_attachment_count? %>
-        <%= middot %>
+        <%= helpers.middot %>
         <span data-key="post.attachments"><%= attachment_label %></span>
       <% end %>
       <% if show_comment_count? %>
-        <%= middot %>
+        <%= helpers.middot %>
         <span data-key="post.comments"><%= comment_label %></span>
       <% end %>
     </div>

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -136,10 +136,4 @@ class PostCardComponent < ViewComponent::Base
   def menu_id
     "post-menu-#{post.id}"
   end
-
-  # Decorative separator between footer items. Hidden from assistive tech so the
-  # status, group and counts read as distinct items rather than "dot".
-  def middot
-    helpers.content_tag(:span, "·", class: "mx-1 text-slate-300", aria: { hidden: true })
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,12 @@ module ApplicationHelper
     truncate(content.strip, length: length)
   end
 
+  # Decorative separator between card footer items. Hidden from assistive tech
+  # so the items read as distinct entries rather than "dot".
+  def middot
+    content_tag(:span, "·", class: "mx-1 text-slate-300", aria: { hidden: true })
+  end
+
   ICONS = {
     # Media
     "pause"          => '<rect x="14" y="3" width="5" height="18" rx="1"/><rect x="5" y="3" width="5" height="18" rx="1"/>',

--- a/test/components/admin/event_log_entry_component_test.rb
+++ b/test/components/admin/event_log_entry_component_test.rb
@@ -65,6 +65,15 @@ class Admin::EventLogEntryComponentTest < ViewComponent::TestCase
     assert_includes result.text, "User:"
   end
 
+  test "#call should reveal the user email on hover" do
+    event = create(:event, user: user)
+
+    result = render_entry(event)
+
+    link = result.css("a[data-key='events.user']").first
+    assert_equal user.email_address, link["title"]
+  end
+
   test "#call should link the subject to the admin filter" do
     feed = create(:feed, user: user)
     event = create(:event, type: "feed_refresh", subject: feed, user: user)
@@ -78,6 +87,27 @@ class Admin::EventLogEntryComponentTest < ViewComponent::TestCase
     assert_includes link["href"], "filter%5Bsubject_type%5D=Feed"
     assert_includes link["href"], "filter%5Bsubject_id%5D=#{feed.id}"
     assert_includes result.text, "Target:"
+  end
+
+  test "#call should reveal the subject name on hover" do
+    feed = create(:feed, user: user)
+    event = create(:event, type: "feed_refresh", subject: feed, user: user)
+
+    result = render_entry(event)
+
+    link = result.css("a[data-key='events.subject']").first
+    assert_equal feed.display_name, link["title"]
+  end
+
+  test "#call should omit the subject hover title when the subject is gone" do
+    event = create(:event, user: user)
+    event.update!(subject_type: "Feed", subject_id: 12_345)
+
+    result = render_entry(event)
+
+    link = result.css("a[data-key='events.subject']").first
+    assert_not_nil link
+    assert_nil link["title"]
   end
 
   test "#call should show System for events without a user" do

--- a/test/components/admin/event_log_entry_component_test.rb
+++ b/test/components/admin/event_log_entry_component_test.rb
@@ -31,6 +31,18 @@ class Admin::EventLogEntryComponentTest < ViewComponent::TestCase
     assert_not_includes result.text, "Warning"
   end
 
+  test "#call should link the severity icon to the level filter" do
+    event = create(:event, level: :error, user: user)
+
+    result = render_entry(event)
+
+    link = result.css("a[data-key='events.severity']").first
+    assert_not_nil link
+    assert_includes link["href"], "/admin/events"
+    assert_includes link["href"], "filter%5Blevel%5D=error"
+    assert_equal "Show error events", link["title"]
+  end
+
   test "#call should link the footer timestamp to the event page" do
     event = create(:event, user: user)
 

--- a/test/components/admin/event_log_entry_component_test.rb
+++ b/test/components/admin/event_log_entry_component_test.rb
@@ -5,40 +5,106 @@ class Admin::EventLogEntryComponentTest < ViewComponent::TestCase
     @user ||= create(:user)
   end
 
+  def render_entry(event)
+    render_inline(Admin::EventLogEntryComponent.new(event: event, href: "/admin/events/#{event.id}"))
+  end
+
+  test "#call should render the humanized message in the card body" do
+    event = create(:event, message: "Something happened", user: user)
+
+    result = render_entry(event)
+
+    description = result.css("[data-key='events.description']").first
+    assert_not_nil description
+    assert_includes description.text, "Something happened"
+  end
+
+  test "#call should render a severity icon instead of a level badge" do
+    event = create(:event, level: :warning, user: user)
+
+    result = render_entry(event)
+
+    icon = result.css("[data-key='events.severity'] svg").first
+    assert_not_nil icon
+    assert_equal "Warning", icon["aria-label"]
+    assert_includes icon["class"], "text-amber-500"
+    assert_not_includes result.text, "Warning"
+  end
+
+  test "#call should link the footer timestamp to the event page" do
+    event = create(:event, user: user)
+
+    result = render_entry(event)
+
+    link = result.css("a[data-key='events.timestamp']").first
+    assert_not_nil link
+    assert_equal "/admin/events/#{event.id}", link["href"]
+  end
+
+  test "#call should link the type to the admin filter" do
+    event = create(:event, type: "custom_event", user: user)
+
+    result = render_entry(event)
+
+    link = result.css("a[data-key='events.type']").first
+    assert_not_nil link
+    assert_equal "custom_event", link.text
+    assert_includes link["href"], "/admin/events"
+    assert_includes link["href"], "filter%5Btype%5D%5B%5D=custom_event"
+  end
+
   test "#call should link the user to the admin filter" do
     event = create(:event, user: user)
 
-    result = render_inline(Admin::EventLogEntryComponent.new(event: event, href: "/admin/events/#{event.id}"))
+    result = render_entry(event)
 
     link = result.css("a[data-key='events.user']").first
     assert_not_nil link
-    assert_equal "User ##{user.id}", link.text
+    assert_equal "##{user.id}", link.text
     assert_includes link["href"], "filter%5Buser_id%5D=#{user.id}"
-    assert_includes link["class"], "underline"
-    assert_not_includes link["class"], "decoration-dotted"
+    assert_includes result.text, "User:"
   end
 
   test "#call should link the subject to the admin filter" do
     feed = create(:feed, user: user)
     event = create(:event, type: "feed_refresh", subject: feed, user: user)
 
-    result = render_inline(Admin::EventLogEntryComponent.new(event: event, href: "/admin/events/#{event.id}"))
+    result = render_entry(event)
 
     link = result.css("a[data-key='events.subject']").first
     assert_not_nil link
-    assert_equal "Feed ##{feed.id}", link.text
+    assert_equal "Feed##{feed.id}", link.text
     assert_includes link["href"], "/admin/events"
     assert_includes link["href"], "filter%5Bsubject_type%5D=Feed"
     assert_includes link["href"], "filter%5Bsubject_id%5D=#{feed.id}"
+    assert_includes result.text, "Target:"
   end
 
   test "#call should show System for events without a user" do
     event = create(:event, user: nil)
 
-    result = render_inline(Admin::EventLogEntryComponent.new(event: event, href: "/admin/events/#{event.id}"))
+    result = render_entry(event)
 
     label = result.css("[data-key='events.user']").first
     assert_not_nil label
     assert_equal "System", label.text
+  end
+
+  test "#call should omit the target for events without a subject" do
+    event = create(:event, user: user)
+
+    result = render_entry(event)
+
+    assert_empty result.css("[data-key='events.subject']")
+    assert_not_includes result.text, "Target:"
+  end
+
+  test "#call should truncate the footer on narrow screens" do
+    event = create(:event, user: user)
+
+    result = render_entry(event)
+
+    footer = result.css("[data-key='events.timestamp']").first.parent
+    assert_includes footer["class"], "truncate"
   end
 end

--- a/test/components/admin/event_log_entry_component_test.rb
+++ b/test/components/admin/event_log_entry_component_test.rb
@@ -141,6 +141,39 @@ class Admin::EventLogEntryComponentTest < ViewComponent::TestCase
     assert_not_includes result.text, "Target:"
   end
 
+  test "#call should tint warning cards with the alert palette" do
+    event = create(:event, level: :warning, user: user)
+
+    result = render_entry(event)
+
+    card = result.css("[data-key='events.#{event.id}']").first
+    assert_includes card["class"], "bg-amber-100"
+    assert_includes card["class"], "border-amber-200"
+  end
+
+  test "#call should tint error cards with the alert palette" do
+    event = create(:event, level: :error, user: user)
+
+    result = render_entry(event)
+
+    card = result.css("[data-key='events.#{event.id}']").first
+    assert_includes card["class"], "bg-red-100"
+    assert_includes card["class"], "border-red-200"
+
+    footer = result.css("a[data-key='events.timestamp']").first.parent
+    assert_includes footer["class"], "border-red-200"
+  end
+
+  test "#call should keep routine cards neutral" do
+    event = create(:event, level: :info, user: user)
+
+    result = render_entry(event)
+
+    card = result.css("[data-key='events.#{event.id}']").first
+    assert_includes card["class"], "bg-white"
+    assert_includes card["class"], "border-slate-200"
+  end
+
   test "#call should truncate the footer on narrow screens" do
     event = create(:event, user: user)
 

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -285,6 +285,19 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select '[data-key="events.type"]', text: "TypeC", count: 0
   end
 
+  test "should filter events by level" do
+    login_as(admin_user)
+
+    create(:event, type: "InfoEvent", level: :info)
+    create(:event, type: "WarningEvent", level: :warning)
+
+    get admin_events_path, params: { filter: { level: "warning" } }
+
+    assert_response :success
+    assert_select '[data-key="events.type"]', text: "WarningEvent", count: 1
+    assert_select '[data-key="events.type"]', text: "InfoEvent", count: 0
+  end
+
   test "should filter events by user_id" do
     login_as(admin_user)
 

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -38,7 +38,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Events Log"
     assert_select '[data-key="events.type"]', "TestEvent"
-    assert_select 'a[data-key="events.user"]', "User ##{user.id}"
+    assert_select 'a[data-key="events.user"]', "##{user.id}"
   end
 
   test "should allow admin users to view event details" do
@@ -222,7 +222,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     get admin_events_path
 
     assert_response :success
-    assert_select '[data-key="events.subject"]', text: "Post #42"
+    assert_select '[data-key="events.subject"]', text: "Post#42"
   end
 
   test "should filter events by subject_type" do
@@ -238,8 +238,8 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '[data-key="events.type"]', count: 2
-    assert_select '[data-key="events.subject"]', text: /User #/, count: 2
-    assert_select '[data-key="events.subject"]', text: /Feed #/, count: 0
+    assert_select '[data-key="events.subject"]', text: /User#/, count: 2
+    assert_select '[data-key="events.subject"]', text: /Feed#/, count: 0
   end
 
   test "should filter events by subject_id" do


### PR DESCRIPTION
Changes:

- Lead each admin event card with the humanized event message next to a severity icon, matching the user-facing events log, instead of a level badge and raw type
- Move the machine-readable details (timestamp, type, user, target) to a middot-separated footer that truncates on narrow screens, like the post card footer
- Make the whole footer a drill-down surface: type, user, target, and the severity icon all link to a filtered log
- Reveal the user email and the target's display name in hover titles, so compact references like `#1` and `Feed#5` stay identifiable
- Tint warning and error cards with the alert palette (amber/red background with a slightly darker matching border) so problems stand out while scanning
- Extract the shared `middot` separator into `ApplicationHelper`

The admin log is a triage surface: the humanized message is what an admin scans for, so it takes the prominent spot, while filter links support drilling down. The timestamp sits leftmost so it survives truncation and keeps the link to the event details.

References:

- Closes #600
- Related PR: #661