### PR TITLE
Add SMBC Comics feed profile

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -129,6 +129,26 @@ class FeedProfile
       title_extractor: "TitleExtractor::RssTitleExtractor",
       output_schema: nil
     },
+    "smbc" => {
+      display_name: "SMBC Comics",
+      description: "Saturday Morning Breakfast Cereal comics with the hovertext and hidden panel",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::SmbcProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "format" => "uri" }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::HttpLoader", config: {} },
+      processor: { class: "Processor::RssProcessor", config: {} },
+      normalizer: { class: "Normalizer::SmbcNormalizer", config: {} },
+      title_extractor: "TitleExtractor::RssTitleExtractor",
+      output_schema: nil
+    },
     "llm_website_extractor" => {
       display_name: "AI page reader",
       description: "Uses AI to extract recent posts from a webpage that doesn't expose an RSS feed",

--- a/app/services/normalizer/smbc_normalizer.rb
+++ b/app/services/normalizer/smbc_normalizer.rb
@@ -11,11 +11,14 @@ module Normalizer
     end
 
     def normalize_comments
-      [hovertext].compact_blank
+      # FreeFeed comments are text-only, so the hidden ("bonus") panel rides
+      # along as a comment whose body is the image URL; FreeFeed renders bare
+      # image URLs inline.
+      [hovertext, hidden_panel_image_url].compact_blank
     end
 
     def normalize_attachment_urls
-      [comic_image_url, hidden_panel_image_url].compact_blank
+      [comic_image_url].compact_blank
     end
 
     def hovertext

--- a/app/services/normalizer/smbc_normalizer.rb
+++ b/app/services/normalizer/smbc_normalizer.rb
@@ -1,0 +1,59 @@
+module Normalizer
+  class SmbcNormalizer < RssNormalizer
+    TITLE_PREFIX = /\ASaturday Morning Breakfast Cereal - /
+    HOVERTEXT_PREFIX = /\AHovertext:\s*/
+
+    private
+
+    def normalize_content
+      title = raw_data.dig("title") || ""
+      title.sub(TITLE_PREFIX, "").strip
+    end
+
+    def normalize_comments
+      [hovertext].compact_blank
+    end
+
+    def normalize_attachment_urls
+      [comic_image_url, hidden_panel_image_url].compact_blank
+    end
+
+    def hovertext
+      paragraph = summary_html.css("p").first
+      return nil unless paragraph
+
+      paragraph.text.sub(HOVERTEXT_PREFIX, "").strip
+    end
+
+    def comic_image_url
+      summary_html.css("img").first&.[]("src")
+    end
+
+    def hidden_panel_image_url
+      return nil if page.blank?
+
+      Nokogiri::HTML(page).css("#aftercomic img").first&.[]("src")
+    end
+
+    def summary_html
+      @summary_html ||= Nokogiri::HTML::DocumentFragment.parse(raw_data.dig("summary") || "")
+    end
+
+    def page
+      return @page if defined?(@page)
+
+      @page = fetch_page(raw_data.dig("link"))
+    end
+
+    def fetch_page(url)
+      return nil if url.blank?
+
+      response = HttpClient.build.get(url)
+      return nil unless response.success?
+
+      response.body
+    rescue HttpClient::Error
+      nil
+    end
+  end
+end

--- a/app/services/profile_matcher/smbc_profile_matcher.rb
+++ b/app/services/profile_matcher/smbc_profile_matcher.rb
@@ -9,7 +9,7 @@ module ProfileMatcher
       return false if input.blank?
 
       uri = URI.parse(input)
-      uri.host&.end_with?(SMBC_DOMAIN)
+      uri.host == SMBC_DOMAIN || uri.host&.end_with?(".#{SMBC_DOMAIN}")
     end
   end
 end

--- a/app/services/profile_matcher/smbc_profile_matcher.rb
+++ b/app/services/profile_matcher/smbc_profile_matcher.rb
@@ -1,0 +1,15 @@
+module ProfileMatcher
+  class SmbcProfileMatcher < Base
+    input_shape :url
+    match_specificity 100
+
+    SMBC_DOMAIN = "smbc-comics.com"
+
+    def match?
+      return false if input.blank?
+
+      uri = URI.parse(input)
+      uri.host&.end_with?(SMBC_DOMAIN)
+    end
+  end
+end

--- a/app/services/profile_matcher/smbc_profile_matcher.rb
+++ b/app/services/profile_matcher/smbc_profile_matcher.rb
@@ -3,13 +3,12 @@ module ProfileMatcher
     input_shape :url
     match_specificity 100
 
-    SMBC_DOMAIN = "smbc-comics.com"
+    HOSTS = %w[smbc-comics.com www.smbc-comics.com].freeze
 
     def match?
       return false if input.blank?
 
-      uri = URI.parse(input)
-      uri.host == SMBC_DOMAIN || uri.host&.end_with?(".#{SMBC_DOMAIN}")
+      HOSTS.include?(URI.parse(input).host)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,4 +91,3 @@ en:
     resend_email_failed:
       name: "Email failed"
       description_html: "Email delivery failed"
-

--- a/test/fixtures/files/feeds/smbc/feed.xml
+++ b/test/fixtures/files/feeds/smbc/feed.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Saturday Morning Breakfast Cereal</title>
+    <atom:link href="http://www.smbc-comics.com/comic/rss" rel="self" type="application/rss+xml" />
+    <link>https://www.smbc-comics.com/</link>
+    <description>Latest Saturday Morning Breakfast Cereal comics and news</description>
+    <language>en-us</language>
+    <item>
+      <title><![CDATA[Saturday Morning Breakfast Cereal - Huh]]></title>
+      <description><![CDATA[<a href="https://www.smbc-comics.com/comic/huh-2"><img src="https://www.smbc-comics.com/comics/1780969506-20260611.png" /><br /><br />Click here to go see the bonus panel!</a><p>Hovertext:<br/>Once I realized this, all those inept AI laundry-folding videos became hilarious.</p><br />Today's News:<br />]]></description>
+      <link>https://www.smbc-comics.com/comic/huh-2</link>
+      <dc:creator><![CDATA[Zach Weinersmith]]></dc:creator>
+      <pubDate>Thu, 11 Jun 2026 11:20:00 -0400</pubDate>
+      <guid>https://www.smbc-comics.com/comic/huh-2</guid>
+    </item>
+    <item>
+      <title><![CDATA[Saturday Morning Breakfast Cereal - Surveil]]></title>
+      <description><![CDATA[<a href="https://www.smbc-comics.com/comic/surveil"><img src="https://www.smbc-comics.com/comics/1780969413-20260610.png" /><br /><br />Click here to go see the bonus panel!</a><p>Hovertext:<br/>I don't know if it's happened yet, but you can bet in the next few years someone will start fitting people out to collect sex training data.</p><br />Today's News:<br />]]></description>
+      <link>https://www.smbc-comics.com/comic/surveil</link>
+      <dc:creator><![CDATA[Zach Weinersmith]]></dc:creator>
+      <pubDate>Wed, 10 Jun 2026 11:20:00 -0400</pubDate>
+      <guid>https://www.smbc-comics.com/comic/surveil</guid>
+    </item>
+  </channel>
+</rss>

--- a/test/fixtures/files/feeds/smbc/feed.xml
+++ b/test/fixtures/files/feeds/smbc/feed.xml
@@ -4,23 +4,23 @@
     <title>Saturday Morning Breakfast Cereal</title>
     <atom:link href="http://www.smbc-comics.com/comic/rss" rel="self" type="application/rss+xml" />
     <link>https://www.smbc-comics.com/</link>
-    <description>Latest Saturday Morning Breakfast Cereal comics and news</description>
+    <description>Latest comics and news</description>
     <language>en-us</language>
     <item>
-      <title><![CDATA[Saturday Morning Breakfast Cereal - Huh]]></title>
-      <description><![CDATA[<a href="https://www.smbc-comics.com/comic/huh-2"><img src="https://www.smbc-comics.com/comics/1780969506-20260611.png" /><br /><br />Click here to go see the bonus panel!</a><p>Hovertext:<br/>Once I realized this, all those inept AI laundry-folding videos became hilarious.</p><br />Today's News:<br />]]></description>
-      <link>https://www.smbc-comics.com/comic/huh-2</link>
-      <dc:creator><![CDATA[Zach Weinersmith]]></dc:creator>
+      <title><![CDATA[Saturday Morning Breakfast Cereal - Sample Comic One]]></title>
+      <description><![CDATA[<a href="https://www.smbc-comics.com/comic/sample-comic-one"><img src="https://www.smbc-comics.com/comics/sample-comic-one.png" /><br /><br />Click here to go see the bonus panel!</a><p>Hovertext:<br/>Sample hovertext for the first comic.</p><br />Today's News:<br />]]></description>
+      <link>https://www.smbc-comics.com/comic/sample-comic-one</link>
+      <dc:creator><![CDATA[Sample Author]]></dc:creator>
       <pubDate>Thu, 11 Jun 2026 11:20:00 -0400</pubDate>
-      <guid>https://www.smbc-comics.com/comic/huh-2</guid>
+      <guid>https://www.smbc-comics.com/comic/sample-comic-one</guid>
     </item>
     <item>
-      <title><![CDATA[Saturday Morning Breakfast Cereal - Surveil]]></title>
-      <description><![CDATA[<a href="https://www.smbc-comics.com/comic/surveil"><img src="https://www.smbc-comics.com/comics/1780969413-20260610.png" /><br /><br />Click here to go see the bonus panel!</a><p>Hovertext:<br/>I don't know if it's happened yet, but you can bet in the next few years someone will start fitting people out to collect sex training data.</p><br />Today's News:<br />]]></description>
-      <link>https://www.smbc-comics.com/comic/surveil</link>
-      <dc:creator><![CDATA[Zach Weinersmith]]></dc:creator>
+      <title><![CDATA[Saturday Morning Breakfast Cereal - Sample Comic Two]]></title>
+      <description><![CDATA[<a href="https://www.smbc-comics.com/comic/sample-comic-two"><img src="https://www.smbc-comics.com/comics/sample-comic-two.png" /><br /><br />Click here to go see the bonus panel!</a><p>Hovertext:<br/>Sample hovertext for the second comic.</p><br />Today's News:<br />]]></description>
+      <link>https://www.smbc-comics.com/comic/sample-comic-two</link>
+      <dc:creator><![CDATA[Sample Author]]></dc:creator>
       <pubDate>Wed, 10 Jun 2026 11:20:00 -0400</pubDate>
-      <guid>https://www.smbc-comics.com/comic/surveil</guid>
+      <guid>https://www.smbc-comics.com/comic/sample-comic-two</guid>
     </item>
   </channel>
 </rss>

--- a/test/fixtures/files/feeds/smbc/normalized.json
+++ b/test/fixtures/files/feeds/smbc/normalized.json
@@ -1,15 +1,15 @@
 {
   "attachment_urls": [
-    "https://www.smbc-comics.com/comics/1780969506-20260611.png",
-    "https://www.smbc-comics.com/comics/178096959820260611after.png"
+    "https://www.smbc-comics.com/comics/sample-comic-one.png",
+    "https://www.smbc-comics.com/comics/sample-comic-one-after.png"
   ],
   "comments": [
-    "Once I realized this, all those inept AI laundry-folding videos became hilarious."
+    "Sample hovertext for the first comic."
   ],
-  "content": "Huh - https://www.smbc-comics.com/comic/huh-2",
+  "content": "Sample Comic One - https://www.smbc-comics.com/comic/sample-comic-one",
   "published_at": "2026-06-11T15:20:00.000Z",
-  "source_url": "https://www.smbc-comics.com/comic/huh-2",
+  "source_url": "https://www.smbc-comics.com/comic/sample-comic-one",
   "status": "enqueued",
-  "uid": "https://www.smbc-comics.com/comic/huh-2",
+  "uid": "https://www.smbc-comics.com/comic/sample-comic-one",
   "validation_errors": []
 }

--- a/test/fixtures/files/feeds/smbc/normalized.json
+++ b/test/fixtures/files/feeds/smbc/normalized.json
@@ -1,0 +1,15 @@
+{
+  "attachment_urls": [
+    "https://www.smbc-comics.com/comics/1780969506-20260611.png",
+    "https://www.smbc-comics.com/comics/178096959820260611after.png"
+  ],
+  "comments": [
+    "Once I realized this, all those inept AI laundry-folding videos became hilarious."
+  ],
+  "content": "Huh - https://www.smbc-comics.com/comic/huh-2",
+  "published_at": "2026-06-11T15:20:00.000Z",
+  "source_url": "https://www.smbc-comics.com/comic/huh-2",
+  "status": "enqueued",
+  "uid": "https://www.smbc-comics.com/comic/huh-2",
+  "validation_errors": []
+}

--- a/test/fixtures/files/feeds/smbc/normalized.json
+++ b/test/fixtures/files/feeds/smbc/normalized.json
@@ -1,10 +1,10 @@
 {
   "attachment_urls": [
-    "https://www.smbc-comics.com/comics/sample-comic-one.png",
-    "https://www.smbc-comics.com/comics/sample-comic-one-after.png"
+    "https://www.smbc-comics.com/comics/sample-comic-one.png"
   ],
   "comments": [
-    "Sample hovertext for the first comic."
+    "Sample hovertext for the first comic.",
+    "https://www.smbc-comics.com/comics/sample-comic-one-after.png"
   ],
   "content": "Sample Comic One - https://www.smbc-comics.com/comic/sample-comic-one",
   "published_at": "2026-06-11T15:20:00.000Z",

--- a/test/fixtures/files/feeds/smbc/page.html
+++ b/test/fixtures/files/feeds/smbc/page.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Saturday Morning Breakfast Cereal - Huh</title>
+</head>
+<body>
+  <div id="cc-comicbody">
+    <img title="Once I realized this, all those inept AI laundry-folding videos became hilarious." src="https://www.smbc-comics.com/comics/1780969506-20260611.png" id="cc-comic" border="0" />
+  </div>
+  <div id="navbottom">
+    <nav class="cc-nav" role="navigation">
+      <a class="cc-first" title="First" rel="first" href="https://www.smbc-comics.com/comic/2002-09-05"></a>
+      <a class="cc-prev" rel="prev" title="Previous" href="https://www.smbc-comics.com/comic/surveil"></a>
+    </nav>
+    <a id="extracomic" onclick='toggleBlock("aftercomic")' class="mobilehide"></a>
+    <div id="aftercomic" onclick='toggleBlock("aftercomic")' style="display:none;" class="mobilehide"><img src='https://www.smbc-comics.com/comics/178096959820260611after.png'></div>
+  </div>
+</body>
+</html>

--- a/test/fixtures/files/feeds/smbc/page.html
+++ b/test/fixtures/files/feeds/smbc/page.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>Saturday Morning Breakfast Cereal - Huh</title>
+  <title>Saturday Morning Breakfast Cereal - Sample Comic One</title>
 </head>
 <body>
   <div id="cc-comicbody">
-    <img title="Once I realized this, all those inept AI laundry-folding videos became hilarious." src="https://www.smbc-comics.com/comics/1780969506-20260611.png" id="cc-comic" border="0" />
+    <img title="Sample hovertext for the first comic." src="https://www.smbc-comics.com/comics/sample-comic-one.png" id="cc-comic" border="0" />
   </div>
   <div id="navbottom">
     <nav class="cc-nav" role="navigation">
-      <a class="cc-first" title="First" rel="first" href="https://www.smbc-comics.com/comic/2002-09-05"></a>
-      <a class="cc-prev" rel="prev" title="Previous" href="https://www.smbc-comics.com/comic/surveil"></a>
+      <a class="cc-first" title="First" rel="first" href="https://www.smbc-comics.com/comic/sample-comic-first"></a>
+      <a class="cc-prev" rel="prev" title="Previous" href="https://www.smbc-comics.com/comic/sample-comic-two"></a>
     </nav>
     <a id="extracomic" onclick='toggleBlock("aftercomic")' class="mobilehide"></a>
-    <div id="aftercomic" onclick='toggleBlock("aftercomic")' style="display:none;" class="mobilehide"><img src='https://www.smbc-comics.com/comics/178096959820260611after.png'></div>
+    <div id="aftercomic" onclick='toggleBlock("aftercomic")' style="display:none;" class="mobilehide"><img src='https://www.smbc-comics.com/comics/sample-comic-one-after.png'></div>
   </div>
 </body>
 </html>

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -9,6 +9,7 @@ class FeedProfileTest < ActiveSupport::TestCase
       "monkeyuser",
       "reddit",
       "rss",
+      "smbc",
       "telegram",
       "twitter",
       "xkcd",

--- a/test/services/normalizer/smbc_normalizer_test.rb
+++ b/test/services/normalizer/smbc_normalizer_test.rb
@@ -35,26 +35,26 @@ class Normalizer::SmbcNormalizerTest < ActiveSupport::TestCase
     assert_equal "Sample Comic One - https://www.smbc-comics.com/comic/sample-comic-one", post.content
   end
 
-  test "#normalize should attach the comic and the hidden panel" do
+  test "#normalize should attach only the comic" do
+    stub_comic_page
+    entry = feed_entry(0)
+
+    post = Normalizer::SmbcNormalizer.new(entry).normalize
+
+    assert_equal ["https://www.smbc-comics.com/comics/sample-comic-one.png"], post.attachment_urls
+  end
+
+  test "#normalize should add the hovertext and hidden panel as comments" do
     stub_comic_page
     entry = feed_entry(0)
 
     post = Normalizer::SmbcNormalizer.new(entry).normalize
 
     expected = [
-      "https://www.smbc-comics.com/comics/sample-comic-one.png",
+      "Sample hovertext for the first comic.",
       "https://www.smbc-comics.com/comics/sample-comic-one-after.png"
     ]
-    assert_equal expected, post.attachment_urls
-  end
-
-  test "#normalize should add the hovertext as a comment" do
-    stub_comic_page
-    entry = feed_entry(0)
-
-    post = Normalizer::SmbcNormalizer.new(entry).normalize
-
-    assert_equal ["Sample hovertext for the first comic."], post.comments
+    assert_equal expected, post.comments
   end
 
   test "#normalize should skip the hidden panel when the page fetch fails" do
@@ -64,6 +64,7 @@ class Normalizer::SmbcNormalizerTest < ActiveSupport::TestCase
     post = Normalizer::SmbcNormalizer.new(entry).normalize
 
     assert_equal ["https://www.smbc-comics.com/comics/sample-comic-one.png"], post.attachment_urls
+    assert_equal ["Sample hovertext for the first comic."], post.comments
     assert_equal "enqueued", post.status
   end
 
@@ -75,6 +76,7 @@ class Normalizer::SmbcNormalizerTest < ActiveSupport::TestCase
     post = Normalizer::SmbcNormalizer.new(entry).normalize
 
     assert_equal ["https://www.smbc-comics.com/comics/sample-comic-one.png"], post.attachment_urls
+    assert_equal ["Sample hovertext for the first comic."], post.comments
     assert_equal "enqueued", post.status
   end
 end

--- a/test/services/normalizer/smbc_normalizer_test.rb
+++ b/test/services/normalizer/smbc_normalizer_test.rb
@@ -66,4 +66,15 @@ class Normalizer::SmbcNormalizerTest < ActiveSupport::TestCase
     assert_equal ["https://www.smbc-comics.com/comics/1780969506-20260611.png"], post.attachment_urls
     assert_equal "enqueued", post.status
   end
+
+  test "#normalize should skip the hidden panel when the page fetch raises a network error" do
+    stub_request(:get, "https://www.smbc-comics.com/comic/huh-2")
+      .to_raise(Faraday::ConnectionFailed.new("connection refused"))
+    entry = feed_entry(0)
+
+    post = Normalizer::SmbcNormalizer.new(entry).normalize
+
+    assert_equal ["https://www.smbc-comics.com/comics/1780969506-20260611.png"], post.attachment_urls
+    assert_equal "enqueued", post.status
+  end
 end

--- a/test/services/normalizer/smbc_normalizer_test.rb
+++ b/test/services/normalizer/smbc_normalizer_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class Normalizer::SmbcNormalizerTest < ActiveSupport::TestCase
+  include FixtureFeedEntries
+
+  def fixture_dir
+    "feeds/smbc"
+  end
+
+  def processor_class
+    Processor::RssProcessor
+  end
+
+  def stub_comic_page
+    stub_request(:get, "https://www.smbc-comics.com/comic/huh-2")
+      .to_return(status: 200, body: file_fixture("feeds/smbc/page.html").read)
+  end
+
+  test "#normalize should match the expected normalization result" do
+    stub_comic_page
+    entry = feed_entry(0)
+
+    normalizer = Normalizer::SmbcNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
+  end
+
+  test "#normalize should strip the title prefix from content" do
+    stub_comic_page
+    entry = feed_entry(0)
+
+    post = Normalizer::SmbcNormalizer.new(entry).normalize
+
+    assert_equal "Huh - https://www.smbc-comics.com/comic/huh-2", post.content
+  end
+
+  test "#normalize should attach the comic and the hidden panel" do
+    stub_comic_page
+    entry = feed_entry(0)
+
+    post = Normalizer::SmbcNormalizer.new(entry).normalize
+
+    expected = [
+      "https://www.smbc-comics.com/comics/1780969506-20260611.png",
+      "https://www.smbc-comics.com/comics/178096959820260611after.png"
+    ]
+    assert_equal expected, post.attachment_urls
+  end
+
+  test "#normalize should add the hovertext as a comment" do
+    stub_comic_page
+    entry = feed_entry(0)
+
+    post = Normalizer::SmbcNormalizer.new(entry).normalize
+
+    assert_equal ["Once I realized this, all those inept AI laundry-folding videos became hilarious."], post.comments
+  end
+
+  test "#normalize should skip the hidden panel when the page fetch fails" do
+    stub_request(:get, "https://www.smbc-comics.com/comic/huh-2").to_return(status: 404)
+    entry = feed_entry(0)
+
+    post = Normalizer::SmbcNormalizer.new(entry).normalize
+
+    assert_equal ["https://www.smbc-comics.com/comics/1780969506-20260611.png"], post.attachment_urls
+    assert_equal "enqueued", post.status
+  end
+end

--- a/test/services/normalizer/smbc_normalizer_test.rb
+++ b/test/services/normalizer/smbc_normalizer_test.rb
@@ -12,7 +12,7 @@ class Normalizer::SmbcNormalizerTest < ActiveSupport::TestCase
   end
 
   def stub_comic_page
-    stub_request(:get, "https://www.smbc-comics.com/comic/huh-2")
+    stub_request(:get, "https://www.smbc-comics.com/comic/sample-comic-one")
       .to_return(status: 200, body: file_fixture("feeds/smbc/page.html").read)
   end
 
@@ -32,7 +32,7 @@ class Normalizer::SmbcNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::SmbcNormalizer.new(entry).normalize
 
-    assert_equal "Huh - https://www.smbc-comics.com/comic/huh-2", post.content
+    assert_equal "Sample Comic One - https://www.smbc-comics.com/comic/sample-comic-one", post.content
   end
 
   test "#normalize should attach the comic and the hidden panel" do
@@ -42,8 +42,8 @@ class Normalizer::SmbcNormalizerTest < ActiveSupport::TestCase
     post = Normalizer::SmbcNormalizer.new(entry).normalize
 
     expected = [
-      "https://www.smbc-comics.com/comics/1780969506-20260611.png",
-      "https://www.smbc-comics.com/comics/178096959820260611after.png"
+      "https://www.smbc-comics.com/comics/sample-comic-one.png",
+      "https://www.smbc-comics.com/comics/sample-comic-one-after.png"
     ]
     assert_equal expected, post.attachment_urls
   end
@@ -54,27 +54,27 @@ class Normalizer::SmbcNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::SmbcNormalizer.new(entry).normalize
 
-    assert_equal ["Once I realized this, all those inept AI laundry-folding videos became hilarious."], post.comments
+    assert_equal ["Sample hovertext for the first comic."], post.comments
   end
 
   test "#normalize should skip the hidden panel when the page fetch fails" do
-    stub_request(:get, "https://www.smbc-comics.com/comic/huh-2").to_return(status: 404)
+    stub_request(:get, "https://www.smbc-comics.com/comic/sample-comic-one").to_return(status: 404)
     entry = feed_entry(0)
 
     post = Normalizer::SmbcNormalizer.new(entry).normalize
 
-    assert_equal ["https://www.smbc-comics.com/comics/1780969506-20260611.png"], post.attachment_urls
+    assert_equal ["https://www.smbc-comics.com/comics/sample-comic-one.png"], post.attachment_urls
     assert_equal "enqueued", post.status
   end
 
   test "#normalize should skip the hidden panel when the page fetch raises a network error" do
-    stub_request(:get, "https://www.smbc-comics.com/comic/huh-2")
+    stub_request(:get, "https://www.smbc-comics.com/comic/sample-comic-one")
       .to_raise(Faraday::ConnectionFailed.new("connection refused"))
     entry = feed_entry(0)
 
     post = Normalizer::SmbcNormalizer.new(entry).normalize
 
-    assert_equal ["https://www.smbc-comics.com/comics/1780969506-20260611.png"], post.attachment_urls
+    assert_equal ["https://www.smbc-comics.com/comics/sample-comic-one.png"], post.attachment_urls
     assert_equal "enqueued", post.status
   end
 end

--- a/test/services/profile_matcher/smbc_profile_matcher_test.rb
+++ b/test/services/profile_matcher/smbc_profile_matcher_test.rb
@@ -30,6 +30,10 @@ class ProfileMatcher::SmbcProfileMatcherTest < ActiveSupport::TestCase
     assert_not matcher("https://example.com/feed.xml").match?
   end
 
+  test "#match? should not match arbitrary smbc-comics.com subdomains" do
+    assert_not matcher("https://blog.smbc-comics.com/feed").match?
+  end
+
   test "#match? should not match URLs that just contain smbc-comics.com in path" do
     assert_not matcher("https://example.com/smbc-comics.com/feed.xml").match?
   end

--- a/test/services/profile_matcher/smbc_profile_matcher_test.rb
+++ b/test/services/profile_matcher/smbc_profile_matcher_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class ProfileMatcher::SmbcProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::SmbcProfileMatcher.new(url)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::SmbcProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 100" do
+    # Higher than RSS (10) so smbc-comics.com URLs prefer the SMBC profile.
+    assert_equal 100, ProfileMatcher::SmbcProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::SmbcProfileMatcher.depends_on_ai
+  end
+
+  test "#match? should match smbc-comics.com URLs" do
+    assert matcher("https://www.smbc-comics.com/comic/rss").match?
+  end
+
+  test "#match? should match the bare smbc-comics.com host" do
+    assert matcher("https://smbc-comics.com/").match?
+  end
+
+  test "#match? should not match non-SMBC URLs" do
+    assert_not matcher("https://example.com/feed.xml").match?
+  end
+
+  test "#match? should not match URLs that just contain smbc-comics.com in path" do
+    assert_not matcher("https://example.com/smbc-comics.com/feed.xml").match?
+  end
+
+  test "#match? should handle blank inputs" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+
+  test "#match? should raise error for invalid URLs" do
+    assert_raises(URI::InvalidURIError) do
+      matcher("not a url").match?
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Add a `smbc` feed profile (matcher, normalizer, registry entry, locale)
- Posts carry the comic image plus the hidden "aftercomic" panel scraped from the entry page, with the hovertext added as a comment; the `Saturday Morning Breakfast Cereal - ` title prefix is stripped from the post text
- Includes a real-feed fixture, matcher/normalizer tests, and a normalization snapshot

Ports the `smbc` feed type from feeder 1. Verified against the live feed: all sampled entries normalized to enqueued posts with both comic and bonus-panel images and the hovertext comment.
