### PR TITLE
Show imgproxy thumbnails for post attachments

### DIFF
--- a/app/components/post_attachments_component.html.erb
+++ b/app/components/post_attachments_component.html.erb
@@ -4,7 +4,7 @@
       <%= link_to url, target: "_blank", rel: "noopener",
             class: "block overflow-hidden rounded-md border border-slate-200 transition hover:border-sky-400" do %>
         <%= image_tag thumbnail_url(url), alt: extract_filename(url), loading: "lazy",
-              width: 100, height: 100, class: "h-24 w-24 bg-slate-100 object-cover" %>
+              width: thumbnail_size, height: thumbnail_size, class: "h-24 w-24 bg-slate-100 object-cover" %>
       <% end %>
     <% end %>
   </div>

--- a/app/components/post_attachments_component.html.erb
+++ b/app/components/post_attachments_component.html.erb
@@ -2,9 +2,9 @@
   <div class="flex flex-wrap gap-3">
     <% attachment_urls.each do |url| %>
       <%= link_to url, target: "_blank", rel: "noopener",
-            class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500 inline-flex items-center" do %>
-        <%= helpers.icon("file-image", css_class: "size-4") %>
-        <span class="sr-only"><%= extract_filename(url) %></span>
+            class: "block overflow-hidden rounded-md border border-slate-200 transition hover:border-sky-400" do %>
+        <%= image_tag thumbnail_url(url), alt: extract_filename(url), loading: "lazy",
+              width: 100, height: 100, class: "h-24 w-24 bg-slate-100 object-cover" %>
       <% end %>
     <% end %>
   </div>

--- a/app/components/post_attachments_component.rb
+++ b/app/components/post_attachments_component.rb
@@ -1,4 +1,6 @@
 class PostAttachmentsComponent < ViewComponent::Base
+  THUMBNAIL_SIZE = 100
+
   def initialize(post:)
     @post = post
   end
@@ -9,6 +11,10 @@ class PostAttachmentsComponent < ViewComponent::Base
 
   def attachment_urls
     @post.attachment_urls
+  end
+
+  def thumbnail_url(url)
+    ImgproxyUrl.thumbnail(url, width: THUMBNAIL_SIZE, height: THUMBNAIL_SIZE)
   end
 
   def extract_filename(url)

--- a/app/components/post_attachments_component.rb
+++ b/app/components/post_attachments_component.rb
@@ -1,6 +1,4 @@
 class PostAttachmentsComponent < ViewComponent::Base
-  THUMBNAIL_SIZE = 100
-
   def initialize(post:)
     @post = post
   end
@@ -14,7 +12,11 @@ class PostAttachmentsComponent < ViewComponent::Base
   end
 
   def thumbnail_url(url)
-    ImgproxyUrl.thumbnail(url, width: THUMBNAIL_SIZE, height: THUMBNAIL_SIZE)
+    ImgproxyUrl.preview(url)
+  end
+
+  def thumbnail_size
+    ImgproxyUrl::THUMBNAIL_SIZE
   end
 
   def extract_filename(url)

--- a/app/components/post_preview_component.html.erb
+++ b/app/components/post_preview_component.html.erb
@@ -37,9 +37,22 @@
         <% end %>
 
         <% if attachments? %>
-          <section class="space-y-2">
+          <section class="space-y-2" data-key="preview.attachments">
             <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Attachments</p>
-            <%= attachments_list %>
+            <% if image_attachments.any? %>
+              <div class="flex flex-wrap gap-2">
+                <% image_attachments.each do |attachment| %>
+                  <%= link_to attachment[:url], target: "_blank", rel: "noopener",
+                        class: "block overflow-hidden rounded-md border border-slate-200 transition hover:border-sky-400" do %>
+                    <%= image_tag thumbnail_url(attachment[:url]), alt: "", loading: "lazy",
+                          width: 100, height: 100, class: "h-24 w-24 bg-slate-100 object-cover" %>
+                  <% end %>
+                <% end %>
+              </div>
+            <% end %>
+            <% if other_attachments.any? %>
+              <%= other_attachments_list %>
+            <% end %>
           </section>
         <% end %>
       </div>

