### PR TITLE
Update heatmap-builder and disable cell borders

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/dreikanter/heatmap-builder.git
-  revision: 9f8c8627b5ce9f6caf82b32c227d766da9cb6743
+  revision: 7ed1949343a6f2e60eb22919b1871e14409ddc11
   specs:
-    heatmap-builder (0.4.1)
+    heatmap-builder (0.4.3)
 
 GIT
   remote: https://github.com/rails/rails.git

--- a/app/components/posts_heatmap_component.rb
+++ b/app/components/posts_heatmap_component.rb
@@ -28,7 +28,8 @@ class PostsHeatmapComponent < ViewComponent::Base
     HeatmapBuilder.build_calendar(
       values: heatmap_values,
       tooltip: ->(date:, score:, value: nil) { value.to_i.to_s },
-      tooltip_attribute: "data-tippy-content"
+      tooltip_attribute: "data-tippy-content",
+      border_lightness_factor: 1
     )
   end
 


### PR DESCRIPTION
Changes:

- Update the `heatmap-builder` dependency to the latest version (0.4.3)
- Set `border_lightness_factor: 1` for the posts heatmap, which removes the borders around calendar cells for a cleaner look
