### PR TITLE
Track published posts per day for the heatmap

### DIFF
--- a/app/components/posts_heatmap_component.rb
+++ b/app/components/posts_heatmap_component.rb
@@ -40,7 +40,7 @@ class PostsHeatmapComponent < ViewComponent::Base
     @metrics_by_date ||= base_scope
       .for_date_range(@start_date, @end_date)
       .group(:date)
-      .sum(:posts_count)
+      .sum(:published_posts_count)
       .transform_values(&:to_i)
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -66,6 +66,7 @@ class PostsController < ApplicationController
     else
       @post.withdrawn!
       log_post_event("post_withdrawn", @post)
+      refresh_published_metric(@post.feed, @post.reposted_at)
     end
 
     @notice = destroy_notice
@@ -95,6 +96,7 @@ class PostsController < ApplicationController
     feed = post.feed
     feed_entry = post.feed_entry
     uid = post.uid
+    reposted_at = post.reposted_at
 
     ActiveRecord::Base.transaction do
       if feed_entry
@@ -105,6 +107,16 @@ class PostsController < ApplicationController
       FeedEntryUid.where(feed_id: feed.id, uid: uid).delete_all
       log_post_event("post_deleted", post, subject: feed)
     end
+
+    refresh_published_metric(feed, reposted_at)
+  end
+
+  # Refresh the cached daily published count after a post leaves the published
+  # set. Only published posts carry a reposted_at, so a nil means nothing to do.
+  def refresh_published_metric(feed, reposted_at)
+    return if reposted_at.nil?
+
+    FeedMetric.recompute_published(feed: feed, date: reposted_at.to_date)
   end
 
   def log_post_event(type, post, subject: post)

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -90,7 +90,10 @@ class PostPublishJob < ApplicationJob
   # Count a post once it's actually on FreeFeed. Guarded on status: an upfront
   # throttle (post never created) doesn't count; a mid-comment one does.
   def count_published(post)
-    Metrics.increment("posts_published_total", status: "published") if post.published?
+    return unless post.published?
+
+    Metrics.increment("posts_published_total", status: "published")
+    FeedMetric.recompute_published(feed: post.feed, date: post.reposted_at.to_date)
   end
 
   def schedule_next(feed)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -265,7 +265,7 @@ class Feed < ApplicationRecord
   # regardless of the original source publication date.
   # @return [Time, nil] most recent repost time or nil if no published posts
   def most_recent_repost_at
-    posts.published.maximum(:updated_at)
+    posts.published.maximum(:reposted_at)
   end
 
   # Returns the count of posts published in the last week (by source date)

--- a/app/models/feed_metric.rb
+++ b/app/models/feed_metric.rb
@@ -3,7 +3,7 @@ class FeedMetric < ApplicationRecord
 
   validates :date, presence: true
   validates :date, uniqueness: { scope: :feed_id }
-  validates :posts_count, :invalid_posts_count,
+  validates :posts_count, :invalid_posts_count, :published_posts_count,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   scope :for_date_range, ->(start_date, end_date) {
@@ -33,5 +33,20 @@ class FeedMetric < ApplicationRecord
       },
       unique_by: [:feed_id, :date]
     )
+  end
+
+  # Recompute the published-post count for a feed/date straight from the posts.
+  # Called after a post is published, withdrawn, or deleted, so the cached
+  # number always matches the current records. Recounting (not incrementing)
+  # means it's safe to call more than once and self-heals on removal.
+  # @param feed [Feed] the feed whose day to refresh
+  # @param date [Date] the repost date to recount
+  def self.recompute_published(feed:, date:)
+    count = feed.posts.published.where(reposted_at: date.all_day).count
+    metric = find_by(feed_id: feed.id, date: date)
+    return if metric.nil? && count.zero?
+
+    metric ||= new(feed_id: feed.id, date: date)
+    metric.update!(published_posts_count: count)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -46,14 +46,6 @@ class Post < ApplicationRecord
     "#{group_url}/#{freefeed_post_id}"
   end
 
