### PR TITLE
Replace "No reposts yet" with em dash in feed stats

### DIFF
--- a/app/components/feed_stats_component.rb
+++ b/app/components/feed_stats_component.rb
@@ -84,7 +84,7 @@ class FeedStatsComponent < ViewComponent::Base
     if @feed.most_recent_repost_at
       helpers.short_time_ago_tag(@feed.most_recent_repost_at)
     else
-      content_tag(:span, "No reposts yet", class: "text-slate-500")
+      content_tag(:span, "–", class: "text-slate-500")
     end
   end
 

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -73,6 +73,6 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     assert_equal "Never", last_refresh_value
 
     most_recent_value = result.css('[data-key="stats.most_recent_repost.value"]').first.text
-    assert_equal "No reposts yet", most_recent_value
+    assert_equal "–", most_recent_value
   end
 end


### PR DESCRIPTION
Changes:

- Replace "No reposts yet" with "–" in the Recent cell of the stats bar when a feed has no reposts
- Update corresponding test assertion