### PR TITLE
Add hover background to event and card items

### DIFF
--- a/app/components/admin/event_log_entry_component.rb
+++ b/app/components/admin/event_log_entry_component.rb
@@ -5,11 +5,11 @@ class Admin::EventLogEntryComponent < ViewComponent::Base
   # while scanning the log; routine events stay neutral. The border picks a
   # slightly darker shade of the background hue, like AlertComponent does.
   LEVEL_TINTS = {
-    "warning" => { border: "border-amber-200", background: "bg-amber-100" },
-    "error" => { border: "border-red-200", background: "bg-red-100" }
+    "warning" => { border: "border-amber-200", background: "bg-amber-100 hover:bg-amber-200" },
+    "error" => { border: "border-red-200", background: "bg-red-100 hover:bg-red-200" }
   }.freeze
 
-  DEFAULT_TINT = { border: "border-slate-200", background: "bg-white" }.freeze
+  DEFAULT_TINT = { border: "border-slate-200", background: "bg-white hover:bg-slate-50" }.freeze
 
   def initialize(event:, href:)
     @event = event
@@ -21,7 +21,7 @@ class Admin::EventLogEntryComponent < ViewComponent::Base
   attr_reader :event, :href
 
   def card_classes
-    helpers.class_names("w-full rounded-lg border shadow-xs", tint[:border], tint[:background])
+    helpers.class_names("w-full rounded-lg border shadow-xs transition duration-75", tint[:border], tint[:background])
   end
 
   def divider_border

--- a/app/components/events_list_entry_component.rb
+++ b/app/components/events_list_entry_component.rb
@@ -7,7 +7,7 @@ class EventsListEntryComponent < ViewComponent::Base
   end
 
   def call
-    content_tag(:li, class: "flex items-center gap-3 px-4 py-2.5",
+    content_tag(:li, class: "flex items-center gap-3 px-4 py-2.5 transition duration-75 hover:bg-slate-50",
                      data: { key: "events.entry", event_type: event.type, event_id: event.id }) do
       safe_join([severity_tag, description_tag, time_tag])
     end

--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= helpers.dom_id(feed) %>" class="w-full rounded-lg border border-slate-200 bg-white shadow-xs">
+<div id="<%= helpers.dom_id(feed) %>" class="w-full rounded-lg border border-slate-200 bg-white shadow-xs transition duration-75 hover:bg-slate-50">
   <div class="flex items-start gap-4 px-5 py-4">
     <div class="flex min-w-0 items-center gap-2">
       <%= link_to title, feed_url,

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -123,9 +123,9 @@ class PostCardComponent < ViewComponent::Base
 
   def card_classes
     helpers.class_names(
-      "w-full rounded-lg border border-slate-200 shadow-xs",
-      "bg-slate-50" => withdrawn?,
-      "bg-white" => !withdrawn?
+      "w-full rounded-lg border border-slate-200 shadow-xs transition duration-75",
+      "bg-slate-50 hover:bg-slate-100" => withdrawn?,
+      "bg-white hover:bg-slate-50" => !withdrawn?
     )
   end
 


### PR DESCRIPTION
Changes:

- Event list entries on /status and /events, feed and post cards, and admin event cards now highlight on mouse hover
- Hover background matches the admin dashboard button cards (`hover:bg-slate-50` with `transition duration-75`)
- Cards with tinted backgrounds (withdrawn posts, warning/error admin events) step one shade darker instead, so the hover stays visible within their palette