### PR TITLE
Return 204 during polling to avoid resetting spinner

### DIFF
--- a/app/controllers/access_tokens/validations_controller.rb
+++ b/app/controllers/access_tokens/validations_controller.rb
@@ -3,6 +3,10 @@ class AccessTokens::ValidationsController < ApplicationController
     access_token = find_access_token
     authorize access_token, policy_class: AccessTokenPolicy
 
+    # Stay silent while validation is still in flight so the poller leaves the
+    # spinner running instead of redrawing (and restarting) it every cycle.
+    return head :no_content if access_token.pending? || access_token.validating?
+
     render turbo_stream: turbo_stream.update(
       "access-token-show",
       partial: "access_tokens/show_content",

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -78,7 +78,7 @@ class FeedIdentificationsController < ApplicationController
       return render(identification_error(error: "Feed identification is taking longer than expected. The feed URL may not be responding. Please try again."))
     end
 
-    render(identification_loading)
+    head :no_content
   end
 
   def handle_success_status

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -19,10 +19,11 @@ class FeedPreviewsController < ApplicationController
     preview = locate_preview
     preview = start_run(preview) if needs_run?(preview)
     preview.timeout! if preview.timed_out?
-    render_state(preview)
+    render_state(preview, inert_while_running: true)
   end
 
-  # POST /feed_preview — explicit refresh: always start a fresh run.
+  # POST /feed_preview — explicit refresh: always start a fresh run. Renders the
+  # processing pane (never inert) so the refresh shows the spinner restarting.
   def create
     render_state(start_run(locate_preview))
   end
@@ -93,13 +94,21 @@ class FeedPreviewsController < ApplicationController
     !Current.user.llm_credentials.active.exists?
   end
 
-  def render_state(preview)
+  def render_state(preview, inert_while_running: false)
     respond_to do |format|
       format.html { render :show, locals: { preview: preview } }
       # Swap only the inner body so the polling host (rendered by `show`) stays
       # mounted across polls; ready/failed bodies carry `data-preview-done`,
-      # which trips the poller's stop-condition.
-      format.turbo_stream { render turbo_stream: turbo_stream.update("feed-preview-body", **state_partial(preview)) }
+      # which trips the poller's stop-condition. While a run is still in flight
+      # the poll stays silent so the spinner keeps its animation instead of
+      # being redrawn every cycle.
+      format.turbo_stream do
+        if inert_while_running && (preview.pending? || preview.processing?)
+          head :no_content
+        else
+          render turbo_stream: turbo_stream.update("feed-preview-body", **state_partial(preview))
+        end
+      end
     end
   end
 

--- a/app/controllers/llm_credentials/validations_controller.rb
+++ b/app/controllers/llm_credentials/validations_controller.rb
@@ -3,6 +3,10 @@ class LlmCredentials::ValidationsController < ApplicationController
     llm_credential = scope.find(params[:llm_credential_id])
     authorize llm_credential, :show?, policy_class: LlmCredentialPolicy
 
+    # Stay silent while validation is still in flight so the poller leaves the
+    # spinner running instead of redrawing (and restarting) it every cycle.
+    return head :no_content if llm_credential.pending? || llm_credential.validating?
+
     render turbo_stream: turbo_stream.update(
       "llm-credential-show",
       partial: "llm_credentials/show_content",

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,4 +1,7 @@
 class AccessToken < ApplicationRecord
+  VALIDATION_POLLING_INTERVAL_MS = 2000
+  VALIDATION_POLLING_MAX_POLLS = 35
+
   belongs_to :user
   has_many :feeds
   has_one :access_token_detail, dependent: :destroy

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -3,7 +3,6 @@ class Feed < ApplicationRecord
   DESCRIPTION_MAX_LENGTH = 100
   TARGET_GROUP_PATTERN = /\A[a-z0-9_-]+\z/.freeze
   TARGET_GROUP_MAX_LENGTH = 80
-  IDENTIFICATION_POLLING_INTERVAL_MS = 2000
 
   SUPPORTED_METRICS = %i[
     posts_count

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -1,5 +1,12 @@
 class FeedIdentification < ApplicationRecord
   IDENTIFICATION_TIMEOUT_SECONDS = 30
+  POLLING_INTERVAL_MS = 2000
+
+  # Poll a couple of cycles past the server-side timeout so a request lands
+  # inside the timed_out? window and renders the friendly error. Matching the
+  # timeout exactly lets the client hit its poll cap first and freeze the
+  # spinner with no message.
+  POLLING_MAX_POLLS = (IDENTIFICATION_TIMEOUT_SECONDS * 1000 / POLLING_INTERVAL_MS) + 2
 
   belongs_to :user
 

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -1,6 +1,8 @@
 class FeedPreview < ApplicationRecord
   PREVIEW_POSTS_LIMIT = 10
   PREVIEW_TIMEOUT_SECONDS = 120
+  POLLING_INTERVAL_MS = 2000
+  POLLING_MAX_POLLS = 75
 
   belongs_to :user
   belongs_to :feed, optional: true

--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -4,6 +4,8 @@
 # encrypted at rest.
 class LlmCredential < ApplicationRecord
   DISPLAY_NAME_MAX_LENGTH = 80
+  VALIDATION_POLLING_INTERVAL_MS = 2000
+  VALIDATION_POLLING_MAX_POLLS = 35
 
   belongs_to :user
   # `dependent` is handled manually by `disable_dependent_feeds` so we can

--- a/app/views/access_tokens/show.html.erb
+++ b/app/views/access_tokens/show.html.erb
@@ -4,8 +4,8 @@
   <div
     data-controller="polling"
     data-polling-endpoint-value="<%= access_token_validation_path(@access_token, feed_id: @feed&.id) %>"
-    data-polling-interval-value="2000"
-    data-polling-max-polls-value="35"
+    data-polling-interval-value="<%= AccessToken::VALIDATION_POLLING_INTERVAL_MS %>"
+    data-polling-max-polls-value="<%= AccessToken::VALIDATION_POLLING_MAX_POLLS %>"
     data-polling-stop-condition-value="[data-status]"
     aria-busy="true">
     <div id="access-token-show" class="space-y-8">

--- a/app/views/feed_previews/show.html.erb
+++ b/app/views/feed_previews/show.html.erb
@@ -6,7 +6,8 @@
   <div data-controller="polling"
        data-polling-endpoint-value="<%= feed_preview_path(profile_key: preview.feed_profile_key, "params" => preview.params, format: :turbo_stream) %>"
        data-polling-stop-condition-value="[data-preview-done]"
-       data-polling-max-polls-value="75">
+       data-polling-interval-value="<%= FeedPreview::POLLING_INTERVAL_MS %>"
+       data-polling-max-polls-value="<%= FeedPreview::POLLING_MAX_POLLS %>">
     <div id="feed-preview-body" data-polling-target="content">
       <% case preview.status %>
       <% when "ready" %>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -3,8 +3,8 @@
      role="status"
      data-controller="polling"
      data-polling-endpoint-value="<%= feed_identifications_path(input: input) %>"
-     data-polling-interval-value="<%= Feed::IDENTIFICATION_POLLING_INTERVAL_MS %>"
-     data-polling-max-polls-value="<%= FeedIdentification::IDENTIFICATION_TIMEOUT_SECONDS / 2 %>"
+     data-polling-interval-value="<%= FeedIdentification::POLLING_INTERVAL_MS %>"
+     data-polling-max-polls-value="<%= FeedIdentification::POLLING_MAX_POLLS %>"
      data-polling-stop-condition-value="[data-identification-state='complete'], [data-identification-state='error']">
   <div class="flex-shrink-0">
     <%= render SpinnerComponent.new %>

--- a/app/views/llm_credentials/show.html.erb
+++ b/app/views/llm_credentials/show.html.erb
@@ -4,8 +4,8 @@
   <div
     data-controller="polling"
     data-polling-endpoint-value="<%= llm_credential_validation_path(@llm_credential, feed_id: @feed&.id) %>"
-    data-polling-interval-value="2000"
-    data-polling-max-polls-value="35"
+    data-polling-interval-value="<%= LlmCredential::VALIDATION_POLLING_INTERVAL_MS %>"
+    data-polling-max-polls-value="<%= LlmCredential::VALIDATION_POLLING_MAX_POLLS %>"
     data-polling-stop-condition-value="[data-credential-state]"
     aria-busy="true">
     <div id="llm-credential-show" class="space-y-8">

--- a/test/controllers/access_tokens/validations_controller_test.rb
+++ b/test/controllers/access_tokens/validations_controller_test.rb
@@ -14,7 +14,8 @@ class AccessTokens::ValidationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
-  test "#show should respond with turbo_stream format" do
+  test "#show should respond with turbo_stream format once validation resolves" do
+    access_token.update!(status: :active)
     sign_in_as user
     get access_token_validation_path(access_token)
 
@@ -22,12 +23,21 @@ class AccessTokens::ValidationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "text/vnd.turbo-stream.html; charset=utf-8", response.content_type
   end
 
-  test "#show should update access-token-show div" do
+  test "#show should update access-token-show div once validation resolves" do
+    access_token.update!(status: :active)
     sign_in_as user
     get access_token_validation_path(access_token)
 
     assert_response :success
     assert_match /turbo-stream.*action="update".*target="access-token-show"/, response.body
+  end
+
+  test "#show should return no content while pending" do
+    sign_in_as user
+    get access_token_validation_path(access_token)
+
+    assert_response :no_content
+    assert_empty response.body
   end
 
   test "#show should not render for other user's token" do
@@ -38,13 +48,13 @@ class AccessTokens::ValidationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "#show should show validating state" do
+  test "#show should return no content while validating" do
     access_token.update!(status: :validating)
     sign_in_as user
     get access_token_validation_path(access_token)
 
-    assert_response :success
-    assert_match /Validating token/, response.body
+    assert_response :no_content
+    assert_empty response.body
   end
 
   test "#show should show active state with data-status attribute" do

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -157,7 +157,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
-  test "#show should return processing state when status is processing" do
+  test "#show should return no content while still processing" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
 
@@ -167,8 +167,8 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     # Check status while still processing (don't perform jobs)
     get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
-    assert_response :success
-    assert_includes response.body, "Checking this feed"
+    assert_response :no_content
+    assert_empty response.body
   end
 
   test "#show should return invalid session error when started_at is missing" do

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -120,6 +120,30 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     assert user.feed_previews.last.pending?
   end
 
+  test "#show should return no content while the preview is still processing" do
+    sign_in_as(user)
+    create(:feed_preview, :processing, user: user, feed_profile_key: "rss",
+                                       params: { "url" => "http://example.com/feed.xml" })
+
+    assert_no_enqueued_jobs do
+      get feed_preview_url(profile_key: "rss", "params" => { url: "http://example.com/feed.xml" }),
+          headers: TURBO_STREAM
+    end
+
+    assert_response :no_content
+    assert_empty response.body
+  end
+
+  test "#create should render the processing pane even though show polls stay silent" do
+    sign_in_as(user)
+
+    post feed_preview_url(profile_key: "rss", "params" => { url: "http://example.com/feed.xml" }),
+         headers: TURBO_STREAM
+
+    assert_response :success
+    assert_match(/data-key="preview.processing"/, response.body)
+  end
+
   test "#show should render the failed state without restarting a run" do
     sign_in_as(user)
     create(:feed_preview, :failed, user: user, feed_profile_key: "rss",

--- a/test/controllers/llm_credentials/validations_controller_test.rb
+++ b/test/controllers/llm_credentials/validations_controller_test.rb
@@ -18,10 +18,21 @@ class LlmCredentials::ValidationsControllerTest < ActionDispatch::IntegrationTes
     assert_redirected_to new_session_path
   end
 
-  test "#show should render the validation polling turbo stream for own credential" do
+  test "#show should return no content while still validating" do
     sign_in_as(user)
 
     get llm_credential_validation_url(credential),
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :no_content
+    assert_empty response.body
+  end
+
+  test "#show should render the validation turbo stream once it resolves" do
+    sign_in_as(user)
+    active = create(:llm_credential, :active, user: user)
+
+    get llm_credential_validation_url(active),
         headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -78,6 +78,15 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     refute_predicate identification, :timed_out?
   end
 
+  test "POLLING_MAX_POLLS should keep the client polling past the server timeout" do
+    client_coverage_ms = FeedIdentification::POLLING_MAX_POLLS * FeedIdentification::POLLING_INTERVAL_MS
+
+    assert_operator(
+      client_coverage_ms, :>, FeedIdentification::IDENTIFICATION_TIMEOUT_SECONDS * 1000,
+      "client must outlast the server timeout so the friendly error renders before it gives up"
+    )
+  end
+
   test "should accept multiple ranked candidates" do
     identification = FeedIdentification.create!(
       user: user,


### PR DESCRIPTION
Changes:

- Poll responses during feed identification now return 204 No Content instead of re-rendering the loading partial

While feed identification is processing, each poll was replacing the entire `#feed-form` element with a fresh copy of the loading partial — including a new `SpinnerComponent`. That restarted the spinner's CSS animation on every tick, causing a visible stutter every 2 seconds.

The polling controller already skips `Turbo.renderStreamMessage` when the response body is empty, and continues scheduling the next poll on any 2xx. A 204 slots in cleanly: the DOM is left untouched, the spinner keeps running, and polling continues until the job finishes.
