### PR TITLE
Use generic sample data in Oglaf test fixtures

### DIFF
--- a/test/fixtures/files/feeds/oglaf/feed.xml
+++ b/test/fixtures/files/feeds/oglaf/feed.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Oglaf! -- Comics. Often dirty.</title>
+    <title>Example Comics</title>
     <link>https://www.oglaf.com/latest/</link>
-    <description>Comics. Often dirty. Updates Sundays.</description>
+    <description>A webcomic. Updates weekly.</description>
     <atom:link href="https://www.oglaf.com/feeds/rss/" rel="self"></atom:link>
     <language>en-us</language>
     <lastBuildDate>Sun, 07 Jun 2026 00:00:00 +0000</lastBuildDate>
     <item>
-      <title>Goat</title>
-      <link>https://www.oglaf.com/goat/</link>
-      <description>&lt;div style="display:block; background-color: #ccc;"&gt;&lt;p&gt;&lt;a href="https://www.oglaf.com/goat/"&gt;&lt;img src="https://media.oglaf.com/story/ttgoat.jpg" /&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;a href="https://www.oglaf.com/goat/"&gt;&lt;img src="https://media.oglaf.com/archive/arc-goat.jpg" width="400" height="100" border="0" alt="https://www.oglaf.com/goat/" /&gt;&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</description>
+      <title>Sample Strip</title>
+      <link>https://www.oglaf.com/sample/</link>
+      <description>&lt;div style="display:block; background-color: #ccc;"&gt;&lt;p&gt;&lt;a href="https://www.oglaf.com/sample/"&gt;&lt;img src="https://media.oglaf.com/story/ttsample.jpg" /&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;a href="https://www.oglaf.com/sample/"&gt;&lt;img src="https://media.oglaf.com/archive/arc-sample.jpg" width="400" height="100" border="0" alt="https://www.oglaf.com/sample/" /&gt;&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</description>
       <pubDate>Sun, 30 Nov 2025 00:00:00 +0000</pubDate>
-      <guid>https://oglaf.com/goat/</guid>
+      <guid>https://oglaf.com/sample/</guid>
     </item>
     <item>
-      <title>Lolth</title>
-      <link>https://www.oglaf.com/lolth/</link>
-      <description>&lt;div style="display:block; background-color: #ccc;"&gt;&lt;p&gt;&lt;a href="https://www.oglaf.com/lolth/"&gt;&lt;img src="https://media.oglaf.com/story/ttlolth.jpg" /&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;a href="https://www.oglaf.com/lolth/"&gt;&lt;img src="https://media.oglaf.com/archive/arc-lolth.jpg" width="400" height="100" border="0" alt="https://www.oglaf.com/lolth/" /&gt;&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</description>
+      <title>Another Strip</title>
+      <link>https://www.oglaf.com/another/</link>
+      <description>&lt;div style="display:block; background-color: #ccc;"&gt;&lt;p&gt;&lt;a href="https://www.oglaf.com/another/"&gt;&lt;img src="https://media.oglaf.com/story/ttanother.jpg" /&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;a href="https://www.oglaf.com/another/"&gt;&lt;img src="https://media.oglaf.com/archive/arc-another.jpg" width="400" height="100" border="0" alt="https://www.oglaf.com/another/" /&gt;&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</description>
       <pubDate>Sun, 07 Jun 2026 00:00:00 +0000</pubDate>
-      <guid>https://oglaf.com/lolth/</guid>
+      <guid>https://oglaf.com/another/</guid>
     </item>
   </channel>
 </rss>

--- a/test/fixtures/files/feeds/oglaf/normalized.json
+++ b/test/fixtures/files/feeds/oglaf/normalized.json
@@ -1,16 +1,16 @@
 {
   "attachment_urls": [
-    "https://media.oglaf.com/comic/goat1.jpg",
-    "https://media.oglaf.com/comic/goat2.jpg"
+    "https://media.oglaf.com/comic/sample1.jpg",
+    "https://media.oglaf.com/comic/sample2.jpg"
   ],
   "comments": [
-    "Territorial disputes with the God of nipples",
-    "My sacred drink is orange juice. Milk is more a work thing"
+    "Sample image title",
+    "Another sample image title"
   ],
-  "content": "Goat - https://www.oglaf.com/goat/",
+  "content": "Sample Strip - https://www.oglaf.com/sample/",
   "published_at": "2025-11-30T00:00:00.000Z",
-  "source_url": "https://www.oglaf.com/goat/",
+  "source_url": "https://www.oglaf.com/sample/",
   "status": "enqueued",
-  "uid": "https://oglaf.com/goat/",
+  "uid": "https://oglaf.com/sample/",
   "validation_errors": []
 }

