### PR TITLE
Use lag() for the metrics push age panel

### DIFF
--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -172,7 +172,7 @@
           "title": "Metrics push age",
           "unit": "s",
           "expr": [
-            "time() - tlast_over_time(feeder_pg_database_size_bytes[1d])"
+            "lag(feeder_pg_database_size_bytes[1d])"
           ],
           "alias": [
             "since last push"


### PR DESCRIPTION
Changes:

- Compute the "Metrics push age" panel with `lag()` instead of the hand-rolled `time() - tlast_over_time(...)` expression

The panel is meant to report seconds since the last metrics push, but `time() - tlast_over_time(...)` is a fragile idiom: VictoriaMetrics evaluates rollup timestamp functions on the query step grid, so the result collapses toward zero and the panel never flags a stalled push. `lag()` is the purpose-built rollup for "seconds since the last raw sample" and reports the real age, while keeping the same web-only gauge semantics (a stale value still means the web process stopped pushing).

References:

- Related PR: #721
