### PR TITLE
Trim event/post UI and limit recent posts

### DIFF
--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -20,7 +20,7 @@ class PostDetailsComponent < ViewComponent::Base
   def add_feed_item(component)
     component.with_item(ListComponent::StatItemComponent.new(
       label: "Feed",
-      value: helpers.link_to(@post.feed.display_name, @post.feed, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500"),
+      value: helpers.link_to(@post.feed.display_name, @post.feed, class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500"),
       key: "post.feed"
     ))
   end
@@ -44,7 +44,7 @@ class PostDetailsComponent < ViewComponent::Base
 
   def add_source_url_item(component)
     value = if @post.source_url.present?
-      helpers.link_to(@post.source_url, @post.source_url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 truncate block")
+      helpers.link_to(@post.source_url, @post.source_url, target: "_blank", rel: "noopener", class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500 truncate block")
     else
       content_tag(:span, "None", class: "text-slate-500")
     end
@@ -83,7 +83,7 @@ class PostDetailsComponent < ViewComponent::Base
   def add_freefeed_post_id_item(component)
     url = @post.freefeed_url
     value = if url
-      helpers.link_to(url, target: "_blank", rel: "noopener", class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center gap-1") do
+      helpers.link_to(url, target: "_blank", rel: "noopener", class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center gap-1") do
         safe_join([
           content_tag(:code, @post.freefeed_post_id, class: "text-sm"),
           helpers.icon("external-link", css_class: "size-3")

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,6 +3,8 @@ class EventsController < ApplicationController
   include EventCursorPagination
   include EventReferencedPosts
 
+  MAX_RECENT_POSTS = 10
+
   def index
     respond_to do |format|
       format.html { render_events_page }
@@ -12,7 +14,7 @@ class EventsController < ApplicationController
 
   def show
     @event = owned_events.find(params[:id])
-    @referenced_posts = referenced_posts(@event)
+    @referenced_posts = referenced_posts(@event).limit(MAX_RECENT_POSTS)
     @previous_event = adjacent_event(:newer)
     @next_event = adjacent_event(:older)
   end

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -16,9 +16,6 @@
         <%= link_to "Reset Filter", admin_events_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
       <% end %>
     <% end %>
-    <% header.with_action_button do %>
-      <%= link_to "Back to Admin", admin_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
-    <% end %>
     <% if @log_endpoint %>
       <% header.with_action_button do %>
         <%= render RefreshButtonComponent.new(data: {

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,11 +1,7 @@
 <% content_for :title, "Users" %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Users") do |header| %>
-    <% header.with_action_button do %>
-      <%= link_to "Back to Admin", admin_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
-    <% end %>
-  <% end %>
+  <%= render PageHeaderComponent.new(title: "Users") %>
 
   <% if @users.any? %>
     <div class="overflow-x-auto rounded-lg border border-slate-200">

--- a/app/views/development/system_status/show.html.erb
+++ b/app/views/development/system_status/show.html.erb
@@ -11,11 +11,7 @@
 %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "System Status") do |header| %>
-    <% header.with_action_button do %>
-      <%= link_to "Back to Admin", admin_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
-    <% end %>
-  <% end %>
+  <%= render PageHeaderComponent.new(title: "System Status") %>
 
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Configuration</h2>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -50,7 +50,7 @@
 
   <% if @referenced_posts.any? %>
     <section class="space-y-4" data-key="events.imported_posts">
-      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Imported Posts</h2>
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Recent Posts</h2>
       <%= render PostsListComponent.new(posts: @referenced_posts) %>
     </section>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,9 +10,6 @@
       ) %>
     <% end %>
     <% header.with_action_button do %>
-      <%= link_to "Back to Posts", posts_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
-    <% end %>
-    <% header.with_action_button do %>
       <%= link_to "Source", feed_entry_path(@post.feed_entry), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>
     <% if policy(@post).destroy? %>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -261,6 +261,20 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_operator response.body.index(newer_dom), :<, response.body.index(older_dom)
   end
 
+  test "#show should limit imported posts to MAX_RECENT_POSTS" do
+    sign_in_as user
+    feed = create(:feed, user: user)
+    event = create(:event, type: "feed_refresh", user: user, subject: feed)
+    posts = create_list(:post, EventsController::MAX_RECENT_POSTS + 2, feed: feed)
+    posts.each { |post| create(:event_reference, event: event, reference: post) }
+
+    get event_path(event)
+
+    assert_response :success
+    rendered = posts.count { |post| response.body.include?(ActionView::RecordIdentifier.dom_id(post)) }
+    assert_equal EventsController::MAX_RECENT_POSTS, rendered
+  end
+
   test "#show should not render the imported posts section without references" do
     sign_in_as user
     event = create(:event, type: "feed_refresh", user: user)


### PR DESCRIPTION
Changes:

- Drop the "Back to Posts" and "Back to Admin" navigation buttons
- Drop the `font-medium` class from the values in the post details list
- Limit the posts shown on the event page to 10 and rename "Imported Posts" to "Recent Posts"

A few small UI cleanups: the back buttons were redundant given browser history, the post detail values read better without the extra weight, and the event page no longer renders an unbounded list of imported posts.