--- a/app/components/post_preview_component.html.erb
+++ b/app/components/post_preview_component.html.erb
@@ -45,7 +45,7 @@
                   <%= link_to attachment[:url], target: "_blank", rel: "noopener",
                         class: "block overflow-hidden rounded-md border border-slate-200 transition hover:border-sky-400" do %>
                     <%= image_tag thumbnail_url(attachment[:url]), alt: "", loading: "lazy",
-                          width: 100, height: 100, class: "h-24 w-24 bg-slate-100 object-cover" %>
+                          width: thumbnail_size, height: thumbnail_size, class: "h-24 w-24 bg-slate-100 object-cover" %>
                   <% end %>
                 <% end %>
               </div>

--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -1,5 +1,4 @@
 class PostPreviewComponent < ViewComponent::Base
-  THUMBNAIL_SIZE = 100
   IMAGE_EXTENSIONS = %w[jpg jpeg png gif webp avif bmp svg].freeze
 
   def initialize(post_data:, index: nil)
@@ -67,7 +66,11 @@ class PostPreviewComponent < ViewComponent::Base
   end
 
   def thumbnail_url(url)
-    ImgproxyUrl.thumbnail(url, width: THUMBNAIL_SIZE, height: THUMBNAIL_SIZE)
+    ImgproxyUrl.preview(url)
+  end
+
+  def thumbnail_size
+    ImgproxyUrl::THUMBNAIL_SIZE
   end
 
   def other_attachments_list

--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -1,4 +1,7 @@
 class PostPreviewComponent < ViewComponent::Base
+  THUMBNAIL_SIZE = 100
+  IMAGE_EXTENSIONS = %w[jpg jpeg png gif webp avif bmp svg].freeze
+
   def initialize(post_data:, index: nil)
     @post_data = post_data || {}
     @index = index
@@ -55,9 +58,21 @@ class PostPreviewComponent < ViewComponent::Base
     valid_attachments.any?
   end
 
-  def attachments_list
+  def image_attachments
+    @image_attachments ||= valid_attachments.select { |attachment| image_attachment?(attachment) }
+  end
+
+  def other_attachments
+    @other_attachments ||= valid_attachments.reject { |attachment| image_attachment?(attachment) }
+  end
+
+  def thumbnail_url(url)
+    ImgproxyUrl.thumbnail(url, width: THUMBNAIL_SIZE, height: THUMBNAIL_SIZE)
+  end
+
+  def other_attachments_list
     helpers.content_tag(:ul, class: "list-disc space-y-2 pl-4") do
-      helpers.safe_join(valid_attachments.map { |attachment| attachment_list_item(attachment) })
+      helpers.safe_join(other_attachments.map { |attachment| attachment_list_item(attachment) })
     end
   end
 
@@ -90,6 +105,19 @@ class PostPreviewComponent < ViewComponent::Base
 
   def attachment_type(attachment)
     attachment.is_a?(Hash) ? attachment["type"].presence : nil
+  end
+
+  # Treat an attachment as an image when its declared type says so, or — when no
+  # type is given — when the URL ends in a known image extension. Only images get
+  # a thumbnail; everything else stays a link to avoid broken previews.
+  def image_attachment?(attachment)
+    type = attachment[:type].to_s.downcase
+    return type.start_with?("image") if type.present?
+
+    extension = File.extname(URI.parse(attachment[:url]).path).delete(".").downcase
+    IMAGE_EXTENSIONS.include?(extension)
+  rescue URI::InvalidURIError
+    false
   end
 
   def attachment_list_item(attachment)

