### PR TITLE
Sort posts by reposting date by default

### DIFF
--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -64,20 +64,23 @@ module Sortable
     config ? config.fetch(:direction, "desc").to_s : "desc"
   end
 
-  # The Arel expression representing the current order clause. Intended
-  # for use in the "index" action that outputs the ordered records.
+  # The SQL order clause for the current sort field and direction, honouring an
+  # optional :nulls placement. Intended for use in the "index" action that
+  # outputs the ordered records.
   #
-  # @return [Arel::Nodes::Ordering]
+  # @return [Arel::Nodes::SqlLiteral]
   def sortable_order
     field_name = sortable_field.to_sym
-    field_sql = sortable_fields.dig(field_name, :order_by)
+    config = sortable_fields.fetch(field_name, {})
+    field_sql = config[:order_by]
 
     if field_sql.blank?
       raise ArgumentError, "Sortable field #{field_name.inspect} must define :order_by SQL"
     end
 
-    arel_field = Arel.sql(field_sql)
-    sortable_direction == "asc" ? arel_field.asc : arel_field.desc
+    clause = "#{field_sql} #{sortable_direction == 'asc' ? 'ASC' : 'DESC'}"
+    clause += " NULLS #{config[:nulls].to_s.upcase}" if config[:nulls].present?
+    Arel.sql(clause)
   end
 
   # Returns the configuration hash describing available sort fields.

--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -64,11 +64,11 @@ module Sortable
     config ? config.fetch(:direction, "desc").to_s : "desc"
   end
 
-  # The SQL order clause for the current sort field and direction, honouring an
+  # The Arel ordering for the current sort field and direction, honouring an
   # optional :nulls placement. Intended for use in the "index" action that
   # outputs the ordered records.
   #
-  # @return [Arel::Nodes::SqlLiteral]
+  # @return [Arel::Nodes::Ordering]
   def sortable_order
     field_name = sortable_field.to_sym
     config = sortable_fields.fetch(field_name, {})
@@ -78,9 +78,14 @@ module Sortable
       raise ArgumentError, "Sortable field #{field_name.inspect} must define :order_by SQL"
     end
 
-    clause = "#{field_sql} #{sortable_direction == 'asc' ? 'ASC' : 'DESC'}"
-    clause += " NULLS #{config[:nulls].to_s.upcase}" if config[:nulls].present?
-    Arel.sql(clause)
+    arel_field = Arel.sql(field_sql)
+    ordering = sortable_direction == "asc" ? arel_field.asc : arel_field.desc
+
+    case config[:nulls]
+    when :first then ordering.nulls_first
+    when :last then ordering.nulls_last
+    else ordering
+    end
   end
 
   # Returns the configuration hash describing available sort fields.

--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -64,9 +64,9 @@ module Sortable
     config ? config.fetch(:direction, "desc").to_s : "desc"
   end
 
-  # The Arel ordering for the current sort field and direction, honouring an
-  # optional :nulls placement. Intended for use in the "index" action that
-  # outputs the ordered records.
+  # The Arel ordering for the current sort field and direction. A field may
+  # request `nulls: :last` to keep rows with a NULL value out of the way.
+  # Intended for use in the "index" action that outputs the ordered records.
   #
   # @return [Arel::Nodes::Ordering]
   def sortable_order
@@ -80,12 +80,7 @@ module Sortable
 
     arel_field = Arel.sql(field_sql)
     ordering = sortable_direction == "asc" ? arel_field.asc : arel_field.desc
