### PR TITLE
Sample gauges from the web role only

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -1,7 +1,13 @@
 # Deploy to these servers.
 servers:
   web:
-    - dev.fffeeder.com
+    hosts:
+      - dev.fffeeder.com
+    env:
+      clear:
+        # Gauge sampling lives in the single Puma process; see
+        # config/initializers/metrics.rb.
+        METRICS_GAUGES: "true"
   jobs:
     hosts:
       - dev.fffeeder.com

--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -4,15 +4,22 @@
 Rails.application.config.after_initialize do
   next unless Metrics.enabled?
 
-  Metrics.gauge("users_active") { User.where(state: :active).count }
-  Metrics.gauge("feeds_enabled") { Feed.where(state: :enabled).count }
-  Metrics.gauge_set("posts_total") do
-    counts = Post.group(:status).count
-    Post.statuses.keys.to_h { |status| [{ status: status }, counts.fetch(status, 0)] }
+  # Gauges are global DB snapshots, so a single process samples them — the one
+  # with METRICS_GAUGES set (the web role; see config/deploy.staging.yml).
+  # Without the gate every process (Puma, SolidQueue supervisor, each worker)
+  # would run identical queries every flush and overwrite the same series.
+  # Counters are per-process and register/push everywhere regardless.
+  if ENV["METRICS_GAUGES"].present?
+    Metrics.gauge("users_active") { User.where(state: :active).count }
+    Metrics.gauge("feeds_enabled") { Feed.where(state: :enabled).count }
+    Metrics.gauge_set("posts_total") do
+      counts = Post.group(:status).count
+      Post.statuses.keys.to_h { |status| [{ status: status }, counts.fetch(status, 0)] }
+    end
+    Metrics.gauge("jobs_ready") { SolidQueue::ReadyExecution.count }
+    Metrics.gauge("pg_database_size_bytes") { PostgresMetrics.database_size }
+    Metrics.gauge_set("pg_table_size_bytes") { PostgresMetrics.table_sizes }
   end
-  Metrics.gauge("jobs_ready") { SolidQueue::ReadyExecution.count }
-  Metrics.gauge("pg_database_size_bytes") { PostgresMetrics.database_size }
-  Metrics.gauge_set("pg_table_size_bytes") { PostgresMetrics.table_sizes }
 
   Metrics.start!
 

--- a/docs/victoriametrics.md
+++ b/docs/victoriametrics.md
@@ -23,8 +23,11 @@ The push side is controlled by app env vars (set under `env:` in the deploy conf
 | `METRICS_FLUSH_INTERVAL` | `15` | Seconds between pushes. Each app process runs a flusher thread on this interval; gauge blocks (the DB queries) execute only at flush time, while counters accumulate in memory and cost nothing extra. |
 | `METRICS_USERNAME` / `METRICS_PASSWORD` | unset | Basic auth for the import endpoint, if it's ever exposed beyond the private network. |
 | `METRICS_INSTANCE` | `host:pid` | Override for the `instance` label on counter series. |
+| `METRICS_GAUGES` | unset | Register the DB-sampled gauges in this process. Set on the web role only, so a single process samples them instead of every process repeating the same queries. Counters are unaffected and push from everywhere. |
 
-Staging sets `METRICS_URL` and `METRICS_FLUSH_INTERVAL: "60"` (the sampled gauges move slowly, so a 60s push loses no visible resolution while quartering the per-process DB sampling); everything else uses defaults. The flush interval is the cheapest lever if the gauges ever get expensive — the charts just get coarser resolution.
+Staging sets `METRICS_URL` and `METRICS_FLUSH_INTERVAL: "60"` globally (the sampled gauges move slowly, so a 60s push loses no visible resolution), plus `METRICS_GAUGES` on the web role; everything else uses defaults. The flush interval is the cheapest lever if the gauges ever get expensive — the charts just get coarser resolution.
+
+One consequence of web-only gauges: if Puma is down, gauge series stop while counters keep flowing from the workers — so a stale "Metrics push age" panel specifically means the web process isn't pushing.
 
 ## Dashboards
 


### PR DESCRIPTION
Changes:

- Gate gauge registration behind a `METRICS_GAUGES` env flag, set only on the staging web role
- Document the new variable and the web-only consequence (a stale push-age panel specifically means Puma isn't pushing)

Previously the Puma process, the SolidQueue supervisor, and each worker all ran identical gauge queries every flush and overwrote the same series — 3x redundant DB sampling. Gauges are global snapshots, so one sampler is enough. The web role is the right home because Puma stays a single process (and in cluster mode, forked workers' flusher threads die on fork anyway, keeping exactly one sampler). Counters are per-process by design and continue to register and push from every process.

References:

- Related PR: #701