### PR TITLE
Skip live publish chains in the watchdog

### DIFF
--- a/app/jobs/publication_scheduler_job.rb
+++ b/app/jobs/publication_scheduler_job.rb
@@ -4,12 +4,18 @@
 # frequently and kicks a publish chain (PostPublishJob) for every enabled feed
 # that has enqueued posts waiting. It is also the chain's watchdog: a stalled or
 # never-started chain is picked up on the next run, including for feeds that were
-# disabled and re-enabled.
+# disabled and re-enabled. Feeds with a live chain are skipped, so it only
+# (re)starts idle ones rather than piling duplicate kicks onto a running chain.
 class PublicationSchedulerJob < ApplicationJob
   queue_as :default
 
   def perform
     Feed.enabled.where(id: feeds_with_enqueued_posts).find_each do |feed|
+      # A held lock means a live chain is already publishing this feed and will
+      # pick up the remaining posts. Kicking it would just enqueue a job that
+      # fails to acquire the lock and skips, so only (re)start idle chains.
+      next if Feed.advisory_lock_exists?("post_publish_#{feed.id}")
+
       PostPublishJob.perform_later(feed.id)
     end
   end

--- a/test/jobs/publication_scheduler_job_test.rb
+++ b/test/jobs/publication_scheduler_job_test.rb
@@ -19,6 +19,19 @@ class PublicationSchedulerJobTest < ActiveJob::TestCase
     end
   end
 
+  test ".perform_now should skip feeds whose publish chain is already running" do
+    feed = create(:feed, :enabled)
+    create(:post, :enqueued, feed: feed)
+
+    # Hold the chain's lock to simulate a live PostPublishJob; the watchdog must
+    # not pile a duplicate kick onto it.
+    Feed.with_advisory_lock("post_publish_#{feed.id}") do
+      assert_no_enqueued_jobs(only: PostPublishJob) do
+        PublicationSchedulerJob.perform_now
+      end
+    end
+  end
+
   test ".perform_now should skip disabled feeds even with enqueued posts" do
     feed = create(:feed, :disabled)
     create(:post, :enqueued, feed: feed)


### PR DESCRIPTION
Changes:

- `PublicationSchedulerJob` skips feeds whose publish chain is already running (per-feed advisory lock held), instead of kicking every enabled feed with enqueued posts every minute

The watchdog's job is to (re)start idle or stalled chains. Kicking a feed that already has a live chain just enqueues a `PostPublishJob` that fails to acquire the lock and skips — wasted job runs. On a backlog resume this produced a burst of hundreds of lock-skip executions. Gating on `advisory_lock_exists?` removes the duplicate kicks while keeping the watchdog's recovery role (a feed with no live chain is still picked up).