### PR TITLE
Respect FreeFeed's rolling rate limit windows

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -5,14 +5,13 @@ class ApplicationJob < ActiveJob::Base
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
 
-  # Count every job run by outcome. Throttles are tracked separately from real
-  # failures since RateLimited reschedules them (they aren't errors).
+  # Count every job run by outcome. A run that deferred itself for rate limiting
+  # (RateLimited#rate_limited?) is throttled, not a real failure — it returns
+  # normally after rescheduling, so we read the flag rather than catch anything.
   around_perform do |job, block|
     block.call
-    Metrics.increment("job_executions_total", job: job.class.name, status: "ok")
-  rescue RateLimit::Throttled
-    Metrics.increment("job_executions_total", job: job.class.name, status: "throttled")
-    raise
+    status = job.try(:rate_limited?) ? "throttled" : "ok"
+    Metrics.increment("job_executions_total", job: job.class.name, status: status)
   rescue StandardError
     Metrics.increment("job_executions_total", job: job.class.name, status: "error")
     raise

--- a/app/jobs/group_purge_job.rb
+++ b/app/jobs/group_purge_job.rb
@@ -17,7 +17,8 @@ class GroupPurgeJob < ApplicationJob
     posts = feed.posts.where.not(freefeed_post_id: [nil, ""])
 
     posts.find_each do |post|
