### PR TITLE
Drop users_active and feeds_enabled gauges

### DIFF
--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -10,8 +10,6 @@ Rails.application.config.after_initialize do
   # would run identical queries every flush and overwrite the same series.
   # Counters are per-process and register/push everywhere regardless.
   if ENV["METRICS_GAUGES"].present?
-    Metrics.gauge("users_active") { User.where(state: :active).count }
-    Metrics.gauge("feeds_enabled") { Feed.where(state: :enabled).count }
     Metrics.gauge_set("posts_count") do
       counts = Post.group(:status).count
       Post.statuses.keys.to_h { |status| [{ status: status }, counts.fetch(status, 0)] }

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -108,17 +108,6 @@
       "title": "Application",
       "panels": [
         {
-          "title": "Users & feeds",
-          "expr": [
-            "feeder_users_active",
-            "feeder_feeds_enabled"
-          ],
-          "alias": [
-            "active users",
-            "enabled feeds"
-          ]
-        },
-        {
           "title": "Queue backlog",
           "expr": [
             "feeder_posts_count{status=\"enqueued\"}",
@@ -158,16 +147,6 @@
           ]
         },
         {
-          "title": "Metrics push age",
-          "unit": "s",
-          "expr": [
-            "time() - tlast_over_time(feeder_users_active[1d])"
-          ],
-          "alias": [
-            "since last push"
-          ]
-        },
-        {
           "title": "Feed refreshes (15m)",
           "expr": [
             "sum(increase(feeder_feed_refresh_total{status=\"ok\"}[15m]))",
@@ -182,6 +161,21 @@
           "title": "Loader errors (15m)",
           "expr": [
             "sum(increase(feeder_loader_errors_total[15m])) by (loader)"
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Metrics health",
+      "panels": [
+        {
+          "title": "Metrics push age",
+          "unit": "s",
+          "expr": [
+            "time() - tlast_over_time(feeder_pg_database_size_bytes[1d])"
+          ],
+          "alias": [
+            "since last push"
           ]
         }
       ]

--- a/test/services/metrics_test.rb
+++ b/test/services/metrics_test.rb
@@ -49,11 +49,11 @@ class MetricsTest < ActiveSupport::TestCase
   test "#gauge should be sampled at render time and carry no instance label" do
     enable!
     value = 5
-    Metrics.gauge("feeds_enabled") { value }
+    Metrics.gauge("jobs_ready") { value }
 
-    assert_includes Metrics.render, "feeder_feeds_enabled 5"
+    assert_includes Metrics.render, "feeder_jobs_ready 5"
     value = 9
-    assert_includes Metrics.render, "feeder_feeds_enabled 9"
+    assert_includes Metrics.render, "feeder_jobs_ready 9"
   end
 
   test "#gauge_set should render a line per label set sampled at render time" do


### PR DESCRIPTION
Changes:

- Drop the `users_active` and `feeds_enabled` gauges and the dashboard chart that displayed them
- Move the "Metrics push age" panel into its own "Metrics health" section

The user and feed count gauges weren't earning their place on the dashboard, so this removes them along with their chart. The push-age panel now reads from `feeder_pg_database_size_bytes` (a web-only gauge), so it still flags a stalled web process, and lives in its own section now that it's no longer grouped with the dropped chart.
