### PR TITLE
Extract shared polling config into StatePolling concern

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,4 +1,6 @@
 class AccessTokensController < ApplicationController
+  include StatePolling
+
   def index
     authorize AccessToken
     @access_tokens = scope.order(created_at: :desc)

--- a/app/controllers/concerns/state_polling.rb
+++ b/app/controllers/concerns/state_polling.rb
@@ -1,0 +1,22 @@
+# Shared client-side polling settings for controllers that render a `polling`
+# Stimulus host (state-tracking pages like token/credential validation, feed
+# identification, and feed preview). Controllers that need a different poll cap
+# override `polling_max_polls`.
+module StatePolling
+  extend ActiveSupport::Concern
+
+  POLLING_INTERVAL_MS = 2000
+  POLLING_MAX_POLLS = 35
+
+  included do
+    helper_method :polling_interval_ms, :polling_max_polls
+  end
+
+  def polling_interval_ms
+    POLLING_INTERVAL_MS
+  end
+
+  def polling_max_polls
+    POLLING_MAX_POLLS
+  end
+end

--- a/app/controllers/concerns/state_polling.rb
+++ b/app/controllers/concerns/state_polling.rb
@@ -1,7 +1,6 @@
-# Shared client-side polling settings for controllers that render a `polling`
-# Stimulus host (state-tracking pages like token/credential validation, feed
-# identification, and feed preview). Controllers that need a different poll cap
-# reassign `self.polling_max_polls` in their class body.
+# Polling settings for controllers that render a `polling` Stimulus host
+# (token/credential validation, feed identification, feed preview). Interval and
+# cap are exposed to views and overridable per controller via class_attribute.
 module StatePolling
   extend ActiveSupport::Concern
 
@@ -10,5 +9,12 @@ module StatePolling
     class_attribute :polling_max_polls, default: 36, instance_writer: false
 
     helper_method :polling_interval_ms, :polling_max_polls
+  end
+
+  # Server-side deadline, set just before the client's final poll so that poll
+  # still renders the outcome instead of leaving the spinner frozen. The first
+  # poll is immediate, so the last lands at (max_polls - 1) * interval.
+  def polling_timeout
+    ((polling_max_polls - 2) * polling_interval_ms).fdiv(1000).seconds
   end
 end

--- a/app/controllers/concerns/state_polling.rb
+++ b/app/controllers/concerns/state_polling.rb
@@ -1,22 +1,14 @@
 # Shared client-side polling settings for controllers that render a `polling`
 # Stimulus host (state-tracking pages like token/credential validation, feed
 # identification, and feed preview). Controllers that need a different poll cap
-# override `polling_max_polls`.
+# reassign `self.polling_max_polls` in their class body.
 module StatePolling
   extend ActiveSupport::Concern
 
-  POLLING_INTERVAL_MS = 2000
-  POLLING_MAX_POLLS = 35
-
   included do
+    class_attribute :polling_interval_ms, default: 2000, instance_writer: false
+    class_attribute :polling_max_polls, default: 35, instance_writer: false
+
     helper_method :polling_interval_ms, :polling_max_polls
-  end
-
-  def polling_interval_ms
-    POLLING_INTERVAL_MS
-  end
-
-  def polling_max_polls
-    POLLING_MAX_POLLS
   end
 end

--- a/app/controllers/concerns/state_polling.rb
+++ b/app/controllers/concerns/state_polling.rb
@@ -6,8 +6,8 @@ module StatePolling
   extend ActiveSupport::Concern
 
   included do
-    class_attribute :polling_interval_ms, default: 2000, instance_writer: false
-    class_attribute :polling_max_polls, default: 35, instance_writer: false
+    class_attribute :polling_interval_ms, default: 2500, instance_writer: false
+    class_attribute :polling_max_polls, default: 36, instance_writer: false
 
     helper_method :polling_interval_ms, :polling_max_polls
   end

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -1,6 +1,12 @@
 class FeedIdentificationsController < ApplicationController
   include StatePolling
 