--- a/test/fixtures/files/feeds/oglaf/page.html
+++ b/test/fixtures/files/feeds/oglaf/page.html
@@ -2,17 +2,17 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
-<title>Goat</title>
-<link rel="canonical" href="https://www.oglaf.com/goat/" />
-<link rel="prev" href="/peace2/" />
-<link rel="next" href="/goat/2/" />
+<title>Sample Strip</title>
+<link rel="canonical" href="https://www.oglaf.com/sample/" />
+<link rel="prev" href="/previous/" />
+<link rel="next" href="/sample/2/" />
 </head>
 <body onload="ld()">
 <div class="content">
-<div id="tt"><img src="https://media.oglaf.com/story/ttgoat.jpg" title="None" /></div>
-<b><img id="strip" src="https://media.oglaf.com/comic/goat1.jpg"
-              alt="Fatty tissue"
-              title="Territorial disputes with the God of nipples"
+<div id="tt"><img src="https://media.oglaf.com/story/ttsample.jpg" title="None" /></div>
+<b><img id="strip" src="https://media.oglaf.com/comic/sample1.jpg"
+              alt="Sample alt text"
+              title="Sample image title"
               /></b>
 </div>
 </body>

--- a/test/fixtures/files/feeds/oglaf/page2.html
+++ b/test/fixtures/files/feeds/oglaf/page2.html
@@ -2,16 +2,16 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
-<title>Goat</title>
-<link rel="canonical" href="https://www.oglaf.com/goat/2/" />
-<link rel="prev" href="/goat/" />
+<title>Sample Strip</title>
+<link rel="canonical" href="https://www.oglaf.com/sample/2/" />
+<link rel="prev" href="/sample/" />
 </head>
 <body onload="ld()">
 <div class="content">
-<div id="tt"><img src="https://media.oglaf.com/story/ttgoat.jpg" title="None" /></div>
-<b><img id="strip" src="https://media.oglaf.com/comic/goat2.jpg"
-              alt="Part of the breast is called &quot;plexus of Sappey&quot; which would be a good name for a diplomat"
-              title="My sacred drink is orange juice. Milk is more a work thing"
+<div id="tt"><img src="https://media.oglaf.com/story/ttsample.jpg" title="None" /></div>
+<b><img id="strip" src="https://media.oglaf.com/comic/sample2.jpg"
+              alt="Another sample alt text"
+              title="Another sample image title"
               /></b>
 </div>
 </body>

--- a/test/services/normalizer/oglaf_normalizer_test.rb
+++ b/test/services/normalizer/oglaf_normalizer_test.rb
@@ -12,9 +12,9 @@ class Normalizer::OglafNormalizerTest < ActiveSupport::TestCase
   end
 
   def stub_story_pages
-    stub_request(:get, "https://www.oglaf.com/goat/")
+    stub_request(:get, "https://www.oglaf.com/sample/")
       .to_return(status: 200, body: file_fixture("#{fixture_dir}/page.html").read)
-    stub_request(:get, "https://www.oglaf.com/goat/2/")
+    stub_request(:get, "https://www.oglaf.com/sample/2/")
       .to_return(status: 200, body: file_fixture("#{fixture_dir}/page2.html").read)
   end
 
@@ -34,24 +34,24 @@ class Normalizer::OglafNormalizerTest < ActiveSupport::TestCase
 
     post = Normalizer::OglafNormalizer.new(entry).normalize
 
-    assert_equal ["https://media.oglaf.com/comic/goat1.jpg", "https://media.oglaf.com/comic/goat2.jpg"], post.attachment_urls
-    assert_equal ["Territorial disputes with the God of nipples", "My sacred drink is orange juice. Milk is more a work thing"], post.comments
+    assert_equal ["https://media.oglaf.com/comic/sample1.jpg", "https://media.oglaf.com/comic/sample2.jpg"], post.attachment_urls
+    assert_equal ["Sample image title", "Another sample image title"], post.comments
   end
 
   test "#normalize should keep collected pages when a page fetch fails" do
