### PR TITLE
Restore base secrets in staging Kamal env

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -75,8 +75,14 @@ env:
     # The sampled gauges move on hour scales; a 60s push loses no visible
     # resolution and quarters the per-process DB sampling.
     METRICS_FLUSH_INTERVAL: "60"
-  # Shared by the web and jobs roles so the app can sign imgproxy URLs. Same
-  # values the standalone imgproxy app verifies against.
+  # Kamal deep-merges this destination over config/deploy.yml, and the merge
+  # replaces arrays rather than concatenating them. So this list must repeat
+  # the base secrets (RAILS_MASTER_KEY, POSTGRES_PASSWORD) — otherwise they
+  # never reach the staging container and the app boots without credentials.
+  # IMGPROXY_KEY/SALT are shared by the web and jobs roles so the app can sign
+  # imgproxy URLs, matching what the standalone imgproxy app verifies against.
   secret:
+    - RAILS_MASTER_KEY
+    - POSTGRES_PASSWORD
     - IMGPROXY_KEY
     - IMGPROXY_SALT


### PR DESCRIPTION
Changes:

- Repeat `RAILS_MASTER_KEY` and `POSTGRES_PASSWORD` in the staging `env.secret` list
- Add a comment explaining why the base secrets must be repeated

Kamal deep-merges the destination config over `config/deploy.yml` and replaces arrays rather than concatenating them. The imgproxy secrets added to the staging config overwrote the inherited `env.secret` list, so `RAILS_MASTER_KEY` (and `POSTGRES_PASSWORD`) stopped reaching the staging container. The app then booted without a decryptable credentials key and aborted with "Missing secret_key_base". Production was unaffected because it has no `env.secret` override and still inherits the base list.

References:

- Caused by: #748