### PR TITLE
Make failed preview a terminal state for polling

### DIFF
--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -49,7 +49,7 @@ class FeedPreviewsController < ApplicationController
   end
 
   def needs_run?(preview)
-    preview.new_record? || preview.failed? || stale_ready?(preview)
+    preview.new_record? || stale_ready?(preview)
   end
 
   # Start a fresh run and return the persisted row. If a concurrent request

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -120,6 +120,35 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     assert user.feed_previews.last.pending?
   end
 
+  test "#show should render the failed state without restarting a run" do
+    sign_in_as(user)
+    create(:feed_preview, :failed, user: user, feed_profile_key: "rss",
+                                   params: { "url" => "http://example.com/feed.xml" })
+
+    assert_no_enqueued_jobs do
+      get feed_preview_url(profile_key: "rss", "params" => { url: "http://example.com/feed.xml" }),
+          headers: TURBO_STREAM
+    end
+
+    assert_response :success
+    assert_match(/data-preview-done/, response.body)
+  end
+
+  test "#create should restart a failed preview and enqueue a job" do
+    sign_in_as(user)
+    create(:feed_preview, :failed, user: user, feed_profile_key: "rss",
+                                   params: { "url" => "http://example.com/feed.xml" })
+
+    assert_no_difference("FeedPreview.count") do
+      assert_enqueued_with(job: FeedPreviewJob) do
+        post feed_preview_url(profile_key: "rss", "params" => { url: "http://example.com/feed.xml" })
+      end
+    end
+
+    assert_response :success
+    assert user.feed_previews.last.pending?
+  end
+
   test "#create should re-enqueue and reset an existing ready preview" do
     sign_in_as(user)
     preview = create(:feed_preview, :completed, user: user, feed_profile_key: "rss",


### PR DESCRIPTION
Changes:

- Remove `failed?` from `needs_run?` so GET `/feed_preview` no longer restarts the job when a previous run failed
- Add tests covering the new terminal-state contract for both GET and POST

The polling endpoint is `GET /feed_preview`. When a job marked a preview `:failed`, the next poll hit `needs_run?` → `failed? == true` → `start_run` reset the status to `:pending` and enqueued a new job — before any partial was rendered. The failed partial (`data-preview-done`) could therefore never reach the client through polling, the "Try again" button was dead code, and every polling tab kept burning job runs against the same broken upstream source.

With `failed?` removed, GET renders the failed partial which carries `data-preview-done`, tripping the stop-condition on the next request. User-initiated retry via POST (the "Try again" button) calls `start_run` unconditionally and is unaffected.

References:

- Part of #538
