### PR TITLE
Add imgproxy config checks to system status

### DIFF
--- a/app/controllers/development/system_status_controller.rb
+++ b/app/controllers/development/system_status_controller.rb
@@ -15,6 +15,9 @@ class Development::SystemStatusController < ApplicationController
       credential_check("resend_key", "Resend key present", :resend_api_token),
       credential_check("resend_signing_secret", "Resend signing secret present", :resend_signing_secret),
       credential_check("honeybadger_key", "Honeybadger API key present", :honeybadger, :api_key),
+      credential_check("imgproxy_endpoint", "imgproxy endpoint present", :imgproxy, :endpoint),
+      credential_check("imgproxy_key", "imgproxy signing key present", :imgproxy, :key),
+      credential_check("imgproxy_salt", "imgproxy signing salt present", :imgproxy, :salt),
       background_jobs_check
     ]
   end

--- a/test/controllers/development/system_status_controller_test.rb
+++ b/test/controllers/development/system_status_controller_test.rb
@@ -41,6 +41,9 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='config.resend_key']", text: /Resend key present/
     assert_select "[data-key='config.resend_signing_secret']", text: /Resend signing secret/
     assert_select "[data-key='config.honeybadger_key']", text: /Honeybadger/
+    assert_select "[data-key='config.imgproxy_endpoint']", text: /imgproxy endpoint/
+    assert_select "[data-key='config.imgproxy_key']", text: /imgproxy signing key/
+    assert_select "[data-key='config.imgproxy_salt']", text: /imgproxy signing salt/
     assert_select "[data-key='config.background_jobs']", text: /Background jobs/
   end
 


### PR DESCRIPTION
Changes:

- Add presence checks for the imgproxy credentials (endpoint, signing key, and salt) to the System Status configuration list

imgproxy only generates signed preview URLs when all three of these credentials are present; if any is missing, previews silently fall back to the raw source image. Surfacing them on the System Status page makes it easy to confirm imgproxy is fully wired up. They use the same neutral-when-absent treatment as the other optional integrations.
