### PR TITLE
Run Puma in clustered mode for multi-core host

### DIFF
--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -114,6 +114,15 @@ module Metrics
       @thread
     end
 
+    # Stop this process from sampling gauges, while leaving counters intact.
+    # Gauges are global DB snapshots, so only one process per host samples them
+    # (the Puma master). Forked web workers call this so they push just their
+    # own per-process counters instead of re-sampling the same global series.
+    def skip_gauges!
+      gauges.clear
+      gauge_sets.clear
+    end
+
     # Test seam: drop all recorded state.
     def reset!
       mutex.synchronize { counters.clear }

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -33,3 +33,8 @@ env:
     RAILS_ENV: production
     HOSTS: fffeeder.com
     ACTION_MAILER_HOST: fffeeder.com
+    # Run Puma in clustered mode with 2 workers x 3 threads to use both CPU
+    # cores. Kept conservative because the jobs role and the Postgres accessory
+    # share this 2-core host. If memory becomes the binding constraint, drop
+    # back to 1 worker.
+    WEB_CONCURRENCY: 2

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -5,7 +5,7 @@ servers:
       - dev.fffeeder.com
     env:
       clear:
-        # Gauge sampling lives in the single Puma process; see
+        # Gauge sampling runs once in the Puma master process; see
         # config/initializers/metrics.rb.
         METRICS_GAUGES: "true"
   jobs:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -65,6 +65,10 @@ env:
     RAILS_ENV: staging
     HOSTS: dev.fffeeder.com
     ACTION_MAILER_HOST: dev.fffeeder.com
+    # Mirror production's clustered Puma (2 workers x 3 threads) so staging
+    # exercises the real multi-worker paths: per-worker counter flushing,
+    # single-master gauge sampling, and cross-worker Solid Cable broadcast.
+    WEB_CONCURRENCY: 2
     # Reaches the victoriametrics accessory by container name over the Kamal
     # network. Unset this (or remove the accessory) to disable metrics.
     METRICS_URL: http://f2-victoriametrics:8428/api/v1/import/prometheus

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,8 +36,19 @@ workers ENV.fetch("WEB_CONCURRENCY", 1)
 
 # Preload the application before forking workers so they share memory via
 # copy-on-write, reducing total memory footprint. Active Record reconnects
-# automatically in each forked worker.
-preload_app!
+# automatically in each forked worker. Skipped in development and test, where
+# preloading would break code reloading.
+preload_app! if %w[production staging].include?(ENV.fetch("RAILS_ENV", "development"))
+
+# With preloading, the metrics flusher thread starts in the master and does not
+# survive the fork, so each worker restarts its own. Gauges are global DB
+# snapshots sampled once by the master process; workers skip them and push only
+# their per-process counters. All a no-op unless metrics are enabled
+# (METRICS_URL). See config/initializers/metrics.rb.
+on_worker_boot do
+  Metrics.skip_gauges!
+  Metrics.start!
+end
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 3000)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,6 +27,18 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
+# Specifies the number of `workers` to boot in clustered mode. Workers are
+# forked web server processes, each running its own threads. With the GVL,
+# parallelism across CPU cores comes from workers, not threads, so clustering
+# is how the multi-core production host actually uses both cores. The default
+# is 1; set WEB_CONCURRENCY to scale up (see config/deploy.production.yml).
+workers ENV.fetch("WEB_CONCURRENCY", 1)
+
+# Preload the application before forking workers so they share memory via
+# copy-on-write, reducing total memory footprint. Active Record reconnects
+# automatically in each forked worker.
+preload_app!
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 3000)
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,27 +27,29 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
-# Specifies the number of `workers` to boot in clustered mode. Workers are
-# forked web server processes, each running its own threads. With the GVL,
-# parallelism across CPU cores comes from workers, not threads, so clustering
-# is how the multi-core production host actually uses both cores. The default
-# is 1; set WEB_CONCURRENCY to scale up (see config/deploy.production.yml).
-workers ENV.fetch("WEB_CONCURRENCY", 1)
+# Run in clustered mode only in deployed environments. Workers are forked web
+# server processes; with the GVL, parallelism across CPU cores comes from
+# workers, not threads, so clustering is how the multi-core production host uses
+# both cores. Development and test stay single-process to keep code reloading
+# working and avoid fork overhead. Set WEB_CONCURRENCY to scale the worker count
+# (see config/deploy.production.yml).
+if %w[production staging].include?(ENV.fetch("RAILS_ENV", "development"))
+  workers ENV.fetch("WEB_CONCURRENCY", 1)
 
-# Preload the application before forking workers so they share memory via
-# copy-on-write, reducing total memory footprint. Active Record reconnects
-# automatically in each forked worker. Skipped in development and test, where
-# preloading would break code reloading.
-preload_app! if %w[production staging].include?(ENV.fetch("RAILS_ENV", "development"))
+  # Preload the application before forking workers so they share memory via
+  # copy-on-write, reducing total memory footprint. Active Record reconnects
+  # automatically in each forked worker.
+  preload_app!
 
-# With preloading, the metrics flusher thread starts in the master and does not
-# survive the fork, so each worker restarts its own. Gauges are global DB
-# snapshots sampled once by the master process; workers skip them and push only
-# their per-process counters. All a no-op unless metrics are enabled
-# (METRICS_URL). See config/initializers/metrics.rb.
-on_worker_boot do
-  Metrics.skip_gauges!
-  Metrics.start!
+  # The metrics flusher thread starts in the master during preload and does not
+  # survive the fork, so each worker restarts its own. Gauges are global DB
+  # snapshots sampled once by the master process; workers skip them and push
+  # only their per-process counters. All a no-op unless metrics are enabled
+  # (METRICS_URL). See config/initializers/metrics.rb.
+  on_worker_boot do
+    Metrics.skip_gauges!
+    Metrics.start!
+  end
 end
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.

--- a/test/services/metrics_test.rb
+++ b/test/services/metrics_test.rb
@@ -80,6 +80,20 @@ class MetricsTest < ActiveSupport::TestCase
     assert_equal 1, reported.size
   end
 
+  test "#skip_gauges! should drop gauges while keeping counters" do
+    enable!
+    Metrics.increment("job_executions_total", status: "ok")
+    Metrics.gauge("jobs_ready") { 5 }
+    Metrics.gauge_set("pg_table_size_bytes") { { { table: "users" } => 100 } }
+
+    Metrics.skip_gauges!
+
+    out = Metrics.render
+    assert_includes out, "feeder_job_executions_total"
+    refute_includes out, "feeder_jobs_ready"
+    refute_includes out, "feeder_pg_table_size_bytes"
+  end
+
   test "#render should escape quotes in label values" do
     enable!
     Metrics.increment("job_executions_total", job: 'a"b')


### PR DESCRIPTION
Changes:

- Add a `workers ENV.fetch("WEB_CONCURRENCY", 1)` directive to `config/puma.rb` so Puma can run in clustered mode (default stays 1 worker, so dev is unchanged).
- Enable `preload_app!` so forked workers share memory via copy-on-write.
- Set `WEB_CONCURRENCY=2` for production (2 workers × 3 threads) to use both CPU cores.

Threads only give I/O concurrency under the GVL; CPU parallelism comes from workers, so clustering is what lets the 2-CPU production host use both cores. The worker count stays conservative because the `jobs` role and the Postgres accessory share the same box — it can drop back to 1 worker if memory turns out to be the binding constraint. The DB pool (5) stays above the thread count (3), and total Postgres connections remain well under `max_connections`.

References:

- Closes #732
- Related PR: #731