-      RateLimit.acquire!(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
+      result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
+      return reschedule_for_rate_limit(result.retry_after) unless result.allowed?
 
       begin
         client.delete_post(post.freefeed_post_id)
@@ -27,5 +28,9 @@ class GroupPurgeJob < ApplicationJob
         # Continue with next post even if one fails
       end
     end
+  rescue RateLimit::Throttled => e
+    # FreeFeed throttled a DELETE mid-batch; defer the rest. Cleared posts have
+    # dropped out of the scope, so the rescheduled run resumes with the remainder.
+    reschedule_for_rate_limit(e.retry_after)
   end
 end

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -50,11 +50,9 @@ class PostPublishJob < ApplicationJob
     count_published(post)
     schedule_next(feed)
   rescue RateLimit::Throttled => e
-    # FreeFeed throttled us mid-publish despite our reservation. Defer the same
-    # post; the idempotency guard in FreefeedPublisher keeps the retry safe. Must
-    # precede the generic rescue so it isn't recorded as a failure. A throttle on
-    # a comment still left a real published post, so count it (the retry skips
-    # it, so it's counted once).
+    # Defer the same post (the idempotency guard keeps the retry safe). Before
+    # the generic rescue so a throttle isn't recorded as a failure. count_published
+    # still fires if a comment throttle had already created the post.
     count_published(post)
     reschedule_for_rate_limit(e.retry_after)
   rescue FreefeedClient::UnauthorizedError
@@ -89,10 +87,8 @@ class PostPublishJob < ApplicationJob
     schedule_next(feed)
   end
 
-  # Count a post as published once it actually exists on FreeFeed. Guarded on the
-  # record's status so the upfront-reservation throttle (post never created)
-  # doesn't count, while a mid-comment throttle (post created, comments cut short)
-  # does.
+  # Count a post once it's actually on FreeFeed. Guarded on status: an upfront
+  # throttle (post never created) doesn't count; a mid-comment one does.
   def count_published(post)
     Metrics.increment("posts_published_total", status: "published") if post.published?
   end

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -47,12 +47,15 @@ class PostPublishJob < ApplicationJob
     return reschedule_for_rate_limit(result.retry_after) unless result.allowed?
 
     FreefeedPublisher.new(post).publish
-    Metrics.increment("posts_published_total", status: "published")
+    count_published(post)
     schedule_next(feed)
   rescue RateLimit::Throttled => e
     # FreeFeed throttled us mid-publish despite our reservation. Defer the same
     # post; the idempotency guard in FreefeedPublisher keeps the retry safe. Must
-    # precede the generic rescue so it isn't recorded as a failure.
+    # precede the generic rescue so it isn't recorded as a failure. A throttle on
+    # a comment still left a real published post, so count it (the retry skips
+    # it, so it's counted once).
+    count_published(post)
     reschedule_for_rate_limit(e.retry_after)
   rescue FreefeedClient::UnauthorizedError
     # Token is no longer valid: disable it and stop the chain.
@@ -84,6 +87,14 @@ class PostPublishJob < ApplicationJob
     Metrics.increment("posts_published_total", status: "rejected")
     Rails.logger.error "Post #{post.id} needs #{posts} POSTs, over the FreeFeed limit; marking failed"
     schedule_next(feed)
+  end
+
+  # Count a post as published once it actually exists on FreeFeed. Guarded on the
+  # record's status so the upfront-reservation throttle (post never created)
+  # doesn't count, while a mid-comment throttle (post created, comments cut short)
+  # does.
+  def count_published(post)
+    Metrics.increment("posts_published_total", status: "published") if post.published?
   end
 
   def schedule_next(feed)

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -43,14 +43,17 @@ class PostPublishJob < ApplicationJob
     posts = post_cost(post)
     return reject_oversized(feed, post, posts) unless within_capacity?(posts)
 
-    RateLimit.acquire!(:freefeed, subject: feed.access_token.rate_limit_subject, cost: { post: posts })
+    result = RateLimit.acquire(:freefeed, subject: feed.access_token.rate_limit_subject, cost: { post: posts })
+    return reschedule_for_rate_limit(result.retry_after) unless result.allowed?
+
     FreefeedPublisher.new(post).publish
     Metrics.increment("posts_published_total", status: "published")
     schedule_next(feed)
-  rescue RateLimit::Throttled
-    # No capacity right now: reschedule the whole job (RateLimited) for the same
-    # post. Must precede the generic rescue so it isn't recorded as a failure.
-    raise
+  rescue RateLimit::Throttled => e
+    # FreeFeed throttled us mid-publish despite our reservation. Defer the same
+    # post; the idempotency guard in FreefeedPublisher keeps the retry safe. Must
+    # precede the generic rescue so it isn't recorded as a failure.
+    reschedule_for_rate_limit(e.retry_after)
   rescue FreefeedClient::UnauthorizedError
     # Token is no longer valid: disable it and stop the chain.
     feed.access_token&.disable_token_and_feeds

--- a/app/jobs/post_withdrawal_job.rb
+++ b/app/jobs/post_withdrawal_job.rb
@@ -12,12 +12,15 @@ class PostWithdrawalJob < ApplicationJob
     access_token = feed.access_token
     return unless access_token&.active?
 
-    RateLimit.acquire!(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
+    result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
+    return reschedule_for_rate_limit(result.retry_after) unless result.allowed?
 
     client = access_token.build_client
     client.delete_post(freefeed_post_id)
 
     Post.where(id: post_id).update_all(freefeed_post_id: nil)
+  rescue RateLimit::Throttled => e
+    reschedule_for_rate_limit(e.retry_after)
   rescue FreefeedClient::Error => e
     Rails.logger.error("Failed to withdraw FreeFeed post #{freefeed_post_id}: #{e.message}")
   end

--- a/app/jobs/rate_limited.rb
+++ b/app/jobs/rate_limited.rb
@@ -10,18 +10,29 @@ module RateLimited
   MAX_ATTEMPTS = 10
   JITTER_SECONDS = 5
 
+  # Reported (never raised) when a job gives up after MAX_ATTEMPTS throttled
+  # runs. A distinct class because RateLimit::Throttled itself is on
+  # Honeybadger's ignore list as expected backpressure.
+  class RetriesExhausted < StandardError; end
+
   included do
     rescue_from(RateLimit::Throttled) do |error|
       if executions < MAX_ATTEMPTS
         retry_job(wait: error.retry_after + rand(0.0..JITTER_SECONDS))
       else
-        Rails.error.report(error, context: { job: self.class.name, arguments: arguments })
+        report_exhausted(error)
         on_rate_limit_exhausted(error)
       end
     end
   end
 
   private
+
+  def report_exhausted(error)
+    exhausted = RetriesExhausted.new("#{self.class.name} gave up after #{executions} throttled runs: #{error.message}")
+    exhausted.set_backtrace(error.backtrace)
+    Rails.error.report(exhausted, context: { job: self.class.name, arguments: arguments })
+  end
 
   # Hook for jobs to clean up any in-progress state left behind when the
   # throttle retries are exhausted. Default is a no-op.

--- a/app/jobs/rate_limited.rb
+++ b/app/jobs/rate_limited.rb
@@ -1,16 +1,13 @@
 # Throttle handling for jobs that reserve RateLimit capacity.
 #
-# Rate limiting here is control flow, not failure: "no capacity right now, come
-# back later". So jobs ask RateLimit.acquire (the non-raising variant) and, when
-# it's not allowed, call reschedule_for_rate_limit to defer themselves. The rare
-# case where FreeFeed itself returns a 429 mid-call still arrives as a raised
-# RateLimit::Throttled; jobs rescue it locally and route it through the same
-# helper. Either way the deferral is handled inside `perform`, so it never
-# surfaces to the error reporter as a fault — only a genuine give-up does.
+# Throttling is control flow, not failure: "no capacity now, come back later".
+# Jobs call the non-raising RateLimit.acquire and, when denied, defer via
+# reschedule_for_rate_limit. A real mid-call 429 still raises RateLimit::Throttled;
+# jobs rescue it locally and route it through the same helper. Handled inside
+# `perform`, a deferral never reaches the error reporter — only a give-up does.
 #
-# Reschedules wait the limiter's retry_after (plus jitter to avoid stampedes),
-# up to MAX_ATTEMPTS. After that it reports once and stops; the recurring
-# schedulers re-kick the work later, so giving up is not permanent.
+# Reschedules wait retry_after (plus jitter), up to MAX_ATTEMPTS, then report
+# once and stop. The recurring schedulers re-kick later, so giving up isn't final.
 module RateLimited
   MAX_ATTEMPTS = 10
   JITTER_SECONDS = 5

--- a/app/jobs/rate_limited.rb
+++ b/app/jobs/rate_limited.rb
@@ -1,37 +1,40 @@
-# Shared throttle handling for jobs that reserve RateLimit capacity.
+# Throttle handling for jobs that reserve RateLimit capacity.
 #
-# On RateLimit::Throttled, reschedules the job after the limiter's retry_after
-# (plus a little jitter to avoid stampedes), up to MAX_ATTEMPTS. After that it
-# reports and gives up — the recurring schedulers re-kick work later, so giving
-# up is not permanent.
+# Rate limiting here is control flow, not failure: "no capacity right now, come
+# back later". So jobs ask RateLimit.acquire (the non-raising variant) and, when
+# it's not allowed, call reschedule_for_rate_limit to defer themselves. The rare
+# case where FreeFeed itself returns a 429 mid-call still arrives as a raised
+# RateLimit::Throttled; jobs rescue it locally and route it through the same
+# helper. Either way the deferral is handled inside `perform`, so it never
+# surfaces to the error reporter as a fault — only a genuine give-up does.
+#
+# Reschedules wait the limiter's retry_after (plus jitter to avoid stampedes),
+# up to MAX_ATTEMPTS. After that it reports once and stops; the recurring
+# schedulers re-kick the work later, so giving up is not permanent.
 module RateLimited
-  extend ActiveSupport::Concern
-
   MAX_ATTEMPTS = 10
   JITTER_SECONDS = 5
 
-  # Reported (never raised) when a job gives up after MAX_ATTEMPTS throttled
-  # runs. A distinct class because RateLimit::Throttled itself is on
-  # Honeybadger's ignore list as expected backpressure.
-  class RetriesExhausted < StandardError; end
-
-  included do
-    rescue_from(RateLimit::Throttled) do |error|
-      if executions < MAX_ATTEMPTS
-        retry_job(wait: error.retry_after + rand(0.0..JITTER_SECONDS))
-      else
-        report_exhausted(error)
-        on_rate_limit_exhausted(error)
-      end
-    end
+  # True once this run has deferred itself for rate limiting. The observability
+  # layer (ApplicationJob) reads it to count the run as throttled rather than ok.
+  def rate_limited?
+    @rate_limited == true
   end
 
   private
 
-  def report_exhausted(error)
-    exhausted = RetriesExhausted.new("#{self.class.name} gave up after #{executions} throttled runs: #{error.message}")
-    exhausted.set_backtrace(error.backtrace)
-    Rails.error.report(exhausted, context: { job: self.class.name, arguments: arguments })
+  # Defer this run because there's no capacity. Reschedules with backoff until
+  # the attempt cap, then reports the throttle once and invokes the cleanup hook.
+  def reschedule_for_rate_limit(retry_after)
+    @rate_limited = true
+
+    if executions < MAX_ATTEMPTS
+      retry_job(wait: retry_after + rand(0.0..JITTER_SECONDS))
+    else
+      error = RateLimit::Throttled.new(retry_after: retry_after)
+      Rails.error.report(error, context: { job: self.class.name, arguments: arguments })
+      on_rate_limit_exhausted(error)
+    end
   end
 
   # Hook for jobs to clean up any in-progress state left behind when the

--- a/app/jobs/token_validation_job.rb
+++ b/app/jobs/token_validation_job.rb
@@ -5,9 +5,12 @@ class TokenValidationJob < ApplicationJob
 
   def perform(access_token)
     # Validation makes two GETs: whoami and managedGroups.
-    RateLimit.acquire!(:freefeed, subject: access_token.rate_limit_subject, cost: { get: 2 })
+    result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { get: 2 })
+    return reschedule_for_rate_limit(result.retry_after) unless result.allowed?
 
     AccessTokenValidationService.new(access_token).call
+  rescue RateLimit::Throttled => e
+    reschedule_for_rate_limit(e.retry_after)
   end
 
   private

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -64,12 +64,27 @@ class AccessToken < ApplicationRecord
     FreefeedClient.new(host: host, token: encrypted_token, rate_limit_subject: rate_limit_subject)
   end
 
-  # Identity used for rate limiting FreeFeed API calls. Keyed per token: FreeFeed
-  # actually meters per account, so multiple tokens for the same FreeFeed user
-  # share its real bucket, but that rare over-count is covered by the 429
-  # backstop. A token id is stable and always present. See docs/rate-limiting.md.
+  # Identity used for rate limiting FreeFeed API calls. FreeFeed meters per
+  # authenticated account (the JWT user id), shared across all of that account's
+  # tokens, so the subject is keyed by FreeFeed instance + user id to collapse
+  # sibling tokens onto one bucket. The user id is only known after validation;
+  # until then (e.g. validation's own GETs) we fall back to a per-token subject.
+  # See docs/rate-limiting.md.
   def rate_limit_subject
-    "freefeed:#{id}"
+    if freefeed_user_id.present?
+      "freefeed:#{freefeed_instance}:#{freefeed_user_id}"
+    else
+      "freefeed:token:#{id}"
+    end
+  end
+
+  # Stable identifier for the FreeFeed instance this token targets. Prefers the
+  # known-host key (production/staging/beta) so different spellings of the same
+  # host — or a bare IP — don't fragment the subject; falls back to the host's
+  # domain for custom instances.
+  def freefeed_instance
+    known = FREEFEED_HOSTS.find { |_key, config| config[:domain] == host_domain }
+    known ? known.first.to_s : host_domain
   end
 
   def host_domain
@@ -85,8 +100,16 @@ class AccessToken < ApplicationRecord
     feeds.update_all(state: :disabled, access_token_id: nil)
   end
 
+  # Drop the limiter bucket when this token is gone. Account-scoped subjects can
+  # be shared by sibling tokens, so only forget once no sibling still uses it.
   def forget_rate_limit_state
-    RateLimit.forget(:freefeed, subject: rate_limit_subject)
+    subject = rate_limit_subject
+    return if freefeed_user_id.present? &&
+              AccessToken.where(freefeed_user_id: freefeed_user_id)
+                         .where.not(id: id)
+                         .any? { |sibling| sibling.rate_limit_subject == subject }
+
+    RateLimit.forget(:freefeed, subject: subject)
   end
 
   def disable_token_and_feeds

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -64,11 +64,10 @@ class AccessToken < ApplicationRecord
     FreefeedClient.new(host: host, token: encrypted_token, rate_limit_subject: rate_limit_subject)
   end
 
-  # Identity used for rate limiting FreeFeed API calls. FreeFeed meters per
-  # authenticated account (the JWT user id), shared across all of that account's
-  # tokens, so the subject is keyed by FreeFeed instance + user id to collapse
-  # sibling tokens onto one bucket. The user id is only known after validation;
-  # until then (e.g. validation's own GETs) we fall back to a per-token subject.
+  # Rate-limit identity for FreeFeed calls. FreeFeed meters per authenticated
+  # account (the JWT user id), shared across that account's tokens, so we key on
+  # instance + user id to collapse sibling tokens onto one bucket. The user id is
+  # known only after validation; until then we fall back to a per-token subject.
   # See docs/rate-limiting.md.
   def rate_limit_subject
     if freefeed_user_id.present?
@@ -78,12 +77,9 @@ class AccessToken < ApplicationRecord
     end
   end
 
-  # Stable identifier for the FreeFeed instance this token targets. Prefers the
-  # known-host key (production/staging/beta) so different spellings of the same
-  # host — or a bare IP — don't fragment the subject; falls back to the host's
-  # domain for custom instances. The domain is canonicalized (case- and
-  # trailing-dot-insensitive, since DNS is) so equivalent hosts collapse onto one
-  # FreeFeed account bucket.
+  # Stable id for the targeted FreeFeed instance: the known-host key
+  # (production/staging/beta), else the host domain. Canonicalized (DNS is
+  # case-insensitive) so equivalent spellings don't fragment the account bucket.
   def freefeed_instance
     domain = host_domain.to_s.downcase.delete_suffix(".")
     known = FREEFEED_HOSTS.find { |_key, config| config[:domain] == domain }

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -81,10 +81,13 @@ class AccessToken < ApplicationRecord
   # Stable identifier for the FreeFeed instance this token targets. Prefers the
   # known-host key (production/staging/beta) so different spellings of the same
   # host — or a bare IP — don't fragment the subject; falls back to the host's
-  # domain for custom instances.
+  # domain for custom instances. The domain is canonicalized (case- and
+  # trailing-dot-insensitive, since DNS is) so equivalent hosts collapse onto one
+  # FreeFeed account bucket.
   def freefeed_instance
-    known = FREEFEED_HOSTS.find { |_key, config| config[:domain] == host_domain }
-    known ? known.first.to_s : host_domain
+    domain = host_domain.to_s.downcase.delete_suffix(".")
+    known = FREEFEED_HOSTS.find { |_key, config| config[:domain] == domain }
+    known ? known.first.to_s : domain
   end
 
   def host_domain

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -11,9 +11,21 @@ class AccessTokenValidationService
     managed_groups = fetch_managed_groups
 
     access_token.with_lock do
-      access_token.update!(status: :active, owner: user_info[:username], last_used_at: Time.current)
+      access_token.update!(
+        status: :active,
+        owner: user_info[:username],
+        freefeed_user_id: user_info[:id],
+        last_used_at: Time.current
+      )
+
       access_token_detail = access_token.access_token_detail || access_token.build_access_token_detail
-      access_token_detail.update!(data: { user_info: user_info, managed_groups: managed_groups })
+
+      access_token_detail.update!(
+        data: {
+          user_info: user_info,
+          managed_groups: managed_groups
+        }
+      )
     end
   rescue FreefeedClient::UnauthorizedError
     access_token.disable_token_and_feeds

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -17,6 +17,11 @@ class AccessTokenValidationService
     end
   rescue FreefeedClient::UnauthorizedError
     access_token.disable_token_and_feeds
+  rescue RateLimit::Throttled
+    # Throttling is control flow, not a validation failure: let it propagate so
+    # the job reschedules. Reporting it here would surface a fault on every
+    # deferred run.
+    raise
   rescue StandardError => e
     Rails.error.report(e, context: { access_token_id: access_token.id })
     raise

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -27,10 +27,11 @@ class FreefeedPublisher
 
     # Persist the id (and mark the post published) before creating comments so a
     # retry can never re-create the post. Comments are therefore best-effort: if
-    # FreeFeed throttles (429) or errors part-way through, the post is already
-    # published, the publish chain advances, and the remaining comments are
-    # dropped rather than retried. The result is predictable and never
-    # duplicated, but the comment set may be incomplete.
+    # FreeFeed throttles (429) on a comment, the post is already published, the
+    # publish chain advances, and the remaining comments are dropped rather than
+    # retried. The result is predictable and never duplicated, but the comment
+    # set may be incomplete. (A non-throttle comment error is wrapped as a
+    # PublishError and marks the already-created post failed — see PostPublishJob.)
     #
     # NOTE: accepted best-effort behaviour for now; full atomic or comment-level
     # resumable publishing is a future improvement (revisit). It is also why a

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -25,9 +25,19 @@ class FreefeedPublisher
     freefeed_post = create_freefeed_post(attachment_ids)
     freefeed_post_id = freefeed_post[:id]
 
-    # Persist the id before creating comments so a later failure (e.g. a 429 on
-    # a comment) can't make a retry re-create the post. Comments are
-    # best-effort once the post exists.
+    # Persist the id (and mark the post published) before creating comments so a
+    # retry can never re-create the post. Comments are therefore best-effort: if
+    # FreeFeed throttles (429) or errors part-way through, the post is already
+    # published, the publish chain advances, and the remaining comments are
+    # dropped rather than retried. The result is predictable and never
+    # duplicated, but the comment set may be incomplete.
+    #
+    # NOTE: accepted best-effort behaviour for now; full atomic or comment-level
+    # resumable publishing is a future improvement (revisit). It is also why a
+    # post is capped at the POST bucket's burst (see PostPublishJob#within_capacity?):
+    # the whole cost is reserved up front so our own limiter never throttles
+    # mid-publish, leaving only a rare server-side 429 to land here, which this
+    # path tolerates safely.
     update_post_with_freefeed_id(freefeed_post_id)
     create_comments(freefeed_post_id)
 

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -25,20 +25,14 @@ class FreefeedPublisher
     freefeed_post = create_freefeed_post(attachment_ids)
     freefeed_post_id = freefeed_post[:id]
 
-    # Persist the id (and mark the post published) before creating comments so a
-    # retry can never re-create the post. Comments are therefore best-effort: if
-    # FreeFeed throttles (429) on a comment, the post is already published, the
-    # publish chain advances, and the remaining comments are dropped rather than
-    # retried. The result is predictable and never duplicated, but the comment
-    # set may be incomplete. (A non-throttle comment error is wrapped as a
-    # PublishError and marks the already-created post failed — see PostPublishJob.)
-    #
-    # NOTE: accepted best-effort behaviour for now; full atomic or comment-level
-    # resumable publishing is a future improvement (revisit). It is also why a
-    # post is capped at the POST bucket's burst (see PostPublishJob#within_capacity?):
-    # the whole cost is reserved up front so our own limiter never throttles
-    # mid-publish, leaving only a rare server-side 429 to land here, which this
-    # path tolerates safely.
+    # Persist the id (marking the post published) before comments, so a retry
+    # can't re-create the post. Comments are best-effort: a 429 on a comment
+    # leaves the post published and drops the rest — predictable, never
+    # duplicated, possibly incomplete. (A non-throttle comment error fails the
+    # post instead; see PostPublishJob.) Accepted for now; atomic/resumable
+    # publishing is the real fix (revisit). Reserving the whole cost up front
+    # (the POST-burst cap) keeps our own limiter from throttling mid-publish, so
+    # only a rare server 429 reaches here.
     update_post_with_freefeed_id(freefeed_post_id)
     create_comments(freefeed_post_id)
 

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -8,4 +8,11 @@ Honeybadger.configure do |config|
   # TODO: Remove after honeybadger-ruby#812 lands and ships: https://github.com/honeybadger-io/honeybadger-ruby/pull/812
   config.solid_queue.insights.enabled = false
   config.exceptions.ignore += [SignalException]
+  # Expected backpressure, not a fault: RateLimited reschedules throttled jobs,
+  # but Honeybadger's around_perform callback sees the exception before
+  # rescue_from runs and would report every reschedule. Throttle visibility
+  # comes from the rate_limit.* events and metrics instead, and RateLimited
+  # reports RetriesExhausted when it gives up for real. (String form: app
+  # classes can't be autoloaded from an initializer.)
+  config.exceptions.ignore += ["RateLimit::Throttled"]
 end

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -8,11 +8,4 @@ Honeybadger.configure do |config|
   # TODO: Remove after honeybadger-ruby#812 lands and ships: https://github.com/honeybadger-io/honeybadger-ruby/pull/812
   config.solid_queue.insights.enabled = false
   config.exceptions.ignore += [SignalException]
-  # Expected backpressure, not a fault: RateLimited reschedules throttled jobs,
-  # but Honeybadger's around_perform callback sees the exception before
-  # rescue_from runs and would report every reschedule. Throttle visibility
-  # comes from the rate_limit.* events and metrics instead, and RateLimited
-  # reports RetriesExhausted when it gives up for real. (String form: app
-  # classes can't be autoloaded from an initializer.)
-  config.exceptions.ignore += ["RateLimit::Throttled"]
 end

--- a/config/initializers/rate_limits.rb
+++ b/config/initializers/rate_limits.rb
@@ -12,12 +12,19 @@
 #   GET            200/min  — whoami, managedGroups (token validation)
 #   DELETE (`all`)  30/min  — post withdrawal / group purge (1 DELETE per post)
 #
+# FreeFeed counts each ceiling over a *rolling* one-minute window, so the most a
+# token bucket can legally spend in any single window is burst + rate (a full
+# bucket plus a minute of refill). Each burst below is therefore capped so that
+# burst + rate stays under the ceiling with margin to spare — the same account
+# may also be used by a human or other clients, and breaching gets the whole
+# account blocked for 1–8 minutes (escalating), including the FreeFeed UI.
+#
 # FreeFeed also allows GET /vN/attachments/:attId/:type 1000/min, but that's the
 # attachment-download route, which Feeder never calls — so it gets no bucket.
 Rails.application.config.to_prepare do
   RateLimit.define :freefeed do
-    limit :post, 50, per: 1.minute   # under FreeFeed POST 60/min
-    limit :get, 150, per: 1.minute   # under FreeFeed GET 200/min
-    limit :delete, 25, per: 1.minute # under FreeFeed `all` fallback 30/min
+    limit :post, 30, per: 1.minute, burst: 20   # worst window 50, under FreeFeed POST 60/min
+    limit :get, 100, per: 1.minute, burst: 30   # worst window 130, under FreeFeed GET 200/min
+    limit :delete, 15, per: 1.minute, burst: 10 # worst window 25, under FreeFeed `all` fallback 30/min
   end
 end

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -187,6 +187,48 @@
       ]
     },
     {
+      "title": "Rate limiting",
+      "panels": [
+        {
+          "title": "Publishing (15m)",
+          "expr": [
+            "sum(increase(feeder_posts_published_total{status=\"published\"}[15m]))",
+            "sum(increase(feeder_posts_published_total{status=\"failed\"}[15m]))",
+            "sum(increase(feeder_posts_published_total{status=\"rejected\"}[15m]))"
+          ],
+          "alias": [
+            "published",
+            "failed",
+            "rejected"
+          ]
+        },
+        {
+          "title": "Job outcomes (15m)",
+          "expr": [
+            "sum(increase(feeder_job_executions_total{status=\"ok\"}[15m]))",
+            "sum(increase(feeder_job_executions_total{status=\"throttled\"}[15m]))",
+            "sum(increase(feeder_job_executions_total{status=\"error\"}[15m]))"
+          ],
+          "alias": [
+            "ok",
+            "throttled",
+            "error"
+          ]
+        },
+        {
+          "title": "Throttles & blocks (15m)",
+          "expr": [
+            "sum(increase(feeder_rate_limit_throttled_total{policy=\"freefeed\"}[15m]))",
+            "sum(increase(feeder_rate_limit_penalized_total{policy=\"freefeed\"}[15m]))"
+          ],
+          "alias": [
+            "throttled",
+            "blocked (429)"
+          ]
+        }
+      ]
+    },
+    {
       "title": "PostgreSQL",
       "panels": [
         {

--- a/db/migrate/20260613120000_add_freefeed_user_id_to_access_tokens.rb
+++ b/db/migrate/20260613120000_add_freefeed_user_id_to_access_tokens.rb
@@ -1,0 +1,21 @@
+class AddFreefeedUserIdToAccessTokens < ActiveRecord::Migration[8.2]
+  def up
+    add_column :access_tokens, :freefeed_user_id, :string
+    add_index :access_tokens, :freefeed_user_id
+
+    # Backfill from the validation detail we already persist, so existing active
+    # tokens get an account-scoped rate-limit subject without re-validating.
+    execute(<<~SQL.squish)
+      UPDATE access_tokens
+      SET freefeed_user_id = access_token_details.data -> 'user_info' ->> 'id'
+      FROM access_token_details
+      WHERE access_token_details.access_token_id = access_tokens.id
+        AND access_token_details.data -> 'user_info' ->> 'id' IS NOT NULL
+    SQL
+  end
+
+  def down
+    remove_index :access_tokens, :freefeed_user_id
+    remove_column :access_tokens, :freefeed_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,8 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_13_145500) do
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.string "freefeed_user_id"
+    t.index ["freefeed_user_id"], name: "index_access_tokens_on_freefeed_user_id"
     t.index ["user_id", "name"], name: "index_access_tokens_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_access_tokens_on_user_id"
   end

--- a/docs/rate-limiting-freefeed.md
+++ b/docs/rate-limiting-freefeed.md
@@ -1,143 +1,111 @@
 # FreeFeed Server API Rate Limiting
 
-How the FreeFeed server limits API requests. Useful as a reference when
-deciding how Feeder should pace its requests to avoid HTTP 429 responses.
+How the FreeFeed server limits API requests — a reference for pacing Feeder's
+requests to avoid HTTP 429s.
 
 > Source: [FreeFeed/freefeed-server](https://github.com/FreeFeed/freefeed-server)
-> at commit `35b39a6` (2026-05-13). The counting algorithm lives in the
-> [`async-ratelimiter`](https://github.com/microlinkhq/async-ratelimiter) package
-> that FreeFeed pins at `~1.6.4`. See [Source references](#source-references) at
-> the bottom for the specific files and symbols behind each claim below.
+> at commit `35b39a6` (2026-05-13); the counting algorithm is the
+> [`async-ratelimiter`][async-ratelimiter] package it pins at `~1.6.4`
+> ([`package.json`][package.json]). Inline file links are permalinks at those
+> versions.
 
 ## Where it runs
 
-A single Koa middleware (`rateLimiterMiddleware`) backed by Redis, applied to
-every public and admin API route. It runs after JWT decoding, so it knows the
-caller's identity. Counters use the `async-ratelimiter` package.
+A single Koa middleware (`rateLimiterMiddleware`, [`rateLimiter.ts`][ratelimiter])
+backed by Redis, applied to every public and admin API route. It runs after JWT
+decoding, so it knows the caller's identity.
 
 ## How a client is identified
 
-- **Authenticated** request → keyed by **user ID**, uses the `authenticated`
-  limits.
-- **Anonymous** request → keyed by **IP address** (`ctx.ip`), uses the
-  `anonymous` limits.
+- **Authenticated** → keyed by **user ID**, uses the `authenticated` limits
+  (~3× the anonymous ones).
+- **Anonymous** → keyed by **IP address** (`ctx.ip`), uses the `anonymous` limits.
 
-Counters are per `clientId + HTTP method`, so each method is tracked
-separately for each client.
+Counters are per `clientId + HTTP method`: each method is tracked separately for
+each client.
 
 ## Default limits
 
-Configured in `config.rateLimit` (`config/default.js`). The time window is an
-ISO-8601 duration; default is `PT1M` (1 minute). **Each value below is a
-separate per-method bucket — there is no combined cap across methods.** `all`
-is *not* an aggregate; it is the fallback limit for methods without their own
-entry (`DELETE`, `PUT`, `PATCH`…), and each such method still gets its own
-bucket using that value.
+From `config.rateLimit` ([`config/default.js`][default]). Each value is a
+separate per-method bucket — there is no combined cap across methods. `all` is
+the fallback for methods without their own entry (`DELETE`, `PUT`, `PATCH`…);
+each such method still gets its own bucket at that value.
 
 | Auth type     | Window | `all` (fallback) | `GET` | `POST` | Attachments (`GET /vN/attachments/:attId/:type`) |
 |---------------|--------|------------------|-------|--------|--------------------------------------------------|
 | Anonymous     | 1 min  | 10               | 100   | —      | 1000                                             |
 | Authenticated | 1 min  | 30               | 200   | 60     | 1000                                             |
 
-Limit resolution precedence (most to least specific):
+Resolution precedence, most to least specific ([`routes.js`][routes],
+[`rateLimiter.ts`][ratelimiter]):
 
 1. Exact route (e.g. `GET /vN/attachments/:attId/:type`; the version prefix is
    normalized to `/vN`).
-2. HTTP method (`GET`, `POST`, …). `HEAD` counts as `GET`.
+2. HTTP method (`HEAD` counts as `GET`).
 3. Fallback `all`.
 
-## How the window is counted (sliding window log)
+## How the window is counted
 
-This is the part that matters most when pacing our own requests, and it is easy
-to get wrong by assuming a fixed window.
+`async-ratelimiter` ([`src/index.js`][async-ratelimiter]) is a **sliding window
+log**. Each allowed request is stored as one member in a Redis sorted set, scored
+by timestamp. On every call it drops members older than `now - duration`
+(`ZREMRANGEBYSCORE`), counts the rest (`ZCARD`), and allows the request only if
+`count < max`, recording it (`ZADD`).
 
-`async-ratelimiter` is a **sliding window log**, not a fixed-window counter and
-not a token bucket. Each allowed request is stored as one member in a Redis
-sorted set, scored by its timestamp. On every call it:
+The rule is therefore **at most `max` requests in any rolling `duration`** (window
+default `PT1M`, 1 min), measured continuously rather than reset on a clock
+boundary. `max` is the only parameter: there is no separate burst allowance on
+top of a rate.
 
-1. drops members older than `now - duration` (`ZREMRANGEBYSCORE`),
-2. counts what remains (`ZCARD`),
-3. allows the request iff `count < max`, recording it (`ZADD`).
+This shapes how Feeder paces itself:
 
-So the rule is exact and unforgiving: **at most `max` requests in any rolling
-`duration`** — measured continuously, not reset on a clock boundary. There is no
-separate "burst" allowance on top of the rate; `max` *is* the burst and the rate
-at once.
+- All `max` requests may go out at once, but the next is admitted only once the
+  oldest ages out of the trailing window.
+- A token bucket on our side admits up to `burst + rate` within one window, which
+  can exceed `max` even when `burst` and `rate` each look safe. Feeder caps each
+  dimension so `burst + rate` stays under the FreeFeed ceiling — see
+  [`rate-limiting.md`](rate-limiting.md) and `config/initializers/rate_limits.rb`.
+- FreeFeed keys per account; Feeder keys per access-token. Multiple tokens for one
+  account share one server-side window but get separate buckets here, so Feeder
+  keeps headroom under the ceiling rather than matching it exactly.
 
-Two consequences that drive our client config:
+## Exceeding the limit
 
-- You **can** legally fire all 60 POSTs in one instant, but then you must wait
-  until the oldest of them ages out of the trailing minute before the next one
-  is admitted. There is no steady "60/min drip" assumption to lean on.
-- Because the window slides, a limiter on our side that allows `burst + rate`
-  tokens within one window (a token bucket) can exceed `max` even when each of
-  `burst` and `rate` looks safe. That is exactly why Feeder caps each dimension
-  so that `burst + rate` stays under the FreeFeed ceiling — see
-  [`docs/rate-limiting.md`](rate-limiting.md) and
-  `config/initializers/rate_limits.rb`.
+Going over does not just delay the next request — the client is **blocked**, and
+repeat breaches escalate ([`rateLimiter.ts`][ratelimiter]):
 
-> Caveat: subjects differ between the two sides. FreeFeed keys per **account**
-> (user id); Feeder keys per **access-token**. Multiple tokens for one FreeFeed
-> user share one server-side sliding window but get independent buckets on our
-> side, so exact parity is impossible — keep headroom under the ceiling.
+- The first breach blocks for `blockDuration` (1 min).
+- The Nth consecutive breach blocks for `blockDuration × repeatBlockMultiplier ×
+  (N − 1)`; with `repeatBlockMultiplier = 2` that is 2, 4, 6, 8 min for the 2nd
+  through 5th.
+- Each breach extends the memory window (`repeatBlockCounterDuration`, 10 min)
+  that decides what counts as "consecutive"; stay clean for its full length and
+  the count resets.
+- While blocked, every request is rejected without consulting the per-method
+  counters.
 
-## What happens when you exceed the limit
-
-Going over the allowance does **not** just throttle the next request — the
-client gets **blocked**, and repeat offenders are punished progressively
-(`rateLimiter.ts`):
-
-- **First breach:** blocked for `blockDuration` (default `PT1M`, 1 min).
-- **Repeat breaches within the memory window:** block duration is multiplied
-  (`repeatBlockMultiplier` = 2 × number of previous blocks). Block times grow
-  roughly 1 → 2 → 4 → 6 → 8 minutes.
-- The "memory" of past breaches (`repeatBlockCounterDuration`, default `PT10M`)
-  is extended with each breach (≈11 → 12 → 14 → 16 minutes). Behave for the
-  full window and all past breaches are forgiven.
-- While blocked, every request is rejected immediately without consulting the
-  per-method counters.
-
-### Response
-
-Exceeding the limit (or being blocked) returns **HTTP 429** with the body
-message `"Slow down"` (`TooManyRequestsException`, `exceptions.js`).
+A blocked or over-limit request returns **HTTP 429** with body `"Slow down"`
+(`TooManyRequestsException`, [`exceptions.js`][exceptions]) and no `Retry-After`.
+Because breaches escalate and reset the forgiveness window, back off for minutes
+after a 429 rather than retrying immediately.
 
 ## Bypasses and toggles
 
-- **Disabled by default** (`config.rateLimit.enabled = false`). A deployment
-  must opt in.
+- **Disabled by default** (`config.rateLimit.enabled = false`); a deployment must
+  opt in.
 - **Allowlist** (`config.rateLimit.allowlist`, default `['::ffff:127.0.0.1']`)
-  skips all limiting. Entries can be IP addresses or user IDs.
+  skips limiting; entries are IPs or user IDs.
 
-## Practical implications for Feeder
+## What this means for publishing
 
-- Authenticate requests where possible — authenticated limits are ~3× higher
-  than anonymous ones (per user, not per shared IP).
-- Limits are per method, not combined. The one that matters for publishing is
-  ~60 POST/min per account (each post can be several POSTs: attachments + post
-  + comments). `GET` is far more generous at 200/min, and methods without their
-  own entry fall back to 30/min each. Keep a safety margin since each bucket is
-  a strict 1-minute window.
-- On a 429, **back off** rather than retry immediately — repeated breaches
-  escalate the block duration and reset the forgiveness window. A clean pause
-  of several minutes is the fastest way back to normal.
-- Bulk attachment fetches (`GET /vN/attachments/:attId/:type`) get a much
-  higher cap (1000/min).
+Each publish is several POSTs (the post, each comment, each attachment upload), so
+the **60 POST/min** authenticated bucket is the binding constraint; `GET`
+(200/min) and the `all` fallback (30/min) are rarely close. Authenticate so these
+higher per-user limits apply.
 
-## Source references
-
-Each claim above was confirmed against source at the pinned versions, not
-inferred. Links are permalinks at FreeFeed commit `35b39a6` and
-`async-ratelimiter` tag `v1.6.4`.
-
-| Claim | Where to confirm |
-|-------|------------------|
-| Limit values (auth POST 60, GET 200, `all` 30; anon GET 100, `all` 10; attachments 1000), window `PT1M`, `blockDuration PT1M`, `repeatBlockMultiplier 2`, `repeatBlockCounterDuration PT10M` | [`config/default.js`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/config/default.js) → `rateLimit` |
-| Middleware, per-`clientId + method` keying, block check before counting, escalation on repeat breaches | [`app/support/rateLimiter.ts`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/support/rateLimiter.ts) |
-| Route/method/`all` precedence; `/vN` version normalization | [`app/routes.js`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/routes.js), [`rateLimiter.ts`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/support/rateLimiter.ts) |
-| HTTP 429 with body `"Slow down"` (`TooManyRequestsException`) | [`app/support/exceptions.js`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/support/exceptions.js) |
-| Sliding-window-log algorithm: sorted set, `ZREMRANGEBYSCORE` → `ZCARD` → `ZADD`, `remaining = max - count`, no burst-on-top | [`async-ratelimiter` `src/index.js`](https://github.com/microlinkhq/async-ratelimiter/blob/v1.6.4/src/index.js), pinned in FreeFeed [`package.json`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/package.json) (`~1.6.4`) |
-
-Verified 2026-06-13. The only thing not read line-by-line is FreeFeed's exact
-`repeat`-block arithmetic; the `1 → 2 → 4 → 6 → 8 min` ladder above is the
-illustrative result of `2 × prior blocks`, not a literal table in the source.
+[default]: https://github.com/FreeFeed/freefeed-server/blob/35b39a6/config/default.js
+[ratelimiter]: https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/support/rateLimiter.ts
+[routes]: https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/routes.js
+[exceptions]: https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/support/exceptions.js
+[package.json]: https://github.com/FreeFeed/freefeed-server/blob/35b39a6/package.json
+[async-ratelimiter]: https://github.com/microlinkhq/async-ratelimiter/blob/v1.6.4/src/index.js

--- a/docs/rate-limiting-freefeed.md
+++ b/docs/rate-limiting-freefeed.md
@@ -4,8 +4,10 @@ How the FreeFeed server limits API requests. Useful as a reference when
 deciding how Feeder should pace its requests to avoid HTTP 429 responses.
 
 > Source: [FreeFeed/freefeed-server](https://github.com/FreeFeed/freefeed-server)
-> at commit `35b39a6` (2026-05-13). Key files: `app/support/rateLimiter.ts`,
-> `config/default.js`, `app/routes.js`, `app/support/exceptions.js`.
+> at commit `35b39a6` (2026-05-13). The counting algorithm lives in the
+> [`async-ratelimiter`](https://github.com/microlinkhq/async-ratelimiter) package
+> that FreeFeed pins at `~1.6.4`. See [Source references](#source-references) at
+> the bottom for the specific files and symbols behind each claim below.
 
 ## Where it runs
 
@@ -43,6 +45,41 @@ Limit resolution precedence (most to least specific):
    normalized to `/vN`).
 2. HTTP method (`GET`, `POST`, …). `HEAD` counts as `GET`.
 3. Fallback `all`.
+
+## How the window is counted (sliding window log)
+
+This is the part that matters most when pacing our own requests, and it is easy
+to get wrong by assuming a fixed window.
+
+`async-ratelimiter` is a **sliding window log**, not a fixed-window counter and
+not a token bucket. Each allowed request is stored as one member in a Redis
+sorted set, scored by its timestamp. On every call it:
+
+1. drops members older than `now - duration` (`ZREMRANGEBYSCORE`),
+2. counts what remains (`ZCARD`),
+3. allows the request iff `count < max`, recording it (`ZADD`).
+
+So the rule is exact and unforgiving: **at most `max` requests in any rolling
+`duration`** — measured continuously, not reset on a clock boundary. There is no
+separate "burst" allowance on top of the rate; `max` *is* the burst and the rate
+at once.
+
+Two consequences that drive our client config:
+
+- You **can** legally fire all 60 POSTs in one instant, but then you must wait
+  until the oldest of them ages out of the trailing minute before the next one
+  is admitted. There is no steady "60/min drip" assumption to lean on.
+- Because the window slides, a limiter on our side that allows `burst + rate`
+  tokens within one window (a token bucket) can exceed `max` even when each of
+  `burst` and `rate` looks safe. That is exactly why Feeder caps each dimension
+  so that `burst + rate` stays under the FreeFeed ceiling — see
+  [`docs/rate-limiting.md`](rate-limiting.md) and
+  `config/initializers/rate_limits.rb`.
+
+> Caveat: subjects differ between the two sides. FreeFeed keys per **account**
+> (user id); Feeder keys per **access-token**. Multiple tokens for one FreeFeed
+> user share one server-side sliding window but get independent buckets on our
+> side, so exact parity is impossible — keep headroom under the ceiling.
 
 ## What happens when you exceed the limit
 
@@ -86,3 +123,21 @@ message `"Slow down"` (`TooManyRequestsException`, `exceptions.js`).
   of several minutes is the fastest way back to normal.
 - Bulk attachment fetches (`GET /vN/attachments/:attId/:type`) get a much
   higher cap (1000/min).
+
+## Source references
+
+Each claim above was confirmed against source at the pinned versions, not
+inferred. Links are permalinks at FreeFeed commit `35b39a6` and
+`async-ratelimiter` tag `v1.6.4`.
+
+| Claim | Where to confirm |
+|-------|------------------|
+| Limit values (auth POST 60, GET 200, `all` 30; anon GET 100, `all` 10; attachments 1000), window `PT1M`, `blockDuration PT1M`, `repeatBlockMultiplier 2`, `repeatBlockCounterDuration PT10M` | [`config/default.js`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/config/default.js) → `rateLimit` |
+| Middleware, per-`clientId + method` keying, block check before counting, escalation on repeat breaches | [`app/support/rateLimiter.ts`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/support/rateLimiter.ts) |
+| Route/method/`all` precedence; `/vN` version normalization | [`app/routes.js`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/routes.js), [`rateLimiter.ts`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/support/rateLimiter.ts) |
+| HTTP 429 with body `"Slow down"` (`TooManyRequestsException`) | [`app/support/exceptions.js`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/app/support/exceptions.js) |
+| Sliding-window-log algorithm: sorted set, `ZREMRANGEBYSCORE` → `ZCARD` → `ZADD`, `remaining = max - count`, no burst-on-top | [`async-ratelimiter` `src/index.js`](https://github.com/microlinkhq/async-ratelimiter/blob/v1.6.4/src/index.js), pinned in FreeFeed [`package.json`](https://github.com/FreeFeed/freefeed-server/blob/35b39a6/package.json) (`~1.6.4`) |
+
+Verified 2026-06-13. The only thing not read line-by-line is FreeFeed's exact
+`repeat`-block arithmetic; the `1 → 2 → 4 → 6 → 8 min` ladder above is the
+illustrative result of `2 × prior blocks`, not a literal table in the source.

--- a/docs/rate-limiting-freefeed.md
+++ b/docs/rate-limiting-freefeed.md
@@ -65,9 +65,10 @@ This shapes how Feeder paces itself:
   can exceed `max` even when `burst` and `rate` each look safe. Feeder caps each
   dimension so `burst + rate` stays under the FreeFeed ceiling — see
   [`rate-limiting.md`](rate-limiting.md) and `config/initializers/rate_limits.rb`.
-- FreeFeed keys per account; Feeder keys per access-token. Multiple tokens for one
-  account share one server-side window but get separate buckets here, so Feeder
-  keeps headroom under the ceiling rather than matching it exactly.
+- FreeFeed keys its counter on the authenticated account (the JWT user id), shared
+  across all of that account's tokens. Feeder keys its subject the same way once a
+  token is validated (`freefeed:<instance>:<user_id>`), so sibling tokens for one
+  account share a single local bucket and can't each spend a separate allowance.
 
 ## Exceeding the limit
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -83,14 +83,18 @@ local accounting mirrors theirs:
 - **Per provider identity, not global** — e.g. FreeFeed limits per account, so
   one busy account must not throttle unrelated ones. A global cap would be both
   too strict and too loose.
-- **Not too fine** — several feeds under the same FreeFeed token share one
-  remote bucket, so the subject is the token's identity, not the feed.
+- **Match the remote's granularity** — FreeFeed meters per authenticated account
+  (the JWT user id), shared across every token and feed of that account, so the
+  subject must be the account, not the token or feed.
 
-For FreeFeed the subject is the **access-token id** (`freefeed:<id>`). FreeFeed
-actually meters per account, so multiple tokens for the same FreeFeed user share
-its real bucket; keying per token over-counts in that rare case, but the `429`
-backstop covers it. A token id is stable and always present (unlike `owner`,
-which is unknown until validation), so it avoids a shifting subject.
+For FreeFeed the subject is **instance + account**:
+`freefeed:<instance>:<freefeed_user_id>`, where `<instance>` is the known-host
+key (`production`/`staging`/`beta`, falling back to the host domain). This keeps
+all of one account's tokens on a single bucket, matching the server's own
+counter. The FreeFeed user id is only known after a token is validated, so until
+then we fall back to a per-token subject (`freefeed:token:<id>`) — acceptable
+because the only pre-validation traffic is validation's own GETs, and the POST
+and DELETE paths always run on already-validated tokens.
 
 ## Public API (sketch)
 

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -19,7 +19,10 @@ class FreefeedClient
   attr_reader :host, :http_client
 
   # Used as the cooldown when a 429 response carries no usable Retry-After.
-  DEFAULT_RETRY_AFTER = 60
+  # FreeFeed never sends Retry-After, and its blocks escalate from 1 up to
+  # 8 minutes on repeat breaches, so back off for several minutes rather than
+  # retrying into a block that is still in force.
+  DEFAULT_RETRY_AFTER = 300
 
   def initialize(host:, token:, http_client: nil, rate_limit_subject: nil, options: {})
     @host = host.chomp("/")

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -24,6 +24,11 @@ class FreefeedClient
   # retrying into a block that is still in force.
   DEFAULT_RETRY_AFTER = 300
 
+  # Padding added to a parsed Retry-After. The header reflects the start of the
+  # server's window; a little extra keeps the retry clear of clock skew and the
+  # window's edge so it doesn't land back inside a still-active block.
+  RETRY_AFTER_BUFFER = 10
+
   def initialize(host:, token:, http_client: nil, rate_limit_subject: nil, options: {})
     @host = host.chomp("/")
     @token = token
@@ -198,7 +203,7 @@ class FreefeedClient
 
   def retry_after_seconds(response)
     seconds = response.headers["retry-after"].to_i
-    seconds.positive? ? seconds : DEFAULT_RETRY_AFTER
+    seconds.positive? ? seconds + RETRY_AFTER_BUFFER : DEFAULT_RETRY_AFTER
   end
 
   # TBD: Consider simplifying response processing. Probably keep the keys

--- a/test/config/honeybadger_config_test.rb
+++ b/test/config/honeybadger_config_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-# Verifies config/initializers/honeybadger.rb.
-class HoneybadgerConfigTest < ActiveSupport::TestCase
-  test "ignores RateLimit::Throttled since RateLimited handles it by rescheduling" do
-    assert_includes Honeybadger.config.ignored_classes, "RateLimit::Throttled"
-  end
-end

--- a/test/config/honeybadger_config_test.rb
+++ b/test/config/honeybadger_config_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+# Verifies config/initializers/honeybadger.rb.
+class HoneybadgerConfigTest < ActiveSupport::TestCase
+  test "ignores RateLimit::Throttled since RateLimited handles it by rescheduling" do
+    assert_includes Honeybadger.config.ignored_classes, "RateLimit::Throttled"
+  end
+end

--- a/test/factories/access_tokens.rb
+++ b/test/factories/access_tokens.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
     trait :active do
       status { :active }
       owner { "testuser" }
+      sequence(:freefeed_user_id) { |n| "ff-user-#{n}" }
     end
 
     trait :inactive do

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -78,6 +78,39 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     assert_equal "post2", post2.reload.freefeed_post_id
   end
 
+  test ".perform_now should reschedule without failing when FreeFeed throttles a DELETE" do
+    post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1")
+      .to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    reported = []
+    assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
+      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
+        GroupPurgeJob.perform_now(feed.id)
+      end
+    end
+
+    assert_empty reported, "a handled mid-batch throttle must not be reported as a fault"
+    assert_equal "post1", post1.reload.freefeed_post_id, "a throttled DELETE must leave the post untouched"
+  end
+
+  test ".perform_now should report and stop when throttle retries are exhausted" do
+    post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
+    job = GroupPurgeJob.new(feed.id)
+    job.executions = RateLimited::MAX_ATTEMPTS
+
+    reported = []
+    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 5) }) do
+      Rails.error.stub(:report, ->(error, **) { reported << error }) do
+        assert_no_enqueued_jobs(only: GroupPurgeJob) { job.perform_now }
+      end
+    end
+
+    assert_equal 1, reported.size
+    assert_instance_of RateLimit::Throttled, reported.first
+    assert_equal "post1", post1.reload.freefeed_post_id, "nothing is deleted when out of capacity"
+  end
+
   test ".perform_now should continue on error and log failure" do
     post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
     post2 = create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -28,28 +28,30 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     assert_nil post3.reload.freefeed_post_id
   end
 
-  test ".perform_now should reserve a delete per post" do
+  test ".perform_now should reserve one delete per post" do
     create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
     create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)
+    subject = access_token.rate_limit_subject
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
     stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
 
-    captured = []
-    RateLimit.stub(:acquire, lambda { |_policy, subject:, cost:|
-      captured << [subject, cost]
-      RateLimit::Result.new(allowed: true, retry_after: 0.0)
-    }) do
+    freeze_time do
       GroupPurgeJob.perform_now(feed.id)
-    end
 
-    assert_equal [[access_token.rate_limit_subject, { delete: 1 }]] * 2, captured
+      capacity = RateLimit.capacity(:freefeed, :delete)
+      assert_equal capacity - 2, freefeed_tokens_left(subject, :delete),
+        "two withdrawals must spend exactly two delete tokens"
+    end
   end
 
   test ".perform_now should reschedule itself when throttled" do
     create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
+    subject = access_token.rate_limit_subject
 
-    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 2) }) do
+    freeze_time do
+      drain_freefeed(subject, :delete, remaining: 0)
+
       assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
         GroupPurgeJob.perform_now(feed.id)
       end
@@ -61,14 +63,14 @@ class GroupPurgeJobTest < ActiveJob::TestCase
   test ".perform_now should keep progress and reschedule the rest when throttled mid-batch" do
     post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
     post2 = create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)
+    subject = access_token.rate_limit_subject
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
 
-    calls = 0
-    RateLimit.stub(:acquire, lambda { |*, **|
-      calls += 1
-      RateLimit::Result.new(allowed: calls == 1, retry_after: calls == 1 ? 0.0 : 5)
-    }) do
+    freeze_time do
+      # One delete token: the first withdrawal spends it, the second throttles.
+      drain_freefeed(subject, :delete, remaining: 1)
+
       assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
         GroupPurgeJob.perform_now(feed.id)
       end
@@ -96,11 +98,14 @@ class GroupPurgeJobTest < ActiveJob::TestCase
 
   test ".perform_now should report and stop when throttle retries are exhausted" do
     post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
+    subject = access_token.rate_limit_subject
     job = GroupPurgeJob.new(feed.id)
     job.executions = RateLimited::MAX_ATTEMPTS
 
     reported = []
-    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 5) }) do
+    freeze_time do
+      drain_freefeed(subject, :delete, remaining: 0)
+
       Rails.error.stub(:report, ->(error, **) { reported << error }) do
         assert_no_enqueued_jobs(only: GroupPurgeJob) { job.perform_now }
       end

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -36,8 +36,9 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
 
     captured = []