-
-    case config[:nulls]
-    when :first then ordering.nulls_first
-    when :last then ordering.nulls_last
-    else ordering
-    end
+    config[:nulls] == :last ? ordering.nulls_last : ordering
   end
 
   # Returns the configuration hash describing available sort fields.

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,6 +3,12 @@ class PostsController < ApplicationController
   include Sortable
 
   SORTABLE_FIELDS = {
+    reposted: {
+      title: "Reposted",
+      order_by: "posts.reposted_at",
+      direction: :desc,
+      nulls: :last
+    },
     published: {
       title: "Published",
       order_by: "posts.published_at",

--- a/db/migrate/20260613201000_add_reposted_at_index_to_posts.rb
+++ b/db/migrate/20260613201000_add_reposted_at_index_to_posts.rb
@@ -1,0 +1,12 @@
+class AddRepostedAtIndexToPosts < ActiveRecord::Migration[8.2]
+  # Sorting the Posts page by repost date defaults to reposted_at across all of
+  # the user's feeds. The existing [feed_id, reposted_at] index only helps when
+  # a single feed is selected; this standalone index backs the unfiltered view.
+  # Match the default ordering (DESC, reposted posts first, NULLs last) so the
+  # planner can satisfy it straight from the index.
+  def change
+    add_index :posts, :reposted_at,
+      order: { reposted_at: "DESC NULLS LAST" },
+      name: "index_posts_on_reposted_at"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_13_200000) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_13_201000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -245,6 +245,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_13_200000) do
     t.index ["feed_id", "reposted_at"], name: "index_posts_on_feed_id_and_reposted_at"
     t.index ["feed_id", "uid"], name: "index_posts_on_feed_id_and_uid", unique: true
     t.index ["feed_id"], name: "index_posts_on_feed_id"
+    t.index ["reposted_at"], name: "index_posts_on_reposted_at", order: "DESC NULLS LAST"
     t.index ["status"], name: "index_posts_on_status"
   end
 

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -459,10 +459,52 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert pos_with < pos_without, "Expected post with comments to appear first"
   end
 
-  test "#index should use default sort when no sort parameter provided" do
+  test "#index should sort posts by reposted date ascending" do
     sign_in_as(user)
-    old_post = create(:post, feed: feed, content: "Old post", published_at: 2.days.ago)
-    new_post = create(:post, feed: feed, content: "New post", published_at: 1.day.ago)
+    old_post = create(:post, :published, feed: feed, content: "Old post", reposted_at: 2.days.ago)
+    new_post = create(:post, :published, feed: feed, content: "New post", reposted_at: 1.day.ago)
+
+    get posts_url(sort: "reposted", direction: "asc")
+    assert_response :success
+
+    response_body = response.body
+    pos_old = response_body.index("Old post")
+    pos_new = response_body.index("New post")
+    assert pos_old < pos_new, "Expected old post to appear before new post"
+  end
+
+  test "#index should sort posts by reposted date descending" do
+    sign_in_as(user)
+    old_post = create(:post, :published, feed: feed, content: "Old post", reposted_at: 2.days.ago)
+    new_post = create(:post, :published, feed: feed, content: "New post", reposted_at: 1.day.ago)
+
+    get posts_url(sort: "reposted", direction: "desc")
+    assert_response :success
+
+    response_body = response.body
+    pos_old = response_body.index("Old post")
+    pos_new = response_body.index("New post")
+    assert pos_new < pos_old, "Expected new post to appear before old post"
+  end
+
+  test "#index should sort unreposted posts last when sorting by reposted date" do
+    sign_in_as(user)
+    reposted_post = create(:post, :published, feed: feed, content: "Reposted post", reposted_at: 1.day.ago)
+    draft_post = create(:post, feed: feed, content: "Draft post", reposted_at: nil)
+
+    get posts_url(sort: "reposted", direction: "desc")
+    assert_response :success
+
+    response_body = response.body
+    pos_reposted = response_body.index("Reposted post")
+    pos_draft = response_body.index("Draft post")
+    assert pos_reposted < pos_draft, "Expected reposted post to appear before the one without a repost date"
+  end
+
+  test "#index should default to sorting by reposted date when no sort parameter provided" do
+    sign_in_as(user)
+    old_post = create(:post, :published, feed: feed, content: "Old post", reposted_at: 2.days.ago)
+    new_post = create(:post, :published, feed: feed, content: "New post", reposted_at: 1.day.ago)
 
     get posts_url
     assert_response :success


### PR DESCRIPTION
Changes:

- Add a "Reposted" sort option to the Posts page, ordering by `reposted_at`
- Make it the default sort, with unreposted posts (no repost date) sorted last
- Add a matching `posts.reposted_at` index to back the default ordering

The Posts page now leads with the most recently reposted content, which is
what people usually come to the page looking for. Since only published posts
carry a `reposted_at`, the sort places drafts and other unreposted items at
the bottom rather than letting their empty dates float to the top. The
`Sortable` concern gained optional NULLS placement so this stays a small,
reusable addition rather than a one-off.
