### PR TITLE
Drop "ago" suffix from Recent repost stat

### DIFF
--- a/app/components/feed_stats_component.rb
+++ b/app/components/feed_stats_component.rb
@@ -82,7 +82,7 @@ class FeedStatsComponent < ViewComponent::Base
 
   def most_recent_repost_value
     if @feed.most_recent_repost_at
-      safe_join([helpers.short_time_ago_tag(@feed.most_recent_repost_at), " ago"])
+      helpers.short_time_ago_tag(@feed.most_recent_repost_at)
     else
       content_tag(:span, "No reposts yet", class: "text-slate-500")
     end

--- a/app/components/user_stats_component.rb
+++ b/app/components/user_stats_component.rb
@@ -53,7 +53,7 @@ class UserStatsComponent < ViewComponent::Base
         key: "most_recent_repost",
         label: "Most recent repost",
         label_short: "Recent",
-        value: user.most_recent_repost_at.present? ? "#{helpers.short_time_ago(user.most_recent_repost_at)} ago" : "—"
+        value: user.most_recent_repost_at.present? ? helpers.short_time_ago(user.most_recent_repost_at) : "—"
       }
     ]
   end

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -26,7 +26,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
 
       most_recent = result.css('[data-key="stats.most_recent_repost"]').first
       assert_not_nil most_recent
-      assert_equal "1h ago", result.css('[data-key="stats.most_recent_repost.value"]').first.text.strip
+      assert_equal "1h", result.css('[data-key="stats.most_recent_repost.value"]').first.text.strip
 
       imported = result.css('[data-key="stats.imported_posts"]').first
       assert_not_nil imported

--- a/test/controllers/statuses_controller_test.rb
+++ b/test/controllers/statuses_controller_test.rb
@@ -75,7 +75,7 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     get status_path
     assert_response :success
     assert_not_nil css_select('[data-key="stats.most_recent_repost"]').first
-    assert_match(/1d ago/, css_select('[data-key="stats.most_recent_repost.value"]').first.text)
+    assert_match(/1d/, css_select('[data-key="stats.most_recent_repost.value"]').first.text)
   end
 
   test "#show should hide most recent repost when no published posts" do


### PR DESCRIPTION
Changes:

- Drop the trailing "ago" from the "Recent" repost value in the feed and user stats bars

The stats bar used `short_time_ago`, whose most-recent bucket renders as
"now". Appending "ago" produced the awkward "now ago" for fresh reposts.
Dropping the suffix keeps these cells consistent with the neighboring
"Refreshed" stat, which already shows a bare relative time (`now`, `5m`,
`1h`, …).