-    RateLimit.stub(:acquire!, lambda { |_policy, subject:, cost:|
+    RateLimit.stub(:acquire, lambda { |_policy, subject:, cost:|
       captured << [subject, cost]
+      RateLimit::Result.new(allowed: true, retry_after: 0.0)
     }) do
       GroupPurgeJob.perform_now(feed.id)
     end
@@ -48,7 +49,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
   test ".perform_now should reschedule itself when throttled" do
     create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
 
-    RateLimit.stub(:acquire!, ->(*, **) { raise RateLimit::Throttled.new(retry_after: 2) }) do
+    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 2) }) do
       assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
         GroupPurgeJob.perform_now(feed.id)
       end
@@ -64,9 +65,9 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
 
     calls = 0
-    RateLimit.stub(:acquire!, lambda { |*, **|
+    RateLimit.stub(:acquire, lambda { |*, **|
       calls += 1
-      raise RateLimit::Throttled.new(retry_after: 5) if calls > 1
+      RateLimit::Result.new(allowed: calls == 1, retry_after: calls == 1 ? 0.0 : 5)
     }) do
       assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
         GroupPurgeJob.perform_now(feed.id)

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -152,6 +152,38 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_equal "enqueued", post.reload.status
   end
 
+  test ".perform_now should keep original publication order across a throttle interruption" do
+    create(:post, :enqueued, feed: feed, published_at: 3.hours.ago, content: "post-1")
+    create(:post, :enqueued, feed: feed, published_at: 2.hours.ago, content: "post-2")
+    create(:post, :enqueued, feed: feed, published_at: 1.hour.ago, content: "post-3")
+
+    published_bodies = []
+    stub_request(:post, "#{access_token.host}/v4/posts").to_return do |request|
+      published_bodies << JSON.parse(request.body).dig("post", "body")
+      {
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { posts: { id: "freefeed-#{SecureRandom.hex(8)}" } }.to_json
+      }
+    end
+
+    # Throttle the chain once, when it reaches the second post; the retried
+    # job must pick that same post up again before touching later ones.
+    acquire_calls = 0
+    acquire = lambda do |*, **|
+      acquire_calls += 1
+      raise RateLimit::Throttled.new(retry_after: 1) if acquire_calls == 2
+    end
+
+    RateLimit.stub(:acquire!, acquire) do
+      perform_enqueued_jobs { PostPublishJob.perform_now(feed.id) }
+    end
+
+    assert_equal %w[post-1 post-2 post-3], published_bodies
+    assert_equal 0, feed.posts.where(status: :enqueued).count
+    assert_equal 4, acquire_calls, "expected three grants plus one throttled attempt"
+  end
+
   test ".perform_now should do nothing when there are no enqueued posts" do
     assert_no_enqueued_jobs(only: PostPublishJob) do
       PostPublishJob.perform_now(feed.id)

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -114,9 +114,9 @@ class PostPublishJobTest < ActiveJob::TestCase
     create(:post, :enqueued, feed: feed, comments: ["a", "b"], attachment_urls: ["u1", "u2", "u3"])
 
     captured = nil
-    RateLimit.stub(:acquire!, lambda { |policy, subject:, cost:|
+    RateLimit.stub(:acquire, lambda { |policy, subject:, cost:|
       captured = [policy, subject, cost]
-      raise RateLimit::Throttled.new(retry_after: 1)
+      RateLimit::Result.new(allowed: false, retry_after: 1)
     }) do
       PostPublishJob.perform_now(feed.id)
     end
@@ -130,7 +130,10 @@ class PostPublishJobTest < ActiveJob::TestCase
 
     # No acquire and no publish happen for an impossible post; the chain advances.
     captured_acquire = false
-    RateLimit.stub(:acquire!, ->(*, **) { captured_acquire = true }) do
+    RateLimit.stub(:acquire, lambda { |*, **|
+      captured_acquire = true
+      RateLimit::Result.new(allowed: true, retry_after: 0.0)
+    }) do
       assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
         PostPublishJob.perform_now(feed.id)
       end
@@ -143,13 +146,29 @@ class PostPublishJobTest < ActiveJob::TestCase
   test ".perform_now should reschedule and keep the post enqueued when throttled" do
     post = create(:post, :enqueued, feed: feed)
 
-    RateLimit.stub(:acquire!, ->(*, **) { raise RateLimit::Throttled.new(retry_after: 2) }) do
+    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 2) }) do
       assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
         PostPublishJob.perform_now(feed.id)
       end
     end
 
     assert_equal "enqueued", post.reload.status
+  end
+
+  test ".perform_now should reschedule without failing when FreeFeed throttles mid-publish" do
+    post = create(:post, :enqueued, feed: feed)
+    stub_request(:post, "#{access_token.host}/v4/posts")
+      .to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    reported = []
+    assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
+      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
+        PostPublishJob.perform_now(feed.id)
+      end
+    end
+
+    assert_equal "enqueued", post.reload.status, "the throttled post must stay enqueued for the retry"
+    assert_empty reported, "a handled mid-publish throttle must not be reported as a fault"
   end
 
   test ".perform_now should keep original publication order across a throttle interruption" do
@@ -172,10 +191,11 @@ class PostPublishJobTest < ActiveJob::TestCase
     acquire_calls = 0
     acquire = lambda do |*, **|
       acquire_calls += 1
-      raise RateLimit::Throttled.new(retry_after: 1) if acquire_calls == 2
+      allowed = acquire_calls != 2
+      RateLimit::Result.new(allowed: allowed, retry_after: allowed ? 0.0 : 1)
     end
 
-    RateLimit.stub(:acquire!, acquire) do
+    RateLimit.stub(:acquire, acquire) do
       perform_enqueued_jobs { PostPublishJob.perform_now(feed.id) }
     end
 

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -155,6 +155,23 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_equal "enqueued", post.reload.status
   end
 
+  test ".perform_now should report and keep the post enqueued when throttle retries are exhausted" do
+    post = create(:post, :enqueued, feed: feed)
+    job = PostPublishJob.new(feed.id)
+    job.executions = RateLimited::MAX_ATTEMPTS
+
+    reported = []
+    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 5) }) do
+      Rails.error.stub(:report, ->(error, **) { reported << error }) do
+        assert_no_enqueued_jobs(only: PostPublishJob) { job.perform_now }
+      end
+    end
+
+    assert_equal 1, reported.size
+    assert_instance_of RateLimit::Throttled, reported.first
+    assert_equal "enqueued", post.reload.status, "the post must stay enqueued for a later run to pick up"
+  end
+
   test ".perform_now should reschedule without failing when FreeFeed throttles mid-publish" do
     post = create(:post, :enqueued, feed: feed)
     stub_request(:post, "#{access_token.host}/v4/posts")

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -210,8 +210,11 @@ class PostPublishJobTest < ActiveJob::TestCase
       .to_return(status: 429, headers: { "Retry-After" => "30" })
 
     reported = []
