### PR TITLE
Track and notify Honeybadger of deployments

### DIFF
--- a/.kamal/hooks/post-deploy
+++ b/.kamal/hooks/post-deploy
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Notify Honeybadger of a successful deploy so reported errors are tied to the
+# released revision.
+#
+# Runs on the deploy host after Kamal finishes (the deploy lock is already
+# released at this point). The notification fires inside the freshly booted
+# app container, where Rails credentials hold the Honeybadger API key and
+# APP_REVISION names the deployed git revision. If no key is configured the
+# rake task is a no-op.
+#
+# Best-effort: a failed notification must not fail an otherwise good deploy,
+# so errors are swallowed.
+
+# Only the f2 app reports to Honeybadger. Skip other services (e.g. imgproxy),
+# which share this hooks directory but ship no Rails app.
+[ "$KAMAL_SERVICE" = "f2" ] || exit 0
+
+bin/kamal app exec --reuse -d "$KAMAL_DESTINATION" "bin/rails honeybadger:notify_deploy" || true

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -2,6 +2,9 @@ Honeybadger.configure do |config|
   config.api_key = Rails.application.credentials.dig(:honeybadger, :api_key)
   config.env = Rails.env
   config.root = Rails.root.to_s
+  # Tie reported errors to the deployed git revision. Kamal injects
+  # APP_REVISION at deploy time (see config/deploy.yml).
+  config.revision = ENV.fetch("APP_REVISION", nil)
   config.development_environments = %w[test development]
   config.insights.enabled = true
   # Honeybadger checks ActiveRecord too early when loading this plugin.

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -236,6 +236,12 @@ EDITOR="code --wait" bin/rails credentials:edit --environment production
 
 If staging does not have a valid key, the app still runs, but logs will include Honeybadger `403` warnings.
 
+Reported errors are tagged with the deployed git revision (`APP_REVISION`, set by
+Kamal), so Honeybadger can group errors by release and show when each first
+appeared. After every `bin/kamal deploy`, the `.kamal/hooks/post-deploy` hook
+notifies Honeybadger of the new deploy by running `bin/rails honeybadger:notify_deploy`
+inside the booted container. With no API key configured the notification is a no-op.
+
 ## Troubleshooting
 
 If deploy fails or the target does not become healthy, check the app and accessory logs:

--- a/lib/tasks/honeybadger.rake
+++ b/lib/tasks/honeybadger.rake
@@ -1,0 +1,12 @@
+namespace :honeybadger do
+  desc "Notify Honeybadger that a new revision has been deployed"
+  task notify_deploy: :environment do
+    if Honeybadger.config[:api_key].blank?
+      puts "Honeybadger API key not configured; skipping deploy notification."
+    elsif Honeybadger.track_deployment(repository: "https://github.com/dreikanter/f2")
+      puts "Honeybadger notified of deploy (#{Honeybadger.config[:revision] || 'unknown revision'})."
+    else
+      warn "Honeybadger deploy notification failed."
+    end
+  end
+end

--- a/test/lib/tasks/honeybadger_test.rb
+++ b/test/lib/tasks/honeybadger_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+require "rake"
+
+class HoneybadgerNotifyDeployTest < ActiveSupport::TestCase
+  setup do
+    F2Rails::Application.load_tasks unless Rake::Task.task_defined?("honeybadger:notify_deploy")
+    @task = Rake::Task["honeybadger:notify_deploy"]
+    @task.reenable
+  end
+
+  test "honeybadger:notify_deploy should track a deployment when the API key is set" do
+    tracked = nil
+
+    Honeybadger.stub(:config, { api_key: "abc123", revision: "deadbeef" }) do
+      Honeybadger.stub(:track_deployment, ->(**opts) { tracked = opts; true }) do
+        capture_io { @task.invoke }
+      end
+    end
+
+    assert_equal "https://github.com/dreikanter/f2", tracked[:repository]
+  end
+
+  test "honeybadger:notify_deploy should skip when no API key is configured" do
+    called = false
+
+    Honeybadger.stub(:config, { api_key: nil }) do
+      Honeybadger.stub(:track_deployment, ->(**) { called = true }) do
+        capture_io { @task.invoke }
+      end
+    end
+
+    refute called
+  end
+end


### PR DESCRIPTION
Changes:

- Tag reported errors with the deployed git revision via `APP_REVISION` (set by Kamal)
- Add a `honeybadger:notify_deploy` Rake task that reports a deploy to Honeybadger
- Fire the notification automatically from a `.kamal/hooks/post-deploy` hook after every deploy

This lets Honeybadger group errors by release and show when each one first appeared. The deploy notification reuses the API key from Rails credentials, no-ops when no key is configured, and is best-effort so it never fails an otherwise-good deploy. The shared hook is scoped to the `f2` service so it stays out of the way of the imgproxy deploy.