-  # Returns the time the post was reposted to FreeFeed, or nil if it hasn't
-  # been published there. This reflects the repost moment, not the original
-  # source publication date (see #published_at).
-  # @return [Time, nil]
-  def reposted_at
-    updated_at if published?
-  end
-
   def normalized_attributes
     as_json(only: NORMALIZED_ATTRIBUTES)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,7 +119,7 @@ class User < ApplicationRecord
   # source publication date.
   # @return [Time, nil] most recent repost timestamp or nil if no published posts
   def most_recent_repost_at
-    published_posts.maximum(:updated_at)
+    published_posts.maximum(:reposted_at)
   end
 
   def posts_published_last_week_count

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -114,7 +114,7 @@ class FreefeedPublisher
   end
 
   def update_post_with_freefeed_id(freefeed_post_id)
-    post.update!(freefeed_post_id: freefeed_post_id, status: :published)
+    post.update!(freefeed_post_id: freefeed_post_id, status: :published, reposted_at: Time.current)
   rescue => e
     raise PublishError, "Failed to update post status: #{e.message}"
   end

--- a/db/migrate/20260613190000_add_reposted_at_to_posts.rb
+++ b/db/migrate/20260613190000_add_reposted_at_to_posts.rb
@@ -1,0 +1,20 @@
+class AddRepostedAtToPosts < ActiveRecord::Migration[8.2]
+  def up
+    add_column :posts, :reposted_at, :datetime
+    add_index :posts, [:feed_id, :reposted_at]
+
+    # Backfill the repost moment for already-published posts. updated_at is the
+    # best available proxy: until now it was what Post#reposted_at returned.
+    execute(<<~SQL.squish)
+      UPDATE posts
+      SET reposted_at = updated_at
+      WHERE status = #{Post.statuses.fetch(:published)}
+        AND reposted_at IS NULL
+    SQL
+  end
+
+  def down
+    remove_index :posts, [:feed_id, :reposted_at]
+    remove_column :posts, :reposted_at
+  end
+end

--- a/db/migrate/20260613190100_add_published_posts_count_to_feed_metrics.rb
+++ b/db/migrate/20260613190100_add_published_posts_count_to_feed_metrics.rb
@@ -1,0 +1,22 @@
+class AddPublishedPostsCountToFeedMetrics < ActiveRecord::Migration[8.2]
+  def up
+    add_column :feed_metrics, :published_posts_count, :integer, default: 0, null: false
+
+    # Backfill from the posts that have actually been reposted to FreeFeed,
+    # bucketed by the day they were published there.
+    execute(<<~SQL.squish)
+      INSERT INTO feed_metrics (feed_id, date, published_posts_count, created_at, updated_at)
+      SELECT feed_id, reposted_at::date, COUNT(*), NOW(), NOW()
+      FROM posts
+      WHERE status = #{Post.statuses.fetch(:published)}
+        AND reposted_at IS NOT NULL
+      GROUP BY feed_id, reposted_at::date
+      ON CONFLICT (feed_id, date)
+      DO UPDATE SET published_posts_count = EXCLUDED.published_posts_count, updated_at = NOW()
+    SQL
+  end
+
+  def down
+    remove_column :feed_metrics, :published_posts_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_13_190000) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_13_190100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -110,6 +110,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_13_190000) do
     t.integer "invalid_posts_count", default: 0, null: false
     t.integer "posts_count", default: 0, null: false
     t.datetime "updated_at", null: false
+    t.integer "published_posts_count", default: 0, null: false
     t.index ["date"], name: "index_feed_metrics_on_date"
     t.index ["feed_id", "date"], name: "index_feed_metrics_on_feed_id_and_date", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_13_145500) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_13_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -238,7 +238,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_13_145500) do
     t.string "uid", null: false
     t.datetime "updated_at", null: false
     t.text "validation_errors", default: [], null: false, array: true