-    Rails.error.stub(:report, ->(*args, **) { reported << args }) do
-      perform_enqueued_jobs { PostPublishJob.perform_now(feed.id) }
+    increments = []
+    Metrics.stub(:increment, ->(name, **tags) { increments << [name, tags] }) do
+      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
+        perform_enqueued_jobs { PostPublishJob.perform_now(feed.id) }
+      end
     end
 
     post.reload
@@ -222,6 +225,9 @@ class PostPublishJobTest < ActiveJob::TestCase
     # Comment creation stops at the throttled comment; the rest are dropped.
     assert_requested :post, "#{access_token.host}/v4/comments", times: 1
     assert_empty reported, "a handled mid-comment throttle must not be reported as a fault"
+
+    published = increments.count { |name, tags| name == "posts_published_total" && tags[:status] == "published" }
+    assert_equal 1, published, "a created post is counted once even when a comment throttles"
   end
 
   test ".perform_now should keep original publication order across a throttle interruption" do

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -134,13 +134,15 @@ class PostPublishJobTest < ActiveJob::TestCase
                                          attachment_urls: Array.new(60) { |i| "https://example.com/#{i}.jpg" })
     subject = access_token.rate_limit_subject
 
-    assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
-      PostPublishJob.perform_now(feed.id)
-    end
+    freeze_time do
+      assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
+        PostPublishJob.perform_now(feed.id)
+      end
 