--- a/app/services/imgproxy_url.rb
+++ b/app/services/imgproxy_url.rb
@@ -1,0 +1,66 @@
+# Builds signed imgproxy URLs for resized image previews.
+#
+# imgproxy verifies an HMAC-SHA256 signature on every request (see
+# docs/deployment-imgproxy.md), so preview URLs must be generated here with the
+# shared key and salt. When imgproxy isn't configured — typically local
+# development and tests — the original source URL is returned unchanged so
+# previews still render straight from the source image.
+class ImgproxyUrl
+  # @param source_url [String] original image URL
+  # @param width [Integer] target width in pixels
+  # @param height [Integer] target height in pixels
+  # @return [String] signed imgproxy URL, or source_url when unconfigured/blank
+  def self.thumbnail(source_url, width:, height:)
+    new(source_url, width: width, height: height).url
+  end
+
+  def initialize(source_url, width:, height:)
+    @source_url = source_url
+    @width = width
+    @height = height
+  end
+
+  def url
+    return source_url.to_s if source_url.blank? || !configured?
+
+    "#{endpoint}/#{signature}#{path}"
+  end
+
+  private
+
+  attr_reader :source_url, :width, :height
+
+  # Resize to fill an exact width x height box, cropping the overflow.
+  def path
+    @path ||= "/rs:fill:#{width}:#{height}/#{encoded_source}"
+  end
+
+  def encoded_source
+    Base64.urlsafe_encode64(source_url, padding: false)
+  end
+
+  def signature
+    digest = OpenSSL::HMAC.digest("sha256", key, salt + path)
+    Base64.urlsafe_encode64(digest, padding: false)
+  end
+
+  def configured?
+    endpoint.present? && config[:key].present? && config[:salt].present?
+  end
+
+  def endpoint
+    config[:endpoint].to_s.chomp("/").presence
+  end
+
+  def key
+    @key ||= [config[:key]].pack("H*")
+  end
+
+  def salt
+    @salt ||= [config[:salt]].pack("H*")
+  end
+
+  def config
+    @config ||= Rails.application.credentials.imgproxy || {}
+  end
+end

--- a/app/services/imgproxy_url.rb
+++ b/app/services/imgproxy_url.rb
@@ -6,12 +6,23 @@
 # development and tests — the original source URL is returned unchanged so
 # previews still render straight from the source image.
 class ImgproxyUrl
+  # Square edge length (px) for attachment preview thumbnails.
+  THUMBNAIL_SIZE = 100
+
   # @param source_url [String] original image URL
   # @param width [Integer] target width in pixels
   # @param height [Integer] target height in pixels
   # @return [String] signed imgproxy URL, or source_url when unconfigured/blank
   def self.thumbnail(source_url, width:, height:)
     new(source_url, width: width, height: height).url
+  end
+
+  # Square preview thumbnail at the standard THUMBNAIL_SIZE.
+  #
+  # @param source_url [String] original image URL
+  # @return [String] signed imgproxy URL, or source_url when unconfigured/blank
+  def self.preview(source_url)
+    thumbnail(source_url, width: THUMBNAIL_SIZE, height: THUMBNAIL_SIZE)
   end
 
   def initialize(source_url, width:, height:)

--- a/config/deploy.imgproxy.yml
+++ b/config/deploy.imgproxy.yml
@@ -44,6 +44,15 @@ env:
     IMGPROXY_ENABLE_WEBP_DETECTION: "true"
     # Long Cache-Control so Cloudflare holds each variant on the edge.
     IMGPROXY_TTL: "31536000"
+    # Reject oversized sources before processing to protect CPU/memory.
+    IMGPROXY_MAX_SRC_RESOLUTION: "50"        # megapixels
+    IMGPROXY_MAX_SRC_FILE_SIZE: "10485760"   # 10 MB
+    IMGPROXY_DOWNLOAD_TIMEOUT: "5"           # seconds
+    # Serve a placeholder (resized to the requested size) when the source can't
+    # be fetched or processed: timeouts, oversize rejections, 404s, bad formats.
+    IMGPROXY_FALLBACK_IMAGE_URL: "https://dev.fffeeder.com/imgproxy-fallback.svg"
+    IMGPROXY_FALLBACK_IMAGE_HTTP_CODE: "200"
+    IMGPROXY_FALLBACK_IMAGE_TTL: "86400"
   secret:
     - IMGPROXY_KEY
     - IMGPROXY_SALT

--- a/public/imgproxy-fallback.svg
+++ b/public/imgproxy-fallback.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" role="img" aria-label="Image unavailable">
+  <rect width="200" height="200" fill="#f1f5f9"/>
+  <g fill="none" stroke="#94a3b8" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="48" y="56" width="104" height="88" rx="10"/>
+    <circle cx="78" cy="86" r="9"/>
+    <path d="M54 134 l30 -32 22 20 20 -24 22 36"/>
+  </g>
+</svg>