+    t.datetime "reposted_at"
     t.index ["feed_entry_id"], name: "index_posts_on_feed_entry_id"
+    t.index ["feed_id", "reposted_at"], name: "index_posts_on_feed_id_and_reposted_at"
     t.index ["feed_id", "uid"], name: "index_posts_on_feed_id_and_uid", unique: true
     t.index ["feed_id"], name: "index_posts_on_feed_id"
     t.index ["status"], name: "index_posts_on_status"

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -12,7 +12,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
   def feed_with_posts
     @feed_with_posts ||= create(:feed).tap do |f|
       create(:feed_entry, feed: f, created_at: 1.hour.ago)
-      create(:post, :published, feed: f, published_at: 2.hours.ago, updated_at: 1.hour.ago)
+      create(:post, :published, feed: f, published_at: 2.hours.ago, reposted_at: 1.hour.ago)
       create(:post, feed: f, published_at: 3.hours.ago)
     end
   end

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -172,7 +172,7 @@ class PostCardComponentTest < ViewComponent::TestCase
 
   test "#render should label published posts as reposted and link to the freefeed post" do
     published_post = create(:post, :published, feed: feed,
-      published_at: 11.hours.ago, updated_at: 10.hours.ago)
+      published_at: 11.hours.ago, reposted_at: 10.hours.ago)
     result = render_inline PostCardComponent.new(post: published_post)
 
     status_link = result.at_css("a[href='#{published_post.freefeed_url}']")
@@ -183,7 +183,7 @@ class PostCardComponentTest < ViewComponent::TestCase
 
   test "#render should keep the duration tight against its parentheses" do
     published_post = create(:post, :published, feed: feed,
-      published_at: 11.hours.ago, updated_at: 10.hours.ago)
+      published_at: 11.hours.ago, reposted_at: 10.hours.ago)
     result = render_inline PostCardComponent.new(post: published_post)
 
     # The label, parens and time tag share one inline wrapper that carries no
@@ -196,7 +196,7 @@ class PostCardComponentTest < ViewComponent::TestCase
   test "#render should show the reposted status as plain text when freefeed url is missing" do
     # A purged post stays published but loses its freefeed_post_id (see GroupPurgeJob)
     purged_post = create(:post, :published, feed: feed, freefeed_post_id: nil,
-      published_at: 11.hours.ago, updated_at: 10.hours.ago)
+      published_at: 11.hours.ago, reposted_at: 10.hours.ago)
     result = render_inline PostCardComponent.new(post: purged_post)
 
     assert_nil purged_post.freefeed_url

--- a/test/components/posts_heatmap_component_test.rb
+++ b/test/components/posts_heatmap_component_test.rb
@@ -10,8 +10,8 @@ class PostsHeatmapComponentTest < ViewComponent::TestCase
     @feed ||= create(:feed, user: user)
   end
 
-  def metric_with_posts
-    @metric_with_posts ||= create(:feed_metric, :with_posts, feed: feed, date: Date.current)
+  def metric_with_published_posts
+    @metric_with_published_posts ||= create(:feed_metric, :with_published_posts, feed: feed, date: Date.current)
   end
 
   test "#render? should return false when there are no metrics" do
@@ -21,47 +21,47 @@ class PostsHeatmapComponentTest < ViewComponent::TestCase
   end
 
   test "#render? should return false when all metrics are outside the 1-year window" do
-    create(:feed_metric, :with_posts, feed: feed, date: 2.years.ago.to_date)
+    create(:feed_metric, :with_published_posts, feed: feed, date: 2.years.ago.to_date)
     component = PostsHeatmapComponent.new(feed: feed)
     render_inline(component)
     assert_not component.render?
   end
 
   test "#render? should return true when there are metrics within the past year" do
