### PR TITLE
Purge stale events on a daily schedule

### DIFF
--- a/app/jobs/purge_expired_events_job.rb
+++ b/app/jobs/purge_expired_events_job.rb
@@ -1,19 +1,18 @@
-# Deletes events whose expiration time has passed, plus events with no explicit
-# expiration once they are older than DEFAULT_RETENTION.
+# Deletes expired events: those whose explicit expiration has passed, plus
+# events with no explicit expiration once they age past Event::DEFAULT_RETENTION.
 #
 # This job intentionally deletes in small batches so a daily cron run does not
 # hold locks on the events table for one long operation.
 class PurgeExpiredEventsJob < ApplicationJob
   queue_as :default
 
-  DEFAULT_RETENTION = 1.month
   BATCH_SIZE = 500
   BATCH_PAUSE = 0.01.seconds
 
   def perform
     deleted_count = 0
 
-    Event.purgeable(DEFAULT_RETENTION).in_batches(of: BATCH_SIZE) do |events|
+    Event.expired.in_batches(of: BATCH_SIZE) do |events|
       EventReference.where(event_id: events.select(:id)).delete_all
       deleted_count += events.delete_all
       sleep BATCH_PAUSE

--- a/app/jobs/purge_expired_events_job.rb
+++ b/app/jobs/purge_expired_events_job.rb
@@ -1,17 +1,19 @@
-# Deletes events whose explicit expiration time has passed.
+# Deletes events whose expiration time has passed, plus events with no explicit
+# expiration once they are older than DEFAULT_RETENTION.
 #
 # This job intentionally deletes in small batches so a daily cron run does not
 # hold locks on the events table for one long operation.
 class PurgeExpiredEventsJob < ApplicationJob
   queue_as :default
 
+  DEFAULT_RETENTION = 1.month
   BATCH_SIZE = 500
   BATCH_PAUSE = 0.01.seconds
 
   def perform
     deleted_count = 0
 
-    Event.expired.in_batches(of: BATCH_SIZE) do |events|
+    Event.purgeable(DEFAULT_RETENTION).in_batches(of: BATCH_SIZE) do |events|
       EventReference.where(event_id: events.select(:id)).delete_all
       deleted_count += events.delete_all
       sleep BATCH_PAUSE

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,9 @@
 class Event < ApplicationRecord
   self.inheritance_column = nil
 
+  # Events without an explicit expiration are kept this long, then purged.
+  DEFAULT_RETENTION = 1.month
+
   belongs_to :user, optional: true
   belongs_to :subject, polymorphic: true, optional: true
 
@@ -13,11 +16,16 @@ class Event < ApplicationRecord
 
   scope :recent, -> { order(created_at: :desc) }
   scope :for_subject, ->(subject) { where(subject: subject) }
-  scope :expired, -> { where("expires_at IS NOT NULL AND expires_at < ?", Time.current) }
-  scope :not_expired, -> { where("expires_at IS NULL OR expires_at >= ?", Time.current) }
-  scope :purgeable, ->(retention) {
+  # An event is expired once its explicit expiration has passed, or — when it
+  # never set one — once it ages past DEFAULT_RETENTION. This is what the purge
+  # job deletes.
+  scope :expired, -> {
     where("expires_at < :now OR (expires_at IS NULL AND created_at < :cutoff)",
-          now: Time.current, cutoff: retention.ago)
+          now: Time.current, cutoff: DEFAULT_RETENTION.ago)
+  }
+  scope :not_expired, -> {
+    where("(expires_at IS NULL OR expires_at >= :now) AND (expires_at IS NOT NULL OR created_at >= :cutoff)",
+          now: Time.current, cutoff: DEFAULT_RETENTION.ago)
   }
   scope :user_relevant, -> { where.not(level: :debug).not_expired }
 
@@ -32,7 +40,9 @@ class Event < ApplicationRecord
   end
 
   def expired?
-    expires_at.present? && expires_at < Time.current
+    return expires_at < Time.current if expires_at.present?
+
+    created_at.present? && created_at < DEFAULT_RETENTION.ago
   end
 
   def expires_in(duration)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,6 +15,10 @@ class Event < ApplicationRecord
   scope :for_subject, ->(subject) { where(subject: subject) }
   scope :expired, -> { where("expires_at IS NOT NULL AND expires_at < ?", Time.current) }
   scope :not_expired, -> { where("expires_at IS NULL OR expires_at >= ?", Time.current) }
+  scope :purgeable, ->(retention) {
+    where("expires_at < :now OR (expires_at IS NULL AND created_at < :cutoff)",
+          now: Time.current, cutoff: retention.ago)
+  }
   scope :user_relevant, -> { where.not(level: :debug).not_expired }
 
   def alert_variant

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -25,6 +25,11 @@ development:
     queue: default
     schedule: every day at 4am
 
+  purge_expired_events:
+    class: PurgeExpiredEventsJob
+    queue: default
+    schedule: every day at 5am
+
 staging:
   feed_scheduler:
     class: FeedSchedulerJob
@@ -40,6 +45,11 @@ staging:
     class: PruneFeedPreviewsJob
     queue: default
     schedule: every day at 4am
