### PR TITLE
Extract dev tools to dedicated page

### DIFF
--- a/app/controllers/devtools_controller.rb
+++ b/app/controllers/devtools_controller.rb
@@ -1,0 +1,5 @@
+class DevtoolsController < ApplicationController
+  def show
+    authorize :access, :dev?
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -163,6 +163,14 @@ module ApplicationHelper
       }
     end
 
+    if policy(:access).dev?
+      items << {
+        name: "Dev Tools",
+        path: devtools_path,
+        active: current_page?(devtools_path) || controller_path.start_with?("devtools")
+      }
+    end
+
     items
   end
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -7,10 +7,18 @@ class Permission < ApplicationRecord
   AVAILABLE_PERMISSIONS = [ADMIN, DEV].freeze
 
   LABELS = {
-    ADMIN => { name: "Admin", description: "Full admin panel access and user management." },
-    DEV   => { name: "Dev", description: "Developer tools and experimental features." }
+    ADMIN => { display_name: "Admin", description: "Full admin panel access and user management." },
+    DEV   => { display_name: "Developer Tools", description: "Developer tools and experimental features." }
   }.freeze
 
   validates :name, presence: true, inclusion: { in: AVAILABLE_PERMISSIONS }
   validates :user_id, uniqueness: { scope: :name }
+
+  def self.display_name(name)
+    LABELS.dig(name, :display_name)
+  end
+
+  def display_name
+    self.class.display_name(name)
+  end
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -7,8 +7,14 @@ class Permission < ApplicationRecord
   AVAILABLE_PERMISSIONS = [ADMIN, DEV].freeze
 
   LABELS = {
-    ADMIN => { display_name: "Admin", description: "Full admin panel access and user management." },
-    DEV   => { display_name: "Developer Tools", description: "Developer tools and experimental features." }
+    ADMIN => {
+      display_name: "Admin",
+      description: "Full admin panel access and user management."
+    },
+    DEV => {
+      display_name: "Developer Tools",
+      description: "Developer tools and experimental features."
+    }
   }.freeze
 
   validates :name, presence: true, inclusion: { in: AVAILABLE_PERMISSIONS }

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -29,7 +29,7 @@
                 data: { key: "permissions.#{perm}" } %>
             </div>
             <div class="text-sm leading-6">
-              <%= label_tag "permission_#{perm}", label[:name], class: "font-semibold text-slate-800" %>
+              <%= label_tag "permission_#{perm}", label[:display_name], class: "font-semibold text-slate-800" %>
               <p class="text-slate-500"><%= label[:description] %></p>
             </div>
           </div>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -23,57 +23,5 @@
         <p class="text-slate-600">View system events, logs, and activity</p>
       </div>
     <% end %>
-
-    <% if policy(:access).dev? %>
-      <%= render CardComponent.new(href: admin_system_status_path) do %>
-        <div class="space-y-4">
-          <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
-            <%= icon("hard-drive", css_class: "size-5") %>
-            <span>System Status</span>
-          </h2>
-          <p class="text-slate-600">Check configuration, disk usage, and other system info</p>
-        </div>
-      <% end %>
-
-      <%= render CardComponent.new(href: mission_control_jobs.root_path, target: "_blank", rel: "noopener noreferrer") do %>
-        <div class="space-y-4">
-          <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
-            <%= icon("hard-hat", css_class: "size-5") %>
-            <span>Background Jobs</span>
-          </h2>
-          <p class="text-slate-600">Monitor and manage background job queues</p>
-        </div>
-      <% end %>
-
-      <%= render CardComponent.new(href: admin_email_previews_path) do %>
-        <div class="space-y-4">
-          <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
-            <%= icon("mail", css_class: "size-5") %>
-            <span>Email Previews</span>
-          </h2>
-          <p class="text-slate-600">Browse rendered previews of all email templates</p>
-        </div>
-      <% end %>
-
-      <%= render CardComponent.new(href: development_sent_emails_path, target: "_blank", rel: "noopener noreferrer") do %>
-        <div class="space-y-4">
-          <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
-            <%= icon("inbox", css_class: "size-5") %>
-            <span>Sent Emails</span>
-          </h2>
-          <p class="text-slate-600">Review emails captured in development</p>
-        </div>
-      <% end %>
-
-      <%= render CardComponent.new(href: development_components_path, target: "_blank", rel: "noopener noreferrer") do %>
-        <div class="space-y-4">
-          <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
-            <%= icon("layout-grid", css_class: "size-5") %>
-            <span>UI Reference</span>
-          </h2>
-          <p class="text-slate-600">Reference for all reusable UI components.</p>
-        </div>
-      <% end %>
-    <% end %>
   </div>
 </div>