-    metric_with_posts
+    metric_with_published_posts
     component = PostsHeatmapComponent.new(feed: feed)
     render_inline(component)
     assert component.render?
   end
 
   test "#call should render an SVG for a feed with metrics" do
-    metric_with_posts
+    metric_with_published_posts
     result = render_inline(PostsHeatmapComponent.new(feed: feed))
     assert result.css("svg").any?
   end
 
   test "#call should render an SVG for a user with metrics across feeds" do
-    create(:feed_metric, :with_posts, feed: feed, date: Date.current)
+    create(:feed_metric, :with_published_posts, feed: feed, date: Date.current)
     result = render_inline(PostsHeatmapComponent.new(user: user))
     assert result.css("svg").any?
   end
 
   test "#call should include data-tippy-content attributes on cells" do
-    metric_with_posts
+    metric_with_published_posts
     result = render_inline(PostsHeatmapComponent.new(feed: feed))
     assert result.css("[data-tippy-content]").any?
   end
 
   test "#call should include data-controller attribute for Stimulus" do
-    metric_with_posts
+    metric_with_published_posts
     result = render_inline(PostsHeatmapComponent.new(feed: feed))
     assert result.css("[data-controller='heatmap']").any?
   end
 
-  test "#call should aggregate posts_count across all feeds for a user" do
+  test "#call should aggregate published_posts_count across all feeds for a user" do
     other_feed = create(:feed, user: user)
-    create(:feed_metric, feed: feed, date: Date.current, posts_count: 3)
-    create(:feed_metric, feed: other_feed, date: Date.current, posts_count: 4)
+    create(:feed_metric, feed: feed, date: Date.current, published_posts_count: 3)
+    create(:feed_metric, feed: other_feed, date: Date.current, published_posts_count: 4)
 
     result = render_inline(PostsHeatmapComponent.new(user: user))
     assert result.css("svg").any?

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -168,6 +168,30 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "info", event.level
   end
 
+  test "#destroy should refresh the daily published metric after withdrawing" do
+    sign_in_as(user)
+    create(:post, :published, feed: feed, reposted_at: Time.current)
+    withdrawing = create(:post, :published, feed: feed, freefeed_post_id: "test-123", reposted_at: Time.current)
+
+    delete post_url(withdrawing), params: { delete_freefeed_post: "1" }
+
+    metric = FeedMetric.find_by(feed: feed, date: Date.current)
+    assert_equal 1, metric.published_posts_count
+  end
+
+  test "#destroy should refresh the daily published metric after deleting the record" do
+    sign_in_as(user)
+    create(:post, :published, feed: feed, reposted_at: Time.current)
+    feed_entry = create(:feed_entry, feed: feed, uid: "entry-1")
+    deleting = create(:post, :published, feed: feed, feed_entry: feed_entry,
+      uid: "entry-1", freefeed_post_id: "test-123", reposted_at: Time.current)
+
+    delete post_url(deleting), params: { delete_freefeed_post: "1", delete_record: "1" }
+
+    metric = FeedMetric.find_by(feed: feed, date: Date.current)
+    assert_equal 1, metric.published_posts_count
+  end
+
   test "#destroy should reload the post page after withdrawing it" do
     sign_in_as(user)
     published_post = create(:post, :published, feed: feed, freefeed_post_id: "test-123")

--- a/test/controllers/statuses_controller_test.rb
+++ b/test/controllers/statuses_controller_test.rb
@@ -70,7 +70,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as user
     feed = create(:feed, user: user)
     entry = create(:feed_entry, feed: feed)
-    create(:post, feed: feed, feed_entry: entry, status: :published, published_at: 1.year.ago, updated_at: 1.day.ago)
+    create(:post, feed: feed, feed_entry: entry, status: :published, published_at: 1.year.ago, reposted_at: 1.day.ago)
 
     get status_path
     assert_response :success

