### PR TITLE
Fix heatmap centering in posts component

### DIFF
--- a/app/components/posts_heatmap_component.rb
+++ b/app/components/posts_heatmap_component.rb
@@ -14,8 +14,10 @@ class PostsHeatmapComponent < ViewComponent::Base
 
   def call
     render(CardComponent.new) do
-      tag.div(class: "flex justify-center overflow-x-auto", data: { controller: "heatmap" }) do
-        raw(heatmap_svg)
+      tag.div(class: "overflow-x-auto", data: { controller: "heatmap" }) do
+        tag.div(class: "w-max mx-auto") do
+          raw(heatmap_svg)
+        end
       end
     end
   end


### PR DESCRIPTION
Changes:

- Replaced `flex justify-center` with a nested wrapper div using `w-max mx-auto` for proper heatmap centering
- Moved the heatmap SVG into the inner wrapper to ensure correct layout behavior

The previous approach using flexbox on the outer container didn't properly center the heatmap SVG. The new structure uses `w-max` (width of content) with `mx-auto` (horizontal centering) on an inner wrapper, which provides more reliable centering while maintaining the `overflow-x-auto` scrolling behavior on the outer container.