--- a/app/views/devtools/show.html.erb
+++ b/app/views/devtools/show.html.erb
@@ -1,0 +1,57 @@
+<% content_for :title, "Dev Tools" %>
+
+<div class="space-y-8">
+  <%= render PageHeaderComponent.new(title: "Dev Tools") %>
+
+  <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <%= render CardComponent.new(href: admin_system_status_path) do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("hard-drive", css_class: "size-5") %>
+          <span>System Status</span>
+        </h2>
+        <p class="text-slate-600">Check configuration, disk usage, and other system info</p>
+      </div>
+    <% end %>
+
+    <%= render CardComponent.new(href: mission_control_jobs.root_path, target: "_blank", rel: "noopener noreferrer") do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("hard-hat", css_class: "size-5") %>
+          <span>Background Jobs</span>
+        </h2>
+        <p class="text-slate-600">Monitor and manage background job queues</p>
+      </div>
+    <% end %>
+
+    <%= render CardComponent.new(href: admin_email_previews_path) do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("mail", css_class: "size-5") %>
+          <span>Email Previews</span>
+        </h2>
+        <p class="text-slate-600">Browse rendered previews of all email templates</p>
+      </div>
+    <% end %>
+
+    <%= render CardComponent.new(href: development_sent_emails_path, target: "_blank", rel: "noopener noreferrer") do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("inbox", css_class: "size-5") %>
+          <span>Sent Emails</span>
+        </h2>
+        <p class="text-slate-600">Review emails captured in development</p>
+      </div>
+    <% end %>
+
+    <%= render CardComponent.new(href: development_components_path, target: "_blank", rel: "noopener noreferrer") do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("layout-grid", css_class: "size-5") %>
+          <span>UI Reference</span>
+        </h2>
+        <p class="text-slate-600">Reference for all reusable UI components.</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
   resources :feed_entries, only: :show
   resource :feed_preview, only: [:show, :create]
   resource :admin, only: :show
+  resource :devtools, only: :show
 
   resource :feed_identifications, only: [:create, :show, :destroy]
 

--- a/test/controllers/admins_controller_test.rb
+++ b/test/controllers/admins_controller_test.rb
@@ -25,17 +25,17 @@ class AdminsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{development_components_path}']", count: 0
   end
 
-  test "should show dev cards when authenticated as admin with dev permission" do
+  test "should not show dev cards on admin panel for admin with dev permission" do
     sign_in_as(admin_dev_user)
     get admin_url
 
     assert_response :success
     assert_select "a[href='#{admin_users_path}']", count: 1
     assert_select "a[href='#{admin_events_path}']", count: 1
-    assert_select "a[href='#{admin_system_status_path}']", count: 1
-    assert_select "a[href='#{mission_control_jobs.root_path}']", count: 1
-    assert_select "a[href='#{development_sent_emails_path}']", count: 1
-    assert_select "a[href='#{development_components_path}']", count: 1
+    assert_select "a[href='#{admin_system_status_path}']", count: 0
+    assert_select "a[href='#{mission_control_jobs.root_path}']", count: 0
+    assert_select "a[href='#{development_sent_emails_path}']", count: 0
+    assert_select "a[href='#{development_components_path}']", count: 0
   end
 
   test "should redirect when authenticated as regular user" do

