### PR TITLE
Truncate detected feed title to NAME_MAX_LENGTH

### DIFF
--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -94,7 +94,7 @@ class FeedIdentificationsController < ApplicationController
     feed = Current.user.feeds.build(
       params: params_for_input,
       feed_profile_key: profile_key,
-      name: recommended["title"]
+      name: recommended["title"]&.truncate(Feed::NAME_MAX_LENGTH, omission: "")
     )
 
     render(identification_success(feed, candidates: feed_identification.candidates))

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -94,7 +94,7 @@ class FeedIdentificationsController < ApplicationController
     feed = Current.user.feeds.build(
       params: params_for_input,
       feed_profile_key: profile_key,
-      name: recommended["title"]&.truncate(Feed::NAME_MAX_LENGTH, omission: "")
+      name: recommended["title"]&.truncate(Feed::NAME_MAX_LENGTH)
     )
 
     render(identification_success(feed, candidates: feed_identification.candidates))

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -519,7 +519,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_select "input[name='feed[name]'][value='#{"A" * Feed::NAME_MAX_LENGTH}']", count: 1
+    assert_select "input[name='feed[name]'][value='#{"A" * (Feed::NAME_MAX_LENGTH - 3)}...']", count: 1
   ensure
     feed_identification&.destroy
   end

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -503,6 +503,27 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "data-key=\"candidate.ai-badge\""
   end
 
+  test "#show should truncate detected title to Feed::NAME_MAX_LENGTH" do
+    sign_in_as(user)
+    url = "http://example.com/feed.xml"
+    long_title = "A" * (Feed::NAME_MAX_LENGTH + 10)
+    feed_identification = FeedIdentification.create!(
+      user: user,
+      input: url,
+      status: :success,
+      candidates: [
+        { "profile_key" => "rss", "title" => long_title, "depends_on_ai" => false, "rank" => 0, "rank_reason" => "" }
+      ]
+    )
+
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "input[name='feed[name]'][value='#{"A" * Feed::NAME_MAX_LENGTH}']", count: 1
+  ensure
+    feed_identification&.destroy
+  end
+
   private
 
   def extract_candidates_payload(body)


### PR DESCRIPTION
Changes:

- Truncate the auto-detected feed title to `Feed::NAME_MAX_LENGTH` when populating the feed name field during identification
- Add test verifying that long detected titles are truncated to the maximum allowed length