### PR TITLE
Keep the publish chain alive on oversized content and missing attachments

### DIFF
--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -58,12 +58,22 @@ class PostPublishJob < ApplicationJob
   rescue FreefeedClient::UnauthorizedError
     # Token is no longer valid: disable it and stop the chain.
     feed.access_token&.disable_token_and_feeds
+  rescue FreefeedPublisher::SourceContentError => e
+    # Source content is gone (e.g. an attachment 404s). Expected external
+    # condition: fail the post and move on, but don't page error tracking.
+    fail_post(feed, post, e)
   rescue => e
     # Poison post: mark it failed and move on so the queue isn't blocked.
+    fail_post(feed, post, e, report: true)
+  end
+
+  # Mark a post failed and advance the chain. Reports to error tracking only for
+  # unexpected faults; expected external failures are logged and skipped.
+  def fail_post(feed, post, error, report: false)
     post.update!(status: :failed)
     Metrics.increment("posts_published_total", status: "failed")
-    Rails.logger.error "Failed to publish post #{post.id}: #{e.message}"
-    Rails.error.report(e, context: { post: post.attributes, feed: feed.attributes })
+    Rails.logger.error "Failed to publish post #{post.id}: #{error.message}"
+    Rails.error.report(error, context: { post: post.attributes, feed: feed.attributes }) if report
     schedule_next(feed)
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -54,6 +54,16 @@ class Post < ApplicationRecord
     as_json(only: NORMALIZED_ATTRIBUTES)
   end
 
+  # Trim a comment to FreeFeed's hard limit so publishing never fails on length.
+  # Truncates rather than dropping, so as much of the text as possible survives.
+  # Applied both when normalizing (clean stored data) and when publishing (the
+  # last line of defense for posts enqueued before truncation existed).
+  def self.clamp_comment(text)
+    return text unless text.is_a?(String) && text.length > MAX_COMMENT_LENGTH
+
+    text.truncate(MAX_COMMENT_LENGTH, omission: "…")
+  end
+
   private
 
   def validate_comments_length

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -25,9 +25,13 @@ class Post < ApplicationRecord
   validates :uid, uniqueness: { scope: :feed_id }
   validates :published_at, presence: true
   validates :source_url, presence: true
-  validates :content, length: { maximum: MAX_CONTENT_LENGTH }
+  # Length limits gate enqueueing only. Once a post leaves the queue (published,
+  # failed, withdrawn) these must not block the status transition, or a post that
+  # slipped past with over-long content would wedge the publish chain: the rescue
+  # that marks it failed would itself fail to save. See PostPublishJob.
+  validates :content, length: { maximum: MAX_CONTENT_LENGTH }, if: :enqueued?
 
