### PR TITLE
Add import threshold feature to skip older posts

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -200,6 +200,9 @@ class FeedsController < ApplicationController
       :llm_credential_id,
       :cron_expression,
       :schedule_interval,
+      :import_after_enabled,
+      :import_after_date,
+      :import_after_time,
       # Only the known input-shape keys are accepted. Anything
       # else inside the params hash would otherwise persist into
       # `feeds.params` jsonb undetected. See the profile schemas.
@@ -217,7 +220,10 @@ class FeedsController < ApplicationController
   # lock in for the rest of the feed's lifetime regardless of later
   # pause/resume. Strong params silently drops them for non-drafts.
   def update_feed_params
-    always_permitted = %i[name description target_group access_token_id llm_credential_id schedule_interval]
+    always_permitted = %i[
+      name description target_group access_token_id llm_credential_id schedule_interval
+      import_after_enabled import_after_date import_after_time
+    ]
     draft_only_permitted = [:url, :feed_profile_key, { params: %i[url query] }]
 
     permitted_keys = @feed&.draft? ? always_permitted + draft_only_permitted : always_permitted

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+import "flowbite"
+
+// Attaches the Flowbite datepicker to its input. Flowbite only auto-inits
+// `datepicker` attributes on turbo:load, which never fires for markup
+// injected via Turbo Streams (e.g. the expanded feed form), so inputs opt
+// in through this controller instead.
+export default class extends Controller {
+  static values = { format: { type: String, default: "yyyy-mm-dd" } }
+
+  connect() {
+    if (!window.Datepicker || this.element.datepicker) return
+
+    this.picker = new window.Datepicker(
+      this.element,
+      { format: this.formatValue, autohide: true },
+      { id: this.element.id || this.element.name, override: true }
+    )
+  }
+
+  disconnect() {
+    if (this.picker) {
+      this.picker.destroyAndRemoveInstance()
+      this.picker = null
+    }
+  }
+}

--- a/app/javascript/controllers/field_toggle_controller.js
+++ b/app/javascript/controllers/field_toggle_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Shows a panel of inputs while a checkbox is checked; hides the panel and
+// clears the inputs when it's unchecked.
+export default class extends Controller {
+  static targets = ["checkbox", "panel", "input"]
+
+  connect() {
+    this.update()
+  }
+
+  toggle() {
+    this.update({ clearWhenHidden: true })
+  }
+
+  update({ clearWhenHidden = false } = {}) {
+    const enabled = this.checkboxTarget.checked
+    this.panelTarget.classList.toggle("hidden", !enabled)
+
+    if (!enabled && clearWhenHidden) {
+      this.inputTargets.forEach((input) => { input.value = "" })
+    }
+  }
+}

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -63,6 +63,7 @@ class Feed < ApplicationRecord
   normalizes :target_group, with: ->(group) { group.present? ? group.to_s.strip.downcase : nil }
 
   validate :cron_expression_is_valid
+  validate :import_after_parts_are_valid
   validate :params_against_profile_schema
   validate :llm_credential_belongs_to_user
   validate :access_token_belongs_to_user
@@ -98,6 +99,39 @@ class Feed < ApplicationRecord
 
   def schedule_display
     SCHEDULE_INTERVALS.dig(schedule_interval, :display) || cron_expression
+  end
+
+  # Form-facing accessors splitting import_after into a checkbox plus
+  # separate date and time inputs. The checkbox drives everything: when it's
+  # off, import_after resets to nil no matter what the date and time fields
+  # contain.
+  def import_after_enabled
+    return @import_after_enabled unless @import_after_enabled.nil?
+
+    import_after.present?
+  end
+
+  def import_after_enabled=(value)
+    @import_after_enabled = ActiveModel::Type::Boolean.new.cast(value) || false
+    recompose_import_after
+  end
+
+  def import_after_date
+    @import_after_date || import_after&.strftime("%Y-%m-%d")
+  end
+
+  def import_after_date=(value)
+    @import_after_date = value.to_s.strip
+    recompose_import_after
+  end
+
+  def import_after_time
+    @import_after_time || import_after&.strftime("%H:%M")
+  end
+
+  def import_after_time=(value)
+    @import_after_time = value.to_s.strip
+    recompose_import_after
   end
 
   # Link to the target group on its FreeFeed instance. Post#freefeed_url
