### PR TITLE
Tidy up access token and credential card menus

### DIFF
--- a/app/components/access_token_card_component.html.erb
+++ b/app/components/access_token_card_component.html.erb
@@ -1,41 +1,10 @@
 <div id="<%= helpers.dom_id(access_token) %>"
      class="w-full rounded-lg border border-slate-200 bg-white shadow-xs"
      data-key="settings.access_tokens.<%= access_token.id %>">
-  <div class="flex items-start justify-between gap-4 px-5 py-4">
+  <div class="flex items-start px-5 py-4">
     <div class="flex min-w-0 items-center gap-2">
       <%= link_to access_token.name, token_url,
             class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
-    </div>
-
-    <div class="relative">
-      <button type="button"
-              id="<%= menu_id %>-button"
-              data-dropdown-toggle="<%= menu_id %>"
-              data-dropdown-placement="bottom-end"
-              class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
-              aria-haspopup="true"
-              aria-expanded="false">
-        <%= helpers.icon("ellipsis", css_class: "size-4") %>
-        <span class="sr-only">More options</span>
-      </button>
-      <div id="<%= menu_id %>"
-           class="z-20 hidden w-40 rounded-lg border border-slate-200 bg-white shadow-sm"
-           role="menu"
-           aria-labelledby="<%= menu_id %>-button">
-        <ul class="py-1">
-          <li>
-            <%= link_to "Edit", edit_url,
-                  class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
-                  role: "menuitem" %>
-          </li>
-          <li>
-            <%= link_to "Delete", "#",
-                  class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
-                  role: "menuitem",
-                  data: { controller: "modal-trigger", modal_trigger_modal_id_value: delete_modal_id, action: "click->modal-trigger#open" } %>
-          </li>
-        </ul>
-      </div>
     </div>
   </div>
 
@@ -51,6 +20,40 @@
         <span>Never used</span>
       <% end %>
     </div>
-    <span class="text-sm text-slate-400"><%= status_label %></span>
+
+    <div class="flex items-center gap-3">
+      <span class="text-sm text-slate-400"><%= status_label %></span>
+
+      <div class="relative shrink-0">
+        <button type="button"
+                id="<%= menu_id %>-button"
+                data-dropdown-toggle="<%= menu_id %>"
+                data-dropdown-placement="bottom-end"
+                class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+                aria-haspopup="true"
+                aria-expanded="false">
+          <%= helpers.icon("ellipsis", css_class: "size-4") %>
+          <span class="sr-only">More options</span>
+        </button>
+        <div id="<%= menu_id %>"
+             class="z-20 hidden w-40 rounded-lg border border-slate-200 bg-white shadow-sm"
+             role="menu"
+             aria-labelledby="<%= menu_id %>-button">
+          <ul class="py-1">
+            <li>
+              <%= link_to "Edit", edit_url,
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem" %>
+            </li>
+            <li>
+              <%= link_to "Delete", "#",
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem",
+                    data: { controller: "modal-trigger", modal_trigger_modal_id_value: delete_modal_id, action: "click->modal-trigger#open" } %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/components/llm_credential_card_component.html.erb
+++ b/app/components/llm_credential_card_component.html.erb
@@ -39,21 +39,41 @@
              role="menu"
              aria-labelledby="<%= menu_id %>-button">
           <ul class="py-1">
+            <li>
+              <%= link_to credential_url,
+                    class: "flex items-center gap-2 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem" do %>
+                <%= helpers.icon("info", css_class: "size-4") %>
+                Details
+              <% end %>
+            </li>
+            <li>
+              <%= link_to edit_url,
+                    class: "flex items-center gap-2 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem" do %>
+                <%= helpers.icon("square-pen", css_class: "size-4") %>
+                Edit
+              <% end %>
+            </li>
             <% unless default? %>
               <li>
-                <%= link_to "Make default",
-                      helpers.llm_credential_default_path(credential),
+                <%= link_to helpers.llm_credential_default_path(credential),
                       data: { turbo_method: :patch },
-                      class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
-                      role: "menuitem" %>
+                      class: "flex items-center gap-2 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                      role: "menuitem" do %>
+                  <%= helpers.icon("star", css_class: "size-4") %>
+                  Make default
+                <% end %>
               </li>
             <% end %>
             <li>
-              <%= link_to "Delete",
-                    helpers.llm_credential_path(credential),
+              <%= link_to helpers.llm_credential_path(credential),
                     data: { turbo_method: :delete, turbo_confirm: "Delete this AI credential? Feeds using it will be disabled." },
-                    class: "block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50",
-                    role: "menuitem" %>
+                    class: "flex items-center gap-2 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem" do %>
+                <%= helpers.icon("trash-2", css_class: "size-4") %>
+                Delete
+              <% end %>
             </li>
           </ul>
         </div>

--- a/app/components/llm_credential_card_component.rb
+++ b/app/components/llm_credential_card_component.rb
@@ -11,6 +11,10 @@ class LlmCredentialCardComponent < ViewComponent::Base
     helpers.llm_credential_path(credential)
   end
 
+  def edit_url
+    helpers.edit_llm_credential_path(credential)
+  end
+
   def provider_name
     LlmProvider.find(credential.provider).display_name
   end

--- a/test/components/llm_credentials_list_component_test.rb
+++ b/test/components/llm_credentials_list_component_test.rb
@@ -55,4 +55,29 @@ class LlmCredentialsListComponentTest < ViewComponent::TestCase
 
     assert_includes result.text, "Status: Active"
   end
+
+  test "#call should render a Details menu item linking to the show page" do
+    result = render_inline(LlmCredentialsListComponent.new(credentials: [credential]))
+    item = result.css("a[role='menuitem']").find { |a| a.text.strip == "Details" }
+
+    assert_not_nil item
+    assert_includes item["href"], "/llm_credentials/#{credential.id}"
+  end
+
+  test "#call should render an Edit menu item linking to the edit page" do
+    result = render_inline(LlmCredentialsListComponent.new(credentials: [credential]))
+    item = result.css("a[role='menuitem']").find { |a| a.text.strip == "Edit" }
+
+    assert_not_nil item
+    assert_includes item["href"], "/llm_credentials/#{credential.id}/edit"
+  end
+
+  test "#call should render the Delete menu item with default text color" do
+    result = render_inline(LlmCredentialsListComponent.new(credentials: [credential]))
+    item = result.css("a[role='menuitem']").find { |a| a.text.strip == "Delete" }
+
+    assert_not_nil item
+    assert_includes item["class"], "text-slate-700"
+    assert_not_includes item["class"], "text-red-600"
+  end
 end


### PR DESCRIPTION
Changes:

- Move the access token card's dropdown menu into the footer, alongside the status label
- Add Details and Edit items to the AI credential card menu, with icons on every menu item
- Use the default text color for the Delete item in both cards instead of red

Keeps the action menus in a consistent place across cards and gives the AI credential menu the same navigation options as the rest of the app.