--- a/test/factories/feed_metrics.rb
+++ b/test/factories/feed_metrics.rb
@@ -4,9 +4,14 @@ FactoryBot.define do
     date { Date.current }
     posts_count { 0 }
     invalid_posts_count { 0 }
+    published_posts_count { 0 }
 
     trait :with_posts do
       posts_count { 5 }
+    end
+
+    trait :with_published_posts do
+      published_posts_count { 4 }
     end
 
     trait :with_invalid_posts do

--- a/test/factories/posts.rb
+++ b/test/factories/posts.rb
@@ -23,6 +23,7 @@ FactoryBot.define do
     trait :published do
       status { :published }
       freefeed_post_id { "freefeed-#{SecureRandom.uuid}" }
+      reposted_at { Time.current }
     end
 
     trait :failed do

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -47,6 +47,16 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_equal 0, feed.posts.where(status: :enqueued).count
   end
 
+  test ".perform_now should record the daily published metric" do
+    create(:post, :enqueued, feed: feed, published_at: 1.hour.ago)
+    stub_publish_success
+
+    perform_enqueued_jobs { PostPublishJob.perform_now(feed.id) }
+
+    metric = FeedMetric.find_by(feed: feed, date: Date.current)
+    assert_equal 1, metric.published_posts_count
+  end
+
   test ".perform_now should mark a failing post as failed, report it, and continue" do
     post = create(:post, :enqueued, feed: feed)
     stub_request(:post, "#{access_token.host}/v4/posts").to_return(status: 500)

--- a/test/models/feed_metric_test.rb
+++ b/test/models/feed_metric_test.rb
@@ -54,6 +54,55 @@ class FeedMetricTest < ActiveSupport::TestCase
     assert metric.errors.of_kind?(:invalid_posts_count, :greater_than_or_equal_to)
   end
 
+  test "should validate published_posts_count is non-negative" do
+    metric = build(:feed_metric, published_posts_count: -1)
+    assert_not metric.valid?
+    assert metric.errors.of_kind?(:published_posts_count, :greater_than_or_equal_to)
+  end
+
+  test "#recompute_published should count published reposts for the day" do
+    create_list(:post, 2, :published, feed: feed, reposted_at: Date.current.noon)
+
+    FeedMetric.recompute_published(feed: feed, date: Date.current)
+
+    assert_equal 2, FeedMetric.find_by(feed: feed, date: Date.current).published_posts_count
+  end
+
+  test "#recompute_published should overwrite a stale count" do
+    create(:feed_metric, feed: feed, date: Date.current, published_posts_count: 9)
+    create(:post, :published, feed: feed, reposted_at: Date.current.noon)
+
+    FeedMetric.recompute_published(feed: feed, date: Date.current)
+
+    assert_equal 1, FeedMetric.find_by(feed: feed, date: Date.current).published_posts_count
+  end
+
+  test "#recompute_published should preserve other counts on the row" do
+    create(:feed_metric, feed: feed, date: Date.current, posts_count: 7, invalid_posts_count: 2)
+    create(:post, :published, feed: feed, reposted_at: Date.current.noon)
+
+    FeedMetric.recompute_published(feed: feed, date: Date.current)
+
+    metric = FeedMetric.find_by(feed: feed, date: Date.current)
+    assert_equal 7, metric.posts_count
+    assert_equal 2, metric.invalid_posts_count
+    assert_equal 1, metric.published_posts_count
+  end
+
+  test "#recompute_published should set the count to zero when reposts are gone" do
+    create(:feed_metric, feed: feed, date: Date.current, published_posts_count: 3)
+
+    FeedMetric.recompute_published(feed: feed, date: Date.current)
+
+    assert_equal 0, FeedMetric.find_by(feed: feed, date: Date.current).published_posts_count
+  end
+
+  test "#recompute_published should not create an empty row when there is no activity" do
+    assert_no_difference "FeedMetric.count" do
+      FeedMetric.recompute_published(feed: feed, date: Date.current)
+    end
+  end
+
   test "should have default values of zero" do
     metric = build(:feed_metric)
     assert_equal 0, metric.posts_count

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -825,8 +825,8 @@ class FeedTest < ActiveSupport::TestCase
   test "#most_recent_repost_at should return latest repost time regardless of original publication date" do
     feed = create(:feed)
     # Older original publication date, but reposted most recently.
