### PR TITLE
Show pagination offset on event log pages

### DIFF
--- a/app/controllers/concerns/event_cursor_pagination.rb
+++ b/app/controllers/concerns/event_cursor_pagination.rb
@@ -53,7 +53,16 @@ module EventCursorPagination
     @events = events
     @older_url = older_page_url
     @newer_url = newer_page_url
+    @offset = page_offset
     @log_endpoint = @newer_url.nil? ? polling_endpoint : nil
+  end
+
+  # How many newer events sit before the top of the current page, i.e. how far
+  # into the log the user has paged. Zero on the latest (first) page.
+  def page_offset
+    return 0 if @events.blank?
+
+    events_scope.where(cursor_condition(">", @events.first.id)).count
   end
 
   def event_log_component

--- a/app/controllers/concerns/event_cursor_pagination.rb
+++ b/app/controllers/concerns/event_cursor_pagination.rb
@@ -58,8 +58,10 @@ module EventCursorPagination
   end
 
   # How many newer events sit before the top of the current page, i.e. how far
-  # into the log the user has paged. Zero on the latest (first) page.
+  # into the log the user has paged. Zero on the latest page, which is also the
+  # only page that polls — so the count never runs on the hot streaming path.
   def page_offset
+    return 0 unless cursor_present?
     return 0 if @events.blank?
 
     events_scope.where(cursor_condition(">", @events.first.id)).count

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -16,6 +16,16 @@ module EventsHelper
     content_tag(:span, level.humanize, class: badge[:class])
   end
 
+  # Explains where the current page sits in the log without leaning on page
+  # numbers: the offset is how many newer events come before what's shown.
+  def events_offset_summary(offset)
+    if offset.zero?
+      "Showing the most recent events."
+    else
+      "#{pluralize(offset, 'newer event')} above what's shown here."
+    end
+  end
+
   def mail_event_types
     ResendWebhooksController::EMAIL_EVENT_HANDLERS.values.pluck(:type) + %w[
       mail.profile_mailer.account_confirmation

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -16,6 +16,9 @@
         <%= link_to "Reset Filter", admin_events_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
       <% end %>
     <% end %>
+    <% header.with_context_paragraph do %>
+      <span data-key="events.offset"><%= events_offset_summary(@offset) %></span>
+    <% end %>
     <% if @log_endpoint %>
       <% header.with_action_button do %>
         <%= render RefreshButtonComponent.new(data: {

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -3,6 +3,9 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Events Log") do |header| %>
     <% header.with_context_paragraph "Everything Feeder has done on your feeds, newest first." %>
+    <% header.with_context_paragraph do %>
+      <span data-key="events.offset"><%= events_offset_summary(@offset) %></span>
+    <% end %>
     <% header.with_action_button do %>
       <%= link_to "Back to Status", status_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>

--- a/db/migrate/20260613145500_add_created_at_id_index_to_events.rb
+++ b/db/migrate/20260613145500_add_created_at_id_index_to_events.rb
@@ -1,0 +1,8 @@
+class AddCreatedAtIdIndexToEvents < ActiveRecord::Migration[8.2]
+  def change
+    # Serves the log's chronological cursor pagination: the page query
+    # (ORDER BY created_at DESC, id DESC LIMIT n), the older/newer boundary
+    # checks, and the page-offset count all compare the (created_at, id) tuple.
+    add_index :events, [:created_at, :id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_12_212655) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_13_145500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -57,6 +57,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_12_212655) do
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index ["created_at", "id"], name: "index_events_on_created_at_and_id"
     t.index ["expires_at"], name: "index_events_on_expires_at", where: "(expires_at IS NOT NULL)"
     t.index ["level", "created_at"], name: "index_events_on_level_and_created_at"
     t.index ["subject_type", "subject_id"], name: "index_events_on_subject_type_and_subject_id"

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -53,6 +53,28 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[data-key='admin.event.user']", "User ##{event.user_id}"
   end
 
+  test "should describe the latest page with a zero offset" do
+    login_as(admin_user)
+    create(:event, user: create(:user))
+
+    get admin_events_path
+
+    assert_response :success
+    assert_select "[data-key='events.offset']", "Showing the most recent events."
+  end
+
+  test "should describe the offset when paging into older events" do
+    with_page_size(2) do
+      login_as(admin_user)
+      events = Array.new(5) { create(:event, user: create(:user)) }
+
+      get admin_events_path, params: { before: events[3].id }
+
+      assert_response :success
+      assert_select "[data-key='events.offset']", "2 newer events above what's shown here."
+    end
+  end
+
   test "should list imported posts referenced by the event" do
     login_as(admin_user)
     feed = create(:feed)

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -66,6 +66,28 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select '[data-event-type="someone_elses"]', count: 0
   end
 
+  test "#index should describe the latest page with a zero offset" do
+    sign_in_as user
+    create(:event, user: user)
+
+    get events_path
+
+    assert_response :success
+    assert_select "[data-key='events.offset']", "Showing the most recent events."
+  end
+
+  test "#index should describe the offset when paging into older events" do
+    with_page_size(2) do
+      sign_in_as user
+      events = Array.new(5) { |i| create(:event, type: "Event#{i}", user: user) }
+
+      get events_path, params: { before: events[3].id }
+
+      assert_response :success
+      assert_select "[data-key='events.offset']", "2 newer events above what's shown here."
+    end
+  end
+
   test "#index should nest entry list items inside a list element" do
     sign_in_as user
     create(:event, type: "feed_refresh", user: user)


### PR DESCRIPTION
Changes:

- Show a short paragraph under the title on `/events` and `/admin/events` describing how far into the log the current page is
- Reads "Showing the most recent events" on the latest page, or "N newer events above what's shown here" when paging into older events

The event log uses cursor-based pagination, so there are no page numbers to show. Instead of an unhelpful "page X of Y", this gives a human-friendly sense of position by counting the newer events that come before the current page.
