### PR TITLE
Add server-side timeout for stuck feed previews

### DIFF
--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -18,6 +18,7 @@ class FeedPreviewsController < ApplicationController
   def show
     preview = locate_preview
     preview = start_run(preview) if needs_run?(preview)
+    preview.timeout! if preview.timed_out?
     render_state(preview)
   end
 

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -33,12 +33,13 @@ class FeedPreview < ApplicationRecord
     (pending? || processing?) && updated_at < PREVIEW_TIMEOUT_SECONDS.seconds.ago
   end
 
-  # Transitions to :failed when still in a non-terminal state and timed out.
-  # Uses a conditional UPDATE so a concurrently completing job can't be clobbered.
+  # Transitions to :failed only if still non-terminal. The status guard in the
+  # UPDATE means a concurrently completing job won't be clobbered.
   def timeout!
     updated = self.class
-                  .where(id: id, status: [self.class.statuses[:pending], self.class.statuses[:processing]])
-                  .update_all(status: self.class.statuses[:failed], updated_at: Time.current)
+                  .where(id: self.id)
+                  .where(status: [:pending, :processing])
+                  .update_all(status: :failed, updated_at: Time.current)
     reload if updated.positive?
   end
 

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -1,5 +1,6 @@
 class FeedPreview < ApplicationRecord
   PREVIEW_POSTS_LIMIT = 10
+  PREVIEW_TIMEOUT_SECONDS = 120
 
   belongs_to :user
   belongs_to :feed, optional: true
@@ -26,6 +27,19 @@ class FeedPreview < ApplicationRecord
   def self.source_input(feed_profile_key, params)
     shape = FeedProfile[feed_profile_key]&.dig(:input_shape) || :url
     (params || {})[shape.to_s]
+  end
+
+  def timed_out?
+    (pending? || processing?) && updated_at < PREVIEW_TIMEOUT_SECONDS.seconds.ago
+  end
+
+  # Transitions to :failed when still in a non-terminal state and timed out.
+  # Uses a conditional UPDATE so a concurrently completing job can't be clobbered.
+  def timeout!
+    updated = self.class
+                  .where(id: id, status: [self.class.statuses[:pending], self.class.statuses[:processing]])
+                  .update_all(status: self.class.statuses[:failed], updated_at: Time.current)
+    reload if updated.positive?
   end
 
   def posts_data

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -244,6 +244,22 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "#show should mark a timed-out preview as failed and render the failed partial" do
+    sign_in_as(user)
+    create(:feed_preview, :processing, user: user, feed_profile_key: "rss",
+                                       params: { "url" => "http://example.com/feed.xml" },
+                                       updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+
+    assert_no_enqueued_jobs do
+      get feed_preview_url(profile_key: "rss", "params" => { url: "http://example.com/feed.xml" }),
+          headers: TURBO_STREAM
+    end
+
+    assert_response :success
+    assert_match(/data-preview-done/, response.body)
+    assert user.feed_previews.last.failed?
+  end
+
   test "#show should scope previews to the current user" do
     other = create(:user)
     create(:feed_preview, :completed, user: other, feed_profile_key: "rss",

--- a/test/models/feed_preview_test.rb
+++ b/test/models/feed_preview_test.rb
@@ -85,6 +85,49 @@ class FeedPreviewTest < ActiveSupport::TestCase
     assert_equal 0, preview.posts_count
   end
 
+  test "#timed_out? should return true for a pending preview past the timeout" do
+    preview = create(:feed_preview, :pending, user: user,
+                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+    assert preview.timed_out?
+  end
+
+  test "#timed_out? should return true for a processing preview past the timeout" do
+    preview = create(:feed_preview, :processing, user: user,
+                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+    assert preview.timed_out?
+  end
+
+  test "#timed_out? should return false for a recently started preview" do
+    preview = create(:feed_preview, :processing, user: user, updated_at: 1.second.ago)
+    refute preview.timed_out?
+  end
+
+  test "#timed_out? should return false for a ready preview" do
+    preview = create(:feed_preview, :completed, user: user,
+                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+    refute preview.timed_out?
+  end
+
+  test "#timed_out? should return false for a failed preview" do
+    preview = create(:feed_preview, :failed, user: user,
+                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+    refute preview.timed_out?
+  end
+
+  test "#timeout! should transition a timed-out processing preview to failed" do
+    preview = create(:feed_preview, :processing, user: user,
+                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+    preview.timeout!
+    assert preview.failed?
+  end
+
+  test "#timeout! should be a no-op for a ready preview" do
+    preview = create(:feed_preview, :completed, user: user,
+                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+    preview.timeout!
+    assert preview.ready?
+  end
+
   test ".digest_for should depend only on the profile's source input" do
     same_source = FeedPreview.digest_for("rss", { "url" => "https://x.test" })
     with_extra = FeedPreview.digest_for("rss", { "url" => "https://x.test", "derived" => "anything" })


### PR DESCRIPTION
Changes:

- Add `PREVIEW_TIMEOUT_SECONDS = 120` constant to `FeedPreview`
- Add `timed_out?` predicate (true when `pending`/`processing` and `updated_at` is older than the timeout)
- Add `timeout!` that conditionally transitions to `:failed` using a guarded `UPDATE` to avoid clobbering a concurrently completing job
- Call `preview.timeout!` in `FeedPreviewsController#show` when `timed_out?`

A preview stuck in `pending` or `processing` (job crashed, SolidQueue down, network hang) kept the polling loop alive indefinitely. With this change, the first poll after 120 seconds transitions the preview to `:failed` server-side. The failed partial carries `data-preview-done`, so the polling stop-condition fires on the next request and the spinner resolves into the standard error state with a "Try again" button.

The `timeout!` `UPDATE` is guarded by status — it only matches rows still in `pending`/`processing` — so a job that finishes just before or during the timeout check is not affected.

References:

- Part of #538
