### PR TITLE
Detect feed name for YouTube channel URLs

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -420,7 +420,7 @@ class FeedProfile
       loader: { class: "Loader::YoutubeLoader", config: {} },
       processor: { class: "Processor::YoutubeProcessor", config: {} },
       normalizer: { class: "Normalizer::YoutubeNormalizer", config: {} },
-      title_extractor: "TitleExtractor::RssTitleExtractor",
+      title_extractor: "TitleExtractor::YoutubeTitleExtractor",
       output_schema: nil
     },
     "telegram" => {

--- a/app/services/title_extractor/youtube_title_extractor.rb
+++ b/app/services/title_extractor/youtube_title_extractor.rb
@@ -1,0 +1,35 @@
+module TitleExtractor
+  # Suggests a feed title for a YouTube channel.
+  #
+  # A channel URL resolves to an HTML page, so the fetched body carries the
+  # channel name in its og:title meta tag rather than an RSS/Atom feed. When
+  # the input is the Atom feed URL directly, the body is the feed XML, so we
+  # fall back to its <title>. As a last resort we derive a handle from the URL.
+  class YoutubeTitleExtractor < Base
+    def title
+      og_title.presence || atom_title.presence || handle.presence
+    end
+
+    private
+
+    def og_title
+      return nil if fetched_body.blank?
+
+      doc = Nokogiri::HTML.parse(fetched_body, nil, "UTF-8")
+      doc.at_css('meta[property="og:title"]')&.[]("content")&.strip
+    rescue StandardError
+      nil
+    end
+
+    def atom_title
+      RssTitleExtractor.new(input, fetched_body).title
+    end
+
+    def handle
+      segment = URI.parse(input.to_s).path.to_s.split("/").find(&:present?)
+      segment if segment&.start_with?("@")
+    rescue URI::InvalidURIError
+      nil
+    end
+  end
+end

--- a/test/services/title_extractor/youtube_title_extractor_test.rb
+++ b/test/services/title_extractor/youtube_title_extractor_test.rb
@@ -23,4 +23,16 @@ class TitleExtractor::YoutubeTitleExtractorTest < ActiveSupport::TestCase
   test "#title should return nil when nothing can be derived" do
     assert_nil extractor("https://www.youtube.com/channel/UCabc123def456ghi789jkl").title
   end
+
+  test "#title should swallow parse errors from the page body" do
+    body = '<html><head><meta property="og:title" content="Sample Tech Channel"></head></html>'
+
+    Nokogiri::HTML.stub(:parse, ->(*) { raise "boom" }) do
+      assert_nil extractor("https://www.youtube.com/channel/UCabc123def456ghi789jkl", body).title
+    end
+  end
+
+  test "#title should swallow invalid URI errors when deriving a handle" do
+    assert_nil extractor("https://www.youtube.com/ bad handle").title
+  end
 end

--- a/test/services/title_extractor/youtube_title_extractor_test.rb
+++ b/test/services/title_extractor/youtube_title_extractor_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class TitleExtractor::YoutubeTitleExtractorTest < ActiveSupport::TestCase
+  def extractor(input, body = nil)
+    TitleExtractor::YoutubeTitleExtractor.new(input, body)
+  end
+
+  test "#title should read the channel name from the page og:title" do
+    body = '<html><head><meta property="og:title" content="Sample Tech Channel"></head></html>'
+    assert_equal "Sample Tech Channel", extractor("https://www.youtube.com/@SampleTech", body).title
+  end
+
+  test "#title should fall back to the Atom feed title for a feed URL" do
+    body = file_fixture("feeds/youtube/feed.xml").read
+    url = "https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123def456ghi789jkl"
+    assert_equal "Sample Tech Channel", extractor(url, body).title
+  end
+
+  test "#title should fall back to the @handle from the URL" do
+    assert_equal "@SampleTech", extractor("https://www.youtube.com/@SampleTech").title
+  end
+
+  test "#title should return nil when nothing can be derived" do
+    assert_nil extractor("https://www.youtube.com/channel/UCabc123def456ghi789jkl").title
+  end
+end


### PR DESCRIPTION
Changes:

- Add `TitleExtractor::YoutubeTitleExtractor` and wire the YouTube profile to it
- Resolve the channel name from the page's og:title, falling back to the Atom feed title and then the URL handle

Feed name detection failed for YouTube channel URLs. A channel URL resolves to an HTML page, but the YouTube profile reused the generic RSS title extractor, which only understands RSS/Atom XML — so it found no title in the fetched page. The dedicated extractor reads the channel name from the page's og:title (the normal case), while still handling a directly pasted feed XML URL and a bare @handle.
