### PR TITLE
Add predefined vmui dashboard for node metrics

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -36,9 +36,10 @@ accessories:
     image: victoriametrics/victoria-metrics:latest
     host: dev.fffeeder.com
     port: "127.0.0.1:8428:8428"
-    cmd: "-retentionPeriod=1 -promscrape.config=/etc/victoriametrics/scrape.yml"
+    cmd: "-retentionPeriod=1 -promscrape.config=/etc/victoriametrics/scrape.yml -vmui.customDashboardsPath=/etc/victoriametrics/dashboards"
     files:
       - config/victoriametrics/scrape.yml:/etc/victoriametrics/scrape.yml
+      - config/victoriametrics/dashboards/node-overview.json:/etc/victoriametrics/dashboards/node-overview.json
     directories:
       - vmdata:/victoria-metrics-data
 

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -2,6 +2,26 @@
   "title": "Node overview",
   "rows": [
     {
+      "title": "CPU",
+      "panels": [
+        {
+          "title": "CPU usage %",
+          "unit": "%",
+          "expr": [
+            "100 * (1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])))"
+          ]
+        },
+        {
+          "title": "Load average",
+          "expr": [
+            "node_load1",
+            "node_load5",
+            "node_load15"
+          ]
+        }
+      ]
+    },
+    {
       "title": "Memory",
       "panels": [
         {

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -16,7 +16,8 @@
           "expr": [
             "node_load1",
             "node_load5",
-            "node_load15"
+            "node_load15",
+            "count(count by (cpu) (node_cpu_seconds_total))"
           ]
         }
       ]

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -82,6 +82,25 @@
       ]
     },
     {
+      "title": "Application",
+      "panels": [
+        {
+          "title": "Users & feeds",
+          "expr": [
+            "feeder_users_active",
+            "feeder_feeds_enabled"
+          ]
+        },
+        {
+          "title": "Queue backlog",
+          "expr": [
+            "feeder_posts_enqueued",
+            "feeder_jobs_ready"
+          ]
+        }
+      ]
+    },
+    {
       "title": "PostgreSQL",
       "panels": [
         {

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -37,6 +37,65 @@
           "expr": [
             "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100"
           ]
+        },
+        {
+          "title": "Swap used",
+          "unit": "bytes",
+          "expr": [
+            "node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes"
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Disk",
+      "panels": [
+        {
+          "title": "Disk space used %",
+          "unit": "%",
+          "expr": [
+            "100 * (1 - node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})"
+          ]
+        },
+        {
+          "title": "Disk I/O",
+          "unit": "bytes/s",
+          "expr": [
+            "sum(rate(node_disk_read_bytes_total{device!~\"loop.*\"}[5m]))",
+            "sum(rate(node_disk_written_bytes_total{device!~\"loop.*\"}[5m]))"
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Network",
+      "panels": [
+        {
+          "title": "Network traffic",
+          "unit": "bytes/s",
+          "expr": [
+            "sum(rate(node_network_receive_bytes_total{device!=\"lo\"}[5m]))",
+            "sum(rate(node_network_transmit_bytes_total{device!=\"lo\"}[5m]))"
+          ]
+        }
+      ]
+    },
+    {
+      "title": "PostgreSQL",
+      "panels": [
+        {
+          "title": "Database size",
+          "unit": "bytes",
+          "expr": [
+            "feeder_pg_database_size_bytes"
+          ]
+        },
+        {
+          "title": "Table sizes",
+          "unit": "bytes",
+          "expr": [
+            "feeder_pg_table_size_bytes"
+          ]
         }
       ]
     }

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -1,0 +1,24 @@
+{
+  "title": "Node overview",
+  "rows": [
+    {
+      "title": "Memory",
+      "panels": [
+        {
+          "title": "Used memory",
+          "unit": "bytes",
+          "expr": [
+            "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes"
+          ]
+        },
+        {
+          "title": "Memory %",
+          "unit": "%",
+          "expr": [
+            "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Changes:

- Add a "Node overview" predefined dashboard for vmui covering CPU (usage %, load average vs. core count), memory (used, %, swap), disk (space used %, I/O), and network traffic
- Add an Application row charting the app-pushed gauges: users/feeds, and queue backlog (enqueued posts, ready jobs)
- Add a PostgreSQL row charting the `feeder_pg_database_size_bytes` and `feeder_pg_table_size_bytes` gauges
- Mount the dashboard into the staging VictoriaMetrics accessory and enable it via `-vmui.customDashboardsPath`

This makes the node-exporter and app-pushed metrics viewable as ready-made charts in vmui's dashboards tab, instead of typing queries manually each time. New dashboards can be added later by dropping more JSON files into `config/victoriametrics/dashboards/`.