### PR TITLE
Limit table size metrics to tracked tables

### DIFF
--- a/app/services/postgres_metrics.rb
+++ b/app/services/postgres_metrics.rb
@@ -5,7 +5,13 @@
 module PostgresMetrics
   # Only the tables worth charting; pushing every table blows past vmui's
   # rendered-series limit and buries the fast-growing ones in noise.
-  TRACKED_TABLES = %w[feed_entries events posts feed_previews feed_entry_uids].freeze
+  TRACKED_TABLES = %w[
+    feed_entries
+    events
+    posts
+    feed_previews
+    feed_entry_uids
+  ].freeze
 
   module_function
 

--- a/app/services/postgres_metrics.rb
+++ b/app/services/postgres_metrics.rb
@@ -3,6 +3,10 @@
 # start without a database; with_connection returns the connection to the
 # pool between samples.
 module PostgresMetrics
+  # Only the tables worth charting; pushing every table blows past vmui's
+  # rendered-series limit and buries the fast-growing ones in noise.
+  TRACKED_TABLES = %w[feed_entries events posts feed_previews feed_entry_uids].freeze
+
   module_function
 
   def database_size
@@ -13,7 +17,8 @@ module PostgresMetrics
 
   def table_sizes
     rows = ApplicationRecord.with_connection do |connection|
-      connection.select_rows("SELECT relname, pg_total_relation_size(relid) FROM pg_stat_user_tables")
+      tables = TRACKED_TABLES.map { |table| connection.quote(table) }.join(", ")
+      connection.select_rows("SELECT relname, pg_total_relation_size(relid) FROM pg_stat_user_tables WHERE relname IN (#{tables})")
     end
     rows.to_h { |table, size| [{ table: table }, size] }
   end

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -171,7 +171,7 @@
           "title": "Table sizes",
           "unit": "bytes",
           "expr": [
-            "feeder_pg_table_size_bytes"
+            "feeder_pg_table_size_bytes{table=~\"feed_entries|events|posts|feed_previews|feed_entry_uids\"}"
           ]
         }
       ]

--- a/test/services/postgres_metrics_test.rb
+++ b/test/services/postgres_metrics_test.rb
@@ -5,10 +5,14 @@ class PostgresMetricsTest < ActiveSupport::TestCase
     assert_operator PostgresMetrics.database_size, :>, 0
   end
 
-  test "#table_sizes should map table label sets to positive byte counts" do
+  test "#table_sizes should map tracked table label sets to positive byte counts" do
     sizes = PostgresMetrics.table_sizes
 
-    assert_operator sizes.fetch({ table: "users" }), :>, 0
-    assert_operator sizes.fetch({ table: "feeds" }), :>, 0
+    assert_equal PostgresMetrics::TRACKED_TABLES.sort, sizes.keys.map { |labels| labels[:table] }.sort
+    sizes.each_value { |size| assert_operator size, :>, 0 }
+  end
+
+  test "#table_sizes should not include untracked tables" do
+    assert_not_includes PostgresMetrics.table_sizes.keys, { table: "users" }
   end
 end


### PR DESCRIPTION
Changes:

- Restrict `PostgresMetrics.table_sizes` to an allowlist of the tables worth charting: `feed_entries`, `events`, `posts`, `feed_previews`, `feed_entry_uids`
- Filter the dashboard's "Table sizes" panel to the same set so historical series from other tables don't clutter the chart

Pushing every table produced 30+ series, which exceeds vmui's rendered-series limit ("Showing 20 series out of 33...") and buries the fast-growing tables in noise. The allowlist also keeps the per-flush `pg_total_relation_size` work bounded.

References:

- Related PR: #698