--- a/test/controllers/devtools_controller_test.rb
+++ b/test/controllers/devtools_controller_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class DevtoolsControllerTest < ActionDispatch::IntegrationTest
+  def user
+    @user ||= create(:user)
+  end
+
+  def admin_user
+    @admin_user ||= create(:user, :admin)
+  end
+
+  def dev_user
+    @dev_user ||= create(:user, :dev)
+  end
+
+  test "should show dev tools when authenticated as dev" do
+    sign_in_as(dev_user)
+    get devtools_url
+
+    assert_response :success
+    assert_select "h1", "Dev Tools"
+    assert_select "a[href='#{admin_system_status_path}']", count: 1
+    assert_select "a[href='#{mission_control_jobs.root_path}']", count: 1
+    assert_select "a[href='#{admin_email_previews_path}']", count: 1
+    assert_select "a[href='#{development_sent_emails_path}']", count: 1
+    assert_select "a[href='#{development_components_path}']", count: 1
+  end
+
+  test "should redirect when authenticated as admin without dev permission" do
+    sign_in_as(admin_user)
+    get devtools_url
+
+    assert_response :redirect
+    assert_redirected_to root_path
+    assert_equal "Access denied. You don't have permission to perform this action.", flash[:alert]
+  end
+
+  test "should redirect when authenticated as regular user" do
+    sign_in_as(user)
+    get devtools_url
+
+    assert_response :redirect
+    assert_redirected_to root_path
+    assert_equal "Access denied. You don't have permission to perform this action.", flash[:alert]
+  end
+
+  test "should redirect when not authenticated" do
+    get devtools_url
+
+    assert_response :redirect
+  end
+end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -7,6 +7,10 @@ class ApplicationHelperTest < ActionView::TestCase
     def index?
       allowed
     end
+
+    def dev?
+      allowed
+    end
   end
 
   def policy(record)
@@ -226,14 +230,34 @@ class ApplicationHelperTest < ActionView::TestCase
 
     self.stub(:current_page?, current_page_stub) do
       self.stub(:controller_path, "admin/dashboard") do
-        self.policy_override = ->(_record) { PolicyStub.new(true) }
+        self.policy_override = ->(record) { PolicyStub.new(record == Event) }
 
         items = navbar_items
-        admin_item = items.last
+        admin_item = items.find { |item| item[:name] == "Admin Panel" }
 
-        assert_equal "Admin Panel", admin_item[:name]
         assert_equal admin_path, admin_item[:path]
         assert_equal true, admin_item[:active]
+        assert_nil items.find { |item| item[:name] == "Dev Tools" }
+      end
+    end
+  end
+
+  test "#navbar_items should include dev tools when allowed" do
+    user = create(:user)
+    Current.session = create(:session, user: user)
+
+    current_page_stub = ->(path, *_args) { path == devtools_path }
+
+    self.stub(:current_page?, current_page_stub) do
+      self.stub(:controller_path, "devtools") do
+        self.policy_override = ->(record) { PolicyStub.new(record == :access) }
+
+        items = navbar_items
+        dev_item = items.find { |item| item[:name] == "Dev Tools" }
+
+        assert_equal devtools_path, dev_item[:path]
+        assert_equal true, dev_item[:active]
+        assert_nil items.find { |item| item[:name] == "Admin Panel" }
       end
     end
   end

--- a/test/models/permission_test.rb
+++ b/test/models/permission_test.rb
@@ -48,4 +48,14 @@ class PermissionTest < ActiveSupport::TestCase
 
     assert permission.valid?
   end
+
+  test ".display_name should return capitalized display name for a permission" do
+    assert_equal "Admin", Permission.display_name(Permission::ADMIN)
+    assert_equal "Developer Tools", Permission.display_name(Permission::DEV)
+  end
+
+  test "#display_name should return the display name for the record's permission" do
+    permission = build(:permission, name: Permission::DEV)
+    assert_equal "Developer Tools", permission.display_name
+  end
 end


### PR DESCRIPTION
Changes:

- Create new `DevtoolsController` with `show` action that requires dev permission
- Move dev tools cards (System Status, Background Jobs, Email Previews, Sent Emails, UI Reference) from admin panel to dedicated `/devtools` page
- Add "Dev Tools" navbar item that appears when user has dev permission
- Update `Permission` model to use `display_name` instead of `name` in labels for better UX
- Add comprehensive tests for devtools controller and navbar integration
- Update admin panel tests to verify dev cards no longer appear there

This change improves information architecture by separating developer tools from admin functions, giving dev tools their own dedicated space while keeping the admin panel focused on user and system management.
