### PR TITLE
Add client-side polling timeout with fallback messages

### DIFF
--- a/app/javascript/controllers/polling_controller.js
+++ b/app/javascript/controllers/polling_controller.js
@@ -11,6 +11,8 @@ export default class extends Controller {
     scope: { type: String, default: "element" }
   }
 
+  static targets = ["timeoutMessage", "content"]
+
   connect() {
     if (this.hasEndpointValue) this.startPolling()
   }
@@ -55,7 +57,12 @@ export default class extends Controller {
       return this._scheduleNext(this.intervalValue)
     }
 
-    if (!this._shouldContinuePolling()) {
+    if (this.stopConditionSatisfied()) {
+      return this.stopPolling()
+    }
+
+    if (this.maxPollsValue > 0 && this._pollCount >= this.maxPollsValue) {
+      this._onTimeout()
       return this.stopPolling()
     }
 
@@ -69,10 +76,9 @@ export default class extends Controller {
     }
   }
 
-  _shouldContinuePolling() {
-    if (this.stopConditionSatisfied()) return false
-    if (this.maxPollsValue > 0 && this._pollCount >= this.maxPollsValue) return false
-    return true
+  _onTimeout() {
+    if (this.hasTimeoutMessageTarget) this.timeoutMessageTarget.hidden = false
+    if (this.hasContentTarget) this.contentTarget.hidden = true
   }
 
   async _performPoll(options = {}) {

--- a/app/views/access_tokens/show.html.erb
+++ b/app/views/access_tokens/show.html.erb
@@ -5,10 +5,17 @@
     data-controller="polling"
     data-polling-endpoint-value="<%= access_token_validation_path(@access_token, feed_id: @feed&.id) %>"
     data-polling-interval-value="2000"
+    data-polling-max-polls-value="35"
     data-polling-stop-condition-value="[data-status]"
     aria-busy="true">
     <div id="access-token-show" class="space-y-8">
       <%= render "access_tokens/show_content", access_token: @access_token, feed_id: @feed&.id %>
+    </div>
+    <div data-polling-target="timeoutMessage" hidden class="mt-4">
+      <%= render AlertComponent.new(variant: :warning) do %>
+        <p class="font-semibold">Validation is taking longer than expected.</p>
+        <p><%= link_to "Refresh the page", request.path, data: { turbo: false }, class: "underline underline-offset-2" %> to check the current status.</p>
+      <% end %>
     </div>
   </div>
 <% else %>

--- a/app/views/feed_previews/show.html.erb
+++ b/app/views/feed_previews/show.html.erb
@@ -5,8 +5,9 @@
       once a terminal (ready/failed) body marks itself done. %>
   <div data-controller="polling"
        data-polling-endpoint-value="<%= feed_preview_path(profile_key: preview.feed_profile_key, "params" => preview.params, format: :turbo_stream) %>"
-       data-polling-stop-condition-value="[data-preview-done]">
-    <div id="feed-preview-body">
+       data-polling-stop-condition-value="[data-preview-done]"
+       data-polling-max-polls-value="75">
+    <div id="feed-preview-body" data-polling-target="content">
       <% case preview.status %>
       <% when "ready" %>
         <%= render "feed_previews/ready", preview: preview %>
@@ -15,6 +16,24 @@
       <% else %>
         <%= render "feed_previews/processing", preview: preview %>
       <% end %>
+    </div>
+    <div data-polling-target="timeoutMessage" hidden>
+      <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800 space-y-3"
+           role="alert"
+           data-key="preview.timeout"
+           data-controller="preview"
+           data-preview-refresh-url-value="<%= feed_preview_path(profile_key: preview.feed_profile_key, "params" => preview.params) %>">
+        <div class="space-y-1">
+          <p class="font-semibold text-slate-800">This is taking longer than expected.</p>
+          <p class="text-slate-600">The source may be slow or unavailable. Give it another go when you're ready.</p>
+        </div>
+        <button type="button"
+                class="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50"
+                data-action="click->preview#refresh"
+                data-key="preview.try-again">
+          Try again
+        </button>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/llm_credentials/show.html.erb
+++ b/app/views/llm_credentials/show.html.erb
@@ -5,10 +5,17 @@
     data-controller="polling"
     data-polling-endpoint-value="<%= llm_credential_validation_path(@llm_credential, feed_id: @feed&.id) %>"
     data-polling-interval-value="2000"
+    data-polling-max-polls-value="35"
     data-polling-stop-condition-value="[data-credential-state]"
     aria-busy="true">
     <div id="llm-credential-show" class="space-y-8">
       <%= render "llm_credentials/show_content", llm_credential: @llm_credential, feed_id: @feed&.id %>
+    </div>
+    <div data-polling-target="timeoutMessage" hidden class="mt-4">
+      <%= render AlertComponent.new(variant: :warning) do %>
+        <p class="font-semibold">The credential check is taking longer than expected.</p>
+        <p><%= link_to "Refresh the page", request.path, data: { turbo: false }, class: "underline underline-offset-2" %> to check the current status.</p>
+      <% end %>
     </div>
   </div>
 <% else %>


### PR DESCRIPTION
Changes:

- Add `timeoutMessage` and `content` targets to `polling_controller.js`; a new `_onTimeout()` method reveals the message and hides the content area
- Inline the stop-condition vs. max-polls checks in `_tick` so the two cases are distinguishable — only max-polls exhaustion triggers `_onTimeout`
- `FeedPreview`: `maxPolls=75` (150s, above the 120s server timeout); timeout message mirrors the failed partial style with a "Try again" button
- `AccessToken` / `LlmCredential`: `maxPolls=35` (70s); neutral warning with a page-refresh link

Previously, when `maxPolls` was exhausted without the server delivering a terminal state, the polling controller stopped silently and left the spinner on screen indefinitely. Users had no way to know something went wrong or what to do next.

The client budget is intentionally set above the server-side timeout for `FeedPreview` so the server gets a chance to deliver the proper `failed` partial first. The client message is a backstop for when the server is unreachable or the job is genuinely stuck.

The `content` target is opt-in — views that want to swap out the spinner on timeout add `data-polling-target="content"` to it; views that don't (access token, credential) just get the message appended below.

References:

- Closes #538
