### PR TITLE
Stop reporting loader errors to error tracker

### DIFF
--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -10,9 +10,13 @@ class FeedRefreshJob < ApplicationJob
       FeedRefreshWorkflow.new(feed).execute
     end
   rescue Loader::Error => e
+    # Loader errors reflect the remote feed's health (HTTP 404/500, timeouts,
+    # connection failures), not a bug on our side. They're already logged,
+    # metered, and tracked as feed failures by the workflow, so we don't report
+    # them to the error tracker — doing so just turns every dead or unreachable
+    # feed into noise.
     Rails.logger.error "Feed #{feed_id} load failed: #{e.message}"
     Metrics.increment("loader_errors_total", profile: feed.feed_profile_key, loader: feed.loader_class.name.demodulize)
-    Rails.error.report(e, context: { feed_id: feed_id })
   rescue WithAdvisoryLock::FailedToAcquireLock
     Rails.logger.info "Feed #{feed_id} is already being processed, skipping"
   end

--- a/test/jobs/feed_refresh_job_test.rb
+++ b/test/jobs/feed_refresh_job_test.rb
@@ -82,6 +82,17 @@ class FeedRefreshJobTest < ActiveJob::TestCase
     assert incremented
   end
 
+  test "does not report Loader::Error to the error tracker" do
+    WebMock.stub_request(:get, feed.url).to_return(status: 404)
+
+    reported = false
+    Rails.error.stub(:report, ->(*, **) { reported = true }) do
+      FeedRefreshJob.perform_now(feed.id)
+    end
+
+    assert_not reported
+  end
+
   test ".perform_now should skip without raising when the feed is already being refreshed" do
     feed = create(:feed, feed_profile_key: "rss")
 


### PR DESCRIPTION
Changes:

- Stop reporting `Loader::Error` to the error tracker from `FeedRefreshJob`
- Keep the existing log line and `loader_errors_total` metric

Loader errors (HTTP 404/500, timeouts, connection failures) reflect the
health of the remote feed, not a bug on our side. They're already logged,
metered, and tracked as feed refresh failures by the workflow, so reporting
them to Honeybadger only turned every dead or unreachable feed into noise.
