### PR TITLE
Remove Vacuum Stats from system status page

### DIFF
--- a/app/services/disk_usage_service.rb
+++ b/app/services/disk_usage_service.rb
@@ -16,7 +16,6 @@ class DiskUsageService
       other_used_percentage: other_used_percentage,
       free_percentage: free_percentage,
       table_usage: table_usage,
-      vacuum_stats: vacuum_stats,
       autovacuum_settings: autovacuum_settings
     }
   end
@@ -98,24 +97,6 @@ class DiskUsageService
         AND pg_class.relkind = 'r'
       ORDER BY
         pg_total_relation_size(pg_class.oid) DESC;
-    SQL
-    ).to_a
-  end
-
-  def vacuum_stats
-    execute_query(<<-SQL
-      SELECT
-        relname,
-        n_live_tup,
-        n_dead_tup,
-        last_vacuum,
-        last_autovacuum,
-        vacuum_count,
-        autovacuum_count
-      FROM
-        pg_stat_user_tables
-      ORDER BY
-        n_dead_tup DESC;
     SQL
     ).to_a
   end

--- a/app/views/development/system_status/show.html.erb
+++ b/app/views/development/system_status/show.html.erb
@@ -92,38 +92,6 @@
   </section>
 
   <section class="space-y-4">
-    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Vacuum Stats</h2>
-    <div class="overflow-x-auto rounded-lg border border-slate-200">
-      <table class="w-full text-left text-sm text-slate-700">
-        <thead class="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600">
-          <tr class="hover:bg-slate-50">
-            <th scope="col" class="px-6 py-3">Table</th>
-            <th scope="col" class="px-6 py-3 text-right">Live Tuples</th>
-            <th scope="col" class="px-6 py-3 text-right">Dead Tuples</th>
-            <th scope="col" class="px-6 py-3">Last Vacuum</th>
-            <th scope="col" class="px-6 py-3">Last Autovacuum</th>
-            <th scope="col" class="px-6 py-3 text-right">Vacuum Count</th>
-            <th scope="col" class="px-6 py-3 text-right">Autovacuum Count</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-slate-200 bg-white">
-          <% @disk_usage[:vacuum_stats].each do |row| %>
-            <tr class="hover:bg-slate-50">
-              <td class="px-6 py-4 whitespace-nowrap font-mono text-sm"><%= row["relname"] %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-right"><%= number_with_delimiter(row["n_live_tup"]) %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-right"><%= number_with_delimiter(row["n_dead_tup"]) %></td>
-              <td class="px-6 py-4 whitespace-nowrap"><%= short_time_ago_tag(row["last_vacuum"]) %></td>
-              <td class="px-6 py-4 whitespace-nowrap"><%= short_time_ago_tag(row["last_autovacuum"]) %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-right"><%= row["vacuum_count"] %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-right"><%= row["autovacuum_count"] %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </section>
-
-  <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Autovacuum Settings</h2>
     <%= render(DescriptionListComponent.new) do |list| %>
       <% @disk_usage[:autovacuum_settings].each do |row| %>

--- a/test/services/disk_usage_service_test.rb
+++ b/test/services/disk_usage_service_test.rb
@@ -41,21 +41,6 @@ class DiskUsageServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test "#call should return vacuum stats as array" do
-    service = DiskUsageService.new(df_command: stub_df_command)
-    result = service.call
-
-    assert_instance_of Array, result[:vacuum_stats]
-    assert result[:vacuum_stats].all? { |row| row.is_a?(Hash) }
-
-    if result[:vacuum_stats].any?
-      first_row = result[:vacuum_stats].first
-      assert first_row.key?("relname")
-      assert first_row.key?("n_live_tup")
-      assert first_row.key?("n_dead_tup")
-    end
-  end
-
   test "#call should return autovacuum settings as array" do
     service = DiskUsageService.new(df_command: stub_df_command)
     result = service.call


### PR DESCRIPTION
Changes:

- Remove the "Vacuum Stats" section from the system status development page
- Drop the now-unused `vacuum_stats` query and test from `DiskUsageService`

The vacuum statistics table is no longer needed on the system status page. The Autovacuum Settings section stays in place for monitoring autovacuum configuration.
