### PR TITLE
Generalize poll-until-done into a shared component and concern

### DIFF
--- a/app/components/polling_shell_component.html.erb
+++ b/app/components/polling_shell_component.html.erb
@@ -1,0 +1,6 @@
+<%= tag.div data: host_data, aria: host_aria do %>
+  <%= tag.div content, id: content_id, class: content_class, data: content_data %>
+  <% if timeout_message? %>
+    <%= tag.div timeout_message, class: timeout_class, hidden: true, data: { polling_target: "timeoutMessage" } %>
+  <% end %>
+<% end %>

--- a/app/components/polling_shell_component.rb
+++ b/app/components/polling_shell_component.rb
@@ -1,0 +1,57 @@
+# Mounts the `polling` Stimulus controller on a stable host element and wraps
+# the body it polls into. The host stays put across polls while the server
+# swaps the inner `content_id` container (the Turbo Stream target); polling
+# stops once a terminal body inside it carries the stop-condition marker
+# (`data-polling-done` by default).
+#
+# Pass the terminal/loading body as the block, and an optional timeout notice
+# via the `timeout_message` slot (shown when the client gives up). Cadence
+# defaults to StatePolling's constants; override per call when a job runs
+# longer.
+class PollingShellComponent < ViewComponent::Base
+  renders_one :timeout_message
+
+  def initialize(
+    endpoint:,
+    content_id:,
+    content_class: nil,
+    content_target: false,
+    stop_condition: "[data-polling-done]",
+    interval: StatePolling::POLLING_INTERVAL_MS,
+    max_polls: StatePolling::POLLING_MAX_POLLS,
+    indicate_busy: true,
+    timeout_class: nil
+  )
+    @endpoint = endpoint
+    @content_id = content_id
+    @content_class = content_class
+    @content_target = content_target
+    @stop_condition = stop_condition
+    @interval = interval
+    @max_polls = max_polls
+    @indicate_busy = indicate_busy
+    @timeout_class = timeout_class
+  end
+
+  private
+
+  attr_reader :content_id, :content_class, :timeout_class
+
+  def host_data
+    {
+      controller: "polling",
+      polling_endpoint_value: @endpoint,
+      polling_interval_value: @interval,
+      polling_max_polls_value: @max_polls,
+      polling_stop_condition_value: @stop_condition
+    }
+  end
+
+  def host_aria
+    @indicate_busy ? { busy: "true" } : {}
+  end
+
+  def content_data
+    @content_target ? { polling_target: "content" } : {}
+  end
+end

--- a/app/controllers/access_tokens/validations_controller.rb
+++ b/app/controllers/access_tokens/validations_controller.rb
@@ -1,11 +1,11 @@
 class AccessTokens::ValidationsController < ApplicationController
+  include StatePolling
+
   def show
     access_token = find_access_token
     authorize access_token, policy_class: AccessTokenPolicy
 