@@ -287,6 +321,30 @@ class Feed < ApplicationRecord
   end
 
   private
+
+  def recompose_import_after
+    self.import_after = compose_import_after
+  end
+
+  def compose_import_after
+    return nil unless import_after_enabled
+    return nil if import_after_date.blank?
+
+    Time.zone.strptime("#{import_after_date} #{import_after_time.presence || '00:00'}", "%Y-%m-%d %H:%M")
+  rescue ArgumentError
+    nil
+  end
+
+  def import_after_parts_are_valid
+    return unless import_after_enabled
+    return if import_after.present?
+
+    if import_after_date.blank?
+      errors.add(:import_after, "needs a date")
+    else
+      errors.add(:import_after, "isn't a valid date and time")
+    end
+  end
 
   def cron_expression_is_valid
     return if cron_expression.blank?

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -56,7 +56,24 @@ class FeedRefreshWorkflow
 
     uids = processed_entries.map(&:uid)
     existing_uids = FeedEntryUid.where(feed_id: feed.id, uid: uids).pluck(:uid).to_set
-    processed_entries.filter { |entry| existing_uids.exclude?(entry.uid) }
+    new_entries = processed_entries.filter { |entry| existing_uids.exclude?(entry.uid) }
+    reject_entries_before_threshold(new_entries)
+  end
+
+  # Entries at or before the feed's import threshold are dropped without
+  # recording their UIDs, so clearing the threshold later lets them import
+  # on a subsequent refresh. Entries without a published date pass through:
+  # we can't tell how old they are, and silently losing them is worse.
+  def reject_entries_before_threshold(entries)
+    threshold = feed.import_after
+    return entries if threshold.blank?
+
+    fresh_entries, stale_entries = entries.partition do |entry|
+      entry.published_at.nil? || entry.published_at > threshold
+    end
+
+    record_stats(entries_before_threshold: stale_entries.size) if stale_entries.any?
+    fresh_entries
   end
 
   def persist_entries(new_entries)

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -9,6 +9,7 @@
       ["buttons", "Buttons"],
       ["text-input", "Text input"],
       ["select", "Select"],
+      ["date-time", "Date & time"],
       ["checkbox", "Checkbox"],
       ["radio-group", "Radio group"],
       ["form-group", "Form group"]
@@ -137,6 +138,51 @@
         <div class="space-y-2">
           <p class="<%= caption_classes %>">Disabled</p>
           <%= select_tag :frequency_disabled, options_for_select(["Every hour"]), disabled: true, class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
+        </div>
+      </div>
+    </section>
+
+    <%# Date & time %>
+    <section id="date-time" class="scroll-mt-6 space-y-4" data-key="section.date-time">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Date & time</h2>
+      <p class="text-slate-600">A calendar picker for dates and the native time input for clock times. The date input mounts the Flowbite datepicker through the <code>datepicker</code> Stimulus controller, so it also works in markup injected via Turbo Streams.</p>
+
+      <div class="grid gap-6 sm:grid-cols-2">
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Date picker</p>
+          <div class="relative">
+            <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+              <%= icon("calendar", css_class: "size-5 text-slate-400") %>
+            </div>
+            <%= text_field_tag :demo_date, nil, placeholder: "Pick a date", autocomplete: "off", class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", data: { controller: "datepicker" } %>
+          </div>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Date picker (filled)</p>
+          <div class="relative">
+            <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+              <%= icon("calendar", css_class: "size-5 text-slate-400") %>
+            </div>
+            <%= text_field_tag :demo_date_filled, Date.current.iso8601, autocomplete: "off", class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2", data: { controller: "datepicker" } %>
+          </div>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Time picker</p>
+          <div class="relative">
+            <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+              <%= icon("clock", css_class: "size-5 text-slate-400") %>
+            </div>
+            <%= time_field_tag :demo_time, "09:30", class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" %>
+          </div>
+        </div>
+        <div class="space-y-2">
+          <p class="<%= caption_classes %>">Time picker (disabled)</p>
+          <div class="relative">
+            <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+              <%= icon("clock", css_class: "size-5 text-slate-400") %>
+            </div>
+            <%= time_field_tag :demo_time_disabled, "09:30", disabled: true, class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed" %>
+          </div>
         </div>
       </div>
     </section>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -163,6 +163,71 @@
           </div>
         </div>
       </div>
