### PR TITLE
Clarify feed-to-group mapping in UI text

### DIFF
--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -28,7 +28,7 @@
                   controller: "groups",
                   groups_endpoint_value: edit_mode ? access_token_groups_path(":access_token_id", feed_id: feed.id) : access_token_groups_path(":access_token_id"),
                   groups_loading_text_value: "Loading groups...",
-                  groups_default_text_value: "The FreeFeed group where posts will be published."
+                  groups_default_text_value: "The FreeFeed group where posts will be published. Each feed can go to its own group, or you can point multiple feeds at the same one."
                 } do |f| %>
     <div class="space-y-10">
       <% if multi_candidate %>

--- a/app/views/feeds/_target_group_selector.html.erb
+++ b/app/views/feeds/_target_group_selector.html.erb
@@ -8,7 +8,7 @@
                      class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
                      required: true %>
       <p class="text-sm text-slate-500">
-        The FreeFeed group where posts will be published.
+        The FreeFeed group where posts will be published. Each feed can go to its own group, or you can point multiple feeds at the same one.
       </p>
       <p class="text-sm text-slate-500">
         Need a new group?


### PR DESCRIPTION
Changes:

- Updated help text for the target group selector to clarify that each feed can be routed to its own group or multiple feeds can share the same group

The previous text was ambiguous about whether a feed could only go to one group or if multiple feeds could share a group. The updated text makes this flexibility explicit, helping users understand their options when configuring feed destinations.