-    create(:post, :published, feed: feed, published_at: 10.days.ago, updated_at: 1.hour.ago)
-    create(:post, :published, feed: feed, published_at: 1.day.ago, updated_at: 2.days.ago)
+    create(:post, :published, feed: feed, published_at: 10.days.ago, reposted_at: 1.hour.ago)
+    create(:post, :published, feed: feed, published_at: 1.day.ago, reposted_at: 2.days.ago)
     create(:post, feed: feed, status: :draft, updated_at: Time.current)
 
     assert_in_delta 1.hour.ago.to_i, feed.most_recent_repost_at.to_i, 1

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -153,13 +153,13 @@ class PostTest < ActiveSupport::TestCase
     assert post.valid?
   end
 
-  test "#reposted_at should return the update time for published posts" do
-    post = create(:post, :published, feed: feed, feed_entry: feed_entry, updated_at: 1.hour.ago)
+  test "#reposted_at should hold the repost moment for published posts" do
+    post = create(:post, :published, feed: feed, feed_entry: feed_entry, reposted_at: 1.hour.ago)
 
     assert_in_delta 1.hour.ago.to_i, post.reposted_at.to_i, 1
   end
 
-  test "#reposted_at should return nil for posts that are not published" do
+  test "#reposted_at should be nil for posts that have not been reposted" do
     post = create(:post, feed: feed, feed_entry: feed_entry, status: :draft)
 
     assert_nil post.reposted_at

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -189,8 +189,8 @@ class UserTest < ActiveSupport::TestCase
     entry3 = create(:feed_entry, feed: feed)
 
     # Older original publication date, but reposted most recently.
-    create(:post, feed: feed, feed_entry: entry1, status: :published, published_at: 10.days.ago, updated_at: 1.hour.ago)
-    create(:post, feed: feed, feed_entry: entry2, status: :published, published_at: 1.day.ago, updated_at: 2.days.ago)
+    create(:post, feed: feed, feed_entry: entry1, status: :published, published_at: 10.days.ago, reposted_at: 1.hour.ago)
+    create(:post, feed: feed, feed_entry: entry2, status: :published, published_at: 1.day.ago, reposted_at: 2.days.ago)
     create(:post, feed: feed, feed_entry: entry3, status: :draft, updated_at: Time.current)
 
     assert_in_delta 1.hour.ago.to_i, user.most_recent_repost_at.to_i, 1

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -177,6 +177,7 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     assert_equal "freefeed_post_123", freefeed_post_id
     assert_equal "freefeed_post_123", post.reload.freefeed_post_id
     assert_equal "published", post.status
+    assert_not_nil post.reposted_at
   end
 
   test "#publish should upload attachments before publishing" do


### PR DESCRIPTION
Changes:

- Record a durable `reposted_at` timestamp when a post lands on FreeFeed, replacing the fragile `updated_at` proxy for the repost moment
- Cache a daily `published_posts_count` per feed, recomputed from the posts whenever one is published, withdrawn, or deleted
- Read the posts heatmap from that cached count so it reflects actual publications instead of refresh-time imports

The heatmap previously counted posts at refresh/import time and only moved when a feed refreshed, so it lagged behind posts still draining through the throttled publish queue. Now each relevant event recomputes the affected day's count straight from the records. Recounting (rather than incrementing a running total) keeps the cache correct and self-healing — a withdrawn or deleted post simply drops out. The new `reposted_at` column makes the per-day grouping possible and is backfilled for existing published posts.