--- a/test/components/post_attachments_component_test.rb
+++ b/test/components/post_attachments_component_test.rb
@@ -6,14 +6,25 @@ class PostAttachmentsComponentTest < ViewComponent::TestCase
     @feed ||= create(:feed)
   end
 
-  test "#render should show attachments with accessible filenames" do
+  test "#render should show attachment thumbnails linking to the originals" do
     post = create(:post, :with_attachments, feed: feed)
 
     result = render_inline(PostAttachmentsComponent.new(post: post))
 
     assert_not_nil result.css('[data-key="post.attachments"]').first
-    assert_equal "image1.jpg", result.css('a[href*="image1.jpg"] span.sr-only').first.text
-    assert_equal "image2.png", result.css('a[href*="image2.png"] span.sr-only').first.text
+    assert_not_nil result.css('a[href="https://example.com/image1.jpg"] img').first
+    assert_equal "image1.jpg", result.css('img[alt="image1.jpg"]').first["alt"]
+    assert_equal "image2.png", result.css('img[alt="image2.png"]').first["alt"]
+  end
+
+  test "#render should fall back to the source url when imgproxy is unconfigured" do
+    post = create(:post, :with_attachments, feed: feed)
+
+    Rails.application.credentials.stub(:imgproxy, nil) do
+      result = render_inline(PostAttachmentsComponent.new(post: post))
+
+      assert_equal "https://example.com/image1.jpg", result.css('img[alt="image1.jpg"]').first["src"]
+    end
   end
 
   test "#render should not render when there are no attachments" do

--- a/test/components/post_preview_component_test.rb
+++ b/test/components/post_preview_component_test.rb
@@ -85,6 +85,20 @@ class PostPreviewComponentTest < ViewComponent::TestCase
     assert_not_nil section.at_css('a[href="https://example.com/clip.mp4"]')
   end
 
+  test "treats attachments with unparseable urls as non-images" do
+    post_data = {
+      "content" => "Body",
+      "attachments" => ["https://example.com/bad image.jpg"]
+    }
+
+    result = render_inline(PostPreviewComponent.new(post_data: post_data))
+
+    section = result.at_css('[data-key="preview.attachments"]')
+    assert_not_nil section
+    assert_empty section.css("img")
+    assert_includes section.text, "https://example.com/bad image.jpg"
+  end
+
   test "renders content without a synthesized title heading" do
     post_data = { "content" => "Lorem ipsum dolor sit amet, the opening line of the post body" }
 

--- a/test/components/post_preview_component_test.rb
+++ b/test/components/post_preview_component_test.rb
@@ -52,6 +52,39 @@ class PostPreviewComponentTest < ViewComponent::TestCase
     assert_includes result.text, "Body"
   end
 
+  test "renders image attachments as thumbnails linking to the originals" do
+    post_data = {
+      "content" => "Body",
+      "attachments" => [
+        { "url" => "https://example.com/photo.png", "type" => "image" },
+        "https://example.com/plain.jpg"
+      ]
+    }
+
+    result = render_inline(PostPreviewComponent.new(post_data: post_data))
+
+    section = result.at_css('[data-key="preview.attachments"]')
+    assert_not_nil section
+    assert_not_nil section.at_css('a[href="https://example.com/photo.png"] img')
+    assert_not_nil section.at_css('a[href="https://example.com/plain.jpg"] img')
+  end
+
+  test "keeps non-image attachments as links" do
+    post_data = {
+      "content" => "Body",
+      "attachments" => [
+        { "url" => "https://example.com/clip.mp4", "type" => "video" }
+      ]
+    }
+
+    result = render_inline(PostPreviewComponent.new(post_data: post_data))
+
+    section = result.at_css('[data-key="preview.attachments"]')
+    assert_not_nil section
+    assert_empty section.css("img")
+    assert_not_nil section.at_css('a[href="https://example.com/clip.mp4"]')
+  end
+
   test "renders content without a synthesized title heading" do
     post_data = { "content" => "Lorem ipsum dolor sit amet, the opening line of the post body" }
 

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -95,14 +95,14 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='post.comments']"
   end
 
-  test "#show should include accessible labels for attachment links" do
+  test "#show should include accessible labels for attachment thumbnails" do
     sign_in_as(user)
     post_with_attachments = create(:post, :published, :with_attachments, feed: feed)
 
     get post_url(post_with_attachments)
     assert_response :success