-    assert_equal "failed", oversized.reload.status
-    assert_not RateLimit::Bucket.exists?(key: "freefeed:#{subject}"),
-      "an impossible post must be rejected before reserving any capacity"
+      assert_equal "failed", oversized.reload.status
+      assert_equal RateLimit.capacity(:freefeed, :post), freefeed_tokens_left(subject, :post),
+        "an impossible post must be rejected before reserving any capacity"
+    end
   end
 
   test ".perform_now should reschedule and keep the post enqueued when throttled" do

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -110,58 +110,65 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_no_enqueued_jobs(only: PostPublishJob)
   end
 
-  test ".perform_now should reserve one POST per post, comment, and attachment" do
+  test ".perform_now should count the post, its comments, and its attachments in the reserved cost" do
     create(:post, :enqueued, feed: feed, comments: ["a", "b"], attachment_urls: ["u1", "u2", "u3"])
+    subject = access_token.rate_limit_subject
 
-    captured = nil
-    RateLimit.stub(:acquire, lambda { |policy, subject:, cost:|
-      captured = [policy, subject, cost]
-      RateLimit::Result.new(allowed: false, retry_after: 1)
-    }) do
-      PostPublishJob.perform_now(feed.id)
-    end
+    freeze_time do
+      # Leave 5 POST tokens — one short of this post's true cost of 6
+      # (1 post + 2 comments + 3 attachments). A run that counted only the post
+      # would publish; counting the extras throttles it before any HTTP call.
+      drain_freefeed(subject, :post, remaining: 5)
 
