### PR TITLE
Show "now" for sub-minute durations

### DIFF
--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -6,7 +6,7 @@ module TimeHelper
 
     case diff
     when 0..59
-      "#{diff.to_i}s"
+      "now"
     when 60..3599
       "#{(diff / 60).to_i}m"
     when 3600..86399

--- a/test/helpers/time_helper_test.rb
+++ b/test/helpers/time_helper_test.rb
@@ -10,10 +10,10 @@ class TimeHelperTest < ActiveSupport::TestCase
     assert_nil short_time_ago(nil)
   end
 
-  test "#short_time_ago should return seconds for recent time" do
+  test "#short_time_ago should return now for recent time" do
     travel_to Time.zone.parse("2025-01-15 15:45:30") do
       time = 30.seconds.ago
-      assert_equal "30s", short_time_ago(time)
+      assert_equal "now", short_time_ago(time)
     end
   end
 


### PR DESCRIPTION
Changes:

- `short_time_ago` now returns "now" for durations under a minute instead of the "Ns" form

This keeps very recent activity from looking noisy ("3s", "12s", …) while still conveying that something just happened. The change also flows through `short_time_ago_tag` and `datetime_with_duration_tag`, which build on this helper.
