### PR TITLE
Space pagination nav from event log contents

### DIFF
--- a/app/components/event_log_component.rb
+++ b/app/components/event_log_component.rb
@@ -17,7 +17,7 @@ class EventLogComponent < ViewComponent::Base
   end
 
   def call
-    content_tag(:div, class: "space-y-2", id: DOM_ID, data: host_data) do
+    content_tag(:div, id: DOM_ID, data: host_data) do
       safe_join([events_body, pagination_nav].compact)
     end
   end
@@ -58,7 +58,7 @@ class EventLogComponent < ViewComponent::Base
   def pagination_nav
     return if @older_url.blank? && @newer_url.blank?
 
-    content_tag(:nav, class: "flex items-center justify-between gap-3", aria: { label: "Events pagination" }, data: { key: "events.pagination" }) do
+    content_tag(:nav, class: "mt-6 flex items-center justify-between gap-3", aria: { label: "Events pagination" }, data: { key: "events.pagination" }) do
       safe_join([newer_link, older_link])
     end
   end

--- a/app/components/events_list_component.rb
+++ b/app/components/events_list_component.rb
@@ -14,7 +14,7 @@ class EventsListComponent < ViewComponent::Base
   end
 
   def call
-    content_tag(:div, id: DOM_ID, class: "space-y-2", data: host_data) do
+    content_tag(:div, id: DOM_ID, data: host_data) do
       safe_join([events_body, pagination_nav].compact)
     end
   end
@@ -32,7 +32,7 @@ class EventsListComponent < ViewComponent::Base
   def pagination_nav
     return if @older_url.blank? && @newer_url.blank?
 
-    content_tag(:nav, class: "flex items-center justify-between gap-3", aria: { label: "Events pagination" }, data: { key: "events.pagination" }) do
+    content_tag(:nav, class: "mt-6 flex items-center justify-between gap-3", aria: { label: "Events pagination" }, data: { key: "events.pagination" }) do
       safe_join([newer_link, older_link])
     end
   end


### PR DESCRIPTION
Changes:

- Add a margin of 6 between the Prev/Next pagination nav and the paginated contents in `EventLogComponent` and `EventsListComponent`

On pages like `/admin/events` (and the user-facing events list), the Newer/Older pagination buttons sat too close to the event cards. The gap was previously driven by the container's `space-y-2`, leaving only a small separation. The spacing now lives on the nav itself, giving it room to breathe.
