### PR TITLE
Auto-disable feeds after repeated refresh failures

### DIFF
--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -10,7 +10,8 @@ class EventDescriptionComponent < ViewComponent::Base
   # Maps event types to the subclass that renders them. Types without an entry
   # fall back to this base component, which renders the plain description.
   SUBCLASSES = {
-    "feed_refresh" => "FeedRefreshDescriptionComponent"
+    "feed_refresh" => "FeedRefreshDescriptionComponent",
+    "feed_auto_disabled" => "FeedAutoDisabledDescriptionComponent"
   }.freeze
 
   def self.for(event)

--- a/app/components/feed_auto_disabled_description_component.rb
+++ b/app/components/feed_auto_disabled_description_component.rb
@@ -1,7 +1,5 @@
 # Appends the failure count to an auto-disable description, e.g.
 # "My Feed was turned off after repeated errors (10 failures in a row)".
-# The threshold is a constant, but spelling it out tells the user how much
-# patience the system had before giving up.
 class FeedAutoDisabledDescriptionComponent < EventDescriptionComponent
   def call
     suffix = error_count_tag

--- a/app/components/feed_auto_disabled_description_component.rb
+++ b/app/components/feed_auto_disabled_description_component.rb
@@ -1,0 +1,20 @@
+# Appends the failure count to an auto-disable description, e.g.
+# "My Feed was turned off after repeated errors (10 failures in a row)".
+# The threshold is a constant, but spelling it out tells the user how much
+# patience the system had before giving up.
+class FeedAutoDisabledDescriptionComponent < EventDescriptionComponent
+  def call
+    suffix = error_count_tag
+    suffix ? safe_join([super, suffix], " ") : super
+  end
+
+  private
+
+  def error_count_tag
+    count = event.metadata["error_count"].to_i
+    return if count.zero?
+
+    helpers.tag.span("(#{helpers.pluralize(count, "failure")} in a row)",
+                     class: "text-slate-400", data: { key: "events.error_count" })
+  end
+end

--- a/app/controllers/concerns/feed_state_events.rb
+++ b/app/controllers/concerns/feed_state_events.rb
@@ -1,0 +1,22 @@
+# Records the user-facing event when a controller flips a feed between the
+# enabled and disabled states. These transitions are all interactive, so the
+# events are logged here rather than via a model callback; system-driven
+# disables (token/credential failures, repeated refresh errors) emit their own
+# events at their own call sites.
+module FeedStateEvents
+  extend ActiveSupport::Concern
+
+  private
+
+  def record_feed_enabled(feed)
+    record_feed_state_event(feed, "feed_enabled")
+  end
+
+  def record_feed_disabled(feed)
+    record_feed_state_event(feed, "feed_disabled")
+  end
+
+  def record_feed_state_event(feed, type)
+    Event.create!(type: type, level: :info, subject: feed, user: feed.user, message: "")
+  end
+end

--- a/app/controllers/concerns/feed_state_events.rb
+++ b/app/controllers/concerns/feed_state_events.rb
@@ -16,6 +16,12 @@ module FeedStateEvents
   end
 
   def record_feed_state_event(feed, type)
-    Event.create!(type: type, level: :info, subject: feed, user: feed.user, message: "")
+    Event.create!(
+      type: type,
+      level: :info,
+      subject: feed,
+      user: feed.user,
+      message: ""
+    )
   end
 end

--- a/app/controllers/concerns/feed_state_events.rb
+++ b/app/controllers/concerns/feed_state_events.rb
@@ -1,8 +1,7 @@
-# Records the user-facing event when a controller flips a feed between the
-# enabled and disabled states. These transitions are all interactive, so the
-# events are logged here rather than via a model callback; system-driven
-# disables (token/credential failures, repeated refresh errors) emit their own
-# events at their own call sites.
+# Logs the feed_enabled/feed_disabled event when a controller flips a feed's
+# state. These transitions are interactive, so they're recorded here rather
+# than in a model callback; system-driven disables (token/credential failures,
+# repeated refresh errors) emit their own events.
 module FeedStateEvents
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/feed_state_events.rb
+++ b/app/controllers/concerns/feed_state_events.rb
@@ -8,17 +8,17 @@ module FeedStateEvents
   private
 
   def record_feed_enabled(feed)
