### PR TITLE
Refresh feed immediately after creating enabled feed

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -143,6 +143,7 @@ class FeedsController < ApplicationController
   def enable_and_respond(feed)
     if feed.enable
       record_feed_enabled(feed)
+      FeedRefreshJob.perform_later(feed.id)
       redirect_to feed_path(feed), success: success_message_for(feed)
     else
       flash.now[:alert] = "Couldn't enable. See issues below."

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -90,6 +90,42 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Feed created and enabled.", flash[:success]
   end
 
+  test "#create should enqueue a refresh when the feed is enabled" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "Test Feed",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_enqueued_with(job: FeedRefreshJob) do
+      post feeds_path, params: { feed: feed_params, enable_feed: "1" }
+    end
+  end
+
+  test "#create should not enqueue a refresh when the feed is saved as draft" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "Test Feed",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_no_enqueued_jobs(only: FeedRefreshJob) do
+      post feeds_path, params: { feed: feed_params, enable_feed: "0" }
+    end
+  end
+
   test "#create should save as draft with blank name" do
     sign_in_as(user)
     access_token


### PR DESCRIPTION
Changes:

- Enqueue a refresh job when a feed is created and enabled, so it starts importing right away instead of waiting for the next scheduled run

Creating an enabled feed now kicks off its first refresh immediately, giving users content without the wait. Feeds saved as drafts don't refresh until they're enabled, since a draft can't load from its source yet.
