### PR TITLE
Restrict xkcd and monkeyuser matchers to exact hosts

### DIFF
--- a/app/services/profile_matcher/monkeyuser_profile_matcher.rb
+++ b/app/services/profile_matcher/monkeyuser_profile_matcher.rb
@@ -9,7 +9,7 @@ module ProfileMatcher
       return false if input.blank?
 
       uri = URI.parse(input)
-      uri.host == MONKEYUSER_DOMAIN || uri.host&.end_with?(".#{MONKEYUSER_DOMAIN}")
+      [MONKEYUSER_DOMAIN, "www.#{MONKEYUSER_DOMAIN}"].include?(uri.host)
     end
   end
 end

--- a/app/services/profile_matcher/xkcd_profile_matcher.rb
+++ b/app/services/profile_matcher/xkcd_profile_matcher.rb
@@ -9,7 +9,7 @@ module ProfileMatcher
       return false if input.blank?
 
       uri = URI.parse(input)
-      uri.host&.end_with?(XKCD_DOMAIN)
+      [XKCD_DOMAIN, "www.#{XKCD_DOMAIN}"].include?(uri.host)
     end
   end
 end

--- a/test/services/profile_matcher/monkeyuser_profile_matcher_test.rb
+++ b/test/services/profile_matcher/monkeyuser_profile_matcher_test.rb
@@ -22,12 +22,20 @@ class ProfileMatcher::MonkeyuserProfileMatcherTest < ActiveSupport::TestCase
     assert matcher("https://monkeyuser.com/index.xml").match?
   end
 
-  test "#match? should match monkeyuser.com subdomains" do
+  test "#match? should match www.monkeyuser.com URLs" do
     assert matcher("https://www.monkeyuser.com/index.xml").match?
   end
 
   test "#match? should not match non-monkeyuser URLs" do
     assert_not matcher("https://example.com/feed.xml").match?
+  end
+
+  test "#match? should not match arbitrary monkeyuser.com subdomains" do
+    assert_not matcher("https://blog.monkeyuser.com/feed.xml").match?
+  end
+
+  test "#match? should not match domains that merely end with monkeyuser.com" do
+    assert_not matcher("https://notmonkeyuser.com/feed.xml").match?
   end
 
   test "#match? should not match URLs that just contain monkeyuser in path" do

--- a/test/services/profile_matcher/xkcd_profile_matcher_test.rb
+++ b/test/services/profile_matcher/xkcd_profile_matcher_test.rb
@@ -22,12 +22,20 @@ class ProfileMatcher::XkcdProfileMatcherTest < ActiveSupport::TestCase
     assert matcher("https://xkcd.com/rss.xml").match?
   end
 
-  test "#match? should match xkcd.com subdomains" do
+  test "#match? should match www.xkcd.com URLs" do
     assert matcher("https://www.xkcd.com/rss.xml").match?
   end
 
   test "#match? should not match non-xkcd URLs" do
     assert_not matcher("https://example.com/feed.xml").match?
+  end
+
+  test "#match? should not match arbitrary xkcd.com subdomains" do
+    assert_not matcher("https://blog.xkcd.com/feed.xml").match?
+  end
+
+  test "#match? should not match domains that merely end with xkcd.com" do
+    assert_not matcher("https://notxkcd.com/feed.xml").match?
   end
 
   test "#match? should not match URLs that just contain xkcd in path" do


### PR DESCRIPTION
Changes:

- Restrict `XkcdProfileMatcher` and `MonkeyuserProfileMatcher` to the bare domain and its `www` host
- Add tests rejecting arbitrary subdomains and suffix lookalike domains

The xkcd matcher used `end_with?("xkcd.com")` without a leading dot, so unrelated domains like `notxkcd.com` matched. One-off feed profiles don't expect source URL variation, so both matchers now use the same exact-host allowlist convention as the other site-specific matchers.