-    assert_select "[data-key='post.attachments'] a[href*='image1.jpg'] span.sr-only", text: "image1.jpg"
-    assert_select "[data-key='post.attachments'] a[href*='image2.png'] span.sr-only", text: "image2.png"
+    assert_select "[data-key='post.attachments'] a[href*='image1.jpg'] img[alt='image1.jpg']"
+    assert_select "[data-key='post.attachments'] a[href*='image2.png'] img[alt='image2.png']"
   end
 
   test "#show should display validation errors when present" do

--- a/test/services/imgproxy_url_test.rb
+++ b/test/services/imgproxy_url_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class ImgproxyUrlTest < ActiveSupport::TestCase
+  KEY = "1a2b3c4d"
+  SALT = "5e6f7a8b"
+
+  def with_imgproxy_config(config)
+    Rails.application.credentials.stub(:imgproxy, config) do
+      yield
+    end
+  end
+
+  test "#thumbnail should build a signed imgproxy url when configured" do
+    source = "https://example.com/photo.jpg"
+
+    with_imgproxy_config(endpoint: "https://imgproxy.example.com", key: KEY, salt: SALT) do
+      url = ImgproxyUrl.thumbnail(source, width: 100, height: 100)
+
+      encoded = Base64.urlsafe_encode64(source, padding: false)
+      path = "/rs:fill:100:100/#{encoded}"
+      signature = Base64.urlsafe_encode64(
+        OpenSSL::HMAC.digest("sha256", [KEY].pack("H*"), [SALT].pack("H*") + path),
+        padding: false
+      )
+
+      assert_equal "https://imgproxy.example.com/#{signature}#{path}", url
+    end
+  end
+
+  test "#thumbnail should encode the requested dimensions" do
+    with_imgproxy_config(endpoint: "https://imgproxy.example.com", key: KEY, salt: SALT) do
+      url = ImgproxyUrl.thumbnail("https://example.com/photo.jpg", width: 50, height: 80)
+
+      assert_includes url, "/rs:fill:50:80/"
+    end
+  end
+
+  test "#thumbnail should drop a trailing slash on the endpoint" do
+    with_imgproxy_config(endpoint: "https://imgproxy.example.com/", key: KEY, salt: SALT) do
+      url = ImgproxyUrl.thumbnail("https://example.com/photo.jpg", width: 100, height: 100)
+
+      assert_not_includes url, "com//"
+    end
+  end
+
+  test "#thumbnail should return the source url when imgproxy is not configured" do
+    with_imgproxy_config(nil) do
+      source = "https://example.com/photo.jpg"
+      assert_equal source, ImgproxyUrl.thumbnail(source, width: 100, height: 100)
+    end
+  end
+
+  test "#thumbnail should return the source url when the key is missing" do
+    with_imgproxy_config(endpoint: "https://imgproxy.example.com", salt: SALT) do
+      source = "https://example.com/photo.jpg"
+      assert_equal source, ImgproxyUrl.thumbnail(source, width: 100, height: 100)
+    end
+  end
+
+  test "#thumbnail should return an empty string for a blank source" do
+    with_imgproxy_config(endpoint: "https://imgproxy.example.com", key: KEY, salt: SALT) do
+      assert_equal "", ImgproxyUrl.thumbnail(nil, width: 100, height: 100)
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Add `ImgproxyUrl`, which builds signed imgproxy URLs (HMAC-SHA256) for resized image previews, reading the endpoint/key/salt from `Rails.application.credentials.imgproxy`
- Render post attachments as small image thumbnails (linking to the originals) on the post page and in the feed preview
- Harden the imgproxy deploy config: cap source resolution/file size/download timeout and serve a placeholder fallback image when a source can't be fetched or processed

Post attachments used to show as plain icon/text links. This renders them as 100×100 thumbnails served through imgproxy, so images are resized and cached at the edge rather than loading full-size from the source. When imgproxy isn't configured (local/test), the helper falls back to the original source URL so previews still render. In the feed preview, only image attachments get thumbnails; other types keep their links to avoid broken previews. The source-size caps protect the imgproxy box from oversized inputs, and the fallback image keeps the thumbnail grid uniform when a source fails.

References:

- Follow-up to #748