-  validate :validate_comments_length
+  validate :validate_comments_length, if: :enqueued?
   validate :validate_enqueued_status
 
   enum :status, {

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -106,7 +106,7 @@ class FreefeedPublisher
 
       client.create_comment(
         post_id: freefeed_post_id,
-        body: comment_text
+        body: Post.clamp_comment(comment_text)
       )
     end
   rescue RateLimit::Throttled

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -5,6 +5,10 @@ class FreefeedPublisher
   class Error < StandardError; end
   class ValidationError < Error; end
   class PublishError < Error; end
+  # Source content couldn't be fetched (e.g. an attachment URL returns 404). An
+  # expected external condition, not an app fault: the job fails the post and
+  # moves on without paging error tracking. See PostPublishJob.
+  class SourceContentError < PublishError; end
 
   attr_reader :post
 
@@ -75,7 +79,7 @@ class FreefeedPublisher
   rescue FreefeedClient::UnauthorizedError
     raise
   rescue FileBuffer::Error => e
-    raise PublishError, "Failed to upload attachments: #{e.message}"
+    raise SourceContentError, "Failed to upload attachments: #{e.message}"
   rescue => e
     raise PublishError, "Failed to upload attachments: #{e.message}"
   end

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -75,15 +75,7 @@ module Normalizer
     end
 
     def comments
-      @comments ||= normalize_comments.map { |comment| truncate_comment(comment) }
-    end
-
-    # FreeFeed rejects comments over the limit. Trim instead of dropping the whole
-    # post, so a long source text (e.g. a YouTube description) still gets reposted.
-    def truncate_comment(comment)
-      return comment unless comment.is_a?(String) && comment.length > Post::MAX_COMMENT_LENGTH
-
-      comment.truncate(Post::MAX_COMMENT_LENGTH, omission: "…")
+      @comments ||= normalize_comments.map { |comment| Post.clamp_comment(comment) }
     end
 
     def normalize_source_url

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -75,7 +75,15 @@ module Normalizer
     end
 
     def comments
-      @comments ||= normalize_comments
+      @comments ||= normalize_comments.map { |comment| truncate_comment(comment) }
+    end
+
+    # FreeFeed rejects comments over the limit. Trim instead of dropping the whole
+    # post, so a long source text (e.g. a YouTube description) still gets reposted.
+    def truncate_comment(comment)
+      return comment unless comment.is_a?(String) && comment.length > Post::MAX_COMMENT_LENGTH
+
+      comment.truncate(Post::MAX_COMMENT_LENGTH, omission: "…")
     end
 
     def normalize_source_url

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -75,6 +75,35 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_equal feed.id, kwargs.dig(:context, :feed)["id"]
   end
 
+  test ".perform_now should fail a post with an unfetchable attachment without reporting it" do
+    post = create(:post, :enqueued, feed: feed, attachment_urls: ["https://example.com/missing.png"])
+    stub_request(:get, "https://example.com/missing.png").to_return(status: 404, body: "Not Found")
+
+    reported = []
+    assert_enqueued_with(job: PostPublishJob, args: [feed.id]) do
+      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
+        PostPublishJob.perform_now(feed.id)
+      end
+    end
+
+    assert_equal "failed", post.reload.status
+    assert_empty reported, "an expected attachment 404 must not be reported as a fault"
+  end
+
+  test ".perform_now should publish a post whose comment exceeds the length limit without wedging" do
+    # Regression: a post that slipped into the queue (via bulk insert) with an
+    # over-long comment used to crash the chain — marking it published, and the
+    # fallback to failed, both re-ran the comment-length validation and raised.
+    post = build(:post, :enqueued, feed: feed, comments: ["a" * (Post::MAX_COMMENT_LENGTH + 1)])
+    post.save!(validate: false)
+    stub_publish_success
+    stub_request(:post, "#{access_token.host}/v4/comments")
+      .to_return(status: 201, headers: { "Content-Type" => "application/json" }, body: { comments: { id: "c1" } }.to_json)
+
+    assert_nothing_raised { PostPublishJob.perform_now(feed.id) }
+    assert_equal "published", post.reload.status
+  end
+
   test ".perform_now should disable the token and stop the chain on UnauthorizedError" do
     post = create(:post, :enqueued, feed: feed)
     stub_request(:post, "#{access_token.host}/v4/posts").to_return(status: 401)

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -165,38 +165,48 @@ class PostTest < ActiveSupport::TestCase
     assert_nil post.reposted_at
   end
 
-  test "should validate content length within FreeFeed limits" do
-    post = build(:post, content: "a" * Post::MAX_CONTENT_LENGTH)
+  test "should validate content length within FreeFeed limits when enqueued" do
+    post = build(:post, :enqueued, content: "a" * Post::MAX_CONTENT_LENGTH)
     assert post.valid?
 
-    post = build(:post, content: "a" * (Post::MAX_CONTENT_LENGTH + 1))
+    post = build(:post, :enqueued, content: "a" * (Post::MAX_CONTENT_LENGTH + 1))
     assert_not post.valid?
     assert post.errors.of_kind?(:content, :too_long)
   end
 
-  test "should validate comments length within FreeFeed limits" do
+  test "should validate comments length within FreeFeed limits when enqueued" do
     valid_comment = "a" * Post::MAX_COMMENT_LENGTH
-    post = build(:post, comments: [valid_comment])
+    post = build(:post, :enqueued, comments: [valid_comment])
     assert post.valid?
 
     long_comment = "a" * (Post::MAX_COMMENT_LENGTH + 1)
-    post = build(:post, comments: [long_comment])
+    post = build(:post, :enqueued, comments: [long_comment])
     assert_not post.valid?
     assert_includes post.errors[:comments], "Comment 1 exceeds maximum length of #{Post::MAX_COMMENT_LENGTH} characters"
   end
 
-  test "should validate multiple comments length" do
+  test "should validate multiple comments length when enqueued" do
     valid_comment = "a" * Post::MAX_COMMENT_LENGTH
     long_comment = "a" * (Post::MAX_COMMENT_LENGTH + 1)
 
-    post = build(:post, comments: [valid_comment, long_comment, valid_comment])
+    post = build(:post, :enqueued, comments: [valid_comment, long_comment, valid_comment])
     assert_not post.valid?
     assert_includes post.errors[:comments], "Comment 2 exceeds maximum length of #{Post::MAX_COMMENT_LENGTH} characters"
   end
 
   test "should handle non-string comments gracefully" do
-    post = build(:post, comments: ["valid", nil, 123, "also valid"])
+    post = build(:post, :enqueued, comments: ["valid", nil, 123, "also valid"])
     assert post.valid?
+  end
+
+  test "should not enforce length limits when leaving the queue" do
+    over_content = "a" * (Post::MAX_CONTENT_LENGTH + 1)
+    over_comment = "a" * (Post::MAX_COMMENT_LENGTH + 1)
+
+    %i[published failed withdrawn].each do |status|
+      post = build(:post, status: status, content: over_content, comments: [over_comment])
+      assert post.valid?, "expected #{status} post to skip length limits, got: #{post.errors.full_messages}"
+    end
   end
 
   test "#normalized_attributes should include only normalized fields" do

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -209,6 +209,24 @@ class PostTest < ActiveSupport::TestCase
     end
   end
 
+  test ".clamp_comment should truncate text over the FreeFeed limit" do
+    long = "a" * (Post::MAX_COMMENT_LENGTH + 100)
+    clamped = Post.clamp_comment(long)
+
+    assert_equal Post::MAX_COMMENT_LENGTH, clamped.length
+    assert clamped.end_with?("…")
+  end
+
+  test ".clamp_comment should leave text within the limit untouched" do
+    text = "a" * Post::MAX_COMMENT_LENGTH
+    assert_equal text, Post.clamp_comment(text)
+  end
+
+  test ".clamp_comment should pass non-string values through unchanged" do
+    assert_nil Post.clamp_comment(nil)
+    assert_equal 123, Post.clamp_comment(123)
+  end
+
   test "#normalized_attributes should include only normalized fields" do
     post = build(:post,
       uid: "test-uid",

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -536,6 +536,16 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     end
   end
 
+  test "#publish should raise SourceContentError when an attachment cannot be downloaded" do
+    image_url = "https://example.com/missing.jpg"
+    post = post_with_content("Post with missing image", attachment_urls: [image_url])
+    stub_request(:get, image_url).to_return(status: 404, body: "Not Found")
+
+    assert_raises(FreefeedPublisher::SourceContentError) do
+      FreefeedPublisher.new(post).publish
+    end
+  end
+
   test "#publish should handle local file attachment" do
     # Create a temporary file
     temp_file = Tempfile.new(["test_image", ".jpg"])

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -444,6 +444,28 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     end
   end
 
+  test "#publish should truncate an over-long comment before sending it to FreeFeed" do
+    long_comment = "a" * (Post::MAX_COMMENT_LENGTH + 100)
+    post = post_with_content("body", comments: [long_comment])
+
+    stub_request(:post, "#{access_token.host}/v4/posts")
+      .to_return(status: 201, headers: { "Content-Type" => "application/json" },
+                 body: { posts: { id: "ff1" } }.to_json)
+
+    sent_bodies = []
+    stub_request(:post, "#{access_token.host}/v4/comments").to_return do |request|
+      sent_bodies << JSON.parse(request.body).dig("comment", "body")
+      { status: 201, headers: { "Content-Type" => "application/json" },
+        body: { comments: { id: "c1" } }.to_json }
+    end
+
+    FreefeedPublisher.new(post).publish
+
+    assert_equal 1, sent_bodies.length
+    assert_equal Post::MAX_COMMENT_LENGTH, sent_bodies.first.length
+    assert sent_bodies.first.end_with?("…")
+  end
+
   test "#publish should raise error when comment creation fails" do
     post = post_with_content("Post with comments", comments: ["Test comment"])
 

--- a/test/services/normalizer/base_test.rb
+++ b/test/services/normalizer/base_test.rb
@@ -39,6 +39,21 @@ class Normalizer::BaseTest < ActiveSupport::TestCase
     assert_equal [], result
   end
 
+  test "#comments should truncate entries longer than the FreeFeed limit" do
+    long_comment = "a" * (Post::MAX_COMMENT_LENGTH + 50)
+    subclass = Class.new(Normalizer::Base) do
+      def self.name = "Normalizer::LongCommentNormalizer"
+      def normalize_comments = raw_data["comments"]
+    end
+    entry = create(:feed_entry, raw_data: { "comments" => [long_comment, "short"] })
+
+    result = subclass.new(entry).send(:comments)
+
+    assert_equal Post::MAX_COMMENT_LENGTH, result.first.length
+    assert result.first.end_with?("…")
+    assert_equal "short", result.last
+  end
+
   test "#normalize should raise MissingUidError when the subclass produces a blank uid" do
     subclass = Class.new(Normalizer::Base) do
       def self.name = "Normalizer::NoUidNormalizer"

--- a/test/services/normalizer/youtube_normalizer_test.rb
+++ b/test/services/normalizer/youtube_normalizer_test.rb
@@ -58,6 +58,23 @@ class Normalizer::YoutubeNormalizerTest < ActiveSupport::TestCase
     assert_equal ["This is a description."], post.comments
   end
 
+  test "#normalize should truncate a description that exceeds the comment limit" do
+    long_description = "a" * (Post::MAX_COMMENT_LENGTH + 100)
+    entry = create(:feed_entry, raw_data: {
+      "title" => "Video",
+      "link" => "https://www.youtube.com/watch?v=abc123",
+      "content" => long_description
+    })
+
+    normalizer = Normalizer::YoutubeNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal 1, post.comments.length
+    assert_equal Post::MAX_COMMENT_LENGTH, post.comments.first.length
+    assert post.comments.first.end_with?("…")
+    assert post.enqueued?, "a truncated comment must still let the post enqueue"
+  end
+
   test "#normalize should produce empty comments when description is blank" do
     entry = create(:feed_entry, raw_data: {
       "title" => "Video",


### PR DESCRIPTION
Changes:

- Gate content/comment length limits to enqueued posts only, so status transitions (published/failed) can't re-trigger validation and wedge the publish chain
- Truncate over-long comments during normalization so long source text (e.g. a YouTube description) still gets reposted
- Treat unfetchable attachments (e.g. an HTTP 404) as an expected external condition: fail the post and move on without paging error tracking

A post that slipped into the queue with an over-long comment used to deadlock the FIFO publish chain. Marking it published, and the rescue's fallback to failed, both re-ran the comment-length validation and raised — so the chain died and the rest of the feed's posts hung in the queue. Length limits now gate enqueueing only, comments are trimmed up front, and a new `SourceContentError` lets the job distinguish expected source failures from real faults.