-    assert_equal [:freefeed, access_token.rate_limit_subject, { post: 6 }], captured
-  end
-
-  test ".perform_now should fail an oversized post and advance the chain" do
-    oversized = create(:post, :enqueued, feed: feed, published_at: 2.hours.ago,
-                                         attachment_urls: Array.new(60) { |i| "https://example.com/#{i}.jpg" })
-
-    # No acquire and no publish happen for an impossible post; the chain advances.
-    captured_acquire = false
-    RateLimit.stub(:acquire, lambda { |*, **|
-      captured_acquire = true
-      RateLimit::Result.new(allowed: true, retry_after: 0.0)
-    }) do
       assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
         PostPublishJob.perform_now(feed.id)
       end
     end
 
+    assert_equal "enqueued", feed.posts.first.reload.status
+    assert_not_requested :post, "#{access_token.host}/v4/posts"
+  end
+
+  test ".perform_now should fail an oversized post and advance the chain" do
+    oversized = create(:post, :enqueued, feed: feed, published_at: 2.hours.ago,
+                                         attachment_urls: Array.new(60) { |i| "https://example.com/#{i}.jpg" })
+    subject = access_token.rate_limit_subject
+
+    assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
+      PostPublishJob.perform_now(feed.id)
+    end
+
     assert_equal "failed", oversized.reload.status
-    refute captured_acquire, "should not try to reserve capacity it can never get"
+    assert_not RateLimit::Bucket.exists?(key: "freefeed:#{subject}"),
+      "an impossible post must be rejected before reserving any capacity"
   end
 
   test ".perform_now should reschedule and keep the post enqueued when throttled" do
     post = create(:post, :enqueued, feed: feed)
+    subject = access_token.rate_limit_subject
 
-    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 2) }) do
+    freeze_time do
+      drain_freefeed(subject, :post, remaining: 0)
+
       assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
         PostPublishJob.perform_now(feed.id)
       end
     end
 
     assert_equal "enqueued", post.reload.status
+    assert_not_requested :post, "#{access_token.host}/v4/posts"
   end
 
   test ".perform_now should report and keep the post enqueued when throttle retries are exhausted" do
     post = create(:post, :enqueued, feed: feed)
+    subject = access_token.rate_limit_subject
     job = PostPublishJob.new(feed.id)
     job.executions = RateLimited::MAX_ATTEMPTS
 
     reported = []
-    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 5) }) do
+    freeze_time do
+      drain_freefeed(subject, :post, remaining: 0)
+
       Rails.error.stub(:report, ->(error, **) { reported << error }) do
         assert_no_enqueued_jobs(only: PostPublishJob) { job.perform_now }
       end
@@ -203,22 +210,27 @@ class PostPublishJobTest < ActiveJob::TestCase
       }
     end
 
-    # Throttle the chain once, when it reaches the second post; the retried
-    # job must pick that same post up again before touching later ones.
-    acquire_calls = 0
-    acquire = lambda do |*, **|
-      acquire_calls += 1
-      allowed = acquire_calls != 2
-      RateLimit::Result.new(allowed: allowed, retry_after: allowed ? 0.0 : 1)
-    end
+    subject = access_token.rate_limit_subject
 
-    RateLimit.stub(:acquire, acquire) do
-      perform_enqueued_jobs { PostPublishJob.perform_now(feed.id) }
+    freeze_time do
+      # One POST token: enough for the first post, then the real bucket is dry.
+      drain_freefeed(subject, :post, remaining: 1)
+
+      PostPublishJob.perform_now(feed.id) # publishes post-1, bucket -> 0
+      PostPublishJob.perform_now(feed.id) # post-2: no tokens, throttles and stays enqueued
+
+      assert_equal ["post-1"], published_bodies
+      assert_equal %w[post-2 post-3], feed.posts.enqueued.order(:published_at).pluck(:content),
+        "the throttled post and its successor must remain, in order"
+
+      travel(2.seconds)                   # refills one token (post rate is 0.5/s)
+      PostPublishJob.perform_now(feed.id) # post-2 resumes — the same post, before post-3
+      travel(2.seconds)
+      PostPublishJob.perform_now(feed.id) # post-3
     end
 
     assert_equal %w[post-1 post-2 post-3], published_bodies
-    assert_equal 0, feed.posts.where(status: :enqueued).count
-    assert_equal 4, acquire_calls, "expected three grants plus one throttled attempt"
+    assert_equal 0, feed.posts.enqueued.count
   end
 
   test ".perform_now should do nothing when there are no enqueued posts" do

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -195,6 +195,35 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_empty reported, "a handled mid-publish throttle must not be reported as a fault"
   end
 
+  # Best-effort publishing: once the post is created its id is persisted, so a
+  # 429 on a later comment leaves the post published with an incomplete comment
+  # set rather than re-creating it. Documents the accepted behaviour (see
+  # FreefeedPublisher#publish) so it stays predictable and safe.
+  test ".perform_now should leave the post published and not duplicated when a comment is throttled" do
+    post = create(:post, :enqueued, feed: feed, content: "body", comments: ["c1", "c2"])
+
+    stub_request(:post, "#{access_token.host}/v4/posts")
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" },
+                 body: { posts: { id: "ff-post-1" } }.to_json)
+    # FreeFeed throttles the first comment, after the post itself was created.
+    stub_request(:post, "#{access_token.host}/v4/comments")
+      .to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    reported = []
+    Rails.error.stub(:report, ->(*args, **) { reported << args }) do
+      perform_enqueued_jobs { PostPublishJob.perform_now(feed.id) }
+    end
+
+    post.reload
+    assert_equal "published", post.status, "the created post is recorded as published"
+    assert_equal "ff-post-1", post.freefeed_post_id
+    # The post is created exactly once and never re-created on the retry chain.
+    assert_requested :post, "#{access_token.host}/v4/posts", times: 1
+    # Comment creation stops at the throttled comment; the rest are dropped.
+    assert_requested :post, "#{access_token.host}/v4/comments", times: 1
+    assert_empty reported, "a handled mid-comment throttle must not be reported as a fault"
+  end
+
   test ".perform_now should keep original publication order across a throttle interruption" do
     create(:post, :enqueued, feed: feed, published_at: 3.hours.ago, content: "post-1")
     create(:post, :enqueued, feed: feed, published_at: 2.hours.ago, content: "post-2")

--- a/test/jobs/post_withdrawal_job_test.rb
+++ b/test/jobs/post_withdrawal_job_test.rb
@@ -30,6 +30,39 @@ class PostWithdrawalJobTest < ActiveJob::TestCase
     assert_not_requested :delete, "#{access_token.host}/v4/posts/test_post_123"
   end
 
+  test ".perform_now should reschedule without failing when the DELETE is throttled mid-call" do
+    post = create(:post, :published, feed: feed, freefeed_post_id: "test_post_123")
+    stub_request(:delete, "#{access_token.host}/v4/posts/test_post_123")
+      .to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    reported = []
+    assert_enqueued_with(job: PostWithdrawalJob) do
+      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
+        PostWithdrawalJob.perform_now(feed.id, "test_post_123", post.id)
+      end
+    end
+
+    assert_empty reported, "a handled throttle must not be reported as a fault"
+    assert_equal "test_post_123", post.reload.freefeed_post_id, "the post id must survive a throttled withdrawal"
+  end
+
+  test ".perform_now should report and stop when throttle retries are exhausted" do
+    post = create(:post, :published, feed: feed, freefeed_post_id: "test_post_123")
+    job = PostWithdrawalJob.new(feed.id, "test_post_123", post.id)
+    job.executions = RateLimited::MAX_ATTEMPTS
+
+    reported = []
+    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 5) }) do
+      Rails.error.stub(:report, ->(error, **) { reported << error }) do
+        assert_no_enqueued_jobs(only: PostWithdrawalJob) { job.perform_now }
+      end
+    end
+
+    assert_equal 1, reported.size
+    assert_instance_of RateLimit::Throttled, reported.first
+    assert_equal "test_post_123", post.reload.freefeed_post_id
+  end
+
   test ".perform_now should delete post from FreeFeed" do
     stub_request(:delete, "#{access_token.host}/v4/posts/test_post_123")
       .to_return(status: 200)

--- a/test/jobs/post_withdrawal_job_test.rb
+++ b/test/jobs/post_withdrawal_job_test.rb
@@ -17,9 +17,9 @@ class PostWithdrawalJobTest < ActiveJob::TestCase
     post = create(:post, :published, feed: feed, freefeed_post_id: "test_post_123")
 
     captured = nil