+  # Poll a couple of cycles past the server-side timeout so a request lands
+  # inside the timed_out? window and renders the friendly error. Matching the
+  # timeout exactly lets the client hit its poll cap first and freeze the
+  # spinner with no message.
+  self.polling_max_polls = (FeedIdentification::TIMEOUT.in_milliseconds / polling_interval_ms) + 2
+
   before_action :require_authentication
 
   rate_limit to: 10, within: 1.minute, by: -> { Current.user.id }, only: :create, with: -> {
@@ -50,10 +56,6 @@ class FeedIdentificationsController < ApplicationController
     when "failed"
       handle_failed_status
     end
-  end
-
-  def polling_max_polls
-    FeedIdentification::POLLING_MAX_POLLS
   end
 
   def destroy

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -1,4 +1,6 @@
 class FeedIdentificationsController < ApplicationController
+  include StatePolling
+
   before_action :require_authentication
 
   rate_limit to: 10, within: 1.minute, by: -> { Current.user.id }, only: :create, with: -> {
@@ -48,6 +50,10 @@ class FeedIdentificationsController < ApplicationController
     when "failed"
       handle_failed_status
     end
+  end
+
+  def polling_max_polls
+    FeedIdentification::POLLING_MAX_POLLS
   end
 
   def destroy

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -1,12 +1,6 @@
 class FeedIdentificationsController < ApplicationController
   include StatePolling
 
-  # Poll a couple of cycles past the ~30s server-side timeout so a request
-  # lands inside the timeout window and renders the friendly error. Matching the
-  # timeout exactly lets the client hit its poll cap first and freeze the
-  # spinner with no message.
-  self.polling_max_polls = 17
-
   before_action :require_authentication
 
   rate_limit to: 10, within: 1.minute, by: -> { Current.user.id }, only: :create, with: -> {

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -1,11 +1,11 @@
 class FeedIdentificationsController < ApplicationController
   include StatePolling
 
-  # Poll a couple of cycles past the server-side timeout so a request lands
-  # inside the timed_out? window and renders the friendly error. Matching the
+  # Poll a couple of cycles past the ~30s server-side timeout so a request
+  # lands inside the timeout window and renders the friendly error. Matching the
   # timeout exactly lets the client hit its poll cap first and freeze the
   # spinner with no message.
-  self.polling_max_polls = (FeedIdentification::TIMEOUT.in_milliseconds / polling_interval_ms) + 2
+  self.polling_max_polls = 17
 
   before_action :require_authentication
 
@@ -81,7 +81,9 @@ class FeedIdentificationsController < ApplicationController
       return render(identification_error(error: "Identification session is invalid. Please try again."))
     end
 
-    if feed_identification.timed_out?
+    # Past the ~30s server-side timeout: drop the row and show the friendly
+    # error so the spinner stops with a message instead of spinning forever.
+    if feed_identification.started_at < 30.seconds.ago
       feed_identification.destroy
       return render(identification_error(error: "Feed identification is taking longer than expected. The feed URL may not be responding. Please try again."))
     end

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -72,7 +72,7 @@ class FeedIdentificationsController < ApplicationController
   def handle_processing_status
     if feed_identification.invalid_processing?
       feed_identification.destroy
-      return render(identification_error(error: "We couldn't identify this feed because something went wrong. Please try again."))
+      return render(identification_error(error: "Error identifying feed. Oh no."))
     end
 
     # Past the ~30s server-side timeout: drop the row and show the friendly

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -75,14 +75,23 @@ class FeedIdentificationsController < ApplicationController
       return render(identification_error(error: "Error identifying feed. Oh no."))
     end
 
-    # Past the ~30s server-side timeout: drop the row and show the friendly
-    # error so the spinner stops with a message instead of spinning forever.
-    if feed_identification.started_at < 30.seconds.ago
+    # Past the timeout: drop the row and show the friendly error so the spinner
+    # stops with a message instead of spinning forever.
+    if feed_identification.started_at < identification_timeout.ago
       feed_identification.destroy
       return render(identification_error(error: "Feed identification is taking longer than expected. The feed URL may not be responding. Please try again."))
     end
 
     head :no_content
+  end
+
+  # The client polls polling_max_polls times every polling_interval_ms, with the
+  # first poll firing immediately. Give up a couple of cycles before it exhausts
+  # that budget so one of the final polls lands in the timed-out window and
+  # renders the message (otherwise the client just stops and the spinner
+  # freezes silently).
+  def identification_timeout
+    ((polling_max_polls - 2) * polling_interval_ms).fdiv(1000).seconds
   end
 
   def handle_success_status

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -72,7 +72,7 @@ class FeedIdentificationsController < ApplicationController
   def handle_processing_status
     if feed_identification.invalid_processing?
       feed_identification.destroy
-      return render(identification_error(error: "Identification session is invalid. Please try again."))
+      return render(identification_error(error: "We couldn't identify this feed because something went wrong. Please try again."))
     end
 
     # Past the ~30s server-side timeout: drop the row and show the friendly

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -75,23 +75,14 @@ class FeedIdentificationsController < ApplicationController
       return render(identification_error(error: "Error identifying feed. Oh no."))
     end
 
-    # Past the timeout: drop the row and show the friendly error so the spinner
+    # Past the deadline: drop the row and show the friendly error so the spinner
     # stops with a message instead of spinning forever.
-    if feed_identification.started_at < identification_timeout.ago
+    if feed_identification.started_at < polling_timeout.ago
       feed_identification.destroy
       return render(identification_error(error: "Feed identification is taking longer than expected. The feed URL may not be responding. Please try again."))
     end
 
     head :no_content
-  end
-
-  # The client polls polling_max_polls times every polling_interval_ms, with the
-  # first poll firing immediately. Give up a couple of cycles before it exhausts
-  # that budget so one of the final polls lands in the timed-out window and
-  # renders the message (otherwise the client just stops and the spinner
-  # freezes silently).
-  def identification_timeout
-    ((polling_max_polls - 2) * polling_interval_ms).fdiv(1000).seconds
   end
 
   def handle_success_status

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -1,4 +1,6 @@
 class FeedPreviewsController < ApplicationController
+  include StatePolling
+
   before_action :require_authentication
   before_action :guard_preview, only: %i[show create]
 
@@ -26,6 +28,10 @@ class FeedPreviewsController < ApplicationController
   # processing pane (never inert) so the refresh shows the spinner restarting.
   def create
     render_state(start_run(locate_preview))
+  end
+
+  def polling_max_polls
+    FeedPreview::POLLING_MAX_POLLS
   end
 
   private

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -1,6 +1,10 @@
 class FeedPreviewsController < ApplicationController
   include StatePolling
 
+  # Previews can take a while (the run fetches and renders remote content), so
+  # the client keeps polling well past the shared default before giving up.
+  POLLING_MAX_POLLS = 75
+
   before_action :require_authentication
   before_action :guard_preview, only: %i[show create]
 
@@ -31,7 +35,7 @@ class FeedPreviewsController < ApplicationController
   end
 
   def polling_max_polls
-    FeedPreview::POLLING_MAX_POLLS
+    POLLING_MAX_POLLS
   end
 
   private

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -3,7 +3,7 @@ class FeedPreviewsController < ApplicationController
 
   # Previews can take a while (the run fetches and renders remote content), so
   # the client keeps polling well past the shared default before giving up.
-  POLLING_MAX_POLLS = 75
+  self.polling_max_polls = 75
 
   before_action :require_authentication
   before_action :guard_preview, only: %i[show create]
@@ -32,10 +32,6 @@ class FeedPreviewsController < ApplicationController
   # processing pane (never inert) so the refresh shows the spinner restarting.
   def create
     render_state(start_run(locate_preview))
-  end
-
-  def polling_max_polls
-    POLLING_MAX_POLLS
   end
 
   private

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -20,7 +20,7 @@ class FeedPreviewsController < ApplicationController
   def show
     preview = locate_preview
     preview = start_run(preview) if needs_run?(preview)
-    preview.timeout! if preview.timed_out?
+    preview.timeout! if (preview.pending? || preview.processing?) && preview.updated_at < polling_timeout.ago
     render_state(preview, inert_while_running: true)
   end
 

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -1,10 +1,6 @@
 class FeedPreviewsController < ApplicationController
   include StatePolling
 
-  # Previews can take a while (the run fetches and renders remote content), so
-  # the client keeps polling well past the shared default before giving up.
-  self.polling_max_polls = 75
-
   before_action :require_authentication
   before_action :guard_preview, only: %i[show create]
 

--- a/app/controllers/llm_credentials_controller.rb
+++ b/app/controllers/llm_credentials_controller.rb
@@ -1,4 +1,6 @@
 class LlmCredentialsController < ApplicationController
+  include StatePolling
+
   def index
     authorize LlmCredential
     @llm_credentials = scope.order(created_at: :desc)

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,7 +1,4 @@
 class AccessToken < ApplicationRecord
-  VALIDATION_POLLING_INTERVAL_MS = 2000
-  VALIDATION_POLLING_MAX_POLLS = 35
-
   belongs_to :user
   has_many :feeds
   has_one :access_token_detail, dependent: :destroy

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -1,11 +1,12 @@
 class FeedIdentification < ApplicationRecord
-  IDENTIFICATION_TIMEOUT_SECONDS = 30
+  # Server gives up identifying a feed after this many seconds.
+  TIMEOUT = 30.seconds
 
   # Poll a couple of cycles past the server-side timeout so a request lands
   # inside the timed_out? window and renders the friendly error. Matching the
   # timeout exactly lets the client hit its poll cap first and freeze the
   # spinner with no message.
-  POLLING_MAX_POLLS = (IDENTIFICATION_TIMEOUT_SECONDS * 1000 / StatePolling::POLLING_INTERVAL_MS) + 2
+  POLLING_MAX_POLLS = (TIMEOUT.in_milliseconds / StatePolling::POLLING_INTERVAL_MS) + 2
 
   belongs_to :user
 
@@ -18,6 +19,6 @@ class FeedIdentification < ApplicationRecord
   end
 
   def timed_out?
-    processing? && started_at.present? && started_at < IDENTIFICATION_TIMEOUT_SECONDS.seconds.ago
+    processing? && started_at.present? && started_at < TIMEOUT.ago
   end
 end

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -2,12 +2,6 @@ class FeedIdentification < ApplicationRecord
   # Server gives up identifying a feed after this many seconds.
   TIMEOUT = 30.seconds
 
-  # Poll a couple of cycles past the server-side timeout so a request lands
-  # inside the timed_out? window and renders the friendly error. Matching the
-  # timeout exactly lets the client hit its poll cap first and freeze the
-  # spinner with no message.
-  POLLING_MAX_POLLS = (TIMEOUT.in_milliseconds / StatePolling::POLLING_INTERVAL_MS) + 2
-
   belongs_to :user
 
   enum :status, { processing: 0, success: 1, failed: 2 }

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -1,12 +1,11 @@
 class FeedIdentification < ApplicationRecord
   IDENTIFICATION_TIMEOUT_SECONDS = 30
-  POLLING_INTERVAL_MS = 2000
 
   # Poll a couple of cycles past the server-side timeout so a request lands
   # inside the timed_out? window and renders the friendly error. Matching the
   # timeout exactly lets the client hit its poll cap first and freeze the
   # spinner with no message.
-  POLLING_MAX_POLLS = (IDENTIFICATION_TIMEOUT_SECONDS * 1000 / POLLING_INTERVAL_MS) + 2
+  POLLING_MAX_POLLS = (IDENTIFICATION_TIMEOUT_SECONDS * 1000 / StatePolling::POLLING_INTERVAL_MS) + 2
 
   belongs_to :user
 

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -1,7 +1,4 @@
 class FeedIdentification < ApplicationRecord
-  # Server gives up identifying a feed after this many seconds.
-  TIMEOUT = 30.seconds
-
   belongs_to :user
 
   enum :status, { processing: 0, success: 1, failed: 2 }
@@ -10,9 +7,5 @@ class FeedIdentification < ApplicationRecord
 
   def invalid_processing?
     processing? && started_at.nil?
-  end
-
-  def timed_out?
-    processing? && started_at.present? && started_at < TIMEOUT.ago
   end
 end

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -1,7 +1,6 @@
 class FeedPreview < ApplicationRecord
   PREVIEW_POSTS_LIMIT = 10
   PREVIEW_TIMEOUT_SECONDS = 120
-  POLLING_INTERVAL_MS = 2000
   POLLING_MAX_POLLS = 75
 
   belongs_to :user

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -1,6 +1,5 @@
 class FeedPreview < ApplicationRecord
   PREVIEW_POSTS_LIMIT = 10
-  PREVIEW_TIMEOUT_SECONDS = 120
 
   belongs_to :user
   belongs_to :feed, optional: true
@@ -27,10 +26,6 @@ class FeedPreview < ApplicationRecord
   def self.source_input(feed_profile_key, params)
     shape = FeedProfile[feed_profile_key]&.dig(:input_shape) || :url
     (params || {})[shape.to_s]
-  end
-
-  def timed_out?
-    (pending? || processing?) && updated_at < PREVIEW_TIMEOUT_SECONDS.seconds.ago
   end
 
   # Transitions to :failed only if still non-terminal. The status guard in the

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -1,7 +1,6 @@
 class FeedPreview < ApplicationRecord
   PREVIEW_POSTS_LIMIT = 10
   PREVIEW_TIMEOUT_SECONDS = 120
-  POLLING_MAX_POLLS = 75
 
   belongs_to :user
   belongs_to :feed, optional: true

--- a/app/models/llm_credential.rb
+++ b/app/models/llm_credential.rb
@@ -4,8 +4,6 @@
 # encrypted at rest.
 class LlmCredential < ApplicationRecord
   DISPLAY_NAME_MAX_LENGTH = 80
-  VALIDATION_POLLING_INTERVAL_MS = 2000
-  VALIDATION_POLLING_MAX_POLLS = 35
 
   belongs_to :user
   # `dependent` is handled manually by `disable_dependent_feeds` so we can

--- a/app/views/access_tokens/show.html.erb
+++ b/app/views/access_tokens/show.html.erb
@@ -4,8 +4,8 @@
   <div
     data-controller="polling"
     data-polling-endpoint-value="<%= access_token_validation_path(@access_token, feed_id: @feed&.id) %>"
-    data-polling-interval-value="<%= AccessToken::VALIDATION_POLLING_INTERVAL_MS %>"
-    data-polling-max-polls-value="<%= AccessToken::VALIDATION_POLLING_MAX_POLLS %>"
+    data-polling-interval-value="<%= polling_interval_ms %>"
+    data-polling-max-polls-value="<%= polling_max_polls %>"
     data-polling-stop-condition-value="[data-status]"
     aria-busy="true">
     <div id="access-token-show" class="space-y-8">

--- a/app/views/feed_previews/show.html.erb
+++ b/app/views/feed_previews/show.html.erb
@@ -6,8 +6,8 @@
   <div data-controller="polling"
        data-polling-endpoint-value="<%= feed_preview_path(profile_key: preview.feed_profile_key, "params" => preview.params, format: :turbo_stream) %>"
        data-polling-stop-condition-value="[data-preview-done]"
-       data-polling-interval-value="<%= FeedPreview::POLLING_INTERVAL_MS %>"
-       data-polling-max-polls-value="<%= FeedPreview::POLLING_MAX_POLLS %>">
+       data-polling-interval-value="<%= polling_interval_ms %>"
+       data-polling-max-polls-value="<%= polling_max_polls %>">
     <div id="feed-preview-body" data-polling-target="content">
       <% case preview.status %>
       <% when "ready" %>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -3,8 +3,8 @@
      role="status"
      data-controller="polling"
      data-polling-endpoint-value="<%= feed_identifications_path(input: input) %>"
-     data-polling-interval-value="<%= FeedIdentification::POLLING_INTERVAL_MS %>"
-     data-polling-max-polls-value="<%= FeedIdentification::POLLING_MAX_POLLS %>"
+     data-polling-interval-value="<%= polling_interval_ms %>"
+     data-polling-max-polls-value="<%= polling_max_polls %>"
      data-polling-stop-condition-value="[data-identification-state='complete'], [data-identification-state='error']">
   <div class="flex-shrink-0">
     <%= render SpinnerComponent.new %>

--- a/app/views/llm_credentials/show.html.erb
+++ b/app/views/llm_credentials/show.html.erb
@@ -4,8 +4,8 @@
   <div
     data-controller="polling"
     data-polling-endpoint-value="<%= llm_credential_validation_path(@llm_credential, feed_id: @feed&.id) %>"
-    data-polling-interval-value="<%= LlmCredential::VALIDATION_POLLING_INTERVAL_MS %>"
-    data-polling-max-polls-value="<%= LlmCredential::VALIDATION_POLLING_MAX_POLLS %>"
+    data-polling-interval-value="<%= polling_interval_ms %>"
+    data-polling-max-polls-value="<%= polling_max_polls %>"
     data-polling-stop-condition-value="[data-credential-state]"
     aria-busy="true">
     <div id="llm-credential-show" class="space-y-8">

--- a/test/controllers/concerns/state_polling_test.rb
+++ b/test/controllers/concerns/state_polling_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class StatePollingTest < ActionController::TestCase
+  class TestController < ActionController::Base
+    include StatePolling
+  end
+
+  tests TestController
+
+  test "#polling_interval_ms and #polling_max_polls should expose defaults" do
+    assert_equal 2500, TestController.polling_interval_ms
+    assert_equal 36, TestController.polling_max_polls
+  end
+
+  test "#polling_timeout should trip before the client exhausts its polling budget" do
+    timeout_ms = TestController.new.polling_timeout.in_milliseconds
+    # First poll is immediate, so the client's last poll lands at (max_polls - 1) * interval.
+    last_poll_ms = (TestController.polling_max_polls - 1) * TestController.polling_interval_ms
+
+    assert_operator timeout_ms, :<, last_poll_ms,
+      "server must time out before the client's final poll so the outcome renders instead of the spinner freezing"
+  end
+end

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -16,6 +16,15 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
+  test "polling_max_polls should keep the client polling past the server timeout" do
+    client_coverage_ms = FeedIdentificationsController.polling_max_polls * FeedIdentificationsController.polling_interval_ms
+
+    assert_operator(
+      client_coverage_ms, :>, FeedIdentification::TIMEOUT.in_milliseconds,
+      "client must outlast the server timeout so the friendly error renders before it gives up"
+    )
+  end
+
   test "#create should create feed detail record and enqueue job for valid URL" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -194,7 +194,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_includes response.body, "identify this feed because something went wrong"
+    assert_includes response.body, "Error identifying feed"
     assert_nil FeedIdentification.find_by(user: user, input: url), "Feed identification should be deleted when invalid"
   end
 

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -16,17 +16,6 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
-  test "identification_timeout should fire before the client exhausts its polling budget" do
-    timeout_ms = FeedIdentificationsController.new.send(:identification_timeout).in_milliseconds
-    # First poll is immediate, so the client's last poll lands at (max_polls - 1) * interval.
-    last_poll_ms = (FeedIdentificationsController.polling_max_polls - 1) * FeedIdentificationsController.polling_interval_ms
-
-    assert_operator(
-      timeout_ms, :<, last_poll_ms,
-      "server must time out before the client's final poll so the error renders instead of the spinner freezing"
-    )
-  end
-
   test "#create should create feed detail record and enqueue job for valid URL" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -180,7 +180,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_empty response.body
   end
 
-  test "#show should return invalid session error when started_at is missing" do
+  test "#show should return error when started_at is missing" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
 
@@ -194,7 +194,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_includes response.body, "Identification session is invalid"
+    assert_includes response.body, "identify this feed because something went wrong"
     assert_nil FeedIdentification.find_by(user: user, input: url), "Feed identification should be deleted when invalid"
   end
 

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -16,12 +16,14 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
-  test "polling_max_polls should keep the client polling past the server timeout" do
-    client_coverage_ms = FeedIdentificationsController.polling_max_polls * FeedIdentificationsController.polling_interval_ms
+  test "identification_timeout should fire before the client exhausts its polling budget" do
+    timeout_ms = FeedIdentificationsController.new.send(:identification_timeout).in_milliseconds
+    # First poll is immediate, so the client's last poll lands at (max_polls - 1) * interval.
+    last_poll_ms = (FeedIdentificationsController.polling_max_polls - 1) * FeedIdentificationsController.polling_interval_ms
 
     assert_operator(
-      client_coverage_ms, :>, 30.seconds.in_milliseconds,
-      "client must outlast the ~30s server timeout so the friendly error renders before it gives up"
+      timeout_ms, :<, last_poll_ms,
+      "server must time out before the client's final poll so the error renders instead of the spinner freezing"
     )
   end
 
@@ -205,9 +207,9 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     # Create processing feed detail via controller
     post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
-    # Manipulate record to simulate long-running job
+    # Manipulate record to simulate a job stuck well past the timeout
     feed_identification = FeedIdentification.find_by(user: user, input: url)
-    feed_identification.update_column(:started_at, 31.seconds.ago)
+    feed_identification.update_column(:started_at, 10.minutes.ago)
 
     get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -20,8 +20,8 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     client_coverage_ms = FeedIdentificationsController.polling_max_polls * FeedIdentificationsController.polling_interval_ms
 
     assert_operator(
-      client_coverage_ms, :>, FeedIdentification::TIMEOUT.in_milliseconds,
-      "client must outlast the server timeout so the friendly error renders before it gives up"
+      client_coverage_ms, :>, 30.seconds.in_milliseconds,
+      "client must outlast the ~30s server timeout so the friendly error renders before it gives up"
     )
   end
 

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -272,7 +272,7 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     create(:feed_preview, :processing, user: user, feed_profile_key: "rss",
                                        params: { "url" => "http://example.com/feed.xml" },
-                                       updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+                                       updated_at: 10.minutes.ago)
 
     assert_no_enqueued_jobs do
       get feed_preview_url(profile_key: "rss", "params" => { url: "http://example.com/feed.xml" }),

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -78,15 +78,6 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     refute_predicate identification, :timed_out?
   end
 
-  test "POLLING_MAX_POLLS should keep the client polling past the server timeout" do
-    client_coverage_ms = FeedIdentification::POLLING_MAX_POLLS * StatePolling::POLLING_INTERVAL_MS
-
-    assert_operator(
-      client_coverage_ms, :>, FeedIdentification::TIMEOUT.in_milliseconds,
-      "client must outlast the server timeout so the friendly error renders before it gives up"
-    )
-  end
-
   test "should accept multiple ranked candidates" do
     identification = FeedIdentification.create!(
       user: user,

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -48,7 +48,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
       user: user,
       input: "https://example.com/feed.xml",
       status: :processing,
-      started_at: (FeedIdentification::IDENTIFICATION_TIMEOUT_SECONDS + 1).seconds.ago
+      started_at: (FeedIdentification::TIMEOUT + 1.second).ago
     )
     assert_predicate identification, :timed_out?
   end
@@ -82,7 +82,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     client_coverage_ms = FeedIdentification::POLLING_MAX_POLLS * StatePolling::POLLING_INTERVAL_MS
 
     assert_operator(
-      client_coverage_ms, :>, FeedIdentification::IDENTIFICATION_TIMEOUT_SECONDS * 1000,
+      client_coverage_ms, :>, FeedIdentification::TIMEOUT.in_milliseconds,
       "client must outlast the server timeout so the friendly error renders before it gives up"
     )
   end

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -79,7 +79,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
   end
 
   test "POLLING_MAX_POLLS should keep the client polling past the server timeout" do
-    client_coverage_ms = FeedIdentification::POLLING_MAX_POLLS * FeedIdentification::POLLING_INTERVAL_MS
+    client_coverage_ms = FeedIdentification::POLLING_MAX_POLLS * StatePolling::POLLING_INTERVAL_MS
 
     assert_operator(
       client_coverage_ms, :>, FeedIdentification::IDENTIFICATION_TIMEOUT_SECONDS * 1000,

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -43,40 +43,6 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     refute_predicate identification, :invalid_processing?
   end
 
-  test "#timed_out? should be true when processing exceeds the identification timeout" do
-    identification = FeedIdentification.new(
-      user: user,
-      input: "https://example.com/feed.xml",
-      status: :processing,
-      started_at: (FeedIdentification::TIMEOUT + 1.second).ago
-    )
-    assert_predicate identification, :timed_out?
-  end
-
-  test "#timed_out? should be false within the identification timeout" do
-    identification = FeedIdentification.new(
-      user: user,
-      input: "https://example.com/feed.xml",
-      status: :processing,
-      started_at: 1.second.ago
-    )
-    refute_predicate identification, :timed_out?
-  end
-
-  test "#timed_out? should be false when started_at is missing" do
-    identification = FeedIdentification.new(user: user, input: "https://example.com/feed.xml", status: :processing, started_at: nil)
-    refute_predicate identification, :timed_out?
-  end
-
-  test "#timed_out? should be false for non-processing status" do
-    identification = FeedIdentification.new(
-      user: user,
-      input: "https://example.com/feed.xml",
-      status: :success,
-      started_at: 1.hour.ago
-    )
-    refute_predicate identification, :timed_out?
-  end
 
   test "should accept multiple ranked candidates" do
     identification = FeedIdentification.create!(

--- a/test/models/feed_preview_test.rb
+++ b/test/models/feed_preview_test.rb
@@ -85,45 +85,14 @@ class FeedPreviewTest < ActiveSupport::TestCase
     assert_equal 0, preview.posts_count
   end
 
-  test "#timed_out? should return true for a pending preview past the timeout" do
-    preview = create(:feed_preview, :pending, user: user,
-                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
-    assert preview.timed_out?
-  end
-
-  test "#timed_out? should return true for a processing preview past the timeout" do
-    preview = create(:feed_preview, :processing, user: user,
-                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
-    assert preview.timed_out?
-  end
-
-  test "#timed_out? should return false for a recently started preview" do
-    preview = create(:feed_preview, :processing, user: user, updated_at: 1.second.ago)
-    refute preview.timed_out?
-  end
-
-  test "#timed_out? should return false for a ready preview" do
-    preview = create(:feed_preview, :completed, user: user,
-                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
-    refute preview.timed_out?
-  end
-
-  test "#timed_out? should return false for a failed preview" do
-    preview = create(:feed_preview, :failed, user: user,
-                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
-    refute preview.timed_out?
-  end
-
-  test "#timeout! should transition a timed-out processing preview to failed" do
-    preview = create(:feed_preview, :processing, user: user,
-                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+  test "#timeout! should transition a processing preview to failed" do
+    preview = create(:feed_preview, :processing, user: user)
     preview.timeout!
     assert preview.failed?
   end
 
   test "#timeout! should be a no-op for a ready preview" do
-    preview = create(:feed_preview, :completed, user: user,
-                     updated_at: (FeedPreview::PREVIEW_TIMEOUT_SECONDS + 1).seconds.ago)
+    preview = create(:feed_preview, :completed, user: user)
     preview.timeout!
     assert preview.ready?
   end


### PR DESCRIPTION
Changes:

- Add a `StatePolling` controller concern holding the shared polling interval and default poll cap, exposed to views as helper methods
- Include it in the four polling controllers (access tokens, AI credentials, feed identification, feed preview)
- Drop the duplicated polling constants from the models, letting controllers override the cap where they need a different one
- Point the polling views at the helper methods instead of model constants

The polling interval and cap were copied across several models with the
same values. Consolidating them in one concern gives a single source of
truth while still letting pages with longer server-side timeouts keep
their own poll cap via a simple override.
