### PR TITLE
Apply observability review fixes

### DIFF
--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -84,7 +84,12 @@ module Metrics
       body = render
       return if body.strip.empty?
 
-      post(body)
+      response = post(body)
+      return if response.is_a?(Net::HTTPSuccess)
+
+      # VM rejecting the payload (bad exposition, auth drift) raises nothing at
+      # the transport layer; without this the data would vanish silently.
+      Rails.logger.warn { "Metrics: push rejected: #{response.code} #{response.body.to_s.byteslice(0, 200)}" }
     rescue SocketError, SystemCallError, Timeout::Error, EOFError => e
       # Transport failures are logged, not reported: a metrics outage is an
       # infrastructure event, not a bug. Reporting every flush attempt (every

--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -12,8 +12,6 @@ Rails.application.config.after_initialize do
   if ENV["METRICS_GAUGES"].present?
     Metrics.gauge("users_active") { User.where(state: :active).count }
     Metrics.gauge("feeds_enabled") { Feed.where(state: :enabled).count }
-    # "_count", not "_total": the Prometheus "_total" suffix implies a counter,
-    # and these are point-in-time gauges.
     Metrics.gauge_set("posts_count") do
       counts = Post.group(:status).count
       Post.statuses.keys.to_h { |status| [{ status: status }, counts.fetch(status, 0)] }

--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -12,11 +12,14 @@ Rails.application.config.after_initialize do
   if ENV["METRICS_GAUGES"].present?
     Metrics.gauge("users_active") { User.where(state: :active).count }
     Metrics.gauge("feeds_enabled") { Feed.where(state: :enabled).count }
-    Metrics.gauge_set("posts_total") do
+    # "_count", not "_total": the Prometheus "_total" suffix implies a counter,
+    # and these are point-in-time gauges.
+    Metrics.gauge_set("posts_count") do
       counts = Post.group(:status).count
       Post.statuses.keys.to_h { |status| [{ status: status }, counts.fetch(status, 0)] }
     end
     Metrics.gauge("jobs_ready") { SolidQueue::ReadyExecution.count }
+    Metrics.gauge("jobs_failed") { SolidQueue::FailedExecution.count }
     Metrics.gauge("pg_database_size_bytes") { PostgresMetrics.database_size }
     Metrics.gauge_set("pg_table_size_bytes") { PostgresMetrics.table_sizes }
   end

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -121,18 +121,20 @@
         {
           "title": "Queue backlog",
           "expr": [
-            "feeder_posts_total{status=\"enqueued\"}",
-            "feeder_jobs_ready"
+            "feeder_posts_count{status=\"enqueued\"}",
+            "feeder_jobs_ready",
+            "feeder_jobs_failed"
           ],
           "alias": [
             "enqueued posts",
-            "ready jobs"
+            "ready jobs",
+            "failed jobs"
           ]
         },
         {
           "title": "Posts by status",
           "expr": [
-            "feeder_posts_total"
+            "feeder_posts_count"
           ]
         },
         {
@@ -159,10 +161,27 @@
           "title": "Metrics push age",
           "unit": "s",
           "expr": [
-            "time() - max(timestamp(feeder_users_active))"
+            "time() - tlast_over_time(feeder_users_active[1d])"
           ],
           "alias": [
             "since last push"
+          ]
+        },
+        {
+          "title": "Feed refreshes (per hour)",
+          "expr": [
+            "sum(increase(feeder_feed_refresh_total{status=\"ok\"}[1h]))",
+            "sum(increase(feeder_feed_refresh_total{status=\"error\"}[1h]))"
+          ],
+          "alias": [
+            "ok",
+            "errors"
+          ]
+        },
+        {
+          "title": "Loader errors (per hour)",
+          "expr": [
+            "sum(increase(feeder_loader_errors_total[1h])) by (loader)"
           ]
         }
       ]

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -138,10 +138,10 @@
           ]
         },
         {
-          "title": "Repost activity (per hour)",
+          "title": "Repost activity (15m)",
           "expr": [
-            "sum(increase(feeder_posts_published_total{status=\"published\"}[1h]))",
-            "sum(increase(feeder_posts_published_total{status=\"failed\"}[1h]))"
+            "sum(increase(feeder_posts_published_total{status=\"published\"}[15m]))",
+            "sum(increase(feeder_posts_published_total{status=\"failed\"}[15m]))"
           ],
           "alias": [
             "published",
@@ -149,9 +149,9 @@
           ]
         },
         {
-          "title": "Job failures (per hour)",
+          "title": "Job failures (15m)",
           "expr": [
-            "sum(increase(feeder_job_executions_total{status=\"error\"}[1h]))"
+            "sum(increase(feeder_job_executions_total{status=\"error\"}[15m]))"
           ],
           "alias": [
             "failed jobs"
@@ -168,10 +168,10 @@
           ]
         },
         {
-          "title": "Feed refreshes (per hour)",
+          "title": "Feed refreshes (15m)",
           "expr": [
-            "sum(increase(feeder_feed_refresh_total{status=\"ok\"}[1h]))",
-            "sum(increase(feeder_feed_refresh_total{status=\"error\"}[1h]))"
+            "sum(increase(feeder_feed_refresh_total{status=\"ok\"}[15m]))",
+            "sum(increase(feeder_feed_refresh_total{status=\"error\"}[15m]))"
           ],
           "alias": [
             "ok",
@@ -179,9 +179,9 @@
           ]
         },
         {
-          "title": "Loader errors (per hour)",
+          "title": "Loader errors (15m)",
           "expr": [
-            "sum(increase(feeder_loader_errors_total[1h])) by (loader)"
+            "sum(increase(feeder_loader_errors_total[15m])) by (loader)"
           ]
         }
       ]

