### PR TITLE
Lay CPU and resource panels side by side

### DIFF
--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -6,6 +6,7 @@
       "panels": [
         {
           "title": "CPU usage %",
+          "width": 6,
           "unit": "%",
           "expr": [
             "100 * (1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])))"
@@ -16,6 +17,7 @@
         },
         {
           "title": "Load average",
+          "width": 6,
           "expr": [
             "node_load1",
             "node_load5",
@@ -36,6 +38,7 @@
       "panels": [
         {
           "title": "Disk I/O",
+          "width": 4,
           "unit": "bytes/s",
           "expr": [
             "sum(rate(node_disk_read_bytes_total{device!~\"loop.*\"}[5m]))",
@@ -48,6 +51,7 @@
         },
         {
           "title": "Memory %",
+          "width": 4,
           "unit": "%",
           "expr": [
             "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100"
@@ -58,6 +62,7 @@
         },
         {
           "title": "Network traffic",
+          "width": 4,
           "unit": "bytes/s",
           "expr": [
             "sum(rate(node_network_receive_bytes_total{device!=\"lo\"}[5m]))",


### PR DESCRIPTION
Changes:

- Set `width` on the CPU row panels (CPU usage %, Load average) and the Resources row panels (Disk I/O, Memory %, Network traffic) so they render side by side

vmui only tiles panels within a row when each has an explicit `width` (1–12 grid columns); without it, panels default to full width and stack vertically. The earlier layout grouped panels into the right rows but omitted widths, so they stacked.
