### PR TITLE
Add post count gauges by status

### DIFF
--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -6,7 +6,10 @@ Rails.application.config.after_initialize do
 
   Metrics.gauge("users_active") { User.where(state: :active).count }
   Metrics.gauge("feeds_enabled") { Feed.where(state: :enabled).count }
-  Metrics.gauge("posts_enqueued") { Post.enqueued.count }
+  Metrics.gauge_set("posts_total") do
+    counts = Post.group(:status).count
+    Post.statuses.keys.to_h { |status| [{ status: status }, counts.fetch(status, 0)] }
+  end
   Metrics.gauge("jobs_ready") { SolidQueue::ReadyExecution.count }
   Metrics.gauge("pg_database_size_bytes") { PostgresMetrics.database_size }
   Metrics.gauge_set("pg_table_size_bytes") { PostgresMetrics.table_sizes }

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -112,12 +112,29 @@
         {
           "title": "Queue backlog",
           "expr": [
-            "feeder_posts_enqueued",
+            "feeder_posts_total{status=\"enqueued\"}",
             "feeder_jobs_ready"
           ],
           "alias": [
             "enqueued posts",
             "ready jobs"
+          ]
+        },
+        {
+          "title": "Posts by status",
+          "expr": [
+            "feeder_posts_total"
+          ]
+        },
+        {
+          "title": "Repost activity (per hour)",
+          "expr": [
+            "sum(increase(feeder_posts_published_total{status=\"published\"}[1h]))",
+            "sum(increase(feeder_posts_published_total{status=\"failed\"}[1h]))"
+          ],
+          "alias": [
+            "published",
+            "failed"
           ]
         }
       ]


### PR DESCRIPTION
Changes:

- Replace the `posts_enqueued` gauge with a `posts_total` gauge family labeled by post status, emitting all statuses with explicit zeros so series don't vanish when a count drops to zero
- Add a "Posts by status" panel and a "Repost activity (per hour)" panel (published vs. failed, from the existing `posts_published_total` counter) to the dashboard
- Point the "Queue backlog" panel at `feeder_posts_total{status="enqueued"}`

References:

- Stacked on PR: #697