### PR TITLE
Pin metrics images and relax flush interval

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -33,7 +33,7 @@ accessories:
   # tunnel: ssh -L 8428:127.0.0.1:8428 dev.fffeeder.com → http://localhost:8428/vmui
   # Remove with: bin/kamal accessory remove victoriametrics -d staging
   victoriametrics:
-    image: victoriametrics/victoria-metrics:latest
+    image: victoriametrics/victoria-metrics:v1.145.0
     host: dev.fffeeder.com
     port: "127.0.0.1:8428:8428"
     cmd: "-retentionPeriod=1 -promscrape.config=/etc/victoriametrics/scrape.yml -vmui.customDashboardsPath=/etc/victoriametrics/dashboards"
@@ -47,7 +47,7 @@ accessories:
   # a read-only mount; scraped by VictoriaMetrics over the Kamal network
   # (see config/victoriametrics/scrape.yml), so no published port.
   node-exporter:
-    image: quay.io/prometheus/node-exporter:latest
+    image: quay.io/prometheus/node-exporter:v1.11.1
     host: dev.fffeeder.com
     cmd: "--path.rootfs=/host"
     volumes:
@@ -62,3 +62,6 @@ env:
     # Reaches the victoriametrics accessory by container name over the Kamal
     # network. Unset this (or remove the accessory) to disable metrics.
     METRICS_URL: http://f2-victoriametrics:8428/api/v1/import/prometheus
+    # The sampled gauges move on hour scales; a 60s push loses no visible
+    # resolution and quarters the per-process DB sampling.
+    METRICS_FLUSH_INTERVAL: "60"

--- a/docs/victoriametrics.md
+++ b/docs/victoriametrics.md
@@ -24,7 +24,7 @@ The push side is controlled by app env vars (set under `env:` in the deploy conf
 | `METRICS_USERNAME` / `METRICS_PASSWORD` | unset | Basic auth for the import endpoint, if it's ever exposed beyond the private network. |
 | `METRICS_INSTANCE` | `host:pid` | Override for the `instance` label on counter series. |
 
-Only `METRICS_URL` is set on staging; everything else uses defaults. Raising `METRICS_FLUSH_INTERVAL` is the cheapest lever if the sampled gauges ever get expensive (they run their queries once per flush, per process) — the charts just get coarser resolution.
+Staging sets `METRICS_URL` and `METRICS_FLUSH_INTERVAL: "60"` (the sampled gauges move slowly, so a 60s push loses no visible resolution while quartering the per-process DB sampling); everything else uses defaults. The flush interval is the cheapest lever if the gauges ever get expensive — the charts just get coarser resolution.
 
 ## Dashboards
 


### PR DESCRIPTION
Changes:

- Pin the staging metrics accessory images: VictoriaMetrics `v1.145.0` and node-exporter `v1.11.1` (previously both `latest`)
- Set `METRICS_FLUSH_INTERVAL: "60"` on staging and update the doc accordingly

Accessory reboots are now the routine way to ship dashboard changes, and with `latest` tags each reboot silently pulled whatever was newest — pinning makes upgrades deliberate. The flush interval change quarters the per-process gauge sampling; the gauges move on hour scales, so nothing visible is lost.

References:

- Related PR: #696