### PR TITLE
Add Next Big Future feed profile

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -89,6 +89,26 @@ class FeedProfile
       title_extractor: "TitleExtractor::RssTitleExtractor",
       output_schema: nil
     },
+    "nextbigfuture" => {
+      display_name: "Next Big Future",
+      description: "Technology news from nextbigfuture.com with cover images",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::NextbigfutureProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "format" => "uri" }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::HttpLoader", config: {} },
+      processor: { class: "Processor::RssProcessor", config: {} },
+      normalizer: { class: "Normalizer::NextbigfutureNormalizer", config: {} },
+      title_extractor: "TitleExtractor::RssTitleExtractor",
+      output_schema: nil
+    },
     "monkeyuser" => {
       display_name: "MonkeyUser",
       description: "MonkeyUser comics for developers",

--- a/app/services/normalizer/nextbigfuture_normalizer.rb
+++ b/app/services/normalizer/nextbigfuture_normalizer.rb
@@ -1,0 +1,55 @@
+module Normalizer
+  class NextbigfutureNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      title = raw_data.dig("title") || ""
+      title.strip
+    end
+
+    def normalize_comments
+      summary = raw_data.dig("summary") || ""
+      return [] if summary.blank?
+
+      text = strip_html(summary)
+      return [] if text.blank?
+
+      [truncate_text(text, max_length: 1500)]
+    end
+
+    def normalize_attachment_urls
+      url = fetch_featured_image
+      url ? [url] : []
+    end
+
+    def fetch_featured_image
+      link = raw_data.dig("link") || raw_data.dig("url")
+      return nil if link.blank?
+
+      html = fetch_page(link)
+      return nil if html.blank?
+
+      doc = Nokogiri::HTML(html)
+      img = doc.css(".featured-image img").first
+      return nil unless img
+
+      src = img["src"]
+      return nil if src.blank?
+
+      # Accept only absolute https URLs (guards against data: URIs)
+      uri = URI.parse(src)
+      uri.is_a?(URI::HTTPS) ? src : nil
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def fetch_page(url)
+      response = HttpClient.build.get(url)
+      return nil unless response.success?
+
+      response.body
+    rescue HttpClient::Error
+      nil
+    end
+  end
+end

--- a/app/services/profile_matcher/nextbigfuture_profile_matcher.rb
+++ b/app/services/profile_matcher/nextbigfuture_profile_matcher.rb
@@ -1,0 +1,15 @@
+module ProfileMatcher
+  class NextbigfutureProfileMatcher < Base
+    input_shape :url
+    match_specificity 100
+
+    NEXTBIGFUTURE_DOMAIN = "nextbigfuture.com"
+
+    def match?
+      return false if input.blank?
+
+      uri = URI.parse(input)
+      uri.host == NEXTBIGFUTURE_DOMAIN || uri.host&.end_with?(".#{NEXTBIGFUTURE_DOMAIN}")
+    end
+  end
+end

--- a/app/services/profile_matcher/nextbigfuture_profile_matcher.rb
+++ b/app/services/profile_matcher/nextbigfuture_profile_matcher.rb
@@ -3,13 +3,13 @@ module ProfileMatcher
     input_shape :url
     match_specificity 100
 
-    NEXTBIGFUTURE_DOMAIN = "nextbigfuture.com"
+    NEXTBIGFUTURE_DOMAINS = ["nextbigfuture.com", "www.nextbigfuture.com"].freeze
 
     def match?
       return false if input.blank?
 
       uri = URI.parse(input)
-      uri.host == NEXTBIGFUTURE_DOMAIN || uri.host&.end_with?(".#{NEXTBIGFUTURE_DOMAIN}")
+      NEXTBIGFUTURE_DOMAINS.include?(uri.host)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,3 +91,4 @@ en:
     resend_email_failed:
       name: "Email failed"
       description_html: "Email delivery failed"
+

--- a/test/fixtures/files/feeds/nextbigfuture/feed.xml
+++ b/test/fixtures/files/feeds/nextbigfuture/feed.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  >
+<channel>
+  <title>NextBigFuture.com</title>
+  <atom:link href="https://www.nextbigfuture.com/feed" rel="self" type="application/rss+xml" />
+  <link>https://www.nextbigfuture.com</link>
+  <description>Coverage of Disruptive Science and Technology</description>
+  <item>
+    <title>What Must You Know Before the SpaceX IPO?</title>
+    <link>https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html</link>
+    <dc:creator><![CDATA[Brian Wang]]></dc:creator>
+    <pubDate>Thu, 11 Jun 2026 15:25:21 +0000</pubDate>
+    <guid isPermaLink="false">https://www.nextbigfuture.com/?p=210332</guid>
+    <description><![CDATA[What must you know before the SpaceX IPO? What many supposed analysts do not understand? They do not understand the AI business. What businesses is SpaceX in and where are they leading? <p class="read-more-container"><a title="What Must You Know Before the SpaceX IPO?" class="read-more button" href="https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html#more-210332">Read more</a></p>]]></description>
+  </item>
+  <item>
+    <title>Forbes Ranks Elon Musk as First Trillionaire</title>
+    <link>https://www.nextbigfuture.com/2026/06/forbes-ranks-elon-musk-as-first-trillionaire.html</link>
+    <dc:creator><![CDATA[Brian Wang]]></dc:creator>
+    <pubDate>Wed, 10 Jun 2026 23:03:18 +0000</pubDate>
+    <guid isPermaLink="false">https://www.nextbigfuture.com/?p=210316</guid>
+    <description><![CDATA[Forbes ranks Elon Musk as the first trillionaire ever. He is over triple the net worth of Larry Page who is second place.]]></description>
+  </item>
+</channel>
+</rss>

--- a/test/fixtures/files/feeds/nextbigfuture/feed.xml
+++ b/test/fixtures/files/feeds/nextbigfuture/feed.xml
@@ -5,25 +5,25 @@
   xmlns:atom="http://www.w3.org/2005/Atom"
   >
 <channel>
-  <title>NextBigFuture.com</title>
-  <atom:link href="https://www.nextbigfuture.com/feed" rel="self" type="application/rss+xml" />
-  <link>https://www.nextbigfuture.com</link>
-  <description>Coverage of Disruptive Science and Technology</description>
+  <title>Example Blog</title>
+  <atom:link href="https://example.com/feed" rel="self" type="application/rss+xml" />
+  <link>https://example.com</link>
+  <description>Sample blog for testing</description>
   <item>
-    <title>What Must You Know Before the SpaceX IPO?</title>
-    <link>https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html</link>
-    <dc:creator><![CDATA[Brian Wang]]></dc:creator>
-    <pubDate>Thu, 11 Jun 2026 15:25:21 +0000</pubDate>
-    <guid isPermaLink="false">https://www.nextbigfuture.com/?p=210332</guid>
-    <description><![CDATA[What must you know before the SpaceX IPO? What many supposed analysts do not understand? They do not understand the AI business. What businesses is SpaceX in and where are they leading? <p class="read-more-container"><a title="What Must You Know Before the SpaceX IPO?" class="read-more button" href="https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html#more-210332">Read more</a></p>]]></description>
+    <title>Sample Article One</title>
+    <link>https://example.com/2025/01/sample-article-one.html</link>
+    <dc:creator><![CDATA[Jane Smith]]></dc:creator>
+    <pubDate>Fri, 03 Jan 2025 10:00:00 +0000</pubDate>
+    <guid isPermaLink="false">https://example.com/?p=1001</guid>
+    <description><![CDATA[This is the first sample article. It contains some introductory text about the topic covered in the post. <p class="read-more-container"><a title="Sample Article One" class="read-more button" href="https://example.com/2025/01/sample-article-one.html#more-1001">Read more</a></p>]]></description>
   </item>
   <item>
-    <title>Forbes Ranks Elon Musk as First Trillionaire</title>
-    <link>https://www.nextbigfuture.com/2026/06/forbes-ranks-elon-musk-as-first-trillionaire.html</link>
-    <dc:creator><![CDATA[Brian Wang]]></dc:creator>
-    <pubDate>Wed, 10 Jun 2026 23:03:18 +0000</pubDate>
-    <guid isPermaLink="false">https://www.nextbigfuture.com/?p=210316</guid>
-    <description><![CDATA[Forbes ranks Elon Musk as the first trillionaire ever. He is over triple the net worth of Larry Page who is second place.]]></description>
+    <title>Sample Article Two</title>
+    <link>https://example.com/2025/01/sample-article-two.html</link>
+    <dc:creator><![CDATA[Jane Smith]]></dc:creator>
+    <pubDate>Thu, 02 Jan 2025 12:00:00 +0000</pubDate>
+    <guid isPermaLink="false">https://example.com/?p=1002</guid>
+    <description><![CDATA[This is the second sample article with a brief summary of its content.]]></description>
   </item>
 </channel>
 </rss>

--- a/test/fixtures/files/feeds/nextbigfuture/normalized.json
+++ b/test/fixtures/files/feeds/nextbigfuture/normalized.json
@@ -1,14 +1,14 @@
 {
   "attachment_urls": [
-    "https://nextbigfuture.s3.amazonaws.com/uploads/2026/06/Screenshot-2026-06-11-at-7.57.24-AM.jpg"
+    "https://example.com/uploads/2025/01/sample-photo.jpg"
   ],
   "comments": [
-    "What must you know before the SpaceX IPO? What many supposed analysts do not understand? They do not understand the AI business. What businesses is SpaceX in and where are they leading? Read more"
+    "This is the first sample article. It contains some introductory text about the topic covered in the post. Read more"
   ],
-  "content": "What Must You Know Before the SpaceX IPO? - https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html",
-  "published_at": "2026-06-11T15:25:21.000Z",
-  "source_url": "https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html",
+  "content": "Sample Article One - https://example.com/2025/01/sample-article-one.html",
+  "published_at": "2025-01-03T10:00:00.000Z",
+  "source_url": "https://example.com/2025/01/sample-article-one.html",
   "status": "enqueued",
-  "uid": "https://www.nextbigfuture.com/?p=210332",
+  "uid": "https://example.com/?p=1001",
   "validation_errors": []
 }

--- a/test/fixtures/files/feeds/nextbigfuture/normalized.json
+++ b/test/fixtures/files/feeds/nextbigfuture/normalized.json
@@ -1,0 +1,14 @@
+{
+  "attachment_urls": [
+    "https://nextbigfuture.s3.amazonaws.com/uploads/2026/06/Screenshot-2026-06-11-at-7.57.24-AM.jpg"
+  ],
+  "comments": [
+    "What must you know before the SpaceX IPO? What many supposed analysts do not understand? They do not understand the AI business. What businesses is SpaceX in and where are they leading? Read more"
+  ],
+  "content": "What Must You Know Before the SpaceX IPO? - https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html",
+  "published_at": "2026-06-11T15:25:21.000Z",
+  "source_url": "https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html",
+  "status": "enqueued",
+  "uid": "https://www.nextbigfuture.com/?p=210332",
+  "validation_errors": []
+}

--- a/test/fixtures/files/feeds/nextbigfuture/page.html
+++ b/test/fixtures/files/feeds/nextbigfuture/page.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html>
-<head><title>What Must You Know Before the SpaceX IPO?</title></head>
+<head><title>Sample Article One</title></head>
 <body>
 <article>
   <div class="featured-image page-header-image-single">
     <img width="961" height="500"
-      src="https://nextbigfuture.s3.amazonaws.com/uploads/2026/06/Screenshot-2026-06-11-at-7.57.24-AM.jpg"
+      src="https://example.com/uploads/2025/01/sample-photo.jpg"
       class="attachment-full size-full" alt="" itemprop="image" />
   </div>
   <header class="entry-header">
-    <h1 class="entry-title">What Must You Know Before the SpaceX IPO?</h1>
+    <h1 class="entry-title">Sample Article One</h1>
   </header>
   <div class="entry-content">
-    <p>What must you know before the SpaceX IPO?</p>
+    <p>This is the first sample article.</p>
   </div>
 </article>
 </body>

--- a/test/fixtures/files/feeds/nextbigfuture/page.html
+++ b/test/fixtures/files/feeds/nextbigfuture/page.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head><title>What Must You Know Before the SpaceX IPO?</title></head>
+<body>
+<article>
+  <div class="featured-image page-header-image-single">
+    <img width="961" height="500"
+      src="https://nextbigfuture.s3.amazonaws.com/uploads/2026/06/Screenshot-2026-06-11-at-7.57.24-AM.jpg"
+      class="attachment-full size-full" alt="" itemprop="image" />
+  </div>
+  <header class="entry-header">
+    <h1 class="entry-title">What Must You Know Before the SpaceX IPO?</h1>
+  </header>
+  <div class="entry-content">
+    <p>What must you know before the SpaceX IPO?</p>
+  </div>
+</article>
+</body>
+</html>

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -8,6 +8,7 @@ class FeedProfileTest < ActiveSupport::TestCase
       "llm_website_extractor",
       "lobsters",
       "monkeyuser",
+      "nextbigfuture",
       "reddit",
       "rss",
       "smbc",

--- a/test/services/normalizer/nextbigfuture_normalizer_test.rb
+++ b/test/services/normalizer/nextbigfuture_normalizer_test.rb
@@ -12,7 +12,7 @@ class Normalizer::NextbigfutureNormalizerTest < ActiveSupport::TestCase
   end
 
   setup do
-    stub_request(:get, "https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html")
+    stub_request(:get, "https://example.com/2025/01/sample-article-one.html")
       .to_return(status: 200, body: file_fixture("feeds/nextbigfuture/page.html").read)
   end
 
@@ -29,7 +29,7 @@ class Normalizer::NextbigfutureNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::NextbigfutureNormalizer.new(entry).normalize
 
-    assert_includes post.content, "What Must You Know Before the SpaceX IPO?"
+    assert_includes post.content, "Sample Article One"
   end
 
   test "#normalize should include stripped summary as a comment" do
@@ -38,7 +38,7 @@ class Normalizer::NextbigfutureNormalizerTest < ActiveSupport::TestCase
     post = Normalizer::NextbigfutureNormalizer.new(entry).normalize
 
     assert_equal 1, post.comments.size
-    assert_includes post.comments.first, "What many supposed analysts do not understand"
+    assert_includes post.comments.first, "introductory text about the topic"
   end
 
   test "#normalize should fetch the featured image from the article page" do
@@ -46,12 +46,12 @@ class Normalizer::NextbigfutureNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::NextbigfutureNormalizer.new(entry).normalize
 
-    assert_equal ["https://nextbigfuture.s3.amazonaws.com/uploads/2026/06/Screenshot-2026-06-11-at-7.57.24-AM.jpg"],
+    assert_equal ["https://example.com/uploads/2025/01/sample-photo.jpg"],
                  post.attachment_urls
   end
 
   test "#normalize should return no attachments when page fetch fails" do
-    stub_request(:get, "https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html")
+    stub_request(:get, "https://example.com/2025/01/sample-article-one.html")
       .to_return(status: 404)
 
     entry = feed_entry(0)

--- a/test/services/normalizer/nextbigfuture_normalizer_test.rb
+++ b/test/services/normalizer/nextbigfuture_normalizer_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class Normalizer::NextbigfutureNormalizerTest < ActiveSupport::TestCase
+  include FixtureFeedEntries
+
+  def fixture_dir
+    "feeds/nextbigfuture"
+  end
+
+  def processor_class
+    Processor::RssProcessor
+  end
+
+  setup do
+    stub_request(:get, "https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html")
+      .to_return(status: 200, body: file_fixture("feeds/nextbigfuture/page.html").read)
+  end
+
+  test "#normalize should match the expected normalization result" do
+    entry = feed_entry(0)
+
+    post = Normalizer::NextbigfutureNormalizer.new(entry).normalize
+
+    assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
+  end
+
+  test "#normalize should extract the title as content" do
+    entry = feed_entry(0)
+
+    post = Normalizer::NextbigfutureNormalizer.new(entry).normalize
+
+    assert_includes post.content, "What Must You Know Before the SpaceX IPO?"
+  end
+
+  test "#normalize should include stripped summary as a comment" do
+    entry = feed_entry(0)
+
+    post = Normalizer::NextbigfutureNormalizer.new(entry).normalize
+
+    assert_equal 1, post.comments.size
+    assert_includes post.comments.first, "What many supposed analysts do not understand"
+  end
+
+  test "#normalize should fetch the featured image from the article page" do
+    entry = feed_entry(0)
+
+    post = Normalizer::NextbigfutureNormalizer.new(entry).normalize
+
+    assert_equal ["https://nextbigfuture.s3.amazonaws.com/uploads/2026/06/Screenshot-2026-06-11-at-7.57.24-AM.jpg"],
+                 post.attachment_urls
+  end
+
+  test "#normalize should return no attachments when page fetch fails" do
+    stub_request(:get, "https://www.nextbigfuture.com/2026/06/what-must-you-know-before-the-spacex-ipo.html")
+      .to_return(status: 404)
+
+    entry = feed_entry(0)
+
+    post = Normalizer::NextbigfutureNormalizer.new(entry).normalize
+
+    assert_equal [], post.attachment_urls
+  end
+end

--- a/test/services/profile_matcher/nextbigfuture_profile_matcher_test.rb
+++ b/test/services/profile_matcher/nextbigfuture_profile_matcher_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class ProfileMatcher::NextbigfutureProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::NextbigfutureProfileMatcher.new(url)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::NextbigfutureProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 100" do
+    # Higher than RSS (10) so nextbigfuture.com URLs prefer the Next Big Future profile.
+    assert_equal 100, ProfileMatcher::NextbigfutureProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::NextbigfutureProfileMatcher.depends_on_ai
+  end
+
+  test "#match? should match nextbigfuture.com URLs" do
+    assert matcher("https://www.nextbigfuture.com/feed").match?
+  end
+
+  test "#match? should match nextbigfuture.com subdomains" do
+    assert matcher("https://nextbigfuture.com/feed").match?
+  end
+
+  test "#match? should not match non-nextbigfuture URLs" do
+    assert_not matcher("https://example.com/feed.xml").match?
+  end
+
+  test "#match? should not match URLs that just contain nextbigfuture in path" do
+    assert_not matcher("https://example.com/nextbigfuture.com/feed").match?
+  end
+
+  test "#match? should handle blank inputs" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+
+  test "#match? should raise error for invalid URLs" do
+    assert_raises(URI::InvalidURIError) do
+      matcher("not a url").match?
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Add a `nextbigfuture` feed profile (matcher, normalizer, registry entry)
- Normalizer fetches the article page to extract the featured image via `.featured-image img`; the entry summary is included as a comment (stripped, truncated to 1500 chars)
- Use generic sample data in test fixtures instead of real article content
- Remove `feed_profiles` locale keys; display names are already in the profile registry

Ports the `nextbigfuture` feed type from feeder 1. Ad-hoc live run loaded 11 entries, with all 3 tested showing correct titles, summaries, and featured image URLs (status: enqueued, no errors).