### PR TITLE
Send User-Agent when downloading attachments

### DIFF
--- a/app/services/file_buffer.rb
+++ b/app/services/file_buffer.rb
@@ -9,6 +9,10 @@
 class FileBuffer
   DEFAULT_CONTENT_TYPE = "application/octet-stream"
 
+  # Some image hosts (notably Reddit's CDN, *.redd.it) reject requests without a
+  # User-Agent with HTTP 403. Net::HTTP sends none by default, so we set one.
+  USER_AGENT = "Feeder".freeze
+
   class Error < StandardError; end
 
   # Initialize a new FileBuffer
@@ -49,7 +53,7 @@ class FileBuffer
 
   def url_to_io(url)
     normalized_url = normalize_url(url)
-    response = http_client.get(normalized_url)
+    response = http_client.get(normalized_url, headers: { "User-Agent" => USER_AGENT })
 
     unless response.success?
       raise Error, "Failed to download attachment from #{url}: HTTP #{response.status}"

--- a/test/services/file_buffer_test.rb
+++ b/test/services/file_buffer_test.rb
@@ -70,6 +70,19 @@ class FileBufferTest < ActiveSupport::TestCase
     assert_equal "image/png", content_type
   end
 
+  test "#load should send a browser-like User-Agent when downloading" do
+    url = "https://example.com/image.jpg"
+    response_body = file_fixture("test_image.jpg").binread
+
+    stub = stub_request(:get, url)
+      .with(headers: { "User-Agent" => FileBuffer::USER_AGENT })
+      .to_return(status: 200, body: response_body)
+
+    FileBuffer.new.load(url)
+
+    assert_requested(stub)
+  end
+
   test "#load should raise error when HTTP request fails" do
     url = "https://example.com/image.jpg"
 


### PR DESCRIPTION
Changes:

- Send a browser-like `User-Agent` header when `FileBuffer` downloads attachments

Reddit's image CDN (`*.redd.it`) rejects requests that carry no `User-Agent`
with HTTP 403, and Net::HTTP (our Faraday adapter's backend) sends none by
default. Every Reddit attachment download therefore failed and surfaced as a
`FreefeedPublisher::PublishError`. Setting a User-Agent on downloads mirrors the
existing convention in the Twitter and Telegram loaders. Scoped to `FileBuffer`
so FreeFeed API calls keep their own client User-Agent.
