### PR TITLE
Sharpen attachment previews on HiDPI displays

### DIFF
--- a/app/components/post_attachments_component.html.erb
+++ b/app/components/post_attachments_component.html.erb
@@ -3,7 +3,7 @@
     <% attachment_urls.each do |url| %>
       <%= link_to url, target: "_blank", rel: "noopener",
             class: "block overflow-hidden rounded-md border border-slate-200 transition hover:border-sky-400" do %>
-        <%= image_tag thumbnail_url(url), alt: extract_filename(url), loading: "lazy",
+        <%= image_tag thumbnail_url(url), alt: extract_filename(url), loading: "lazy", srcset: thumbnail_srcset(url),
               width: thumbnail_size, height: thumbnail_size, class: "h-24 w-24 bg-slate-100 object-cover" %>
       <% end %>
     <% end %>

--- a/app/components/post_attachments_component.rb
+++ b/app/components/post_attachments_component.rb
@@ -15,6 +15,10 @@ class PostAttachmentsComponent < ViewComponent::Base
     ImgproxyUrl.preview(url)
   end
 
+  def thumbnail_srcset(url)
+    ImgproxyUrl.preview_srcset(url)
+  end
+
   def thumbnail_size
     ImgproxyUrl::THUMBNAIL_SIZE
   end

--- a/app/components/post_preview_component.html.erb
+++ b/app/components/post_preview_component.html.erb
@@ -44,7 +44,7 @@
                 <% image_attachments.each do |attachment| %>
                   <%= link_to attachment[:url], target: "_blank", rel: "noopener",
                         class: "block overflow-hidden rounded-md border border-slate-200 transition hover:border-sky-400" do %>
-                    <%= image_tag thumbnail_url(attachment[:url]), alt: "", loading: "lazy",
+                    <%= image_tag thumbnail_url(attachment[:url]), alt: "", loading: "lazy", srcset: thumbnail_srcset(attachment[:url]),
                           width: thumbnail_size, height: thumbnail_size, class: "h-24 w-24 bg-slate-100 object-cover" %>
                   <% end %>
                 <% end %>

--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -69,6 +69,10 @@ class PostPreviewComponent < ViewComponent::Base
     ImgproxyUrl.preview(url)
   end
 
+  def thumbnail_srcset(url)
+    ImgproxyUrl.preview_srcset(url)
+  end
+
   def thumbnail_size
     ImgproxyUrl::THUMBNAIL_SIZE
   end

--- a/app/services/imgproxy_url.rb
+++ b/app/services/imgproxy_url.rb
@@ -25,6 +25,17 @@ class ImgproxyUrl
     thumbnail(source_url, width: THUMBNAIL_SIZE, height: THUMBNAIL_SIZE)
   end
 
+  # 1x/2x srcset for a square preview, so HiDPI displays get a sharp image
+  # instead of an upscaled THUMBNAIL_SIZE thumbnail.
+  #
+  # @param source_url [String] original image URL
+  # @return [String] srcset value ("<url> 1x, <url> 2x")
+  def self.preview_srcset(source_url)
+    one_x = preview(source_url)
+    two_x = thumbnail(source_url, width: THUMBNAIL_SIZE * 2, height: THUMBNAIL_SIZE * 2)
+    "#{one_x} 1x, #{two_x} 2x"
+  end
+
   def initialize(source_url, width:, height:)
     @source_url = source_url
     @width = width

--- a/app/services/imgproxy_url.rb
+++ b/app/services/imgproxy_url.rb
@@ -7,7 +7,7 @@
 # previews still render straight from the source image.
 class ImgproxyUrl
   # Square edge length (px) for attachment preview thumbnails.
-  THUMBNAIL_SIZE = 100
+  THUMBNAIL_SIZE = 96
 
   # @param source_url [String] original image URL
   # @param width [Integer] target width in pixels

--- a/test/services/imgproxy_url_test.rb
+++ b/test/services/imgproxy_url_test.rb
@@ -62,4 +62,18 @@ class ImgproxyUrlTest < ActiveSupport::TestCase
       assert_equal "", ImgproxyUrl.thumbnail(nil, width: 100, height: 100)
     end
   end
+
+  test "#preview_srcset should offer 1x and 2x thumbnails for HiDPI displays" do
+    size = ImgproxyUrl::THUMBNAIL_SIZE
+
+    with_imgproxy_config(endpoint: "https://imgproxy.example.com", key: KEY, salt: SALT) do
+      srcset = ImgproxyUrl.preview_srcset("https://example.com/photo.jpg")
+      one_x, two_x = srcset.split(", ")
+
+      assert_includes one_x, "/rs:fill:#{size}:#{size}/"
+      assert one_x.end_with?(" 1x")
+      assert_includes two_x, "/rs:fill:#{size * 2}:#{size * 2}/"
+      assert two_x.end_with?(" 2x")
+    end
+  end
 end


### PR DESCRIPTION
Changes:

- Set `THUMBNAIL_SIZE` to 96px so generated thumbnails match the `h-24 w-24` display box exactly, avoiding browser downscaling
- Add `ImgproxyUrl.preview_srcset` and wire it into the attachment preview components as a `srcset`

Attachment previews are displayed in a 96px box but were generated at 100px and served at a single resolution, so they looked soft — slightly from the 100→96 downscale, and noticeably on retina screens where a 96px image gets upscaled. The thumbnail size now matches the box, and a 1x/2x srcset lets HiDPI displays pull a 192px variant for a sharp result.