--- a/docs/victoriametrics.md
+++ b/docs/victoriametrics.md
@@ -3,7 +3,7 @@
 Staging runs VictoriaMetrics as a Kamal accessory (`config/deploy.staging.yml`) with its built-in web UI (vmui). It collects metrics from two directions:
 
 - **Scrape:** VM pulls host OS metrics (CPU, memory, disk, network) from the `node-exporter` accessory, per `config/victoriametrics/scrape.yml`.
-- **Push:** the app sends its own `feeder_*` metrics (counters and gauges, including PostgreSQL sizes) to VM's import endpoint every ~15 seconds. See `app/services/metrics.rb` and `config/initializers/metrics.rb`.
+- **Push:** the app sends its own `feeder_*` metrics (counters and gauges, including PostgreSQL sizes) to VM's import endpoint on the configured flush interval — 60 seconds on staging. See `app/services/metrics.rb` and `config/initializers/metrics.rb`.
 
 VM is bound to localhost on the server, so view the UI through an SSH tunnel:
 

--- a/test/services/metrics_test.rb
+++ b/test/services/metrics_test.rb
@@ -100,6 +100,20 @@ class MetricsTest < ActiveSupport::TestCase
     end
   end
 
+  test "#flush! should log non-2xx responses without raising" do
+    enable!
+    stub_request(:post, "https://vm.test/api/v1/import/prometheus").to_return(status: 400, body: "bad exposition")
+    Metrics.increment("job_executions_total", status: "ok")
+
+    logged = []
+    Rails.logger.stub(:warn, ->(*args, &blk) { logged << (blk ? blk.call : args.first) }) do
+      assert_nothing_raised { Metrics.flush! }
+    end
+
+    assert logged.any? { |line| line.include?("400") && line.include?("bad exposition") },
+           "expected a warning with the response code and body, got: #{logged.inspect}"
+  end
+
   test "#flush! should log transport errors without reporting to error tracker" do
     enable!
     stub_request(:post, "https://vm.test/api/v1/import/prometheus").to_raise(Errno::ECONNREFUSED)


### PR DESCRIPTION
Changes:

- Log non-2xx responses from the metrics import endpoint — VM rejecting a payload previously looked identical to success
- Rename the `posts_total` gauge to `posts_count` (the `_total` suffix conventionally means counter and invites broken `rate()` queries later)
- Fix the "Metrics push age" panel to use `tlast_over_time(...[1d])` so it keeps climbing during an outage instead of going blank after VM's ~5m lookback window
- Add a `jobs_failed` gauge (SolidQueue failed-execution stock) as a third line on the Queue backlog panel
- Add "Feed refreshes" and "Loader errors" panels from counters the app already records
- Use 15m windows on all throughput panels (repost activity, job failures, feed refreshes, loader errors) for faster incident visibility

Follows up on the holistic observability review (own pass cross-checked with a Codex run). The `posts_count` rename drops the old `feeder_posts_total` series history — acceptable while the metric is days old.

References:

- Related PR: #698
- Related PR: #702