### PR TITLE
Add Litterbox Comics feed profile

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -129,6 +129,26 @@ class FeedProfile
       title_extractor: "TitleExtractor::RssTitleExtractor",
       output_schema: nil
     },
+    "litterbox" => {
+      display_name: "Litterbox Comics",
+      description: "Family life comics from Litterbox Comics, bonus panels included",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::LitterboxProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "format" => "uri" }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::HttpLoader", config: {} },
+      processor: { class: "Processor::RssProcessor", config: {} },
+      normalizer: { class: "Normalizer::LitterboxNormalizer", config: {} },
+      title_extractor: "TitleExtractor::RssTitleExtractor",
+      output_schema: nil
+    },
     "smbc" => {
       display_name: "SMBC Comics",
       description: "Saturday Morning Breakfast Cereal comics with the hovertext and hidden panel",

--- a/app/services/normalizer/litterbox_normalizer.rb
+++ b/app/services/normalizer/litterbox_normalizer.rb
@@ -25,12 +25,6 @@ module Normalizer
       ["Bonus panel: #{url}"]
     end
 
-    def validate_content
-      errors = super
-      errors << "bonus" if bonus_post?
-      errors
-    end
-
     def fetch_article_page
       @article_page ||= begin
         response = HttpClient.build.get(source_url)
@@ -59,10 +53,6 @@ module Normalizer
 
       base = link.sub(%r{/+\z}, "")
       "#{base}-bonus/"
-    end
-
-    def bonus_post?
-      source_url.to_s.match?(%r{-bonus/?$})
     end
   end
 end

--- a/app/services/normalizer/litterbox_normalizer.rb
+++ b/app/services/normalizer/litterbox_normalizer.rb
@@ -1,0 +1,68 @@
+module Normalizer
+  class LitterboxNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      title = raw_data.dig("title") || ""
+      title.strip
+    end
+
+    def normalize_attachment_urls
+      page = fetch_article_page
+      doc = Nokogiri::HTML(page || "")
+
+      if doc.css(".swiper-wrapper").present?
+        doc.css(".swiper-wrapper img").pluck("src").compact_blank
+      else
+        [extract_images(raw_data.dig("content") || "").first].compact
+      end
+    end
+
+    def normalize_comments
+      url = bonus_panel_image_url
+      return [] if url.blank?
+
+      ["Bonus panel: #{url}"]
+    end
+
+    def validate_content
+      errors = super
+      errors << "bonus" if bonus_post?
+      errors
+    end
+
+    def fetch_article_page
+      @article_page ||= begin
+        response = HttpClient.build.get(source_url)
+        response.success? ? response.body : nil
+      rescue HttpClient::Error
+        nil
+      end
+    end
+
+    def bonus_panel_image_url
+      bonus_url = bonus_panel_url
+      return nil if bonus_url.blank?
+
+      response = HttpClient.build.get(bonus_url)
+      return nil unless response.success?
+
+      doc = Nokogiri::HTML(response.body)
+      doc.at_css('meta[property="og:image"]')&.[]("content")
+    rescue HttpClient::Error
+      nil
+    end
+
+    def bonus_panel_url
+      link = source_url.to_s
+      return nil if link.blank?
+
+      base = link.sub(%r{/+\z}, "")
+      "#{base}-bonus/"
+    end
+
+    def bonus_post?
+      source_url.to_s.match?(%r{-bonus/?$})
+    end
+  end
+end

--- a/app/services/profile_matcher/litterbox_profile_matcher.rb
+++ b/app/services/profile_matcher/litterbox_profile_matcher.rb
@@ -5,7 +5,7 @@ module ProfileMatcher
 
     LITTERBOX_HOSTS = %w[litterboxcomics.com www.litterboxcomics.com].freeze
     FEEDBURNER_HOST = "feeds.feedburner.com"
-    LITTERBOX_FEEDBURNER_PATH = "/litterboxcomics"
+    LITTERBOX_FEEDBURNER_PATH = "/litterboxcomics/"
 
     def match?
       return false if input.blank?

--- a/app/services/profile_matcher/litterbox_profile_matcher.rb
+++ b/app/services/profile_matcher/litterbox_profile_matcher.rb
@@ -1,0 +1,30 @@
+module ProfileMatcher
+  class LitterboxProfileMatcher < Base
+    input_shape :url
+    match_specificity 100
+
+    LITTERBOX_DOMAIN = "litterboxcomics.com"
+    FEEDBURNER_DOMAIN = "feedburner.com"
+    LITTERBOX_PATH_PATTERN = "litterboxcomics"
+
+    def match?
+      return false if input.blank?
+
+      uri = URI.parse(input)
+      return false if uri.host.blank?
+
+      litterbox_host?(uri) || feedburner_litterbox?(uri)
+    end
+
+    private
+
+    def litterbox_host?(uri)
+      uri.host == LITTERBOX_DOMAIN || uri.host.end_with?(".#{LITTERBOX_DOMAIN}")
+    end
+
+    def feedburner_litterbox?(uri)
+      (uri.host == FEEDBURNER_DOMAIN || uri.host&.end_with?(".#{FEEDBURNER_DOMAIN}")) &&
+        uri.path.to_s.include?(LITTERBOX_PATH_PATTERN)
+    end
+  end
+end

--- a/app/services/profile_matcher/litterbox_profile_matcher.rb
+++ b/app/services/profile_matcher/litterbox_profile_matcher.rb
@@ -3,7 +3,7 @@ module ProfileMatcher
     input_shape :url
     match_specificity 100
 
-    LITTERBOX_DOMAIN = "litterboxcomics.com"
+    LITTERBOX_HOSTS = %w[litterboxcomics.com www.litterboxcomics.com].freeze
     FEEDBURNER_DOMAIN = "feedburner.com"
     LITTERBOX_PATH_PATTERN = "litterboxcomics"
 
@@ -19,7 +19,7 @@ module ProfileMatcher
     private
 
     def litterbox_host?(uri)
-      uri.host == LITTERBOX_DOMAIN || uri.host.end_with?(".#{LITTERBOX_DOMAIN}")
+      LITTERBOX_HOSTS.include?(uri.host)
     end
 
     def feedburner_litterbox?(uri)

--- a/app/services/profile_matcher/litterbox_profile_matcher.rb
+++ b/app/services/profile_matcher/litterbox_profile_matcher.rb
@@ -4,8 +4,8 @@ module ProfileMatcher
     match_specificity 100
 
     LITTERBOX_HOSTS = %w[litterboxcomics.com www.litterboxcomics.com].freeze
-    FEEDBURNER_DOMAIN = "feedburner.com"
-    LITTERBOX_PATH_PATTERN = "litterboxcomics"
+    FEEDBURNER_HOST = "feeds.feedburner.com"
+    LITTERBOX_FEEDBURNER_PATH = "/litterboxcomics"
 
     def match?
       return false if input.blank?
@@ -23,8 +23,8 @@ module ProfileMatcher
     end
 
     def feedburner_litterbox?(uri)
-      (uri.host == FEEDBURNER_DOMAIN || uri.host&.end_with?(".#{FEEDBURNER_DOMAIN}")) &&
-        uri.path.to_s.include?(LITTERBOX_PATH_PATTERN)
+      uri.host == FEEDBURNER_HOST &&
+        uri.path.to_s.start_with?(LITTERBOX_FEEDBURNER_PATH)
     end
   end
 end

--- a/test/fixtures/files/feeds/litterbox/bonus_page.html
+++ b/test/fixtures/files/feeds/litterbox/bonus_page.html
@@ -2,14 +2,14 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <meta property="og:image" content="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-bonus.png" />
-  <title>Dark Chocolate Bonus - Litterbox Comics</title>
+  <meta property="og:image" content="https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one-bonus.png" />
+  <title>Sample Comic One Bonus - Litterbox Comics</title>
 </head>
 <body>
   <article class="entry-content">
     <div class="wp-block-image">
       <figure class="aligncenter size-full">
-        <img src="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-bonus.png" alt="Bonus panel" />
+        <img src="https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one-bonus.png" alt="Bonus panel" />
       </figure>
     </div>
   </article>

--- a/test/fixtures/files/feeds/litterbox/bonus_page.html
+++ b/test/fixtures/files/feeds/litterbox/bonus_page.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta property="og:image" content="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-bonus.png" />
+  <title>Dark Chocolate Bonus - Litterbox Comics</title>
+</head>
+<body>
+  <article class="entry-content">
+    <div class="wp-block-image">
+      <figure class="aligncenter size-full">
+        <img src="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-bonus.png" alt="Bonus panel" />
+      </figure>
+    </div>
+  </article>
+</body>
+</html>

--- a/test/fixtures/files/feeds/litterbox/feed.xml
+++ b/test/fixtures/files/feeds/litterbox/feed.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Litterbox Comics</title>
+    <atom:link href="https://www.litterboxcomics.com/feed/" rel="self" type="application/rss+xml"/>
+    <link>https://www.litterboxcomics.com/</link>
+    <description></description>
+    <lastBuildDate>Tue, 09 Jun 2026 16:00:00 +0000</lastBuildDate>
+    <language>en-US</language>
+    <item>
+      <title>Dark Chocolate</title>
+      <link>https://www.litterboxcomics.com/dark-chocolate/</link>
+      <dc:creator><![CDATA[Chesca Hause]]></dc:creator>
+      <pubDate>Tue, 09 Jun 2026 16:00:00 +0000</pubDate>
+      <guid isPermaLink="false">https://www.litterboxcomics.com/?p=33732</guid>
+      <description><![CDATA[<p>BONUS PANEL on Patreon!</p>
+<p>The post <a href="https://www.litterboxcomics.com/dark-chocolate/">Dark Chocolate</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+]]></description>
+      <content:encoded><![CDATA[<div class="wp-block-image">
+<figure class="aligncenter size-full is-resized"><img src="https://i0.wp.com/www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate.png?resize=1000%2C1249&ssl=1" alt="" class="wp-image-33733" /></figure>
+</div>
+<p>The post <a href="https://www.litterboxcomics.com/dark-chocolate/">Dark Chocolate</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+]]></content:encoded>
+    </item>
+    <item>
+      <title>Cube</title>
+      <link>https://www.litterboxcomics.com/cube/</link>
+      <dc:creator><![CDATA[Chesca Hause]]></dc:creator>
+      <pubDate>Tue, 02 Jun 2026 16:00:00 +0000</pubDate>
+      <guid isPermaLink="false">https://www.litterboxcomics.com/?p=33726</guid>
+      <description><![CDATA[<p>BONUS PANEL on Patreon!</p>
+<p>The post <a href="https://www.litterboxcomics.com/cube/">Cube</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+]]></description>
+      <content:encoded><![CDATA[<div class="wp-block-image">
+<figure class="aligncenter size-full is-resized"><img src="https://i0.wp.com/www.litterboxcomics.com/wp-content/uploads/2026/05/cube.png?resize=1000%2C1249&ssl=1" alt="" class="wp-image-33728" /></figure>
+</div>
+<p>The post <a href="https://www.litterboxcomics.com/cube/">Cube</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+]]></content:encoded>
+    </item>
+  </channel>
+</rss>

--- a/test/fixtures/files/feeds/litterbox/feed.xml
+++ b/test/fixtures/files/feeds/litterbox/feed.xml
@@ -11,33 +11,33 @@
     <lastBuildDate>Tue, 09 Jun 2026 16:00:00 +0000</lastBuildDate>
     <language>en-US</language>
     <item>
-      <title>Dark Chocolate</title>
-      <link>https://www.litterboxcomics.com/dark-chocolate/</link>
-      <dc:creator><![CDATA[Chesca Hause]]></dc:creator>
+      <title>Sample Comic One</title>
+      <link>https://www.litterboxcomics.com/sample-comic-one/</link>
+      <dc:creator><![CDATA[Sample Author]]></dc:creator>
       <pubDate>Tue, 09 Jun 2026 16:00:00 +0000</pubDate>
-      <guid isPermaLink="false">https://www.litterboxcomics.com/?p=33732</guid>
+      <guid isPermaLink="false">https://www.litterboxcomics.com/sample-comic-one/</guid>
       <description><![CDATA[<p>BONUS PANEL on Patreon!</p>
-<p>The post <a href="https://www.litterboxcomics.com/dark-chocolate/">Dark Chocolate</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+<p>The post <a href="https://www.litterboxcomics.com/sample-comic-one/">Sample Comic One</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
 ]]></description>
       <content:encoded><![CDATA[<div class="wp-block-image">
-<figure class="aligncenter size-full is-resized"><img src="https://i0.wp.com/www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate.png?resize=1000%2C1249&ssl=1" alt="" class="wp-image-33733" /></figure>
+<figure class="aligncenter size-full is-resized"><img src="https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one.png" alt="" class="wp-image-1001" /></figure>
 </div>
-<p>The post <a href="https://www.litterboxcomics.com/dark-chocolate/">Dark Chocolate</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+<p>The post <a href="https://www.litterboxcomics.com/sample-comic-one/">Sample Comic One</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
 ]]></content:encoded>
     </item>
     <item>
-      <title>Cube</title>
-      <link>https://www.litterboxcomics.com/cube/</link>
-      <dc:creator><![CDATA[Chesca Hause]]></dc:creator>
+      <title>Sample Comic Two</title>
+      <link>https://www.litterboxcomics.com/sample-comic-two/</link>
+      <dc:creator><![CDATA[Sample Author]]></dc:creator>
       <pubDate>Tue, 02 Jun 2026 16:00:00 +0000</pubDate>
-      <guid isPermaLink="false">https://www.litterboxcomics.com/?p=33726</guid>
+      <guid isPermaLink="false">https://www.litterboxcomics.com/sample-comic-two/</guid>
       <description><![CDATA[<p>BONUS PANEL on Patreon!</p>
-<p>The post <a href="https://www.litterboxcomics.com/cube/">Cube</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+<p>The post <a href="https://www.litterboxcomics.com/sample-comic-two/">Sample Comic Two</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
 ]]></description>
       <content:encoded><![CDATA[<div class="wp-block-image">
-<figure class="aligncenter size-full is-resized"><img src="https://i0.wp.com/www.litterboxcomics.com/wp-content/uploads/2026/05/cube.png?resize=1000%2C1249&ssl=1" alt="" class="wp-image-33728" /></figure>
+<figure class="aligncenter size-full is-resized"><img src="https://www.litterboxcomics.com/wp-content/uploads/sample-comic-two.png" alt="" class="wp-image-1002" /></figure>
 </div>
-<p>The post <a href="https://www.litterboxcomics.com/cube/">Cube</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+<p>The post <a href="https://www.litterboxcomics.com/sample-comic-two/">Sample Comic Two</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
 ]]></content:encoded>
     </item>
   </channel>

--- a/test/fixtures/files/feeds/litterbox/normalized.json
+++ b/test/fixtures/files/feeds/litterbox/normalized.json
@@ -1,14 +1,14 @@
 {
   "attachment_urls": [
-    "https://i0.wp.com/www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate.png?resize=1000%2C1249&ssl=1"
+    "https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one.png"
   ],
   "comments": [
-    "Bonus panel: https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-bonus.png"
+    "Bonus panel: https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one-bonus.png"
   ],
-  "content": "Dark Chocolate - https://www.litterboxcomics.com/dark-chocolate/",
+  "content": "Sample Comic One - https://www.litterboxcomics.com/sample-comic-one/",
   "published_at": "2026-06-09T16:00:00.000Z",
-  "source_url": "https://www.litterboxcomics.com/dark-chocolate/",
+  "source_url": "https://www.litterboxcomics.com/sample-comic-one/",
   "status": "enqueued",
-  "uid": "https://www.litterboxcomics.com/?p=33732",
+  "uid": "https://www.litterboxcomics.com/sample-comic-one/",
   "validation_errors": []
 }

--- a/test/fixtures/files/feeds/litterbox/normalized.json
+++ b/test/fixtures/files/feeds/litterbox/normalized.json
@@ -1,0 +1,14 @@
+{
+  "attachment_urls": [
+    "https://i0.wp.com/www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate.png?resize=1000%2C1249&ssl=1"
+  ],
+  "comments": [
+    "Bonus panel: https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-bonus.png"
+  ],
+  "content": "Dark Chocolate - https://www.litterboxcomics.com/dark-chocolate/",
+  "published_at": "2026-06-09T16:00:00.000Z",
+  "source_url": "https://www.litterboxcomics.com/dark-chocolate/",
+  "status": "enqueued",
+  "uid": "https://www.litterboxcomics.com/?p=33732",
+  "validation_errors": []
+}

--- a/test/fixtures/files/feeds/litterbox/page.html
+++ b/test/fixtures/files/feeds/litterbox/page.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Dark Chocolate - Litterbox Comics</title>
+</head>
+<body>
+  <article class="entry-content">
+    <div class="wp-block-image">
+      <figure class="aligncenter size-full">
+        <img src="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate.png" alt="Dark Chocolate comic" />
+      </figure>
+    </div>
+    <p>The post <a href="https://www.litterboxcomics.com/dark-chocolate/">Dark Chocolate</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+  </article>
+</body>
+</html>

--- a/test/fixtures/files/feeds/litterbox/page.html
+++ b/test/fixtures/files/feeds/litterbox/page.html
@@ -2,16 +2,16 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>Dark Chocolate - Litterbox Comics</title>
+  <title>Sample Comic One - Litterbox Comics</title>
 </head>
 <body>
   <article class="entry-content">
     <div class="wp-block-image">
       <figure class="aligncenter size-full">
-        <img src="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate.png" alt="Dark Chocolate comic" />
+        <img src="https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one.png" alt="Sample Comic One" />
       </figure>
     </div>
-    <p>The post <a href="https://www.litterboxcomics.com/dark-chocolate/">Dark Chocolate</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
+    <p>The post <a href="https://www.litterboxcomics.com/sample-comic-one/">Sample Comic One</a> appeared first on <a href="https://www.litterboxcomics.com">Litterbox Comics</a>.</p>
   </article>
 </body>
 </html>

--- a/test/fixtures/files/feeds/litterbox/page_swiper.html
+++ b/test/fixtures/files/feeds/litterbox/page_swiper.html
@@ -2,14 +2,14 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>Dark Chocolate - Litterbox Comics</title>
+  <title>Sample Comic One - Litterbox Comics</title>
 </head>
 <body>
   <article class="entry-content">
     <div class="swiper-container">
       <div class="swiper-wrapper">
-        <div class="swiper-slide"><img src="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-1.png" alt="Page 1" /></div>
-        <div class="swiper-slide"><img src="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-2.png" alt="Page 2" /></div>
+        <div class="swiper-slide"><img src="https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one-1.png" alt="Page 1" /></div>
+        <div class="swiper-slide"><img src="https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one-2.png" alt="Page 2" /></div>
       </div>
     </div>
   </article>

--- a/test/fixtures/files/feeds/litterbox/page_swiper.html
+++ b/test/fixtures/files/feeds/litterbox/page_swiper.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Dark Chocolate - Litterbox Comics</title>
+</head>
+<body>
+  <article class="entry-content">
+    <div class="swiper-container">
+      <div class="swiper-wrapper">
+        <div class="swiper-slide"><img src="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-1.png" alt="Page 1" /></div>
+        <div class="swiper-slide"><img src="https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-2.png" alt="Page 2" /></div>
+      </div>
+    </div>
+  </article>
+</body>
+</html>

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
     expected = [
+      "litterbox",
       "llm_web_search",
       "llm_website_extractor",
       "lobsters",

--- a/test/services/normalizer/litterbox_normalizer_test.rb
+++ b/test/services/normalizer/litterbox_normalizer_test.rb
@@ -64,18 +64,6 @@ class Normalizer::LitterboxNormalizerTest < ActiveSupport::TestCase
     ], post.attachment_urls
   end
 
-  test "#normalize should reject bonus posts with 'bonus' validation error" do
-    entry = feed_entry(0)
-    entry.raw_data["link"] = "https://www.litterboxcomics.com/sample-comic-one-bonus/"
-    stub_request(:get, "https://www.litterboxcomics.com/sample-comic-one-bonus-bonus/")
-      .to_return(status: 404, body: "")
-
-    post = Normalizer::LitterboxNormalizer.new(entry).normalize
-
-    assert_includes post.validation_errors, "bonus"
-    assert post.rejected?
-  end
-
   test "#normalize should handle bonus page fetch failure gracefully" do
     stub_request(:get, "https://www.litterboxcomics.com/sample-comic-one-bonus/")
       .to_raise(HttpClient::Error)

--- a/test/services/normalizer/litterbox_normalizer_test.rb
+++ b/test/services/normalizer/litterbox_normalizer_test.rb
@@ -12,9 +12,9 @@ class Normalizer::LitterboxNormalizerTest < ActiveSupport::TestCase
   end
 
   setup do
-    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate/")
+    stub_request(:get, "https://www.litterboxcomics.com/sample-comic-one/")
       .to_return(status: 200, body: file_fixture("feeds/litterbox/page.html").read)
-    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate-bonus/")
+    stub_request(:get, "https://www.litterboxcomics.com/sample-comic-one-bonus/")
       .to_return(status: 200, body: file_fixture("feeds/litterbox/bonus_page.html").read)
   end
 
@@ -32,7 +32,7 @@ class Normalizer::LitterboxNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::LitterboxNormalizer.new(entry).normalize
 
-    assert_equal "Dark Chocolate - https://www.litterboxcomics.com/dark-chocolate/", post.content
+    assert_equal "Sample Comic One - https://www.litterboxcomics.com/sample-comic-one/", post.content
   end
 
   test "#normalize should include the bonus panel as a comment" do
@@ -40,7 +40,7 @@ class Normalizer::LitterboxNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::LitterboxNormalizer.new(entry).normalize
 
-    assert_equal ["Bonus panel: https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-bonus.png"], post.comments
+    assert_equal ["Bonus panel: https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one-bonus.png"], post.comments
   end
 
   test "#normalize should fall back to content HTML image when page has no swiper" do
@@ -48,28 +48,26 @@ class Normalizer::LitterboxNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::LitterboxNormalizer.new(entry).normalize
 
-    assert_includes post.attachment_urls, "https://i0.wp.com/www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate.png?resize=1000%2C1249&ssl=1"
+    assert_includes post.attachment_urls, "https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one.png"
   end
 
   test "#normalize should use swiper images when page has swiper-wrapper" do
-    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate/")
+    stub_request(:get, "https://www.litterboxcomics.com/sample-comic-one/")
       .to_return(status: 200, body: file_fixture("feeds/litterbox/page_swiper.html").read)
 
     entry = feed_entry(0)
     post = Normalizer::LitterboxNormalizer.new(entry).normalize
 
     assert_equal [
-      "https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-1.png",
-      "https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-2.png"
+      "https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one-1.png",
+      "https://www.litterboxcomics.com/wp-content/uploads/sample-comic-one-2.png"
     ], post.attachment_urls
   end
 
   test "#normalize should reject bonus posts with 'bonus' validation error" do
     entry = feed_entry(0)
-    entry.raw_data["link"] = "https://www.litterboxcomics.com/dark-chocolate-bonus/"
-    # setup already stubs dark-chocolate-bonus/ for the article fetch;
-    # stub the bonus-of-bonus URL that will be derived
-    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate-bonus-bonus/")
+    entry.raw_data["link"] = "https://www.litterboxcomics.com/sample-comic-one-bonus/"
+    stub_request(:get, "https://www.litterboxcomics.com/sample-comic-one-bonus-bonus/")
       .to_return(status: 404, body: "")
 
     post = Normalizer::LitterboxNormalizer.new(entry).normalize
@@ -79,7 +77,7 @@ class Normalizer::LitterboxNormalizerTest < ActiveSupport::TestCase
   end
 
   test "#normalize should handle bonus page fetch failure gracefully" do
-    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate-bonus/")
+    stub_request(:get, "https://www.litterboxcomics.com/sample-comic-one-bonus/")
       .to_raise(HttpClient::Error)
 
     entry = feed_entry(0)

--- a/test/services/normalizer/litterbox_normalizer_test.rb
+++ b/test/services/normalizer/litterbox_normalizer_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class Normalizer::LitterboxNormalizerTest < ActiveSupport::TestCase
+  include FixtureFeedEntries
+
+  def fixture_dir
+    "feeds/litterbox"
+  end
+
+  def processor_class
+    Processor::RssProcessor
+  end
+
+  setup do
+    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate/")
+      .to_return(status: 200, body: file_fixture("feeds/litterbox/page.html").read)
+    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate-bonus/")
+      .to_return(status: 200, body: file_fixture("feeds/litterbox/bonus_page.html").read)
+  end
+
+  test "#normalize should match the expected normalization result" do
+    entry = feed_entry(0)
+
+    normalizer = Normalizer::LitterboxNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
+  end
+
+  test "#normalize should use the entry title as content" do
+    entry = feed_entry(0)
+
+    post = Normalizer::LitterboxNormalizer.new(entry).normalize
+
+    assert_equal "Dark Chocolate - https://www.litterboxcomics.com/dark-chocolate/", post.content
+  end
+
+  test "#normalize should include the bonus panel as a comment" do
+    entry = feed_entry(0)
+
+    post = Normalizer::LitterboxNormalizer.new(entry).normalize
+
+    assert_equal ["Bonus panel: https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-bonus.png"], post.comments
+  end
+
+  test "#normalize should fall back to content HTML image when page has no swiper" do
+    entry = feed_entry(0)
+
+    post = Normalizer::LitterboxNormalizer.new(entry).normalize
+
+    assert_includes post.attachment_urls, "https://i0.wp.com/www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate.png?resize=1000%2C1249&ssl=1"
+  end
+
+  test "#normalize should use swiper images when page has swiper-wrapper" do
+    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate/")
+      .to_return(status: 200, body: file_fixture("feeds/litterbox/page_swiper.html").read)
+
+    entry = feed_entry(0)
+    post = Normalizer::LitterboxNormalizer.new(entry).normalize
+
+    assert_equal [
+      "https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-1.png",
+      "https://www.litterboxcomics.com/wp-content/uploads/2026/06/dark-chocolate-2.png"
+    ], post.attachment_urls
+  end
+
+  test "#normalize should reject bonus posts with 'bonus' validation error" do
+    entry = feed_entry(0)
+    entry.raw_data["link"] = "https://www.litterboxcomics.com/dark-chocolate-bonus/"
+    # setup already stubs dark-chocolate-bonus/ for the article fetch;
+    # stub the bonus-of-bonus URL that will be derived
+    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate-bonus-bonus/")
+      .to_return(status: 404, body: "")
+
+    post = Normalizer::LitterboxNormalizer.new(entry).normalize
+
+    assert_includes post.validation_errors, "bonus"
+    assert post.rejected?
+  end
+
+  test "#normalize should handle bonus page fetch failure gracefully" do
+    stub_request(:get, "https://www.litterboxcomics.com/dark-chocolate-bonus/")
+      .to_raise(HttpClient::Error)
+
+    entry = feed_entry(0)
+    post = Normalizer::LitterboxNormalizer.new(entry).normalize
+
+    assert_equal [], post.comments
+  end
+end

--- a/test/services/profile_matcher/litterbox_profile_matcher_test.rb
+++ b/test/services/profile_matcher/litterbox_profile_matcher_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class ProfileMatcher::LitterboxProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::LitterboxProfileMatcher.new(url)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::LitterboxProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 100" do
+    assert_equal 100, ProfileMatcher::LitterboxProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::LitterboxProfileMatcher.depends_on_ai
+  end
+
+  test "#match? should match litterboxcomics.com URLs" do
+    assert matcher("https://www.litterboxcomics.com/feed/").match?
+  end
+
+  test "#match? should match litterboxcomics.com without subdomain" do
+    assert matcher("https://litterboxcomics.com/feed/").match?
+  end
+
+  test "#match? should match feedburner.com URLs containing litterboxcomics in path" do
+    assert matcher("https://feeds.feedburner.com/litterboxcomics/yS3QAzAMEMP").match?
+  end
+
+  test "#match? should not match feedburner.com URLs without litterboxcomics in path" do
+    assert_not matcher("https://feeds.feedburner.com/someotherfeed/abc123").match?
+  end
+
+  test "#match? should not match non-litterbox URLs" do
+    assert_not matcher("https://example.com/feed.xml").match?
+  end
+
+  test "#match? should not match URLs that just contain litterboxcomics in path but wrong domain" do
+    assert_not matcher("https://evillitterboxcomics.com/feed/").match?
+  end
+
+  test "#match? should handle blank inputs" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+
+  test "#match? should raise error for invalid URLs" do
+    assert_raises(URI::InvalidURIError) do
+      matcher("not a url").match?
+    end
+  end
+end

--- a/test/services/profile_matcher/litterbox_profile_matcher_test.rb
+++ b/test/services/profile_matcher/litterbox_profile_matcher_test.rb
@@ -37,6 +37,10 @@ class ProfileMatcher::LitterboxProfileMatcherTest < ActiveSupport::TestCase
     assert_not matcher("https://feeds.feedburner.com/other/litterboxcomics").match?
   end
 
+  test "#match? should not match feedburner.com URLs with litterboxcomics as path prefix of another feed" do
+    assert_not matcher("https://feeds.feedburner.com/litterboxcomicsevil/yS3QAzAMEMP").match?
+  end
+
   test "#match? should not match non-feeds feedburner subdomain" do
     assert_not matcher("https://www.feedburner.com/litterboxcomics/yS3QAzAMEMP").match?
   end

--- a/test/services/profile_matcher/litterbox_profile_matcher_test.rb
+++ b/test/services/profile_matcher/litterbox_profile_matcher_test.rb
@@ -25,12 +25,20 @@ class ProfileMatcher::LitterboxProfileMatcherTest < ActiveSupport::TestCase
     assert matcher("https://litterboxcomics.com/feed/").match?
   end
 
-  test "#match? should match feedburner.com URLs containing litterboxcomics in path" do
+  test "#match? should match feeds.feedburner.com URLs with litterboxcomics path" do
     assert matcher("https://feeds.feedburner.com/litterboxcomics/yS3QAzAMEMP").match?
   end
 
-  test "#match? should not match feedburner.com URLs without litterboxcomics in path" do
+  test "#match? should not match feedburner.com URLs without litterboxcomics path" do
     assert_not matcher("https://feeds.feedburner.com/someotherfeed/abc123").match?
+  end
+
+  test "#match? should not match feedburner.com URLs with litterboxcomics not at path start" do
+    assert_not matcher("https://feeds.feedburner.com/other/litterboxcomics").match?
+  end
+
+  test "#match? should not match non-feeds feedburner subdomain" do
+    assert_not matcher("https://www.feedburner.com/litterboxcomics/yS3QAzAMEMP").match?
   end
 
   test "#match? should not match non-litterbox URLs" do


### PR DESCRIPTION
Changes:

- Add a `litterbox` feed profile (matcher, normalizer, registry entry)
- Matcher handles `litterboxcomics.com` URLs and FeedBurner feed URLs with `litterboxcomics` in the path
- Normalizer scrapes the article page for `.swiper-wrapper` image galleries; falls back to first image from `content:encoded` when unavailable
- Derives a bonus panel URL (`-bonus/`) and fetches `og:image` from it as a comment; standalone bonus posts are rejected with a `"bonus"` validation error
