### PR TITLE
Add legend aliases to multi-line dashboard panels

### DIFF
--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -6,7 +6,10 @@ Rails.application.config.after_initialize do
 
   Metrics.gauge("users_active") { User.where(state: :active).count }
   Metrics.gauge("feeds_enabled") { Feed.where(state: :enabled).count }
-  Metrics.gauge("posts_enqueued") { Post.enqueued.count }
+  Metrics.gauge_set("posts_total") do
+    counts = Post.group(:status).count
+    Post.statuses.keys.to_h { |status| [{ status: status }, counts.fetch(status, 0)] }
+  end
   Metrics.gauge("jobs_ready") { SolidQueue::ReadyExecution.count }
   Metrics.gauge("pg_database_size_bytes") { PostgresMetrics.database_size }
   Metrics.gauge_set("pg_table_size_bytes") { PostgresMetrics.table_sizes }

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -9,6 +9,9 @@
           "unit": "%",
           "expr": [
             "100 * (1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])))"
+          ],
+          "alias": [
+            "busy"
           ]
         },
         {
@@ -36,6 +39,9 @@
           "unit": "bytes",
           "expr": [
             "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes"
+          ],
+          "alias": [
+            "used"
           ]
         },
         {
@@ -43,6 +49,9 @@
           "unit": "%",
           "expr": [
             "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100"
+          ],
+          "alias": [
+            "used"
           ]
         },
         {
@@ -50,6 +59,9 @@
           "unit": "bytes",
           "expr": [
             "node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes"
+          ],
+          "alias": [
+            "used"
           ]
         }
       ]
@@ -62,6 +74,9 @@
           "unit": "%",
           "expr": [
             "100 * (1 - node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})"
+          ],
+          "alias": [
+            "used"
           ]
         },
         {
@@ -147,6 +162,9 @@
           "unit": "bytes",
           "expr": [
             "feeder_pg_database_size_bytes"
+          ],
+          "alias": [
+            "total size"
           ]
         },
         {

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -112,12 +112,29 @@
         {
           "title": "Queue backlog",
           "expr": [
-            "feeder_posts_enqueued",
+            "feeder_posts_total{status=\"enqueued\"}",
             "feeder_jobs_ready"
           ],
           "alias": [
             "enqueued posts",
             "ready jobs"
+          ]
+        },
+        {
+          "title": "Posts by status",
+          "expr": [
+            "feeder_posts_total"
+          ]
+        },
+        {
+          "title": "Repost activity (per hour)",
+          "expr": [
+            "sum(increase(feeder_posts_published_total{status=\"published\"}[1h]))",
+            "sum(increase(feeder_posts_published_total{status=\"failed\"}[1h]))"
+          ],
+          "alias": [
+            "published",
+            "failed"
           ]
         }
       ]

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -18,6 +18,12 @@
             "node_load5",
             "node_load15",
             "count(count by (cpu) (node_cpu_seconds_total))"
+          ],
+          "alias": [
+            "1m",
+            "5m",
+            "15m",
+            "CPU cores"
           ]
         }
       ]
@@ -64,6 +70,10 @@
           "expr": [
             "sum(rate(node_disk_read_bytes_total{device!~\"loop.*\"}[5m]))",
             "sum(rate(node_disk_written_bytes_total{device!~\"loop.*\"}[5m]))"
+          ],
+          "alias": [
+            "read",
+            "write"
           ]
         }
       ]
@@ -77,6 +87,10 @@
           "expr": [
             "sum(rate(node_network_receive_bytes_total{device!=\"lo\"}[5m]))",
             "sum(rate(node_network_transmit_bytes_total{device!=\"lo\"}[5m]))"
+          ],
+          "alias": [
+            "receive",
+            "transmit"
           ]
         }
       ]
@@ -89,6 +103,10 @@
           "expr": [
             "feeder_users_active",
             "feeder_feeds_enabled"
+          ],
+          "alias": [
+            "active users",
+            "enabled feeds"
           ]
         },
         {
@@ -96,6 +114,10 @@
           "expr": [
             "feeder_posts_enqueued",
             "feeder_jobs_ready"
+          ],
+          "alias": [
+            "enqueued posts",
+            "ready jobs"
           ]
         }
       ]


### PR DESCRIPTION
Changes:

- Add `alias` legend names to every panel in the node overview dashboard — multi-line panels (load average, disk I/O, network, users & feeds, queue backlog, repost activity) and single-line panels (CPU, memory, swap, disk space, database size)
- Replace the `posts_enqueued` gauge with a `posts_total` gauge family labeled by post status, emitting all statuses with explicit zeros (merged in from #698)
- Add "Posts by status" and "Repost activity (per hour)" panels

Without aliases, vmui labels each line with the raw PromQL expression, which is hard to read at a glance. The two per-series panels (posts by status, table sizes) intentionally keep their label-based legends — an alias there would collapse all lines into one name.

References:

- Includes PR: #698