### PR TITLE
Show capacity and DB size on disk space chart

### DIFF
--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -60,13 +60,17 @@
       "title": "Disk",
       "panels": [
         {
-          "title": "Disk space used %",
-          "unit": "%",
+          "title": "Disk space",
+          "unit": "bytes",
           "expr": [
-            "100 * (1 - node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})"
+            "feeder_pg_database_size_bytes",
+            "node_filesystem_size_bytes{mountpoint=\"/\"} - node_filesystem_avail_bytes{mountpoint=\"/\"}",
+            "node_filesystem_size_bytes{mountpoint=\"/\"}"
           ],
           "alias": [
-            "used"
+            "database",
+            "used",
+            "capacity"
           ]
         },
         {


### PR DESCRIPTION
Changes:

- Convert the "Disk space used %" panel to absolute bytes with three lines: database size, total used space, and disk capacity as a constant ceiling

Percentages hide how much room is actually left and how much of the usage is the database; with all three on one bytes scale, the gap between "used" and "capacity" is the remaining headroom, and the gap between "database" and "used" is everything else (Docker images, logs, VM data).

References:

- Related PR: #695