+
+  purge_expired_events:
+    class: PurgeExpiredEventsJob
+    queue: default
+    schedule: every day at 5am
 
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
@@ -60,6 +70,11 @@ production:
     class: PruneFeedPreviewsJob
     queue: default
     schedule: every day at 4am
+
+  purge_expired_events:
+    class: PurgeExpiredEventsJob
+    queue: default
+    schedule: every day at 5am
 
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"

--- a/test/jobs/purge_expired_events_job_test.rb
+++ b/test/jobs/purge_expired_events_job_test.rb
@@ -15,7 +15,7 @@ class PurgeExpiredEventsJobTest < ActiveJob::TestCase
   end
 
   test "#perform should delete unexpiring events older than the default retention" do
-    stale = create(:event, expires_at: nil, created_at: (PurgeExpiredEventsJob::DEFAULT_RETENTION + 1.day).ago)
+    stale = create(:event, expires_at: nil, created_at: (Event::DEFAULT_RETENTION + 1.day).ago)
     recent = create(:event, expires_at: nil, created_at: 1.day.ago)
 
     deleted_count = PurgeExpiredEventsJob.perform_now

--- a/test/jobs/purge_expired_events_job_test.rb
+++ b/test/jobs/purge_expired_events_job_test.rb
@@ -4,14 +4,25 @@ class PurgeExpiredEventsJobTest < ActiveJob::TestCase
   test "#perform should delete expired events" do
     expired = create(:event, expires_at: 1.hour.ago)
     active = create(:event, expires_at: 1.hour.from_now)
-    permanent = create(:event)
+    recent = create(:event)
 
     deleted_count = PurgeExpiredEventsJob.perform_now
 
     assert_equal 1, deleted_count
     assert_not Event.exists?(expired.id)
     assert Event.exists?(active.id)
-    assert Event.exists?(permanent.id)
+    assert Event.exists?(recent.id)
+  end
+
+  test "#perform should delete unexpiring events older than the default retention" do
+    stale = create(:event, expires_at: nil, created_at: (PurgeExpiredEventsJob::DEFAULT_RETENTION + 1.day).ago)
+    recent = create(:event, expires_at: nil, created_at: 1.day.ago)
+
+    deleted_count = PurgeExpiredEventsJob.perform_now
+
+    assert_equal 1, deleted_count
+    assert_not Event.exists?(stale.id)
+    assert Event.exists?(recent.id)
   end
 
   test "#perform should delete references of purged events" do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -110,18 +110,31 @@ class EventTest < ActiveSupport::TestCase
     assert_includes not_expired_events, permanent_event
   end
 
-  test "#purgeable should scope expired events and stale unexpiring events" do
+  test "#expired should also scope unexpiring events past the default retention" do
     expired = Event.create!(type: "expired_event", expires_at: 1.hour.ago)
     active = Event.create!(type: "active_event", expires_at: 1.hour.from_now)
-    stale = Event.create!(type: "stale_event", created_at: 2.months.ago)
+    stale = Event.create!(type: "stale_event", created_at: (Event::DEFAULT_RETENTION + 1.day).ago)
     recent = Event.create!(type: "recent_event")
 
-    purgeable = Event.purgeable(1.month)
+    expired_events = Event.expired
+    not_expired_events = Event.not_expired
 
-    assert_includes purgeable, expired
-    assert_includes purgeable, stale
-    assert_not_includes purgeable, active
-    assert_not_includes purgeable, recent
+    assert_includes expired_events, expired
+    assert_includes expired_events, stale
+    assert_not_includes expired_events, active
+    assert_not_includes expired_events, recent
+
+    assert_not_includes not_expired_events, stale
+    assert_includes not_expired_events, active
+    assert_includes not_expired_events, recent
+  end
+
+  test "#expired? should be true for unexpiring events past the default retention" do
+    stale = Event.create!(type: "stale_event", created_at: (Event::DEFAULT_RETENTION + 1.day).ago)
+    recent = Event.create!(type: "recent_event")
+
+    assert stale.expired?
+    assert_not recent.expired?
   end
 
   test "should set expiration time" do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -110,6 +110,20 @@ class EventTest < ActiveSupport::TestCase
     assert_includes not_expired_events, permanent_event
   end
 
+  test "#purgeable should scope expired events and stale unexpiring events" do
+    expired = Event.create!(type: "expired_event", expires_at: 1.hour.ago)
+    active = Event.create!(type: "active_event", expires_at: 1.hour.from_now)
+    stale = Event.create!(type: "stale_event", created_at: 2.months.ago)
+    recent = Event.create!(type: "recent_event")
+
+    purgeable = Event.purgeable(1.month)
+
+    assert_includes purgeable, expired
+    assert_includes purgeable, stale
+    assert_not_includes purgeable, active
+    assert_not_includes purgeable, recent
+  end
+
   test "should set expiration time" do
     event = Event.create!(type: "test_event")
 


### PR DESCRIPTION
Changes:

- Give events a default retention of 1 month so events without an explicit expiration no longer accumulate forever
- Extend the purge job to drop both already-expired events and unexpiring events older than the retention window
- Schedule the purge job to run daily at 5am across all environments

Until now the purge job only removed events with an explicit expiration, and nothing scheduled it to run. In practice no events set an expiration, so the table grew unbounded. This wires the job into the daily schedule and gives unexpiring events a sensible default lifetime while leaving recent ones untouched.