-    RateLimit.stub(:acquire!, lambda { |_policy, subject:, cost:|
+    RateLimit.stub(:acquire, lambda { |_policy, subject:, cost:|
       captured = [subject, cost]
-      raise RateLimit::Throttled.new(retry_after: 2)
+      RateLimit::Result.new(allowed: false, retry_after: 2)
     }) do
       assert_enqueued_with(job: PostWithdrawalJob) do
         PostWithdrawalJob.perform_now(feed.id, "test_post_123", post.id)

--- a/test/jobs/post_withdrawal_job_test.rb
+++ b/test/jobs/post_withdrawal_job_test.rb
@@ -16,17 +16,16 @@ class PostWithdrawalJobTest < ActiveJob::TestCase
   test ".perform_now should reserve a delete and reschedule when throttled" do
     post = create(:post, :published, feed: feed, freefeed_post_id: "test_post_123")
 
-    captured = nil
-    RateLimit.stub(:acquire, lambda { |_policy, subject:, cost:|
-      captured = [subject, cost]
-      RateLimit::Result.new(allowed: false, retry_after: 2)
-    }) do
+    subject = access_token.rate_limit_subject
+
+    freeze_time do
+      drain_freefeed(subject, :delete, remaining: 0)
+
       assert_enqueued_with(job: PostWithdrawalJob) do
         PostWithdrawalJob.perform_now(feed.id, "test_post_123", post.id)
       end
     end
 
-    assert_equal [access_token.rate_limit_subject, { delete: 1 }], captured
     assert_not_requested :delete, "#{access_token.host}/v4/posts/test_post_123"
   end
 
@@ -48,11 +47,14 @@ class PostWithdrawalJobTest < ActiveJob::TestCase
 
   test ".perform_now should report and stop when throttle retries are exhausted" do
     post = create(:post, :published, feed: feed, freefeed_post_id: "test_post_123")
+    subject = access_token.rate_limit_subject
     job = PostWithdrawalJob.new(feed.id, "test_post_123", post.id)
     job.executions = RateLimited::MAX_ATTEMPTS
 
     reported = []
-    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 5) }) do
+    freeze_time do
+      drain_freefeed(subject, :delete, remaining: 0)
+
       Rails.error.stub(:report, ->(error, **) { reported << error }) do
         assert_no_enqueued_jobs(only: PostWithdrawalJob) { job.perform_now }
       end

--- a/test/jobs/rate_limited_test.rb
+++ b/test/jobs/rate_limited_test.rb
@@ -5,7 +5,7 @@ class RateLimitedTest < ActiveJob::TestCase
     include RateLimited
 
     def perform
-      raise RateLimit::Throttled.new(retry_after: 3)
+      reschedule_for_rate_limit(3)
     end
   end
 
@@ -15,7 +15,7 @@ class RateLimitedTest < ActiveJob::TestCase
     cattr_accessor :exhausted_with
 
     def perform
-      raise RateLimit::Throttled.new(retry_after: 3)
+      reschedule_for_rate_limit(3)
     end
 
     private
@@ -25,13 +25,34 @@ class RateLimitedTest < ActiveJob::TestCase
     end
   end
 
-  test "reschedules the job when throttled within the attempt cap" do
+  test "#reschedule_for_rate_limit reschedules the job within the attempt cap" do
     assert_enqueued_with(job: ThrottledJob) do
       ThrottledJob.perform_now
     end
   end
 
-  test "gives up and reports RetriesExhausted once the attempt cap is reached" do
+  test "#reschedule_for_rate_limit marks the run as rate limited" do
+    job = ThrottledJob.new
+    job.perform_now
+
+    assert job.rate_limited?
+  end
+
+  test "#rate_limited? should be false for a run that was not throttled" do
+    assert_not ThrottledJob.new.rate_limited?
+  end
+
+  test "a throttled run is counted as throttled rather than ok" do
+    increments = []
+    Metrics.stub(:increment, ->(name, **tags) { increments << [name, tags] }) do
+      ThrottledJob.perform_now
+    end
+
+    statuses = increments.select { |name, _| name == "job_executions_total" }.map { |_, tags| tags[:status] }
+    assert_equal ["throttled"], statuses
+  end
+
+  test "#reschedule_for_rate_limit reports a throttle once the attempt cap is reached" do
     job = ThrottledJob.new
     job.executions = RateLimited::MAX_ATTEMPTS
 
@@ -41,11 +62,10 @@ class RateLimitedTest < ActiveJob::TestCase
     end
 
     assert_equal 1, reported.size
-    assert_instance_of RateLimited::RetriesExhausted, reported.first
-    assert_includes reported.first.message, "Rate limited"
+    assert_instance_of RateLimit::Throttled, reported.first
   end
 
-  test "invokes on_rate_limit_exhausted once the attempt cap is reached" do
+  test "#reschedule_for_rate_limit invokes on_rate_limit_exhausted once the attempt cap is reached" do
     HookJob.exhausted_with = nil
     job = HookJob.new
     job.executions = RateLimited::MAX_ATTEMPTS

--- a/test/jobs/rate_limited_test.rb
+++ b/test/jobs/rate_limited_test.rb
@@ -31,7 +31,7 @@ class RateLimitedTest < ActiveJob::TestCase
     end
   end
 
-  test "gives up and reports once the attempt cap is reached" do
+  test "gives up and reports RetriesExhausted once the attempt cap is reached" do
     job = ThrottledJob.new
     job.executions = RateLimited::MAX_ATTEMPTS
 
@@ -41,7 +41,8 @@ class RateLimitedTest < ActiveJob::TestCase
     end
 
     assert_equal 1, reported.size
-    assert_instance_of RateLimit::Throttled, reported.first
+    assert_instance_of RateLimited::RetriesExhausted, reported.first
+    assert_includes reported.first.message, "Rate limited"
   end
 
   test "invokes on_rate_limit_exhausted once the attempt cap is reached" do

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -39,6 +39,21 @@ class TokenValidationJobTest < ActiveJob::TestCase
     assert access_token.pending?
   end
 
+  test ".perform_now should reschedule without failing when validation is throttled mid-call" do
+    stub_request(:get, "#{access_token.host}/v4/users/whoami")
+      .to_return(status: 429, headers: { "Retry-After" => "30" })
+
+    reported = []
+    assert_enqueued_with(job: TokenValidationJob) do
+      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
+        TokenValidationJob.perform_now(access_token)
+      end
+    end
+
+    assert_empty reported, "a handled throttle must not be reported as a fault"
+    assert_not access_token.reload.inactive?, "a throttle must not disable the token"
+  end
+
   test ".perform_now should mark token as active when validation succeeds" do
     stub_successful_freefeed_response
 

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -10,26 +10,31 @@ class TokenValidationJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should reserve two GETs and reschedule when throttled" do
-    captured = nil
-    RateLimit.stub(:acquire, lambda { |_policy, subject:, cost:|
-      captured = [subject, cost]
-      RateLimit::Result.new(allowed: false, retry_after: 2)
-    }) do
+    subject = access_token.rate_limit_subject
+
+    freeze_time do
+      # Leave one GET token — short of validation's cost of 2, so it throttles
+      # before either GET goes out.
+      drain_freefeed(subject, :get, remaining: 1)
+
       assert_enqueued_with(job: TokenValidationJob) do
         TokenValidationJob.perform_now(access_token)
       end
     end
 
-    assert_equal [access_token.rate_limit_subject, { get: 2 }], captured
+    assert_not_requested :get, "#{access_token.host}/v4/users/whoami"
   end
 
   test ".perform_now should reset token to pending when throttle retries are exhausted" do
     access_token.validating!
+    subject = access_token.rate_limit_subject
 
     job = TokenValidationJob.new(access_token)
     job.executions = RateLimited::MAX_ATTEMPTS
 
-    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 2) }) do
+    freeze_time do
+      drain_freefeed(subject, :get, remaining: 0)
+
       Rails.error.stub(:report, ->(*, **) { }) do
         assert_no_enqueued_jobs { job.perform_now }
       end

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -11,9 +11,9 @@ class TokenValidationJobTest < ActiveJob::TestCase
 
   test ".perform_now should reserve two GETs and reschedule when throttled" do
     captured = nil
