### PR TITLE
Skip image attachments for Reddit posts

### DIFF
--- a/app/services/normalizer/reddit_normalizer.rb
+++ b/app/services/normalizer/reddit_normalizer.rb
@@ -11,6 +11,15 @@ module Normalizer
       body.present? ? "#{title}\n\n#{body}" : title
     end
 
+    # Reddit's RSS only exposes images through its preview CDN
+    # (*.redd.it), which serves a block page with HTTP 403 to non-browser
+    # clients. There's no reliable way to download these, so we skip image
+    # attachments for Reddit posts entirely. The permalink in the content
+    # still links back to the original post with its media.
+    def normalize_attachment_urls
+      []
+    end
+
     def extract_post_body
       summary = raw_data.dig("summary") || ""
       return "" if summary.blank?

--- a/test/fixtures/files/feeds/reddit/feed.xml
+++ b/test/fixtures/files/feeds/reddit/feed.xml
@@ -23,5 +23,14 @@
       <dc:creator>rubydev</dc:creator>
     </item>
 
+    <item>
+      <title>Putin’s road to ruin: Ukraine hits key Russian supply line</title>
+      <link>https://www.reddit.com/r/worldnews/comments/1u51o58/putins_road_to_ruin/</link>
+      <guid isPermaLink="true">https://www.reddit.com/r/worldnews/comments/1u51o58/putins_road_to_ruin/</guid>
+      <pubDate>Sat, 13 Jun 2026 20:44:16 +0000</pubDate>
+      <description>&lt;table&gt;&lt;tr&gt;&lt;td&gt;&lt;a href="https://www.reddit.com/r/worldnews/comments/1u51o58/putins_road_to_ruin/"&gt;&lt;img src="https://external-preview.redd.it/fmPCRJKGyTXaUgg4zsLsXYT5q0K8yrEYF5P_Stv1JBc.jpeg?width=640&amp;crop=smart&amp;auto=webp&amp;s=477ae616fe3eddd77514ad38e5c9dea6a4662c22" alt="Putin’s road to ruin"&gt;&lt;/a&gt;&lt;/td&gt;&lt;td&gt; &amp;#32; submitted by &amp;#32; &lt;a href="https://www.reddit.com/user/newsbot"&gt; /u/newsbot &lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</description>
+      <dc:creator>newsbot</dc:creator>
+    </item>
+
   </channel>
 </rss>

--- a/test/services/normalizer/reddit_normalizer_test.rb
+++ b/test/services/normalizer/reddit_normalizer_test.rb
@@ -43,6 +43,15 @@ class Normalizer::RedditNormalizerTest < ActiveSupport::TestCase
     assert_not_includes post.content, "/u/techuser"
   end
 
+  test "#normalize should skip preview-CDN image attachments" do
+    entry = feed_entry(2)
+
+    normalizer = Normalizer::RedditNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal [], post.attachment_urls
+  end
+
   test "#normalize should include Reddit permalink as source URL" do
     entry = feed_entry(0)
 


### PR DESCRIPTION
Changes:

- Skip image attachments when normalizing Reddit posts

Reddit's RSS only exposes images through its preview CDN (*.redd.it), which serves a block page with HTTP 403 to non-browser clients. There's no reliable way to download these, so publishing such posts was failing on the attachment upload step. Skipping the images lets the post publish normally — its content still links back to the original Reddit post where the media lives.