+
+      <details class="group rounded-md border border-slate-200"
+               <%= "open" if feed.import_after_enabled || f.object.errors[:import_after].any? %>
+               data-key="form.advanced-options">
+        <summary class="flex cursor-pointer select-none items-center justify-between gap-2 px-4 py-3 font-semibold text-slate-800 marker:content-none [&::-webkit-details-marker]:hidden">
+          Advanced options
+          <%= icon("chevron-down", css_class: "size-5 text-slate-400 transition group-open:rotate-180") %>
+        </summary>
+
+        <div class="space-y-6 border-t border-slate-200 px-4 py-4" data-controller="field-toggle">
+          <div class="flex items-start">
+            <div class="flex h-6 items-center">
+              <%= f.check_box :import_after_enabled,
+                              data: {
+                                field_toggle_target: "checkbox",
+                                action: "change->field-toggle#toggle",
+                                key: "form.import-after-enabled"
+                              } %>
+            </div>
+            <div class="ml-3">
+              <%= f.label :import_after_enabled, "Skip older posts", class: "block font-semibold text-slate-800 mb-0" %>
+              <p class="text-sm text-slate-500">Only import posts published after a date you pick.</p>
+            </div>
+          </div>
+
+          <div class="space-y-2 <%= "hidden" unless feed.import_after_enabled %>"
+               data-field-toggle-target="panel"
+               data-key="form.import-after-fields">
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="relative">
+                <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+                  <%= icon("calendar", css_class: "size-5 text-slate-400") %>
+                </div>
+                <%= f.text_field :import_after_date,
+                                 placeholder: "Pick a date",
+                                 autocomplete: "off",
+                                 class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                                 aria: { label: "Import posts published after this date" },
+                                 data: {
+                                   controller: "datepicker",
+                                   field_toggle_target: "input",
+                                   key: "form.import-after-date"
+                                 } %>
+              </div>
+              <div class="relative">
+                <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+                  <%= icon("clock", css_class: "size-5 text-slate-400") %>
+                </div>
+                <%= f.time_field :import_after_time,
+                                 class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                                 aria: { label: "Import posts published after this time" },
+                                 data: {
+                                   field_toggle_target: "input",
+                                   key: "form.import-after-time"
+                                 } %>
+              </div>
+            </div>
+            <% if f.object.errors[:import_after].any? %>
+              <p class="text-sm text-red-600"><%= f.object.errors[:import_after].to_sentence.capitalize %></p>
+            <% else %>
+              <p class="text-sm text-slate-500">Posts published before this moment will be skipped. Time is UTC.</p>
+            <% end %>
+          </div>
+        </div>
+      </details>
     </div>
 
     <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">

--- a/test/controllers/development/components_controller_test.rb
+++ b/test/controllers/development/components_controller_test.rb
@@ -17,6 +17,9 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select '[data-key="toc"]'
     assert_select '[data-key="section.buttons"]'
+    assert_select '[data-key="section.date-time"]'
+    assert_select '[data-key="section.date-time"] input[data-controller="datepicker"]'
+    assert_select '[data-key="section.date-time"] input[type="time"]'
     assert_select '[data-key="section.form-group"]'
     assert_select '[data-key="section.page-header"]'
     assert_select '[data-key="section.event-description"]'

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -545,6 +545,101 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "2h", feed.schedule_interval
   end
 
