### PR TITLE
Add VictoriaMetrics operations doc

### DIFF
--- a/docs/victoriametrics.md
+++ b/docs/victoriametrics.md
@@ -13,6 +13,19 @@ ssh -L 8428:127.0.0.1:8428 dev.fffeeder.com
 
 Then open http://localhost:8428/vmui.
 
+## App push configuration
+
+The push side is controlled by app env vars (set under `env:` in the deploy config, applied by a regular `bin/kamal deploy` — no accessory reboot involved):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `METRICS_URL` | unset | VM import endpoint. Unset means metrics are a complete no-op (dev, test). |
+| `METRICS_FLUSH_INTERVAL` | `15` | Seconds between pushes. Each app process runs a flusher thread on this interval; gauge blocks (the DB queries) execute only at flush time, while counters accumulate in memory and cost nothing extra. |
+| `METRICS_USERNAME` / `METRICS_PASSWORD` | unset | Basic auth for the import endpoint, if it's ever exposed beyond the private network. |
+| `METRICS_INSTANCE` | `host:pid` | Override for the `instance` label on counter series. |
+
+Only `METRICS_URL` is set on staging; everything else uses defaults. Raising `METRICS_FLUSH_INTERVAL` is the cheapest lever if the sampled gauges ever get expensive (they run their queries once per flush, per process) — the charts just get coarser resolution.
+
 ## Dashboards
 
 Predefined dashboards live in `config/victoriametrics/dashboards/` as JSON files. Each file becomes its own tab on vmui's Dashboards page; the file's `title` field is the tab label. The accessory mounts each file individually under `files:` and points vmui at the directory with `-vmui.customDashboardsPath`.

--- a/docs/victoriametrics.md
+++ b/docs/victoriametrics.md
@@ -1,0 +1,58 @@
+# VictoriaMetrics on Staging
+
+Staging runs VictoriaMetrics as a Kamal accessory (`config/deploy.staging.yml`) with its built-in web UI (vmui). It collects metrics from two directions:
+
+- **Scrape:** VM pulls host OS metrics (CPU, memory, disk, network) from the `node-exporter` accessory, per `config/victoriametrics/scrape.yml`.
+- **Push:** the app sends its own `feeder_*` metrics (counters and gauges, including PostgreSQL sizes) to VM's import endpoint every ~15 seconds. See `app/services/metrics.rb` and `config/initializers/metrics.rb`.
+
+VM is bound to localhost on the server, so view the UI through an SSH tunnel:
+
+```
+ssh -L 8428:127.0.0.1:8428 dev.fffeeder.com
+```
+
+Then open http://localhost:8428/vmui.
+
+## Dashboards
+
+Predefined dashboards live in `config/victoriametrics/dashboards/` as JSON files. Each file becomes its own tab on vmui's Dashboards page; the file's `title` field is the tab label. The accessory mounts each file individually under `files:` and points vmui at the directory with `-vmui.customDashboardsPath`.
+
+To add a dashboard:
+
+1. Create the JSON file in `config/victoriametrics/dashboards/`.
+2. Add a matching mount line to the `victoriametrics` accessory in `config/deploy.staging.yml`:
+
+   ```yaml
+   files:
+     - config/victoriametrics/dashboards/<name>.json:/etc/victoriametrics/dashboards/<name>.json
+   ```
+
+3. Merge, then reboot the accessory (below).
+
+Editing an existing dashboard is the same minus step 2.
+
+## Applying changes
+
+Dashboard and scrape config changes do **not** ship with `bin/kamal deploy` — accessories are managed separately. After merging, run from an up-to-date `main` checkout:
+
+```
+bin/kamal accessory reboot victoriametrics -d staging
+```
+
+Kamal uploads the mounted files from your local working tree, so make sure you're on the commit you want to ship. The reboot recreates the container with fresh files and flags.
+
+What requires a reboot and what doesn't:
+
+| Change | VM reboot needed? |
+|---|---|
+| App pushes a new `feeder_*` metric | No — appears on the next flush after the app deploy |
+| Dashboard JSON added or edited | Yes — vmui loads dashboards once at startup |
+| `scrape.yml` edited | Yes — the file only reaches the host on reboot |
+
+New series have no backfill: charts for a newly added metric start at the moment it first arrives, and panels referencing it are empty for earlier time ranges. That's expected.
+
+## Safety notes
+
+- Metrics history survives reboots — it lives in the `vmdata` volume on the host.
+- The reboot causes a few seconds of downtime. App pushes during that window fail gracefully (logged, never raised) and node-exporter data has a small gap; both recover on their own.
+- To tear the whole thing down: `bin/kamal accessory remove victoriametrics -d staging` and unset `METRICS_URL`.


### PR DESCRIPTION
Changes:

- Add `docs/victoriametrics.md` covering the staging metrics setup: scrape vs. push architecture, vmui access, adding/editing predefined dashboards, and which changes require an accessory reboot vs. none
- Document the metrics push env vars (`METRICS_URL`, `METRICS_FLUSH_INTERVAL`, auth, instance label) and the flush mechanics: gauges query the DB once per flush per process, counters accumulate in memory for free

Captures the operational knowledge from setting up the predefined dashboard so it doesn't have to be rediscovered: dashboard changes don't ship with `kamal deploy` and need `bin/kamal accessory reboot victoriametrics -d staging`, files are uploaded from the local checkout, and metrics history survives reboots via the `vmdata` volume.

References:

- Related PR: #695