### PR TITLE
Enable Solid Cable on the primary database

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -10,9 +10,6 @@ test:
 
 production: &production
   adapter: solid_cable
-  connects_to:
-    database:
-      writing: cable
   polling_interval: 0.1.seconds
   message_retention: 1.day
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -92,10 +92,6 @@ production:
     <<: *primary_production
     database: f2_production_queue
     migrations_paths: db/queue_migrate
-  cable:
-    <<: *primary_production
-    database: f2_production_cable
-    migrations_paths: db/cable_migrate
 
 staging:
   primary: &primary_staging
@@ -112,7 +108,3 @@ staging:
     <<: *primary_staging
     database: f2_staging_queue
     migrations_paths: db/queue_migrate
-  cable:
-    <<: *primary_staging
-    database: f2_staging_cable
-    migrations_paths: db/cable_migrate

--- a/db/migrate/20260614091900_create_solid_cable_tables.rb
+++ b/db/migrate/20260614091900_create_solid_cable_tables.rb
@@ -1,0 +1,14 @@
+class CreateSolidCableTables < ActiveRecord::Migration[8.2]
+  def change
+    create_table :solid_cable_messages do |t|
+      t.binary :channel, limit: 1024, null: false
+      t.binary :payload, limit: 536870912, null: false
+      t.datetime :created_at, null: false
+      t.integer :channel_hash, limit: 8, null: false
+
+      t.index :channel
+      t.index :channel_hash
+      t.index :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_13_201000) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_14_091900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -265,6 +265,16 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_13_201000) do
     t.string "user_agent"
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.binary "channel", null: false
+    t.binary "payload", null: false
+    t.datetime "created_at", null: false
+    t.bigint "channel_hash", null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
   end
 
   create_table "solid_cache_entries", force: :cascade do |t|


### PR DESCRIPTION
Changes:

- Add the `solid_cable_messages` table via a standard migration, so Action Cable has a backing store in production and staging.
- Point the `solid_cable` adapter at the primary database connection and drop the now-unused separate `cable` database definitions.

Solid Cable was already listed in the Gemfile and referenced in `config/cable.yml`, but it had no table to write to and pointed at a dedicated `cable` database that was never created. This finishes the setup by giving it a backing table and running it on the primary connection, matching how Solid Queue already works. Development still uses the in-process `async` adapter and test uses the `test` adapter, so this only affects production and staging.

With this in place, background jobs can broadcast Turbo Stream updates over Action Cable, which opens the door to replacing the existing client-side polling flows (feed identification, feed preview, token and credential validation) with server-pushed updates.