+  test "#edit should render collapsed advanced options when no import threshold is set" do
+    sign_in_as(user)
+
+    get edit_feed_url(feed)
+
+    assert_response :success
+    assert_select 'details[data-key="form.advanced-options"]:not([open])'
+    assert_select '[data-key="form.import-after-fields"].hidden'
+    assert_select 'input[name="feed[import_after_enabled]"][type=checkbox][checked]', false
+  end
+
+  test "#edit should expand advanced options when an import threshold is set" do
+    sign_in_as(user)
+    feed.update!(import_after: Time.utc(2026, 1, 15, 10, 30))
+
+    get edit_feed_url(feed)
+
+    assert_response :success
+    assert_select 'details[data-key="form.advanced-options"][open]'
+    assert_select 'input[name="feed[import_after_enabled]"][type=checkbox][checked]'
+    assert_select 'input[data-key="form.import-after-date"][value="2026-01-15"]'
+    assert_select 'input[data-key="form.import-after-time"][value="10:30"]'
+  end
+
+  test "#update should set import_after from threshold params" do
+    sign_in_as(user)
+
+    patch feed_url(feed), params: {
+      feed: {
+        import_after_enabled: "1",
+        import_after_date: "2026-01-15",
+        import_after_time: "10:30"
+      }
+    }
+
+    assert_redirected_to feed_path(feed)
+    assert_equal Time.zone.parse("2026-01-15 10:30"), feed.reload.import_after
+  end
+
+  test "#update should clear import_after when threshold checkbox is unchecked" do
+    sign_in_as(user)
+    feed.update!(import_after: Time.utc(2026, 1, 15, 10, 30))
+
+    patch feed_url(feed), params: {
+      feed: {
+        import_after_enabled: "0",
+        import_after_date: "2026-01-15",
+        import_after_time: "10:30"
+      }
+    }
+
+    assert_redirected_to feed_path(feed)
+    assert_nil feed.reload.import_after
+  end
+
+  test "#update should rerender with an error for an invalid threshold date" do
+    sign_in_as(user)
+
+    patch feed_url(feed), params: {
+      feed: {
+        import_after_enabled: "1",
+        import_after_date: "not-a-date",
+        import_after_time: ""
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select 'details[data-key="form.advanced-options"][open]'
+    assert_match "Isn&#39;t a valid date and time", response.body
+    assert_nil feed.reload.import_after
+  end
+
+  test "#create should accept import threshold params" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "Test Feed",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h",
+      import_after_enabled: "1",
+      import_after_date: "2026-01-15",
+      import_after_time: "10:30"
+    }
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: { feed: feed_params, enable_feed: "0" }
+    end
+
+    assert_equal Time.zone.parse("2026-01-15 10:30"), Feed.last.import_after
+  end
+
   test "#update should show additional message for enabled feeds" do
     sign_in_as(user)
     enabled_feed = create(:feed, user: user, state: :enabled, access_token: access_token)

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -847,4 +847,85 @@ class FeedTest < ActiveSupport::TestCase
 
     assert_equal 2, feed.posts_published_last_week_count
   end
+
+  test "#import_after_enabled should default to false when import_after is blank" do
+    feed = build(:feed)
+
+    assert_not feed.import_after_enabled
+  end
+
+  test "#import_after_enabled should be true when import_after is set" do
+    feed = build(:feed, import_after: Time.utc(2026, 1, 15, 10, 30))
+
+    assert feed.import_after_enabled
+    assert_equal "2026-01-15", feed.import_after_date
+    assert_equal "10:30", feed.import_after_time
+  end
+
+  test "#import_after_enabled= should compose import_after from date and time parts" do
+    feed = build(:feed)
+    feed.assign_attributes(
+      import_after_enabled: "1",
+      import_after_date: "2026-01-15",
+      import_after_time: "10:30"
+    )
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+    assert_equal Time.zone.parse("2026-01-15 10:30"), feed.import_after
+  end
+
+  test "#import_after_enabled= should default time to midnight when blank" do
+    feed = build(:feed)
+    feed.assign_attributes(
+      import_after_enabled: "1",
+      import_after_date: "2026-01-15",
+      import_after_time: ""
+    )
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+    assert_equal Time.zone.parse("2026-01-15 00:00"), feed.import_after
+  end
+
+  test "#import_after_enabled= should reset import_after when disabled" do
+    feed = build(:feed, import_after: Time.utc(2026, 1, 15, 10, 30))
+    feed.assign_attributes(
+      import_after_enabled: "0",
+      import_after_date: "2026-01-15",
+      import_after_time: "10:30"
+    )
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+    assert_nil feed.import_after
+  end
+
+  test "should require a date when import threshold is enabled" do
+    feed = build(:feed)
+    feed.assign_attributes(import_after_enabled: "1", import_after_date: "", import_after_time: "")
+
+    assert_not feed.valid?
+    assert_includes feed.errors[:import_after], "needs a date"
+    assert_nil feed.import_after
+  end
+
+  test "should reject an unparseable import threshold date" do
+    feed = build(:feed)
+    feed.assign_attributes(import_after_enabled: "1", import_after_date: "not-a-date", import_after_time: "10:30")
+
+    assert_not feed.valid?
+    assert_includes feed.errors[:import_after], "isn't a valid date and time"
+    assert_nil feed.import_after
+  end
+
+  test "#import_after_date should return the submitted value after a failed validation" do
+    feed = build(:feed)
+    feed.assign_attributes(import_after_enabled: "1", import_after_date: "not-a-date")
+
+    assert_equal "not-a-date", feed.import_after_date
+  end
+
+  test "should stay valid when import_after is set directly without parts" do
+    feed = build(:feed, import_after: Time.utc(2026, 1, 15))
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
 end

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -188,6 +188,62 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 1, workflow.stats[:new_posts]
   end
 
+  test "#execute should skip entries published at or before the import threshold" do
+    test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss", import_after: 3.hours.ago)
+
+    sample_rss = <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Test Feed</title>
+          <item>
+            <guid>old-entry</guid>
+            <title>Old Entry</title>
+            <description>Published before the threshold</description>
+            <link>https://example.com/old</link>
+            <pubDate>#{5.hours.ago.rfc822}</pubDate>
+          </item>
+          <item>
+            <guid>fresh-entry</guid>
+            <title>Fresh Entry</title>
+            <description>Published after the threshold</description>
+            <link>https://example.com/fresh</link>
+            <pubDate>#{1.hour.ago.rfc822}</pubDate>
+          </item>
+        </channel>
+      </rss>
+    RSS
+
+    WebMock.stub_request(:get, test_feed.url).to_return(body: sample_rss, status: 200)
+
+    workflow = FeedRefreshWorkflow.new(test_feed)
+    result = workflow.execute
+
+    assert_equal 1, result.length
+    assert_equal ["fresh-entry"], FeedEntry.where(feed: test_feed).pluck(:uid)
+
+    # Skipped entries leave no UID record, so they can still import later
+    # if the threshold is cleared.
+    assert_equal ["fresh-entry"], FeedEntryUid.where(feed: test_feed).pluck(:uid)
+
+    assert_equal 2, workflow.stats[:total_entries]
+    assert_equal 1, workflow.stats[:new_entries]
+    assert_equal 1, workflow.stats[:entries_before_threshold]
+  end
+
+  test "#filter_new_entries should keep entries without a published date despite the import threshold" do
+    test_feed = create(:feed, import_after: 1.hour.ago)
+    workflow = FeedRefreshWorkflow.new(test_feed)
+
+    undated_entry = FeedEntry.new(feed: test_feed, uid: "undated-entry", published_at: nil)
+    stale_entry = FeedEntry.new(feed: test_feed, uid: "old-entry", published_at: 2.hours.ago)
+
+    result = workflow.send(:filter_new_entries, [undated_entry, stale_entry])
+
+    assert_equal ["undated-entry"], result.map(&:uid)
+    assert_equal 1, workflow.stats[:entries_before_threshold]
+  end
+
   test "#execute should handle HTTP loading errors gracefully" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 


### PR DESCRIPTION
Changes:

- Add `import_after` timestamp field to feeds to allow skipping posts published before a cutoff date
- Implement form UI with collapsible "Advanced options" section containing date/time pickers for setting the threshold
- Add virtual attributes (`import_after_enabled`, `import_after_date`, `import_after_time`) to compose/decompose the timestamp for form handling
- Validate that a date is provided when the threshold is enabled, and that the date/time can be parsed
- Filter feed entries during refresh to skip those published at or before the threshold (without recording their UIDs, allowing re-import if threshold is cleared later)
- Entries without a published date pass through the filter regardless of threshold
- Add Stimulus controllers for date picker integration (`datepicker_controller`) and conditional field visibility (`field_toggle_controller`)
- Update component library documentation with date/time input examples
- Add comprehensive test coverage for form behavior, validation, and entry filtering

The threshold feature lets users avoid re-importing old content when setting up a feed, while keeping the UI clean by hiding advanced options when not in use.
