### PR TITLE
Add MonkeyUser feed profile

### DIFF
--- a/app/helpers/component_options_helper.rb
+++ b/app/helpers/component_options_helper.rb
@@ -9,12 +9,6 @@ module ComponentOptionsHelper
     Current.user.access_tokens.active.exists?
   end
 
-  def feed_profile_options
-    FeedProfile.all.map do |key|
-      [t("feed_profiles.#{key}"), key]
-    end
-  end
-
   def human_readable_cron(cron_expression)
     return "not configured" if cron_expression.blank?
 

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -89,6 +89,26 @@ class FeedProfile
       title_extractor: "TitleExtractor::RssTitleExtractor",
       output_schema: nil
     },
+    "monkeyuser" => {
+      display_name: "MonkeyUser",
+      description: "MonkeyUser comics for developers",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::MonkeyuserProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "format" => "uri" }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::HttpLoader", config: {} },
+      processor: { class: "Processor::RssProcessor", config: {} },
+      normalizer: { class: "Normalizer::MonkeyuserNormalizer", config: {} },
+      title_extractor: "TitleExtractor::RssTitleExtractor",
+      output_schema: nil
+    },
     "llm_website_extractor" => {
       display_name: "AI page reader",
       description: "Uses AI to extract recent posts from a webpage that doesn't expose an RSS feed",

--- a/app/services/normalizer/monkeyuser_normalizer.rb
+++ b/app/services/normalizer/monkeyuser_normalizer.rb
@@ -1,0 +1,62 @@
+module Normalizer
+  class MonkeyuserNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      title = raw_data.dig("title") || ""
+      title.strip
+    end
+
+    def normalize_attachment_urls
+      [comic_image_url].compact_blank
+    end
+
+    def normalize_comments
+      hovertext = comic_image&.[]("title")
+      [hovertext&.strip].compact_blank
+    end
+
+    # A comic post without the comic itself is useless.
+    def validate_content
+      errors = super
+      errors << "missing_images" if attachment_urls.empty?
+      errors
+    end
+
+    def comic_image_url
+      src = comic_image&.[]("src")
+      return nil if src.blank?
+
+      URI.join(page_url, src).to_s
+    rescue URI::Error
+      nil
+    end
+
+    def comic_image
+      return @comic_image if defined?(@comic_image)
+
+      @comic_image = page.presence && Nokogiri::HTML(page).css(".comic img").first
+    end
+
+    def page_url
+      raw_data.dig("link") || ""
+    end
+
+    def page
+      return @page if defined?(@page)
+
+      @page = fetch_page(page_url)
+    end
+
+    def fetch_page(url)
+      return nil if url.blank?
+
+      response = HttpClient.build.get(url)
+      return nil unless response.success?
+
+      response.body
+    rescue HttpClient::Error
+      nil
+    end
+  end
+end

--- a/app/services/profile_matcher/monkeyuser_profile_matcher.rb
+++ b/app/services/profile_matcher/monkeyuser_profile_matcher.rb
@@ -9,7 +9,7 @@ module ProfileMatcher
       return false if input.blank?
 
       uri = URI.parse(input)
-      uri.host&.end_with?(MONKEYUSER_DOMAIN)
+      uri.host == MONKEYUSER_DOMAIN || uri.host&.end_with?(".#{MONKEYUSER_DOMAIN}")
     end
   end
 end

--- a/app/services/profile_matcher/monkeyuser_profile_matcher.rb
+++ b/app/services/profile_matcher/monkeyuser_profile_matcher.rb
@@ -1,0 +1,15 @@
+module ProfileMatcher
+  class MonkeyuserProfileMatcher < Base
+    input_shape :url
+    match_specificity 100
+
+    MONKEYUSER_DOMAIN = "monkeyuser.com"
+
+    def match?
+      return false if input.blank?
+
+      uri = URI.parse(input)
+      uri.host&.end_with?(MONKEYUSER_DOMAIN)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,7 +92,3 @@ en:
       name: "Email failed"
       description_html: "Email delivery failed"
 
-  feed_profiles:
-    rss: "RSS Feed"
-    xkcd: "XKCD Comics"
-    monkeyuser: "MonkeyUser"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,3 +95,4 @@ en:
   feed_profiles:
     rss: "RSS Feed"
     xkcd: "XKCD Comics"
+    monkeyuser: "MonkeyUser"

--- a/test/fixtures/files/feeds/monkeyuser/feed.xml
+++ b/test/fixtures/files/feeds/monkeyuser/feed.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Monkeyuser</title>
+    <link>https://www.monkeyuser.com/</link>
+    <description>Recent content on Monkeyuser</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-us</language>
+    <lastBuildDate>Thu, 10 Apr 2025 00:00:00 +0000</lastBuildDate>
+    <atom:link href="https://www.monkeyuser.com/index.xml" rel="self" type="application/rss+xml"/>
+    <item>
+      <title>Just a button</title>
+      <link>https://www.monkeyuser.com/2025/button/</link>
+      <pubDate>Thu, 10 Apr 2025 00:00:00 +0000</pubDate>
+      <guid>https://www.monkeyuser.com/2025/button/</guid>
+      <description/>
+    </item>
+    <item>
+      <title>10x</title>
+      <link>https://www.monkeyuser.com/2025/10x/</link>
+      <pubDate>Mon, 17 Mar 2025 00:00:00 +0000</pubDate>
+      <guid>https://www.monkeyuser.com/2025/10x/</guid>
+      <description/>
+    </item>
+  </channel>
+</rss>

--- a/test/fixtures/files/feeds/monkeyuser/feed.xml
+++ b/test/fixtures/files/feeds/monkeyuser/feed.xml
@@ -9,17 +9,17 @@
     <lastBuildDate>Thu, 10 Apr 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="https://www.monkeyuser.com/index.xml" rel="self" type="application/rss+xml"/>
     <item>
-      <title>Just a button</title>
-      <link>https://www.monkeyuser.com/2025/button/</link>
+      <title>Sample title one</title>
+      <link>https://www.monkeyuser.com/2025/sample-one/</link>
       <pubDate>Thu, 10 Apr 2025 00:00:00 +0000</pubDate>
-      <guid>https://www.monkeyuser.com/2025/button/</guid>
+      <guid>https://www.monkeyuser.com/2025/sample-one/</guid>
       <description/>
     </item>
     <item>
-      <title>10x</title>
-      <link>https://www.monkeyuser.com/2025/10x/</link>
+      <title>Sample title two</title>
+      <link>https://www.monkeyuser.com/2025/sample-two/</link>
       <pubDate>Mon, 17 Mar 2025 00:00:00 +0000</pubDate>
-      <guid>https://www.monkeyuser.com/2025/10x/</guid>
+      <guid>https://www.monkeyuser.com/2025/sample-two/</guid>
       <description/>
     </item>
   </channel>

--- a/test/fixtures/files/feeds/monkeyuser/normalized.json
+++ b/test/fixtures/files/feeds/monkeyuser/normalized.json
@@ -1,0 +1,14 @@
+{
+  "attachment_urls": [
+    "https://www.monkeyuser.com/2025/button/justabutton.png"
+  ],
+  "comments": [
+    "It's not you... it's just a button."
+  ],
+  "content": "Just a button - https://www.monkeyuser.com/2025/button/",
+  "published_at": "2025-04-10T00:00:00.000Z",
+  "source_url": "https://www.monkeyuser.com/2025/button/",
+  "status": "enqueued",
+  "uid": "https://www.monkeyuser.com/2025/button/",
+  "validation_errors": []
+}

--- a/test/fixtures/files/feeds/monkeyuser/normalized.json
+++ b/test/fixtures/files/feeds/monkeyuser/normalized.json
@@ -1,14 +1,14 @@
 {
   "attachment_urls": [
-    "https://www.monkeyuser.com/2025/button/justabutton.png"
+    "https://www.monkeyuser.com/2025/sample-one/sample-image.png"
   ],
   "comments": [
-    "It's not you... it's just a button."
+    "Sample hover text."
   ],
-  "content": "Just a button - https://www.monkeyuser.com/2025/button/",
+  "content": "Sample title one - https://www.monkeyuser.com/2025/sample-one/",
   "published_at": "2025-04-10T00:00:00.000Z",
-  "source_url": "https://www.monkeyuser.com/2025/button/",
+  "source_url": "https://www.monkeyuser.com/2025/sample-one/",
   "status": "enqueued",
-  "uid": "https://www.monkeyuser.com/2025/button/",
+  "uid": "https://www.monkeyuser.com/2025/sample-one/",
   "validation_errors": []
 }

--- a/test/fixtures/files/feeds/monkeyuser/page.html
+++ b/test/fixtures/files/feeds/monkeyuser/page.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang=en-us dir=ltr>
+<head>
+  <meta charset=utf-8>
+  <meta name=viewport content="width=device-width">
+  <title>Just a button | Monkeyuser</title>
+</head>
+<body>
+<header>
+  <a href=/><img class=logo src=/images/logo.png width=100 height=100 alt=MonkeyUser></a>
+  <h1>MonkeyUser</h1>
+  <nav>
+    <ul>
+      <li><a class=button href=/>Home</a></li>
+      <li><a class=button href=/tags>Tags</a></li>
+    </ul>
+  </nav>
+</header>
+<main>
+  <div class=comic>
+    <a href="/2025/button/?ref=comic"><time datetime=2025-04-10T00:00:00+00:00>🗓️ April 10, 2025 | <b>Just a button</b></time></a>
+    <div class=content>
+      <p><img src=/2025/button/justabutton.png alt="Just  a button" title="It's not you... it's just a button."></p>
+    </div>
+    <span class=tags><a href=/tags/button/ class=tag>button</a>
+      <a href=/tags/product/ class=tag>product</a></span>
+  </div>
+</main>
+<footer><p>Copyright Monkeyuser 2025. All rights reserved. [<a href=index.xml>RSS</a>]</p></footer>
+</body>
+</html>

--- a/test/fixtures/files/feeds/monkeyuser/page.html
+++ b/test/fixtures/files/feeds/monkeyuser/page.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset=utf-8>
   <meta name=viewport content="width=device-width">
-  <title>Just a button | Monkeyuser</title>
+  <title>Sample title one | Monkeyuser</title>
 </head>
 <body>
 <header>
@@ -18,12 +18,12 @@
 </header>
 <main>
   <div class=comic>
-    <a href="/2025/button/?ref=comic"><time datetime=2025-04-10T00:00:00+00:00>🗓️ April 10, 2025 | <b>Just a button</b></time></a>
+    <a href="/2025/sample-one/?ref=comic"><time datetime=2025-04-10T00:00:00+00:00>🗓️ April 10, 2025 | <b>Sample title one</b></time></a>
     <div class=content>
-      <p><img src=/2025/button/justabutton.png alt="Just  a button" title="It's not you... it's just a button."></p>
+      <p><img src=/2025/sample-one/sample-image.png alt="Sample title one" title="Sample hover text."></p>
     </div>
-    <span class=tags><a href=/tags/button/ class=tag>button</a>
-      <a href=/tags/product/ class=tag>product</a></span>
+    <span class=tags><a href=/tags/tag-one/ class=tag>tag-one</a>
+      <a href=/tags/tag-two/ class=tag>tag-two</a></span>
   </div>
 </main>
 <footer><p>Copyright Monkeyuser 2025. All rights reserved. [<a href=index.xml>RSS</a>]</p></footer>

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
-    assert_equal ["llm_web_search", "llm_website_extractor", "reddit", "rss", "telegram", "twitter", "xkcd", "youtube"], FeedProfile.all.sort
+    assert_equal ["llm_web_search", "llm_website_extractor", "monkeyuser", "reddit", "rss", "telegram", "twitter", "xkcd", "youtube"], FeedProfile.all.sort
   end
 
   test ".exists? returns true for valid profile key" do

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -2,7 +2,19 @@ require "test_helper"
 
 class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
-    assert_equal ["llm_web_search", "llm_website_extractor", "monkeyuser", "reddit", "rss", "telegram", "twitter", "xkcd", "youtube"], FeedProfile.all.sort
+    expected = [
+      "llm_web_search",
+      "llm_website_extractor",
+      "monkeyuser",
+      "reddit",
+      "rss",
+      "telegram",
+      "twitter",
+      "xkcd",
+      "youtube"
+    ]
+
+    assert_equal expected, FeedProfile.all.sort
   end
 
   test ".exists? returns true for valid profile key" do

--- a/test/services/normalizer/monkeyuser_normalizer_test.rb
+++ b/test/services/normalizer/monkeyuser_normalizer_test.rb
@@ -66,4 +66,17 @@ class Normalizer::MonkeyuserNormalizerTest < ActiveSupport::TestCase
     assert_equal "rejected", post.status
     assert_includes post.validation_errors, "missing_images"
   end
+
+  test "#normalize should reject the post when the comic image src is a malformed URI" do
+    stub_request(:get, "https://www.monkeyuser.com/2025/button/")
+      .to_return(status: 200, body: <<~HTML)
+        <html><body><img class="comic" src="/bad path/image.png" title="Alt text" /></body></html>
+      HTML
+    entry = feed_entry(0)
+
+    post = Normalizer::MonkeyuserNormalizer.new(entry).normalize
+
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "missing_images"
+  end
 end

--- a/test/services/normalizer/monkeyuser_normalizer_test.rb
+++ b/test/services/normalizer/monkeyuser_normalizer_test.rb
@@ -12,7 +12,7 @@ class Normalizer::MonkeyuserNormalizerTest < ActiveSupport::TestCase
   end
 
   def stub_comic_page
-    stub_request(:get, "https://www.monkeyuser.com/2025/button/")
+    stub_request(:get, "https://www.monkeyuser.com/2025/sample-one/")
       .to_return(status: 200, body: file_fixture("#{fixture_dir}/page.html").read)
   end
 
@@ -32,7 +32,7 @@ class Normalizer::MonkeyuserNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::MonkeyuserNormalizer.new(entry).normalize
 
-    assert_equal ["https://www.monkeyuser.com/2025/button/justabutton.png"], post.attachment_urls
+    assert_equal ["https://www.monkeyuser.com/2025/sample-one/sample-image.png"], post.attachment_urls
   end
 
   test "#normalize should add the comic hovertext as a comment" do
@@ -41,11 +41,11 @@ class Normalizer::MonkeyuserNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::MonkeyuserNormalizer.new(entry).normalize
 
-    assert_equal ["It's not you... it's just a button."], post.comments
+    assert_equal ["Sample hover text."], post.comments
   end
 
   test "#normalize should reject the post when the comic page is unavailable" do
-    stub_request(:get, "https://www.monkeyuser.com/2025/button/").to_return(status: 500)
+    stub_request(:get, "https://www.monkeyuser.com/2025/sample-one/").to_return(status: 500)
     entry = feed_entry(0)
 
     post = Normalizer::MonkeyuserNormalizer.new(entry).normalize

--- a/test/services/normalizer/monkeyuser_normalizer_test.rb
+++ b/test/services/normalizer/monkeyuser_normalizer_test.rb
@@ -70,7 +70,7 @@ class Normalizer::MonkeyuserNormalizerTest < ActiveSupport::TestCase
   test "#normalize should reject the post when the comic image src is a malformed URI" do
     stub_request(:get, "https://www.monkeyuser.com/2025/button/")
       .to_return(status: 200, body: <<~HTML)
-        <html><body><img class="comic" src="/bad path/image.png" title="Alt text" /></body></html>
+        <html><body><div class="comic"><img src="/bad path/image.png" title="Alt text" /></div></body></html>
       HTML
     entry = feed_entry(0)
 

--- a/test/services/normalizer/monkeyuser_normalizer_test.rb
+++ b/test/services/normalizer/monkeyuser_normalizer_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Normalizer::MonkeyuserNormalizerTest < ActiveSupport::TestCase
+  include FixtureFeedEntries
+
+  def fixture_dir
+    "feeds/monkeyuser"
+  end
+
+  def processor_class
+    Processor::RssProcessor
+  end
+
+  def stub_comic_page
+    stub_request(:get, "https://www.monkeyuser.com/2025/button/")
+      .to_return(status: 200, body: file_fixture("#{fixture_dir}/page.html").read)
+  end
+
+  test "#normalize should match the expected normalization result" do
+    stub_comic_page
+    entry = feed_entry(0)
+
+    normalizer = Normalizer::MonkeyuserNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
+  end
+
+  test "#normalize should attach the comic image with an absolutized URL" do
+    stub_comic_page
+    entry = feed_entry(0)
+
+    post = Normalizer::MonkeyuserNormalizer.new(entry).normalize
+
+    assert_equal ["https://www.monkeyuser.com/2025/button/justabutton.png"], post.attachment_urls
+  end
+
+  test "#normalize should add the comic hovertext as a comment" do
+    stub_comic_page
+    entry = feed_entry(0)
+
+    post = Normalizer::MonkeyuserNormalizer.new(entry).normalize
+
+    assert_equal ["It's not you... it's just a button."], post.comments
+  end
+
+  test "#normalize should reject the post when the comic page is unavailable" do
+    stub_request(:get, "https://www.monkeyuser.com/2025/button/").to_return(status: 500)
+    entry = feed_entry(0)
+
+    post = Normalizer::MonkeyuserNormalizer.new(entry).normalize
+
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "missing_images"
+    assert_empty post.attachment_urls
+    assert_empty post.comments
+  end
+end

--- a/test/services/normalizer/monkeyuser_normalizer_test.rb
+++ b/test/services/normalizer/monkeyuser_normalizer_test.rb
@@ -55,4 +55,15 @@ class Normalizer::MonkeyuserNormalizerTest < ActiveSupport::TestCase
     assert_empty post.attachment_urls
     assert_empty post.comments
   end
+
+  test "#normalize should reject the post when the comic page fetch raises a network error" do
+    stub_request(:get, "https://www.monkeyuser.com/2025/button/")
+      .to_raise(Faraday::ConnectionFailed.new("connection refused"))
+    entry = feed_entry(0)
+
+    post = Normalizer::MonkeyuserNormalizer.new(entry).normalize
+
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "missing_images"
+  end
 end

--- a/test/services/profile_matcher/monkeyuser_profile_matcher_test.rb
+++ b/test/services/profile_matcher/monkeyuser_profile_matcher_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class ProfileMatcher::MonkeyuserProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::MonkeyuserProfileMatcher.new(url)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::MonkeyuserProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 100" do
+    # Higher than RSS (10) so monkeyuser.com URLs prefer the MonkeyUser profile.
+    assert_equal 100, ProfileMatcher::MonkeyuserProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::MonkeyuserProfileMatcher.depends_on_ai
+  end
+
+  test "#match? should match monkeyuser.com URLs" do
+    assert matcher("https://monkeyuser.com/index.xml").match?
+  end
+
+  test "#match? should match monkeyuser.com subdomains" do
+    assert matcher("https://www.monkeyuser.com/index.xml").match?
+  end
+
+  test "#match? should not match non-monkeyuser URLs" do
+    assert_not matcher("https://example.com/feed.xml").match?
+  end
+
+  test "#match? should not match URLs that just contain monkeyuser in path" do
+    assert_not matcher("https://example.com/monkeyuser.com/feed.xml").match?
+  end
+
+  test "#match? should handle blank inputs" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+
+  test "#match? should raise error for invalid URLs" do
+    assert_raises(URI::InvalidURIError) do
+      matcher("not a url").match?
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Add a `monkeyuser` feed profile (matcher, normalizer, registry entry)
- Posts carry the comic title, the comic image scraped from the entry page (`.comic img`, absolutized against the page URL), and the image hovertext as a comment; posts without a retrievable comic image are rejected with `missing_images`
- Remove the stale `feed_profiles` locale section and the unused `feed_profile_options` helper — profile display names live in the `FeedProfile` registry
- Includes a real-feed fixture, matcher/normalizer tests, and a normalization snapshot

Ports the `monkeyuser` feed type from feeder 1. Verified with an ad-hoc live run against https://www.monkeyuser.com/index.xml: 289 entries loaded, first three normalized into enqueued posts with real comic image URLs and hovertext comments.