-    record_feed_state_event(feed, "feed_enabled")
+    record_feed_state_event(feed, "feed_enabled", :info)
   end
 
   def record_feed_disabled(feed)
-    record_feed_state_event(feed, "feed_disabled")
+    record_feed_state_event(feed, "feed_disabled", :warning)
   end
 
-  def record_feed_state_event(feed, type)
+  def record_feed_state_event(feed, type, level)
     Event.create!(
       type: type,
-      level: :info,
+      level: level,
       subject: feed,
       user: feed.user,
       message: ""

--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -1,5 +1,6 @@
 class FeedStatusesController < ApplicationController
   include FeedHelper
+  include FeedStateEvents
 
   def update
     @feed = load_feed
@@ -21,6 +22,7 @@ class FeedStatusesController < ApplicationController
     feed.with_lock do
       if feed.can_be_enabled?
         feed.enabled!
+        record_feed_enabled(feed)
         respond_with_status(feed, success: "Feed enabled.")
       else
         missing_parts = feed_missing_enablement_parts(feed)
@@ -32,6 +34,7 @@ class FeedStatusesController < ApplicationController
   def disable(feed)
     feed.with_lock do
       feed.disabled!
+      record_feed_disabled(feed)
       respond_with_status(feed, success: "Feed disabled.")
     end
   end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,6 +1,7 @@
 class FeedsController < ApplicationController
   include Pagination
   include Sortable
+  include FeedStateEvents
 
   MAX_RECENT_POSTS = 5
   MAX_RECENT_EVENTS = 10
@@ -100,6 +101,7 @@ class FeedsController < ApplicationController
       # Capture interval-change signal from the first save before the
       # promotion attempt's save overwrites `saved_changes`.
       interval_changed = @feed.saved_change_to_cron_expression?
+      record_feed_disabled(@feed) if @feed.saved_change_to_state? && @feed.disabled?
       cleanup_feed_identification(@feed.url) if @feed.url
 
       if require_llm_credentials?
@@ -140,6 +142,7 @@ class FeedsController < ApplicationController
 
   def enable_and_respond(feed)
     if feed.enable
+      record_feed_enabled(feed)
       redirect_to feed_path(feed), success: success_message_for(feed)
     else
       flash.now[:alert] = "Couldn't enable. See issues below."
@@ -150,6 +153,7 @@ class FeedsController < ApplicationController
   def promote_and_redirect(feed, interval_changed)
     feed.transaction do
       if feed.enable
+        record_feed_enabled(feed)
         feed.reset_schedule! if interval_changed && feed.feed_schedule.present?
       end
     end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -3,6 +3,7 @@ class FeedsController < ApplicationController
   include Sortable
 
   MAX_RECENT_POSTS = 5
+  MAX_RECENT_EVENTS = 10
 
   SORTABLE_FIELDS = {
     name: {
@@ -72,6 +73,7 @@ class FeedsController < ApplicationController
     @feed = load_feed
     authorize @feed
     @recent_posts = recent_posts(@feed)
+    @recent_events = recent_events(@feed)
     @has_llm_usages = @feed.llm_usages.exists?
   end
 
@@ -179,6 +181,10 @@ class FeedsController < ApplicationController
       .preload(feed: :access_token)
       .order(published_at: :desc)
       .limit(MAX_RECENT_POSTS)
+  end
+
+  def recent_events(feed)
+    feed.events.user_relevant.recent.limit(MAX_RECENT_EVENTS)
   end
 
   def pagination_scope

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -323,10 +323,10 @@ class Feed < ApplicationRecord
     end
   end
 
-  # Bumps the failure streak after a failed refresh and, once it hits the
-  # threshold, turns the feed off. Returns true when this call disabled it.
-  # No-op past the threshold for a feed already disabled elsewhere (e.g. a
-  # credential auth error in the same run), so we never double-disable.
+  # Bumps the failure streak after a failed refresh and turns the feed off once
+  # it hits the threshold. Returns true when this call disabled it. Skips the
+  # disable if the feed was already disabled elsewhere this run (e.g. a
+  # credential auth error), so we never disable twice.
   def record_refresh_failure!
     increment!(:consecutive_failures)
     return false if consecutive_failures < MAX_CONSECUTIVE_FAILURES
@@ -336,8 +336,7 @@ class Feed < ApplicationRecord
     true
   end
 
-  # Clears the streak after a successful refresh. Skips the write on the common
-  # path where there's nothing to clear.
+  # Clears the streak after a successful refresh.
   def reset_refresh_failures!
     return if consecutive_failures.zero?
 
@@ -346,12 +345,10 @@ class Feed < ApplicationRecord
 
   private
 
-  # Pulls the feed out of the enabled state and records why, stamping the event
-  # with the streak length so the activity log can tell the user how many
-  # failures it took. Resets the counter so a later re-enable starts fresh.
-  # update_columns writes the state flip and counter reset in one statement and
-  # skips validations they don't need; the feed_auto_disabled event carries the
-  # reason, mirroring the credential/token disable paths and their own events.
+  # Disables the feed and records a feed_auto_disabled event stamped with the
+  # streak length, so the activity log shows how many failures it took. Resets
+  # the counter so a re-enable starts clean. update_columns flips the state and
+  # zeroes the counter in one write, skipping validations neither needs.
   def disable_after_repeated_failures!
     failure_count = consecutive_failures
 

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -52,7 +52,6 @@ class Feed < ApplicationRecord
   PREVIEW_FRESHNESS_WINDOW = 60.minutes
 
   after_update :create_schedule_on_enable
-  after_update :create_state_change_event
 
   validates :name, uniqueness: { scope: :user_id }, length: { maximum: NAME_MAX_LENGTH }
   validates :name, presence: true, if: :enabled?
@@ -350,9 +349,9 @@ class Feed < ApplicationRecord
   # Pulls the feed out of the enabled state and records why, stamping the event
   # with the streak length so the activity log can tell the user how many
   # failures it took. Resets the counter so a later re-enable starts fresh.
-  # update_columns skips the generic feed_disabled state-change event in favor
-  # of this richer feed_auto_disabled one, mirroring the credential/token
-  # disable paths that emit their own aggregate events.
+  # update_columns writes the state flip and counter reset in one statement and
+  # skips validations they don't need; the feed_auto_disabled event carries the
+  # reason, mirroring the credential/token disable paths and their own events.
   def disable_after_repeated_failures!
     failure_count = consecutive_failures
 
@@ -450,19 +449,5 @@ class Feed < ApplicationRecord
     return if feed_schedule.present?
 
     reset_schedule!
-  end
-
-  def create_state_change_event
-    return unless saved_change_to_state?
-
-    type = if enabled?
-      "feed_enabled"
-    elsif disabled?
-      "feed_disabled"
-    end
-
-    return unless type
-
-    Event.create!(type: type, level: :info, subject: self, user: user, message: "")
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -29,6 +29,11 @@ class Feed < ApplicationRecord
   # feed has no schedule yet. Must be a key in SCHEDULE_INTERVALS.
   DEFAULT_SCHEDULE_INTERVAL = "2h"
 
+  # Consecutive refresh failures that trip the auto-disable. A reachable source
+  # resets the streak, so this only fires for a source that's broken run after
+  # run (dead URL, persistent 5xx, etc.), not the occasional hiccup.
+  MAX_CONSECUTIVE_FAILURES = 10
+
   belongs_to :user
   belongs_to :access_token, optional: true
   belongs_to :llm_credential, optional: true
@@ -319,7 +324,50 @@ class Feed < ApplicationRecord
     end
   end
 
+  # Bumps the failure streak after a failed refresh and, once it hits the
+  # threshold, turns the feed off. Returns true when this call disabled it.
+  # No-op past the threshold for a feed already disabled elsewhere (e.g. a
+  # credential auth error in the same run), so we never double-disable.
+  def record_refresh_failure!
+    increment!(:consecutive_failures)
+    return false if consecutive_failures < MAX_CONSECUTIVE_FAILURES
+    return false unless reload.enabled?
+
+    disable_after_repeated_failures!
+    true
+  end
+
+  # Clears the streak after a successful refresh. Skips the write on the common
+  # path where there's nothing to clear.
+  def reset_refresh_failures!
+    return if consecutive_failures.zero?
+
+    update_column(:consecutive_failures, 0)
+  end
+
   private
+
+  # Pulls the feed out of the enabled state and records why, stamping the event
+  # with the streak length so the activity log can tell the user how many
+  # failures it took. Resets the counter so a later re-enable starts fresh.
+  # update_columns skips the generic feed_disabled state-change event in favor
+  # of this richer feed_auto_disabled one, mirroring the credential/token
+  # disable paths that emit their own aggregate events.
+  def disable_after_repeated_failures!
+    failure_count = consecutive_failures
+
+    transaction do
+      update_columns(state: self.class.states[:disabled], consecutive_failures: 0)
+      Event.create!(
+        type: "feed_auto_disabled",
+        level: :warning,
+        subject: self,
+        user: user,
+        message: "",
+        metadata: { error_count: failure_count }
+      )
+    end
+  end
 
   def recompose_import_after
     self.import_after = compose_import_after

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -29,6 +29,7 @@ class FeedRefreshWorkflow
     record_error_stats(error, current_step: current_step)
     disable_credential_on_auth_error(error)
     create_feed_refresh_error_event(error)
+    feed.record_refresh_failure!
   end
 
   def initialize_workflow(*)
@@ -161,6 +162,7 @@ class FeedRefreshWorkflow
     rejected_posts_count = posts.count(&:rejected?)
 
     record_completed_at
+    feed.reset_refresh_failures!
     Metrics.increment("feed_refresh_total", status: "ok", profile: feed.feed_profile_key)
     create_feed_refresh_stats_event(posts)
 

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -19,6 +19,16 @@
   <% end %>
 
   <section class="space-y-4">
+    <div class="flex items-center justify-between">
+      <h2 class="text-2xl font-semibold text-slate-900">Recent activity</h2>
+      <% if @recent_events.any? %>
+        <%= link_to "View all", events_path(filter: { subject_type: "Feed", subject_id: @feed.id }), class: "text-sm font-semibold text-sky-600 hover:text-sky-500", data: { key: "feed.events.view_all" } %>
+      <% end %>
+    </div>
+    <%= render EventsListComponent.new(events: @recent_events) %>
+  </section>
+
+  <section class="space-y-4">
     <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
       <h2 class="text-2xl font-semibold mb-0 text-slate-900">Recent posts</h2>
       <% if @recent_posts.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,9 @@ en:
     feed_disabled:
       name: "Feed disabled"
       description_html: "%{subject_link} disabled"
+    feed_auto_disabled:
+      name: "Feed turned off"
+      description_html: "%{subject_link} was turned off after repeated errors"
     feed_refresh:
       name: "Feed refreshed"
       description_html: "%{subject_link} refreshed"

--- a/db/migrate/20260613200000_add_consecutive_failures_to_feeds.rb
+++ b/db/migrate/20260613200000_add_consecutive_failures_to_feeds.rb
@@ -1,0 +1,5 @@
+class AddConsecutiveFailuresToFeeds < ActiveRecord::Migration[8.2]
+  def change
+    add_column :feeds, :consecutive_failures, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_13_190100) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_13_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -155,6 +155,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_13_190100) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.bigint "llm_credential_id"
+    t.integer "consecutive_failures", default: 0, null: false
     t.index ["access_token_id"], name: "index_feeds_on_access_token_id"
     t.index ["llm_credential_id"], name: "index_feeds_on_llm_credential_id"
     t.index ["user_id"], name: "index_feeds_on_user_id"

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -37,6 +37,12 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     assert_instance_of FeedRefreshDescriptionComponent, EventDescriptionComponent.for(event)
   end
 
+  test ".for should pick the auto-disable subclass for feed_auto_disabled events" do
+    event = Event.create!(type: "feed_auto_disabled", level: :warning, subject: feed, user: user, message: "", metadata: {})
+
+    assert_instance_of FeedAutoDisabledDescriptionComponent, EventDescriptionComponent.for(event)
+  end
+
   test ".for should fall back to the base component for other event types" do
     event = Event.create!(type: "email_changed", level: :info, subject: user, user: user, message: "", metadata: {})
 

--- a/test/components/feed_auto_disabled_description_component_test.rb
+++ b/test/components/feed_auto_disabled_description_component_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+require "view_component/test_case"
+
+class FeedAutoDisabledDescriptionComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed
+    @feed ||= create(:feed, user: user, name: "Test Feed")
+  end
+
+  def event(error_count: 10)
+    Event.create!(type: "feed_auto_disabled", level: :warning, subject: feed, user: user,
+                  message: "", metadata: { error_count: error_count })
+  end
+
+  test "#call should append the failure count" do
+    result = render_inline(FeedAutoDisabledDescriptionComponent.new(event: event(error_count: 10)))
+
+    assert_includes result.to_html, "turned off"
+    assert_equal "(10 failures in a row)", result.css("[data-key='events.error_count']").first&.text
+  end
+
+  test "#call should omit the suffix when the count is missing" do
+    result = render_inline(FeedAutoDisabledDescriptionComponent.new(event: event(error_count: 0)))
+
+    assert_includes result.to_html, "turned off"
+    assert_nil result.css("[data-key='events.error_count']").first
+  end
+
+  test ".for should resolve to this component for feed_auto_disabled events" do
+    assert_instance_of FeedAutoDisabledDescriptionComponent, EventDescriptionComponent.for(event)
+  end
+end

--- a/test/components/feed_auto_disabled_description_component_test.rb
+++ b/test/components/feed_auto_disabled_description_component_test.rb
@@ -28,8 +28,4 @@ class FeedAutoDisabledDescriptionComponentTest < ViewComponent::TestCase
     assert_includes result.to_html, "turned off"
     assert_nil result.css("[data-key='events.error_count']").first
   end
-
-  test ".for should resolve to this component for feed_auto_disabled events" do
-    assert_instance_of FeedAutoDisabledDescriptionComponent, EventDescriptionComponent.for(event)
-  end
 end

--- a/test/controllers/feed_statuses_controller_test.rb
+++ b/test/controllers/feed_statuses_controller_test.rb
@@ -44,13 +44,15 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "#update should record a feed_disabled event when disabling" do
+  test "#update should record a warning feed_disabled event when disabling" do
     sign_in_as(user)
     feed.update!(state: :enabled)
 
     assert_difference("Event.where(type: 'feed_disabled', subject: feed).count", 1) do
       patch feed_status_path(feed), params: { status: "disabled" }
     end
+
+    assert_equal "warning", Event.where(type: "feed_disabled", subject: feed).last.level
   end
 
   test "#update should respond with turbo stream when enabling" do

--- a/test/controllers/feed_statuses_controller_test.rb
+++ b/test/controllers/feed_statuses_controller_test.rb
@@ -36,6 +36,23 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "disabled", feed.state
   end
 
+  test "#update should record a feed_enabled event when enabling" do
+    sign_in_as(user)
+
+    assert_difference("Event.where(type: 'feed_enabled', subject: feed).count", 1) do
+      patch feed_status_path(feed), params: { status: "enabled" }
+    end
+  end
+
+  test "#update should record a feed_disabled event when disabling" do
+    sign_in_as(user)
+    feed.update!(state: :enabled)
+
+    assert_difference("Event.where(type: 'feed_disabled', subject: feed).count", 1) do
+      patch feed_status_path(feed), params: { status: "disabled" }
+    end
+  end
+
   test "#update should respond with turbo stream when enabling" do
     sign_in_as(user)
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -470,6 +470,19 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h2", text: "Stats", count: 1
   end
 
+  test "#show should render a recent activity section with the feed's events" do
+    create(:event, type: "feed_auto_disabled", subject: feed, user: user, level: :warning,
+                   message: "", metadata: { error_count: Feed::MAX_CONSECUTIVE_FAILURES })
+    sign_in_as(user)
+
+    get feed_url(feed)
+
+    assert_response :success
+    assert_select "h2", text: "Recent activity", count: 1
+    assert_select "[data-key='events.entry'][data-event-type='feed_auto_disabled']"
+    assert_select "[data-key='events.error_count']", text: "(10 failures in a row)"
+  end
+
   test "#show should return not found for other user's feed" do
     sign_in_as(user)
     get feed_url(other_feed)

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -835,6 +835,44 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Paused Feed", enabled_feed.name
   end
 
+  test "#update should record a feed_enabled event when promoting a draft" do
+    sign_in_as(user)
+    draft = create(:feed, :draft, user: user, access_token: access_token,
+                                  target_group: "tg",
+                                  feed_profile_key: "rss",
+                                  params: { "url" => "http://example.com/feed.xml" })
+
+    assert_difference("Event.where(type: 'feed_enabled', subject: draft).count", 1) do
+      patch feed_url(draft), params: { feed: { name: "Promoted Feed" }, enable_feed: "1" }
+    end
+  end
+
+  test "#update should record a feed_disabled event when pausing a feed" do
+    sign_in_as(user)
+    enabled_feed = create(:feed, :enabled, user: user, access_token: access_token)
+
+    assert_difference("Event.where(type: 'feed_disabled', subject: enabled_feed).count", 1) do
+      patch feed_url(enabled_feed), params: { feed: { name: "Paused Feed" } }
+    end
+  end
+
+  test "#create should record a feed_enabled event when enabling on creation" do
+    sign_in_as(user)
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "New Feed",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_difference("Event.where(type: 'feed_enabled').count", 1) do
+      post feeds_path, params: { feed: feed_params, enable_feed: "1" }
+    end
+  end
+
   test "#update should save and redirect to token setup when commit signals token gate" do
     sign_in_as(user)
     draft = create(:feed, :draft, user: user)

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -762,48 +762,6 @@ class FeedTest < ActiveSupport::TestCase
     assert_not_empty feed.errors
   end
 
-  test "#create_state_change_event should create feed_enabled event when feed is enabled" do
-    feed = create(:feed, :disabled)
-
-    assert_difference("Event.where(type: 'feed_enabled').count", 1) do
-      feed.update!(state: :enabled)
-    end
-
-    event = Event.where(type: "feed_enabled").last
-    assert_equal feed, event.subject
-    assert_equal feed.user, event.user
-    assert_equal "info", event.level
-  end
-
-  test "#create_state_change_event should create feed_disabled event when feed is disabled" do
-    feed = create(:feed, :enabled)
-
-    assert_difference("Event.where(type: 'feed_disabled').count", 1) do
-      feed.update!(state: :disabled)
-    end
-
-    event = Event.where(type: "feed_disabled").last
-    assert_equal feed, event.subject
-    assert_equal feed.user, event.user
-    assert_equal "info", event.level
-  end
-
-  test "#create_state_change_event should not create event when state is unchanged" do
-    feed = create(:feed, :disabled)
-
-    assert_no_difference("Event.count") do
-      feed.update!(name: "new-name")
-    end
-  end
-
-  test "#create_state_change_event should not create event when transitioning to draft" do
-    feed = create(:feed, :disabled)
-
-    assert_no_difference("Event.count") do
-      feed.update!(state: :draft)
-    end
-  end
-
   test "#target_group_url should return the group URL when token and group are present" do
     feed = create(:feed, target_group: "testgroup")
 

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -906,6 +906,7 @@ class FeedTest < ActiveSupport::TestCase
 
     event = Event.find_by(subject: feed, type: "feed_auto_disabled")
     assert_not_nil event
+    assert_equal "warning", event.level
     assert_equal Feed::MAX_CONSECUTIVE_FAILURES, event.metadata["error_count"]
     assert_nil Event.find_by(subject: feed, type: "feed_disabled")
   end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -928,4 +928,43 @@ class FeedTest < ActiveSupport::TestCase
 
     assert feed.valid?, feed.errors.full_messages.inspect
   end
+
+  test "#record_refresh_failure! should bump the streak without disabling below the threshold" do
+    feed = create(:feed, :enabled, consecutive_failures: 2)
+
+    assert_not feed.record_refresh_failure!
+    assert_equal 3, feed.reload.consecutive_failures
+    assert feed.enabled?
+  end
+
+  test "#record_refresh_failure! should disable the feed and record the count at the threshold" do
+    feed = create(:feed, :enabled, consecutive_failures: Feed::MAX_CONSECUTIVE_FAILURES - 1)
+
+    assert feed.record_refresh_failure!
+
+    feed.reload
+    assert feed.disabled?
+    assert_equal 0, feed.consecutive_failures
+
+    event = Event.find_by(subject: feed, type: "feed_auto_disabled")
+    assert_not_nil event
+    assert_equal Feed::MAX_CONSECUTIVE_FAILURES, event.metadata["error_count"]
+    assert_nil Event.find_by(subject: feed, type: "feed_disabled")
+  end
+
+  test "#record_refresh_failure! should not disable a feed already disabled elsewhere" do
+    feed = create(:feed, :enabled, consecutive_failures: Feed::MAX_CONSECUTIVE_FAILURES - 1)
+    Feed.where(id: feed.id).update_all(state: Feed.states[:disabled])
+
+    assert_not feed.record_refresh_failure!
+    assert_nil Event.find_by(subject: feed, type: "feed_auto_disabled")
+  end
+
+  test "#reset_refresh_failures! should clear the streak" do
+    feed = create(:feed, :enabled, consecutive_failures: 4)
+
+    feed.reset_refresh_failures!
+
+    assert_equal 0, feed.reload.consecutive_failures
+  end
 end

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -556,6 +556,47 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     end
   end
 
+  test "#execute should increment the failure streak on error" do
+    test_feed = create(:feed, :enabled, url: "https://example.com/feed.xml", feed_profile_key: "rss")
+    WebMock.stub_request(:get, test_feed.url).to_timeout
+
+    assert_raises(Loader::Error) { FeedRefreshWorkflow.new(test_feed).execute }
+
+    assert_equal 1, test_feed.reload.consecutive_failures
+    assert test_feed.enabled?
+  end
+
+  test "#execute should reset the failure streak after a successful refresh" do
+    test_feed = create(:feed, :enabled, url: "https://example.com/feed.xml",
+                                         feed_profile_key: "rss", consecutive_failures: 3)
+    empty_rss = <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0"><channel><title>Empty</title></channel></rss>
+    RSS
+    WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
+
+    FeedRefreshWorkflow.new(test_feed).execute
+
+    assert_equal 0, test_feed.reload.consecutive_failures
+  end
+
+  test "#execute should turn the feed off after too many consecutive failures" do
+    test_feed = create(:feed, :enabled, url: "https://example.com/feed.xml", feed_profile_key: "rss",
+                                         consecutive_failures: Feed::MAX_CONSECUTIVE_FAILURES - 1)
+    WebMock.stub_request(:get, test_feed.url).to_timeout
+
+    assert_raises(Loader::Error) { FeedRefreshWorkflow.new(test_feed).execute }
+
+    test_feed.reload
+    assert test_feed.disabled?
+    assert_equal 0, test_feed.consecutive_failures
+
+    event = Event.find_by(subject: test_feed, type: "feed_auto_disabled")
+    assert_not_nil event
+    assert_equal "warning", event.level
+    assert_equal Feed::MAX_CONSECUTIVE_FAILURES, event.metadata["error_count"]
+  end
+
   test "#execute should aggregate feed metrics for multiple refreshes on same day" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -580,23 +580,6 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 0, test_feed.reload.consecutive_failures
   end
 
-  test "#execute should turn the feed off after too many consecutive failures" do
-    test_feed = create(:feed, :enabled, url: "https://example.com/feed.xml", feed_profile_key: "rss",
-                                         consecutive_failures: Feed::MAX_CONSECUTIVE_FAILURES - 1)
-    WebMock.stub_request(:get, test_feed.url).to_timeout
-
-    assert_raises(Loader::Error) { FeedRefreshWorkflow.new(test_feed).execute }
-
-    test_feed.reload
-    assert test_feed.disabled?
-    assert_equal 0, test_feed.consecutive_failures
-
-    event = Event.find_by(subject: test_feed, type: "feed_auto_disabled")
-    assert_not_nil event
-    assert_equal "warning", event.level
-    assert_equal Feed::MAX_CONSECUTIVE_FAILURES, event.metadata["error_count"]
-  end
-
   test "#execute should aggregate feed metrics for multiple refreshes on same day" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 


### PR DESCRIPTION
Changes:

- Track a per-feed consecutive-failure streak that increments on a failed refresh and resets on a successful one
- Turn a feed off automatically once it fails the refresh `MAX_CONSECUTIVE_FAILURES` (10) times in a row, recording a `feed_auto_disabled` event that carries how many failures it took
- Surface a "Recent activity" section on the feed page so the auto-disable (and other events) are visible to the owner

Previously an unreachable source kept failing on every scheduled refresh forever, with no backoff and no signal to the user beyond the event log. This bounds how long a genuinely broken source keeps retrying while leaving transient hiccups alone — any reachable refresh clears the streak.

References:

- Closes #511