-    stub_request(:get, "https://www.oglaf.com/goat/")
+    stub_request(:get, "https://www.oglaf.com/sample/")
       .to_return(status: 200, body: file_fixture("#{fixture_dir}/page.html").read)
-    stub_request(:get, "https://www.oglaf.com/goat/2/").to_return(status: 500)
+    stub_request(:get, "https://www.oglaf.com/sample/2/").to_return(status: 500)
     entry = feed_entry(0)
 
     post = Normalizer::OglafNormalizer.new(entry).normalize
 
-    assert_equal ["https://media.oglaf.com/comic/goat1.jpg"], post.attachment_urls
-    assert_equal ["Territorial disputes with the God of nipples"], post.comments
+    assert_equal ["https://media.oglaf.com/comic/sample1.jpg"], post.attachment_urls
+    assert_equal ["Sample image title"], post.comments
   end
 
   test "#normalize should return no attachments when the first page fetch raises a network error" do
-    stub_request(:get, "https://www.oglaf.com/goat/")
+    stub_request(:get, "https://www.oglaf.com/sample/")
       .to_raise(Faraday::ConnectionFailed.new("connection refused"))
     entry = feed_entry(0)
 
@@ -62,38 +62,38 @@ class Normalizer::OglafNormalizerTest < ActiveSupport::TestCase
   end
 
   test "#normalize should stop following pages when the next-page URL is malformed" do
-    stub_request(:get, "https://www.oglaf.com/goat/")
+    stub_request(:get, "https://www.oglaf.com/sample/")
       .to_return(status: 200, body: <<~HTML)
         <html>
-        <head><link rel="next" href="/goat story/2/" /></head>
-        <body><img id="strip" src="https://media.oglaf.com/comic/goat1.jpg" title="Alt text" /></body>
+        <head><link rel="next" href="/sample story/2/" /></head>
+        <body><img id="strip" src="https://media.oglaf.com/comic/sample1.jpg" title="Alt text" /></body>
         </html>
       HTML
     entry = feed_entry(0)
 
     post = Normalizer::OglafNormalizer.new(entry).normalize
 
-    assert_equal ["https://media.oglaf.com/comic/goat1.jpg"], post.attachment_urls
+    assert_equal ["https://media.oglaf.com/comic/sample1.jpg"], post.attachment_urls
     assert_equal "enqueued", post.status
   end
 
   test "#normalize should not follow a next link that points at another story" do
-    stub_request(:get, "https://www.oglaf.com/lolth/").to_return(status: 200, body: <<~HTML)
+    stub_request(:get, "https://www.oglaf.com/another/").to_return(status: 200, body: <<~HTML)
       <html>
-      <head><link rel="next" href="/accounting/" /></head>
-      <body><img id="strip" src="https://media.oglaf.com/comic/lolth.jpg" title="two sets of demonweb arms, four demonweb pits" /></body>
+      <head><link rel="next" href="/unrelated/" /></head>
+      <body><img id="strip" src="https://media.oglaf.com/comic/another.jpg" title="Another strip title" /></body>
       </html>
     HTML
     entry = feed_entry(1)
 
     post = Normalizer::OglafNormalizer.new(entry).normalize
 
-    assert_equal ["https://media.oglaf.com/comic/lolth.jpg"], post.attachment_urls
+    assert_equal ["https://media.oglaf.com/comic/another.jpg"], post.attachment_urls
     assert_equal "enqueued", post.status
   end
 
   test "#normalize should report via Rails.error when img#strip is absent on a fetched page" do
-    stub_request(:get, "https://www.oglaf.com/goat/")
+    stub_request(:get, "https://www.oglaf.com/sample/")
       .to_return(status: 200, body: "<html><body><p>No strip here</p></body></html>")
     entry = feed_entry(0)
     reported = []


### PR DESCRIPTION
Changes:

- Replace story-specific content in Oglaf test fixtures (strip names, image paths, alt/title text) with neutral sample data
- Update normalizer tests to match the new fixture URLs and values

References:

- Follow-up to #675
