### PR TITLE
Default datepicker to today; reset on checkbox enable

### DIFF
--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import "flowbite"
+import { format } from "date-fns/utc"
 
 // Attaches the Flowbite datepicker to its input. Flowbite only auto-inits
 // `datepicker` attributes on turbo:load, which never fires for markup
@@ -35,6 +36,6 @@ export default class extends Controller {
   }
 
   #today() {
-    return new Intl.DateTimeFormat('en-CA', { timeZone: 'UTC' }).format(new Date())
+    return format(new Date(), "yyyy-MM-dd")
   }
 }

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -11,6 +11,10 @@ export default class extends Controller {
   connect() {
     if (!window.Datepicker || this.element.datepicker) return
 
+    if (!this.element.value) {
+      this.element.value = this.#today()
+    }
+
     this.picker = new window.Datepicker(
       this.element,
       { format: this.formatValue, autohide: true },
@@ -23,5 +27,21 @@ export default class extends Controller {
       this.picker.destroyAndRemoveInstance()
       this.picker = null
     }
+  }
+
+  reset() {
+    if (this.picker) {
+      this.picker.setDate(new Date())
+    } else {
+      this.element.value = this.#today()
+    }
+  }
+
+  #today() {
+    const d = new Date()
+    const yyyy = d.getFullYear()
+    const mm = String(d.getMonth() + 1).padStart(2, "0")
+    const dd = String(d.getDate()).padStart(2, "0")
+    return `${yyyy}-${mm}-${dd}`
   }
 }

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -30,14 +30,11 @@ export default class extends Controller {
   }
 
   reset() {
-    if (this.picker) {
-      this.picker.setDate(new Date())
-    } else {
-      this.element.value = this.#today()
-    }
+    this.element.value = this.#today()
+    this.picker?.setDate(new Date())
   }
 
   #today() {
-    return new Date().toISOString().slice(0, 10)
+    return new Intl.DateTimeFormat('en-CA', { timeZone: 'UTC' }).format(new Date())
   }
 }

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -38,10 +38,6 @@ export default class extends Controller {
   }
 
   #today() {
-    const d = new Date()
-    const yyyy = d.getFullYear()
-    const mm = String(d.getMonth() + 1).padStart(2, "0")
-    const dd = String(d.getDate()).padStart(2, "0")
-    return `${yyyy}-${mm}-${dd}`
+    return new Date().toISOString().slice(0, 10)
   }
 }

--- a/app/javascript/controllers/field_toggle_controller.js
+++ b/app/javascript/controllers/field_toggle_controller.js
@@ -11,6 +11,9 @@ export default class extends Controller {
 
   toggle() {
     this.update({ clearWhenHidden: true })
+    if (this.checkboxTarget.checked) {
+      this.dispatch("enabled", { bubbles: true })
+    }
   }
 
   update({ clearWhenHidden = false } = {}) {

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -196,6 +196,7 @@
                                  aria: { label: "Import posts published after this date" },
                                  data: {
                                    controller: "datepicker",
+                                   action: "field-toggle:enabled@window->datepicker#reset",
                                    field_toggle_target: "input",
                                    key: "form.import-after-date"
                                  } %>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": "true",
   "dependencies": {
     "@tailwindcss/cli": "^4.3.0",
+    "date-fns": "^4.4.0",
     "flowbite": "^4.0.2",
     "nodemon": "^3.1.14",
     "tailwindcss": "^4.3.0",


### PR DESCRIPTION
Changes:

- Datepicker now defaults to today's date when the input is empty (set before the Flowbite picker initialises so it reads the correct value)
- Enabling the "Skip older posts" checkbox resets the date to today via a `field-toggle:enabled` event dispatched to the datepicker's `reset()` action
- Works correctly whether the Advanced options section starts collapsed or expanded