### PR TITLE
Add Lobsters feed profile

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -109,6 +109,26 @@ class FeedProfile
       title_extractor: "TitleExtractor::RssTitleExtractor",
       output_schema: nil
     },
+    "lobsters" => {
+      display_name: "Lobsters",
+      description: "Stories from lobste.rs with a link to the discussion",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::LobstersProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "format" => "uri" }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::HttpLoader", config: {} },
+      processor: { class: "Processor::RssProcessor", config: {} },
+      normalizer: { class: "Normalizer::LobstersNormalizer", config: {} },
+      title_extractor: "TitleExtractor::RssTitleExtractor",
+      output_schema: nil
+    },
     "llm_website_extractor" => {
       display_name: "AI page reader",
       description: "Uses AI to extract recent posts from a webpage that doesn't expose an RSS feed",

--- a/app/services/normalizer/lobsters_normalizer.rb
+++ b/app/services/normalizer/lobsters_normalizer.rb
@@ -1,0 +1,27 @@
+module Normalizer
+  class LobstersNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      title = raw_data.dig("title") || ""
+      title.strip
+    end
+
+    def normalize_comments
+      return [] if discussion_url.blank?
+
+      [["Comments: #{discussion_url}", tags].compact_blank.join(" ")]
+    end
+
+    # The entry guid points at the lobste.rs discussion page, while the
+    # entry link points at the external story.
+    def discussion_url
+      raw_data.dig("id")
+    end
+
+    def tags
+      categories = raw_data.dig("categories") || []
+      categories.map { |category| "##{category}" }.join(" ")
+    end
+  end
+end

--- a/app/services/profile_matcher/lobsters_profile_matcher.rb
+++ b/app/services/profile_matcher/lobsters_profile_matcher.rb
@@ -1,0 +1,14 @@
+module ProfileMatcher
+  class LobstersProfileMatcher < Base
+    input_shape :url
+    match_specificity 100
+
+    LOBSTERS_DOMAIN = "lobste.rs"
+
+    def match?
+      return false if input.blank?
+
+      URI.parse(input).host == LOBSTERS_DOMAIN
+    end
+  end
+end

--- a/test/fixtures/files/feeds/lobsters/feed.xml
+++ b/test/fixtures/files/feeds/lobsters/feed.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Lobsters: sample - Sample tag</title>
+    <link>https://lobste.rs/</link>
+    <atom:link href="https://lobste.rs/t/sample.rss" rel="self"/>
+    <description>sample - Sample tag</description>
+    <pubDate>Thu, 12 Sep 2024 10:00:00 +0000</pubDate>
+    <ttl>120</ttl>
+    <item>
+      <title>First Sample Story</title>
+      <link>https://example.com/first-sample-story</link>
+      <guid>https://lobste.rs/s/aaaaaa</guid>
+      <author>example.com by sampleuser</author>
+      <pubDate>Thu, 12 Sep 2024 09:00:00 +0000</pubDate>
+      <comments>https://lobste.rs/s/aaaaaa/first_sample_story</comments>
+      <description>&lt;p&gt;&lt;a href="https://lobste.rs/s/aaaaaa/first_sample_story"&gt;Comments&lt;/a&gt;&lt;/p&gt;</description>
+      <category>sample</category>
+      <category>testing</category>
+    </item>
+    <item>
+      <title>Second Sample Story</title>
+      <link>https://example.com/second-sample-story</link>
+      <guid>https://lobste.rs/s/bbbbbb</guid>
+      <author>example.org via anotheruser</author>
+      <pubDate>Wed, 11 Sep 2024 15:30:00 +0000</pubDate>
+      <comments>https://lobste.rs/s/bbbbbb/second_sample_story</comments>
+      <description>&lt;p&gt;&lt;a href="https://lobste.rs/s/bbbbbb/second_sample_story"&gt;Comments&lt;/a&gt;&lt;/p&gt;</description>
+      <category>sample</category>
+    </item>
+  </channel>
+</rss>

--- a/test/fixtures/files/feeds/lobsters/normalized.json
+++ b/test/fixtures/files/feeds/lobsters/normalized.json
@@ -1,0 +1,12 @@
+{
+  "attachment_urls": [],
+  "comments": [
+    "Comments: https://lobste.rs/s/aaaaaa #sample #testing"
+  ],
+  "content": "First Sample Story - https://example.com/first-sample-story",
+  "published_at": "2024-09-12T09:00:00.000Z",
+  "source_url": "https://example.com/first-sample-story",
+  "status": "enqueued",
+  "uid": "https://lobste.rs/s/aaaaaa",
+  "validation_errors": []
+}

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -5,6 +5,7 @@ class FeedProfileTest < ActiveSupport::TestCase
     expected = [
       "llm_web_search",
       "llm_website_extractor",
+      "lobsters",
       "monkeyuser",
       "reddit",
       "rss",

--- a/test/services/normalizer/lobsters_normalizer_test.rb
+++ b/test/services/normalizer/lobsters_normalizer_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Normalizer::LobstersNormalizerTest < ActiveSupport::TestCase
+  include FixtureFeedEntries
+
+  def fixture_dir
+    "feeds/lobsters"
+  end
+
+  def processor_class
+    Processor::RssProcessor
+  end
+
+  test "#normalize should match the expected normalization result" do
+    entry = feed_entry(0)
+
+    normalizer = Normalizer::LobstersNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
+  end
+
+  test "#normalize should link the discussion page with tags in a comment" do
+    entry = feed_entry(0)
+
+    post = Normalizer::LobstersNormalizer.new(entry).normalize
+
+    assert_equal ["Comments: https://lobste.rs/s/aaaaaa #sample #testing"], post.comments
+  end
+
+  test "#normalize should use the external story URL as source_url" do
+    entry = feed_entry(0)
+
+    post = Normalizer::LobstersNormalizer.new(entry).normalize
+
+    assert_equal "https://example.com/first-sample-story", post.source_url
+  end
+end

--- a/test/services/profile_matcher/lobsters_profile_matcher_test.rb
+++ b/test/services/profile_matcher/lobsters_profile_matcher_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class ProfileMatcher::LobstersProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::LobstersProfileMatcher.new(url)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::LobstersProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 100" do
+    # Higher than RSS (10) so lobste.rs URLs prefer the Lobsters profile.
+    assert_equal 100, ProfileMatcher::LobstersProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::LobstersProfileMatcher.depends_on_ai
+  end
+
+  test "#match? should match lobste.rs URLs" do
+    assert matcher("https://lobste.rs/t/sample.rss").match?
+  end
+
+  test "#match? should match the lobste.rs front page feed" do
+    assert matcher("https://lobste.rs/rss").match?
+  end
+
+  test "#match? should not match non-lobsters URLs" do
+    assert_not matcher("https://example.com/feed.xml").match?
+  end
+
+  test "#match? should not match URLs that just contain lobste.rs in path" do
+    assert_not matcher("https://example.com/lobste.rs/feed.xml").match?
+  end
+
+  test "#match? should handle blank inputs" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+
+  test "#match? should raise error for invalid URLs" do
+    assert_raises(URI::InvalidURIError) do
+      matcher("not a url").match?
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Add a `lobsters` feed profile (matcher, normalizer, registry entry, locale)
- Posts carry the story title and external link; the lobste.rs discussion URL and tags go into a comment
- Reuses `Loader::HttpLoader` and `Processor::RssProcessor`; the entry guid (discussion page) serves as the post uid
- Includes a real-feed fixture, matcher/normalizer tests, and a normalization snapshot

Ports the `lobsters` feed type from feeder 1. Verified end to end with an ad-hoc run against the live `https://lobste.rs/t/ruby.rss` feed.