-    RateLimit.stub(:acquire!, lambda { |_policy, subject:, cost:|
+    RateLimit.stub(:acquire, lambda { |_policy, subject:, cost:|
       captured = [subject, cost]
-      raise RateLimit::Throttled.new(retry_after: 2)
+      RateLimit::Result.new(allowed: false, retry_after: 2)
     }) do
       assert_enqueued_with(job: TokenValidationJob) do
         TokenValidationJob.perform_now(access_token)
@@ -29,7 +29,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
     job = TokenValidationJob.new(access_token)
     job.executions = RateLimited::MAX_ATTEMPTS
 
-    RateLimit.stub(:acquire!, ->(*, **) { raise RateLimit::Throttled.new(retry_after: 2) }) do
+    RateLimit.stub(:acquire, ->(*, **) { RateLimit::Result.new(allowed: false, retry_after: 2) }) do
       Rails.error.stub(:report, ->(*, **) { }) do
         assert_no_enqueued_jobs { job.perform_now }
       end

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -331,10 +331,14 @@ class FreefeedClientTest < ActiveSupport::TestCase
     penalized = nil
     RateLimit.stub(:penalize, ->(name, subject:, retry_after:) { penalized = [name, subject, retry_after] }) do
       error = assert_raises(RateLimit::Throttled) { client.create_post(body: "hi", feeds: ["g"]) }
-      assert_equal 30, error.retry_after
+      assert_equal 30 + FreefeedClient::RETRY_AFTER_BUFFER, error.retry_after
     end
 
-    assert_equal [:freefeed, "freefeed:1", 30], penalized
+    assert_equal [:freefeed, "freefeed:1", 30 + FreefeedClient::RETRY_AFTER_BUFFER], penalized
+  end
+
+  test "Retry-After is padded with a buffer to stay clear of the server window" do
+    assert_equal 10, FreefeedClient::RETRY_AFTER_BUFFER
   end
 
   test "default cooldown is several minutes to wait out FreeFeed's escalating blocks" do
@@ -368,7 +372,7 @@ class FreefeedClientTest < ActiveSupport::TestCase
 
     RateLimit.stub(:penalize, ->(*, **) { }) do
       error = assert_raises(RateLimit::Throttled) { client.whoami }
-      assert_equal 20, error.retry_after
+      assert_equal 20 + FreefeedClient::RETRY_AFTER_BUFFER, error.retry_after
     end
   end
 
@@ -379,9 +383,9 @@ class FreefeedClientTest < ActiveSupport::TestCase
     penalized = nil
     RateLimit.stub(:penalize, ->(_name, subject:, retry_after:) { penalized = [subject, retry_after] }) do
       error = assert_raises(RateLimit::Throttled) { client.delete_post("p1") }
-      assert_equal 15, error.retry_after
+      assert_equal 15 + FreefeedClient::RETRY_AFTER_BUFFER, error.retry_after
     end
 
-    assert_equal ["freefeed:1", 15], penalized
+    assert_equal ["freefeed:1", 15 + FreefeedClient::RETRY_AFTER_BUFFER], penalized
   end
 end

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -337,6 +337,10 @@ class FreefeedClientTest < ActiveSupport::TestCase
     assert_equal [:freefeed, "freefeed:1", 30], penalized
   end
 
+  test "default cooldown is several minutes to wait out FreeFeed's escalating blocks" do
+    assert_equal 300, FreefeedClient::DEFAULT_RETRY_AFTER
+  end
+
   test "429 without Retry-After uses the default cooldown" do
     client = FreefeedClient.new(host: @host, token: @token, rate_limit_subject: "freefeed:1")
     stub_request(:post, "#{@host}/v4/posts").to_return(status: 429)

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -36,6 +36,16 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert_equal "my.freefeed.example", create(:access_token, host: "https://my.freefeed.example").freefeed_instance
   end
 
+  test "#rate_limit_subject is stable across equivalent host spellings" do
+    a = create(:access_token, host: "https://freefeed.net", freefeed_user_id: "u-7")
+    b = create(:access_token, host: "https://FREEFEED.NET", freefeed_user_id: "u-7")
+    c = create(:access_token, host: "https://Custom.Example.COM", freefeed_user_id: "u-7")
+
+    assert_equal "freefeed:production:u-7", a.rate_limit_subject
+    assert_equal a.rate_limit_subject, b.rate_limit_subject, "case must not split the account bucket"
+    assert_equal "freefeed:custom.example.com:u-7", c.rate_limit_subject
+  end
+
   test ".build_with_token stores encrypted token and sets pending status" do
     token = AccessToken.build_with_token(
       name: "Test Token",

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -11,8 +11,29 @@ class AccessTokenTest < ActiveSupport::TestCase
     @user ||= create(:user)
   end
 
-  test "#rate_limit_subject is keyed by the token id" do
-    assert_equal "freefeed:#{access_token.id}", access_token.rate_limit_subject
+  test "#rate_limit_subject is keyed by FreeFeed instance and user id once validated" do
+    token = create(:access_token, :active, host: "https://freefeed.net", freefeed_user_id: "u-42")
+    assert_equal "freefeed:production:u-42", token.rate_limit_subject
+  end
+
+  test "#rate_limit_subject collapses sibling tokens of the same account onto one subject" do
+    a = create(:access_token, host: "https://freefeed.net", freefeed_user_id: "u-42")
+    b = create(:access_token, host: "https://freefeed.net", freefeed_user_id: "u-42")
+    assert_equal a.rate_limit_subject, b.rate_limit_subject
+  end
+
+  test "#rate_limit_subject falls back to the token id before validation" do
+    token = create(:access_token) # pending, no freefeed_user_id yet
+    assert_equal "freefeed:token:#{token.id}", token.rate_limit_subject
+  end
+
+  test "#freefeed_instance uses the known-host key" do
+    assert_equal "staging", create(:access_token, host: "https://candy.freefeed.net").freefeed_instance
+    assert_equal "production", create(:access_token, host: "https://freefeed.net").freefeed_instance
+  end
+
+  test "#freefeed_instance falls back to the domain for a custom host" do
+    assert_equal "my.freefeed.example", create(:access_token, host: "https://my.freefeed.example").freefeed_instance
   end
 
   test ".build_with_token stores encrypted token and sets pending status" do
@@ -193,6 +214,24 @@ class AccessTokenTest < ActiveSupport::TestCase
     token.destroy!
 
     assert_not RateLimit::Bucket.exists?(key: "freefeed:#{token.rate_limit_subject}")
+  end
+
+  test "destroying one token keeps the shared bucket while a sibling still uses it" do
+    shared = { host: "https://freefeed.net", freefeed_user_id: "u-99" }
+    a = create(:access_token, :active, **shared)
+    b = create(:access_token, :active, **shared)
+    assert_equal a.rate_limit_subject, b.rate_limit_subject
+
+    RateLimit.acquire(:freefeed, subject: a.rate_limit_subject, cost: { get: 1 })
+    bucket_key = "freefeed:#{a.rate_limit_subject}"
+
+    a.destroy!
+
+    assert RateLimit::Bucket.exists?(key: bucket_key), "sibling b still uses the account bucket"
+
+    b.destroy!
+
+    assert_not RateLimit::Bucket.exists?(key: bucket_key), "last token gone, bucket forgotten"
   end
 
   test "destroying access token disables enabled feeds and nullifies their access_token_id" do

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -217,31 +217,37 @@ class AccessTokenTest < ActiveSupport::TestCase
   end
 
   test "destroying access token forgets its rate limit state" do
-    token = create(:access_token, :active)
-    RateLimit.acquire(:freefeed, subject: token.rate_limit_subject, cost: { get: 1 })
-    assert RateLimit::Bucket.exists?(key: "freefeed:#{token.rate_limit_subject}")
+    freeze_time do
+      token = create(:access_token, :active)
+      subject = token.rate_limit_subject
+      drain_freefeed(subject, :get, remaining: 0)
+      assert_not RateLimit.acquire(:freefeed, subject: subject, cost: { get: 1 }).allowed?
 
-    token.destroy!
+      token.destroy!
 
-    assert_not RateLimit::Bucket.exists?(key: "freefeed:#{token.rate_limit_subject}")
+      assert RateLimit.acquire(:freefeed, subject: subject, cost: { get: 1 }).allowed?,
+        "a forgotten subject starts fresh"
+    end
   end
 
   test "destroying one token keeps the shared bucket while a sibling still uses it" do
-    shared = { host: "https://freefeed.net", freefeed_user_id: "u-99" }
-    a = create(:access_token, :active, **shared)
-    b = create(:access_token, :active, **shared)
-    assert_equal a.rate_limit_subject, b.rate_limit_subject
+    freeze_time do
+      shared = { host: "https://freefeed.net", freefeed_user_id: "u-99" }
+      a = create(:access_token, :active, **shared)
+      b = create(:access_token, :active, **shared)
+      subject = a.rate_limit_subject
+      assert_equal subject, b.rate_limit_subject
 
-    RateLimit.acquire(:freefeed, subject: a.rate_limit_subject, cost: { get: 1 })
-    bucket_key = "freefeed:#{a.rate_limit_subject}"
+      drain_freefeed(subject, :get, remaining: 0)
 
-    a.destroy!
+      a.destroy!
+      assert_not RateLimit.acquire(:freefeed, subject: subject, cost: { get: 1 }).allowed?,
+        "the shared bucket survives while sibling b still uses it"
 
-    assert RateLimit::Bucket.exists?(key: bucket_key), "sibling b still uses the account bucket"
-
-    b.destroy!
-
-    assert_not RateLimit::Bucket.exists?(key: bucket_key), "last token gone, bucket forgotten"
+      b.destroy!
+      assert RateLimit.acquire(:freefeed, subject: subject, cost: { get: 1 }).allowed?,
+        "the bucket is forgotten once the last token is gone"
+    end
   end
 
   test "destroying access token disables enabled feeds and nullifies their access_token_id" do

--- a/test/services/access_token_validation_service_test.rb
+++ b/test/services/access_token_validation_service_test.rb
@@ -49,6 +49,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
 
     assert_equal "active", access_token.reload.status
     assert_equal "testuser", access_token.owner
+    assert_equal "user123", access_token.freefeed_user_id
     assert_not_nil access_token.last_used_at
   end
 

--- a/test/services/metrics_test.rb
+++ b/test/services/metrics_test.rb
@@ -2,8 +2,10 @@ require "test_helper"
 
 # A throwaway job used to exercise the ApplicationJob metrics hook.
 class MetricsProbeJob < ApplicationJob
+  include RateLimited
+
   def perform(mode)
-    raise RateLimit::Throttled.new(retry_after: 1) if mode == :throttle
+    reschedule_for_rate_limit(1) if mode == :throttle
     raise "boom" if mode == :error
   end
 end
@@ -130,7 +132,7 @@ class MetricsTest < ActiveSupport::TestCase
     enable!
 
     MetricsProbeJob.perform_now(:ok)
-    assert_raises(RateLimit::Throttled) { MetricsProbeJob.perform_now(:throttle) }
+    MetricsProbeJob.perform_now(:throttle)
     assert_raises(RuntimeError) { MetricsProbeJob.perform_now(:error) }
 
     out = Metrics.render

--- a/test/services/rate_limit_freefeed_policy_test.rb
+++ b/test/services/rate_limit_freefeed_policy_test.rb
@@ -1,29 +1,54 @@
 require "test_helper"
 
 # Verifies the :freefeed policy registered by config/initializers/rate_limits.rb.
+#
+# FreeFeed meters each method over a *rolling* one-minute window, so the most a
+# token bucket can spend in any single window is burst + rate (a full bucket
+# plus a minute of refill). Every dimension must keep that sum under FreeFeed's
+# ceiling, or bursts get the whole account blocked server-side.
 class RateLimitFreefeedPolicyTest < ActiveSupport::TestCase
-  test "the :freefeed policy limits posts under FreeFeed's POST ceiling" do
-    limit = RateLimit.policy(:freefeed).buckets_for(post: 1).map(&:first).sole
+  FREEFEED_CEILINGS = { post: 60, get: 200, delete: 30 }.freeze
 
-    assert_equal 50, limit.rate
+  test "the :freefeed policy limits posts under FreeFeed's POST ceiling" do
+    limit = limit_for(:post)
+
+    assert_equal 30, limit.rate
+    assert_equal 20, limit.burst
     assert_equal 60, limit.window
   end
 
   test "the :freefeed policy limits gets under FreeFeed's GET ceiling" do
-    limit = RateLimit.policy(:freefeed).buckets_for(get: 1).map(&:first).sole
+    limit = limit_for(:get)
 
-    assert_equal 150, limit.rate
+    assert_equal 100, limit.rate
+    assert_equal 30, limit.burst
     assert_equal 60, limit.window
   end
 
   test "the :freefeed policy limits deletes under FreeFeed's fallback ceiling" do
-    limit = RateLimit.policy(:freefeed).buckets_for(delete: 1).map(&:first).sole
+    limit = limit_for(:delete)
 
-    assert_equal 25, limit.rate
+    assert_equal 15, limit.rate
+    assert_equal 10, limit.burst
     assert_equal 60, limit.window
+  end
+
+  test "worst-case rolling-minute spend stays under FreeFeed's ceiling for every dimension" do
+    FREEFEED_CEILINGS.each do |dimension, ceiling|
+      limit = limit_for(dimension)
+
+      assert_operator limit.burst + limit.rate, :<, ceiling,
+        "#{dimension}: burst #{limit.burst} + rate #{limit.rate} must stay under FreeFeed's #{ceiling}/min"
+    end
   end
 
   test "the :freefeed policy fails open" do
     assert RateLimit.policy(:freefeed).fail_open?
+  end
+
+  private
+
+  def limit_for(dimension)
+    RateLimit.policy(:freefeed).buckets_for(dimension => 1).map(&:first).sole
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,10 +19,32 @@ require "super_diff"
 # Load support modules in deterministic order
 Dir[Rails.root.join("test/support/**/*.rb")].sort.each { |f| require f }
 
+# Drive the real RateLimit limiter in tests instead of stubbing acquire, so the
+# job specs exercise actual token-bucket behaviour. Use inside freeze_time so
+# nothing refills mid-setup, and travel/travel_to to let it refill.
+module RateLimitTestHelper
+  # Spend real tokens so the FreeFeed subject's bucket holds exactly `remaining`
+  # for `dimension`.
+  def drain_freefeed(subject, dimension, remaining: 0)
+    capacity = RateLimit.capacity(:freefeed, dimension)
+    (capacity - remaining).times do
+      RateLimit.acquire(:freefeed, subject: subject, cost: { dimension => 1 })
+    end
+  end
+
+  # How many `dimension` tokens the subject has left, measured by spending them.
+  # Consumes the remainder, so call it only at the end of a test.
+  def freefeed_tokens_left(subject, dimension)
+    capacity = RateLimit.capacity(:freefeed, dimension)
+    (1..capacity).count { RateLimit.acquire(:freefeed, subject: subject, cost: { dimension => 1 }).allowed? }
+  end
+end
+
 module ActiveSupport
   class TestCase
     include FactoryBot::Syntax::Methods
     include SnapshotTesting
+    include RateLimitTestHelper
 
     # Run tests in parallel with specified workers
     # Disable parallel testing when SimpleCov is running to get accurate coverage


### PR DESCRIPTION
Changes:

- Cap each rate limit dimension's burst so worst-case spend in a rolling minute (burst + rate) stays under FreeFeed's per-method ceiling
- Back off on a 429 without Retry-After, and pad a parsed Retry-After with a small buffer, to stay clear of FreeFeed's escalating blocks
- Treat throttling as control flow: jobs use the non-raising `RateLimit.acquire` and defer themselves via `reschedule_for_rate_limit`, so the common path raises nothing and never reaches the error reporter — no Honeybadger ignore entry, no extra error class
- Let `RateLimit::Throttled` propagate untouched through `AccessTokenValidationService` (it was rescued as a generic error and reported as a fault on every deferred validation run)
- Pin the publish-order invariant and the per-job throttle paths with tests: ordering across a throttle, mid-call 429 reschedules, and retry-cap exhaustion for each rate-limited job
- Document FreeFeed's sliding-window-log limiter in `docs/rate-limiting-freefeed.md`, with inline source references
- Bump brakeman to 8.0.5

FreeFeed counts each limit over a *rolling* one-minute window (a sliding window log, confirmed in `async-ratelimiter`), while our token bucket allowed burst + rate (up to ~100 POSTs/min against FreeFeed's 60) in a single window. Draining a publish backlog therefore breached the server limit and got the whole account blocked — escalating from 1 to 8 minutes on re-breach and rejecting every request, including the owner's own UI sessions ("Slow down"). With bursts capped, the publish chain self-paces under the server window, and a backlog drains safely through the throttle-and-reschedule backpressure.

A throttle is not a failure but expected backpressure, so the limiter signals it as a value (`acquire` returns an allowed/retry_after result) rather than an exception. Jobs branch on it explicitly and reschedule. The only remaining `RateLimit::Throttled` raise is a real FreeFeed 429 mid-call, which jobs rescue locally; a genuine give-up after the attempt cap is reported once. Publication order is preserved throughout: each run takes the earliest enqueued post, and a throttled run leaves it enqueued so the retry resumes on the same post.