### PR TITLE
Align event navigation with the timeline direction

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -45,11 +45,11 @@ class Admin::EventsController < ApplicationController
   end
 
   def previous_event(event)
-    events_scope.where("id > ?", event.id).order(id: :asc).first
+    events_scope.where("id < ?", event.id).order(id: :desc).first
   end
 
   def next_event(event)
-    events_scope.where("id < ?", event.id).order(id: :desc).first
+    events_scope.where("id > ?", event.id).order(id: :asc).first
   end
 
   def events_scope

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,8 +15,8 @@ class EventsController < ApplicationController
   def show
     @event = owned_events.find(params[:id])
     @referenced_posts = referenced_posts(@event).limit(MAX_RECENT_POSTS)
-    @previous_event = adjacent_event(:newer)
-    @next_event = adjacent_event(:older)
+    @previous_event = adjacent_event(:older)
+    @next_event = adjacent_event(:newer)
   end
 
   private
@@ -25,8 +25,8 @@ class EventsController < ApplicationController
     Event.where(user: Current.user).user_relevant
   end
 
-  # Navigates the user's own log in the same chronological order as the list:
-  # "previous" is the next-newer event, "next" is the next-older one.
+  # Navigates the user's own log along the natural timeline direction:
+  # "previous" is the next-older event, "next" is the next-newer one.
   def adjacent_event(direction)
     if direction == :newer
       owned_events.where(cursor_condition(">", @event.id)).order(created_at: :asc, id: :asc).first

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -20,9 +20,6 @@
         <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-300 shadow-sm cursor-not-allowed">Next →</span>
       <% end %>
     <% end %>
-    <% header.with_action_button do %>
-      <%= link_to "Back to Events", admin_events_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
-    <% end %>
   <% end %>
 
   <%= render AlertComponent.new(variant: @event.alert_variant) do %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,9 +20,6 @@
         <span class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-300 shadow-sm cursor-not-allowed">Next →</span>
       <% end %>
     <% end %>
-    <% header.with_action_button do %>
-      <%= link_to "Back to Status", status_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
-    <% end %>
   <% end %>
 
   <%= render AlertComponent.new(variant: @event.alert_variant) do %>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -335,8 +335,8 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     get event_path(current)
 
     assert_response :success
-    assert_select "a[href='#{event_path(newer)}']", text: "← Previous"
-    assert_select "a[href='#{event_path(older)}']", text: "Next →"
+    assert_select "a[href='#{event_path(older)}']", text: "← Previous"
+    assert_select "a[href='#{event_path(newer)}']", text: "Next →"
   end
 
   test "#show should disable navigation at the ends of the log" do


### PR DESCRIPTION
Changes:

- Swap the Next/Prev targets on `/events/:id` and `/admin/events/:id` so "Previous" goes to the older event and "Next" to the newer one
- Remove the "Back to Status" / "Back to Events" buttons from the event detail pages

Event navigation was inverted: "Previous" pointed at newer events and "Next" at older ones. Now it follows the natural timeline — "Previous" steps back in time, "Next" moves forward — which matches what people expect when paging through a log.
