### PR TITLE
Add index on posts.status

### DIFF
--- a/db/migrate/20260612212655_add_index_to_posts_status.rb
+++ b/db/migrate/20260612212655_add_index_to_posts_status.rb
@@ -1,0 +1,5 @@
+class AddIndexToPostsStatus < ActiveRecord::Migration[8.2]
+  def change
+    add_index :posts, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_07_150000) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_12_212655) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -238,6 +238,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_07_150000) do
     t.index ["feed_entry_id"], name: "index_posts_on_feed_entry_id"
     t.index ["feed_id", "uid"], name: "index_posts_on_feed_id_and_uid", unique: true
     t.index ["feed_id"], name: "index_posts_on_feed_id"
+    t.index ["status"], name: "index_posts_on_status"
   end
 
   create_table "rate_limit_buckets", force: :cascade do |t|


### PR DESCRIPTION
Changes:

- Add an index on `posts.status`

The `posts_total` metrics gauge runs `Post.group(:status).count` on every metrics flush (every 15 seconds, per process). Without an index that's a sequential scan of the whole table on each sample; the index lets PostgreSQL satisfy it with an index-only scan, which keeps the cost flat as the posts table grows.

References:

- Related PR: #698