### PR TITLE
Don't retry FeedPreviewJob on workflow errors

### DIFF
--- a/app/jobs/feed_preview_job.rb
+++ b/app/jobs/feed_preview_job.rb
@@ -14,7 +14,10 @@ class FeedPreviewJob < ApplicationJob
     # marked the preview failed; this is a user-state condition, not a crash.
     Rails.logger.info "FeedPreviewJob: no AI credential for preview #{feed_preview_id}: #{e.message}"
   rescue => e
+    # The workflow already transitioned the preview to :failed. Do not re-raise:
+    # retrying would reset status back to :processing (via initialize_workflow),
+    # causing the status to oscillate and leaving the client polling indefinitely.
     Rails.logger.error "FeedPreviewJob failed for preview #{feed_preview_id}: #{e.message}"
-    raise
+    Rails.error.report(e, context: { feed_preview_id: feed_preview_id })
   end
 end

--- a/test/jobs/feed_preview_job_test.rb
+++ b/test/jobs/feed_preview_job_test.rb
@@ -28,12 +28,13 @@ class FeedPreviewJobTest < ActiveJob::TestCase
     end
   end
 
-  test "#perform should swallow workflow errors to prevent retry oscillation" do
+  test "#perform should mark the preview failed and not retry when the loader fails" do
     preview = create(:feed_preview, feed_profile_key: "rss",
                      params: { "url" => "https://example.com/feed.xml" }, run_id: "run-1")
 
-    FeedPreviewWorkflow.stub(:new, ->(*, **) { raise StandardError, "Could not find YouTube RSS feed link" }) do
-      assert_nothing_raised { FeedPreviewJob.perform_now(preview.id, "run-1") }
-    end
+    stub_request(:get, "https://example.com/feed.xml").to_return(status: 500)
+
+    assert_nothing_raised { FeedPreviewJob.perform_now(preview.id, "run-1") }
+    assert preview.reload.failed?
   end
 end

--- a/test/jobs/feed_preview_job_test.rb
+++ b/test/jobs/feed_preview_job_test.rb
@@ -27,4 +27,13 @@ class FeedPreviewJobTest < ActiveJob::TestCase
       assert_nothing_raised { FeedPreviewJob.perform_now(preview.id, "run-1") }
     end
   end
+
+  test "#perform should swallow workflow errors to prevent retry oscillation" do
+    preview = create(:feed_preview, feed_profile_key: "rss",
+                     params: { "url" => "https://example.com/feed.xml" }, run_id: "run-1")
+
+    FeedPreviewWorkflow.stub(:new, ->(*, **) { raise StandardError, "Could not find YouTube RSS feed link" }) do
+      assert_nothing_raised { FeedPreviewJob.perform_now(preview.id, "run-1") }
+    end
+  end
 end


### PR DESCRIPTION
Changes:

- Remove `raise` from `FeedPreviewJob`'s catch-all rescue so SolidQueue does not retry failed preview jobs
- Add `Rails.error.report` to preserve Honeybadger visibility for swallowed errors
- Add test covering the no-retry behaviour for workflow errors

When a workflow step raises (e.g. "Could not find YouTube RSS feed link"), `Workflow#execute` calls `on_error` — which transitions the preview to `:failed` — then re-raises. The job's previous catch-all re-raised again, scheduling a SolidQueue retry. On retry, `initialize_workflow` calls `transition!(status: :processing)`, which succeeds because the `run_id` still matches, flipping the preview back to `:processing`. This oscillation between `:failed` and `:processing` across retry rounds meant the polling client could poll continuously without ever landing on the terminal state.

References:

- Closes #538