-    # Stay silent while validation is still in flight so the poller leaves the
-    # spinner running instead of redrawing (and restarting) it every cycle.
-    return head :no_content if access_token.pending? || access_token.validating?
+    return head :no_content if keep_polling?(access_token)
 
     render turbo_stream: turbo_stream.update(
       "access-token-show",

--- a/app/controllers/concerns/state_polling.rb
+++ b/app/controllers/concerns/state_polling.rb
@@ -1,0 +1,26 @@
+# Server-side half of the "poll until a background job finishes" pattern. The
+# JS `polling` Stimulus controller drives the request loop; this concern owns
+# the cadence it runs at and the rule for when the server should stay silent.
+#
+# Cadence lives here rather than on the model because it describes polling
+# behavior, not domain data. PollingShellComponent reads these constants as its
+# defaults; a controller whose work runs longer hands a different value to the
+# component instead.
+module StatePolling
+  extend ActiveSupport::Concern
+
+  # Re-poll every two seconds; the client gives up after ~70s and shows the
+  # "taking longer than expected" message.
+  POLLING_INTERVAL_MS = 2000
+  POLLING_MAX_POLLS = 35
+
+  private
+
+  # True while the background job is still in flight. Controllers answer with
+  # `head :no_content` in that window so the poller keeps the spinner it already
+  # drew instead of redrawing (and restarting) it every cycle. Override when a
+  # record's in-progress states differ from the default pending/validating pair.
+  def keep_polling?(record)
+    record.pending? || record.validating?
+  end
+end

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -1,4 +1,6 @@
 class FeedPreviewsController < ApplicationController
+  include StatePolling
+
   before_action :require_authentication
   before_action :guard_preview, only: %i[show create]
 
@@ -36,6 +38,12 @@ class FeedPreviewsController < ApplicationController
     return render_cleared if source_blank? || !FeedProfile.exists?(profile_key)
 
     render_credential_gate if needs_credential_gate?
+  end
+
+  # A preview is in flight while pending or processing (it has no validating
+  # state), so the poll stays silent across both.
+  def keep_polling?(preview)
+    preview.pending? || preview.processing?
   end
 
   def previews
@@ -98,12 +106,12 @@ class FeedPreviewsController < ApplicationController
     respond_to do |format|
       format.html { render :show, locals: { preview: preview } }
       # Swap only the inner body so the polling host (rendered by `show`) stays
-      # mounted across polls; ready/failed bodies carry `data-preview-done`,
+      # mounted across polls; ready/failed bodies carry `data-polling-done`,
       # which trips the poller's stop-condition. While a run is still in flight
       # the poll stays silent so the spinner keeps its animation instead of
       # being redrawn every cycle.
       format.turbo_stream do
-        if inert_while_running && (preview.pending? || preview.processing?)
+        if inert_while_running && keep_polling?(preview)
           head :no_content
         else
           render turbo_stream: turbo_stream.update("feed-preview-body", **state_partial(preview))

--- a/app/controllers/llm_credentials/validations_controller.rb
+++ b/app/controllers/llm_credentials/validations_controller.rb
@@ -1,11 +1,11 @@
 class LlmCredentials::ValidationsController < ApplicationController
+  include StatePolling
+
   def show
     llm_credential = scope.find(params[:llm_credential_id])
     authorize llm_credential, :show?, policy_class: LlmCredentialPolicy
 
-    # Stay silent while validation is still in flight so the poller leaves the
-    # spinner running instead of redrawing (and restarting) it every cycle.
-    return head :no_content if llm_credential.pending? || llm_credential.validating?
+    return head :no_content if keep_polling?(llm_credential)
 
     render turbo_stream: turbo_stream.update(
       "llm-credential-show",

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,7 +1,4 @@
 class AccessToken < ApplicationRecord
-  VALIDATION_POLLING_INTERVAL_MS = 2000
-  VALIDATION_POLLING_MAX_POLLS = 35
-
   belongs_to :user
   has_many :feeds
   has_one :access_token_detail, dependent: :destroy

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -1,7 +1,8 @@
 class FeedPreview < ApplicationRecord
   PREVIEW_POSTS_LIMIT = 10
   PREVIEW_TIMEOUT_SECONDS = 120
-  POLLING_INTERVAL_MS = 2000
+  # Preview fetches run longer than the generic StatePolling default, so the
+  # client polls further before giving up.
   POLLING_MAX_POLLS = 75
 
   belongs_to :user

--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -4,8 +4,6 @@
 # encrypted at rest.
 class LlmCredential < ApplicationRecord
   DISPLAY_NAME_MAX_LENGTH = 80
-  VALIDATION_POLLING_INTERVAL_MS = 2000
-  VALIDATION_POLLING_MAX_POLLS = 35
 
   belongs_to :user
   # `dependent` is handled manually by `disable_dependent_feeds` so we can

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -48,7 +48,7 @@
     </div>
   <% end %>
 <% elsif access_token.active? %>
-  <%= render AlertComponent.new(variant: :success, icon: "circle-check", data: { status: "active" }) do %>
+  <%= render AlertComponent.new(variant: :success, icon: "circle-check", data: { status: "active", polling_done: true }) do %>
     <span>Token is valid and ready to use</span>
   <% end %>
 
@@ -103,7 +103,7 @@
     <% end %>
   </div>
 <% elsif access_token.inactive? %>
-  <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive" }) do %>
+  <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive", polling_done: true }) do %>
     <span>Token is inactive and cannot be used to access FreeFeed API. This token failed validation. It may be expired, revoked, or incorrectly copied.</span>
   <% end %>
 

--- a/app/views/access_tokens/show.html.erb
+++ b/app/views/access_tokens/show.html.erb
@@ -1,23 +1,19 @@
 <% content_for :title, "Access Token" %>
 
 <% if @access_token.pending? || @access_token.validating? %>
-  <div
-    data-controller="polling"
-    data-polling-endpoint-value="<%= access_token_validation_path(@access_token, feed_id: @feed&.id) %>"
-    data-polling-interval-value="<%= AccessToken::VALIDATION_POLLING_INTERVAL_MS %>"
-    data-polling-max-polls-value="<%= AccessToken::VALIDATION_POLLING_MAX_POLLS %>"
-    data-polling-stop-condition-value="[data-status]"
-    aria-busy="true">
-    <div id="access-token-show" class="space-y-8">
-      <%= render "access_tokens/show_content", access_token: @access_token, feed_id: @feed&.id %>
-    </div>
-    <div data-polling-target="timeoutMessage" hidden class="mt-4">
+  <%= render PollingShellComponent.new(
+        endpoint: access_token_validation_path(@access_token, feed_id: @feed&.id),
+        content_id: "access-token-show",
+        content_class: "space-y-8",
+        timeout_class: "mt-4") do |shell| %>
+    <% shell.with_timeout_message do %>
       <%= render AlertComponent.new(variant: :warning) do %>
         <p class="font-semibold">Validation is taking longer than expected.</p>
         <p><%= link_to "Refresh the page", request.path, data: { turbo: false }, class: "underline underline-offset-2" %> to check the current status.</p>
       <% end %>
-    </div>
-  </div>
+    <% end %>
+    <%= render "access_tokens/show_content", access_token: @access_token, feed_id: @feed&.id %>
+  <% end %>
 <% else %>
   <div id="access-token-show" class="space-y-8">
     <%= render "access_tokens/show_content", access_token: @access_token, feed_id: @feed&.id %>

--- a/app/views/feed_previews/_failed.html.erb
+++ b/app/views/feed_previews/_failed.html.erb
@@ -4,7 +4,7 @@
      data-key="preview.failed"
      data-controller="preview"
      data-preview-refresh-url-value="<%= feed_preview_path(profile_key: preview.feed_profile_key, "params" => preview.params) %>"
-     data-preview-done>
+     data-polling-done>
   <div class="space-y-1">
     <p class="font-semibold text-slate-800">We couldn't build a preview.</p>
     <p class="text-slate-600">Something went wrong fetching this source. Double-check it and give it another go.</p>

--- a/app/views/feed_previews/_ready.html.erb
+++ b/app/views/feed_previews/_ready.html.erb
@@ -3,7 +3,7 @@
      data-controller="preview"
      data-preview-refresh-url-value="<%= feed_preview_path(profile_key: preview.feed_profile_key, "params" => preview.params) %>"
      data-key="preview.success"
-     data-preview-done>
+     data-polling-done>
   <div class="flex flex-wrap items-center justify-between gap-2">
     <div class="space-y-1">
       <p class="font-semibold text-slate-800">Here's what we'd post</p>

--- a/app/views/feed_previews/show.html.erb
+++ b/app/views/feed_previews/show.html.erb
@@ -2,23 +2,13 @@
 <%= turbo_frame_tag "feed-preview" do %>
   <%# Stable polling host: polls the preview endpoint and swaps only the inner
       body, so the controller element is never torn down mid-poll. Polling stops
-      once a terminal (ready/failed) body marks itself done. %>
-  <div data-controller="polling"
-       data-polling-endpoint-value="<%= feed_preview_path(profile_key: preview.feed_profile_key, "params" => preview.params, format: :turbo_stream) %>"
-       data-polling-stop-condition-value="[data-preview-done]"
-       data-polling-interval-value="<%= FeedPreview::POLLING_INTERVAL_MS %>"
-       data-polling-max-polls-value="<%= FeedPreview::POLLING_MAX_POLLS %>">
-    <div id="feed-preview-body" data-polling-target="content">
-      <% case preview.status %>
-      <% when "ready" %>
-        <%= render "feed_previews/ready", preview: preview %>
-      <% when "failed" %>
-        <%= render "feed_previews/failed", preview: preview %>
-      <% else %>
-        <%= render "feed_previews/processing", preview: preview %>
-      <% end %>
-    </div>
-    <div data-polling-target="timeoutMessage" hidden>
+      once a terminal (ready/failed) body marks itself data-polling-done. %>
+  <%= render PollingShellComponent.new(
+        endpoint: feed_preview_path(profile_key: preview.feed_profile_key, "params" => preview.params, format: :turbo_stream),
+        content_id: "feed-preview-body",
+        content_target: true,
+        max_polls: FeedPreview::POLLING_MAX_POLLS) do |shell| %>
+    <% shell.with_timeout_message do %>
       <div class="rounded-lg border border-red-200 bg-red-100 px-4 py-3 text-red-800 space-y-3"
            role="alert"
            data-key="preview.timeout"
@@ -35,6 +25,14 @@
           Try again
         </button>
       </div>
-    </div>
-  </div>
+    <% end %>
+    <% case preview.status %>
+    <% when "ready" %>
+      <%= render "feed_previews/ready", preview: preview %>
+    <% when "failed" %>
+      <%= render "feed_previews/failed", preview: preview %>
+    <% else %>
+      <%= render "feed_previews/processing", preview: preview %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -19,6 +19,7 @@
   <% when "active" %>
     <div class="rounded-lg border border-emerald-200 bg-emerald-50 p-4 space-y-2"
          data-credential-state="active"
+         data-polling-done
          data-key="llm_credential.active">
       <p class="font-semibold text-emerald-900">Credential is active</p>
       <% if llm_credential.last_validated_at %>
@@ -28,6 +29,7 @@
   <% when "inactive" %>
     <div class="rounded-lg border border-red-200 bg-red-50 p-4 space-y-2"
          data-credential-state="inactive"
+         data-polling-done
          data-key="llm_credential.inactive">
       <p class="font-semibold text-red-900">This key didn't work</p>
       <% if llm_credential.last_error.present? %>

--- a/app/views/llm_credentials/show.html.erb
+++ b/app/views/llm_credentials/show.html.erb
@@ -1,23 +1,19 @@
 <% content_for :title, "AI Credential" %>
 
 <% if @llm_credential.pending? || @llm_credential.validating? %>
-  <div
-    data-controller="polling"
-    data-polling-endpoint-value="<%= llm_credential_validation_path(@llm_credential, feed_id: @feed&.id) %>"
-    data-polling-interval-value="<%= LlmCredential::VALIDATION_POLLING_INTERVAL_MS %>"
-    data-polling-max-polls-value="<%= LlmCredential::VALIDATION_POLLING_MAX_POLLS %>"
-    data-polling-stop-condition-value="[data-credential-state]"
-    aria-busy="true">
-    <div id="llm-credential-show" class="space-y-8">
-      <%= render "llm_credentials/show_content", llm_credential: @llm_credential, feed_id: @feed&.id %>
-    </div>
-    <div data-polling-target="timeoutMessage" hidden class="mt-4">
+  <%= render PollingShellComponent.new(
+        endpoint: llm_credential_validation_path(@llm_credential, feed_id: @feed&.id),
+        content_id: "llm-credential-show",
+        content_class: "space-y-8",
+        timeout_class: "mt-4") do |shell| %>
+    <% shell.with_timeout_message do %>
       <%= render AlertComponent.new(variant: :warning) do %>
         <p class="font-semibold">The credential check is taking longer than expected.</p>
         <p><%= link_to "Refresh the page", request.path, data: { turbo: false }, class: "underline underline-offset-2" %> to check the current status.</p>
       <% end %>
-    </div>
-  </div>
+    <% end %>
+    <%= render "llm_credentials/show_content", llm_credential: @llm_credential, feed_id: @feed&.id %>
+  <% end %>
 <% else %>
   <div id="llm-credential-show" class="space-y-8">
     <%= render "llm_credentials/show_content", llm_credential: @llm_credential, feed_id: @feed&.id %>

--- a/test/components/polling_shell_component_test.rb
+++ b/test/components/polling_shell_component_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+require "view_component/test_case"
+
+class PollingShellComponentTest < ViewComponent::TestCase
+  def render_shell(**options, &block)
+    block ||= proc { "body" }
+    render_inline(
+      PollingShellComponent.new(endpoint: "/poll", content_id: "show", **options),
+      &block
+    )
+  end
+
+  test "#call should mount the polling controller on the host with the endpoint" do
+    host = render_shell.at_css("[data-controller='polling']")
+
+    assert_not_nil host
+    assert_equal "/poll", host["data-polling-endpoint-value"]
+  end
+
+  test "#call should default cadence to the StatePolling constants" do
+    host = render_shell.at_css("[data-controller='polling']")
+
+    assert_equal StatePolling::POLLING_INTERVAL_MS.to_s, host["data-polling-interval-value"]
+    assert_equal StatePolling::POLLING_MAX_POLLS.to_s, host["data-polling-max-polls-value"]
+  end
+
+  test "#call should let callers override cadence" do
+    host = render_shell(interval: 5000, max_polls: 99).at_css("[data-controller='polling']")
+
+    assert_equal "5000", host["data-polling-interval-value"]
+    assert_equal "99", host["data-polling-max-polls-value"]
+  end
+
+  test "#call should default the stop condition to the standard marker" do
+    host = render_shell.at_css("[data-controller='polling']")
+
+    assert_equal "[data-polling-done]", host["data-polling-stop-condition-value"]
+  end
+
+  test "#call should wrap the body in the content container as the stream target" do
+    container = render_shell(content_class: "space-y-8") { "inner" }.at_css("#show")
+
+    assert_not_nil container
+    assert_equal "inner", container.text.strip
+    assert_includes container["class"], "space-y-8"
+  end
+
+  test "#call should mark the host busy by default" do
+    assert_equal "true", render_shell.at_css("[data-controller='polling']")["aria-busy"]
+  end
+
+  test "#call should omit aria-busy when indicate_busy is false" do
+    host = render_shell(indicate_busy: false).at_css("[data-controller='polling']")
+
+    assert_nil host["aria-busy"]
+  end
+
+  test "#call should flag the content target only when requested" do
+    assert_nil render_shell.at_css("#show")["data-polling-target"]
+    assert_equal "content", render_shell(content_target: true).at_css("#show")["data-polling-target"]
+  end
+
+  test "#call should render a hidden timeout message slot" do
+    result = render_inline(PollingShellComponent.new(endpoint: "/poll", content_id: "show")) do |shell|
+      shell.with_timeout_message { "Taking too long" }
+      "body"
+    end
+
+    timeout = result.at_css("[data-polling-target='timeoutMessage']")
+    assert_not_nil timeout
+    assert timeout.has_attribute?("hidden")
+    assert_equal "Taking too long", timeout.text.strip
+  end
+
+  test "#call should omit the timeout container without the slot" do
+    assert_nil render_shell.at_css("[data-polling-target='timeoutMessage']")
+  end
+end

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -155,7 +155,7 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_match(/data-preview-done/, response.body)
+    assert_match(/data-polling-done/, response.body)
   end
 
   test "#create should restart a failed preview and enqueue a job" do
@@ -280,7 +280,7 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_match(/data-preview-done/, response.body)
+    assert_match(/data-polling-done/, response.body)
     assert user.feed_previews.last.failed?
   end
 


### PR DESCRIPTION
Changes:

- Add a `StatePolling` controller concern that owns the polling cadence defaults and an overridable `keep_polling?` predicate (the rule for staying silent while a background job is in flight)
- Add `PollingShellComponent` to render the polling host, the stream-target container, and a timeout-message slot, replacing duplicated markup across the token, credential, and preview views
- Standardize the stop-condition marker to `data-polling-done` (was three different ad-hoc selectors); the component defaults to it
- Wire `AccessTokens::ValidationsController`, `LlmCredentials::ValidationsController`, and `FeedPreviewsController` to the concern, and drop the now-redundant polling constants from the `AccessToken`/`LlmCredential` models

The "poll until a background process completes" flow was repeated across four feature areas with slightly different controllers, near-identical views, and four separate cadence constants. This consolidates the shared parts — the server's silent-while-busy rule and the view shell — while leaving genuinely different cases alone: `feed_identifications` keeps its bespoke view (its poller host is replaced wholesale, so it stops via disconnect rather than the marker), and the event-log components keep their continuous-tail setup.