### PR TITLE
Fix RSS 1.0 title extraction and add hostname fallback

### DIFF
--- a/app/services/title_extractor/base.rb
+++ b/app/services/title_extractor/base.rb
@@ -19,5 +19,14 @@ module TitleExtractor
     def title
       raise NotImplementedError, "Subclasses must implement #title"
     end
+
+    protected
+
+    def hostname_from_url
+      host = URI.parse(input.to_s).host.to_s.sub(/\Awww\./, "")
+      host.presence
+    rescue URI::InvalidURIError
+      nil
+    end
   end
 end

--- a/app/services/title_extractor/rss_title_extractor.rb
+++ b/app/services/title_extractor/rss_title_extractor.rb
@@ -4,29 +4,27 @@ module TitleExtractor
     # Extracts the feed title from RSS XML
     # @return [String, nil] the feed title or nil if it cannot be extracted
     def title
-      return nil if fetched_body.blank?
+      return hostname_from_url if fetched_body.blank?
 
       doc = Nokogiri::XML(fetched_body)
-      extract_title(doc)
+      extract_title(doc).presence || hostname_from_url
     rescue Nokogiri::XML::SyntaxError
-      nil
+      hostname_from_url
     end
 
     private
 
-    RDF_NS = { "rdf" => "http://www.w3.org/1999/02/22-rdf-syntax-ns#" }.freeze
+    RSS1_NS = { "rdf" => "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rss1" => "http://purl.org/rss/1.0/" }.freeze
     ATOM_NS = { "atom" => "http://www.w3.org/2005/Atom" }.freeze
 
     def extract_title(doc)
-      # Try RSS 2.0 format
       rss_title = doc.at_xpath("//channel/title")&.text
       return rss_title.strip if rss_title.present?
 
-      # Try RSS 1.0 (RDF) format
-      rdf_title = doc.at_xpath("//rdf:RDF/channel/title", RDF_NS)&.text
+      # RSS 1.0 (RDF): channel and title are in the http://purl.org/rss/1.0/ default namespace
+      rdf_title = doc.at_xpath("//rdf:RDF/rss1:channel/rss1:title", RSS1_NS)&.text
       return rdf_title.strip if rdf_title.present?
 
-      # Try Atom format (e.g. YouTube)
       atom_title = doc.at_xpath("//atom:feed/atom:title", ATOM_NS)&.text
       atom_title&.strip
     end

--- a/app/services/title_extractor/youtube_title_extractor.rb
+++ b/app/services/title_extractor/youtube_title_extractor.rb
@@ -21,8 +21,15 @@ module TitleExtractor
       nil
     end
 
+    ATOM_NS = { "atom" => "http://www.w3.org/2005/Atom" }.freeze
+
     def atom_title
-      RssTitleExtractor.new(input, fetched_body).title
+      return nil if fetched_body.blank?
+
+      doc = Nokogiri::XML(fetched_body)
+      doc.at_xpath("//atom:feed/atom:title", ATOM_NS)&.text&.strip&.presence
+    rescue Nokogiri::XML::SyntaxError
+      nil
     end
 
     def handle

--- a/test/services/feed_identification_fetcher_test.rb
+++ b/test/services/feed_identification_fetcher_test.rb
@@ -90,7 +90,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_not_nil feed_identification
     assert_equal "success", feed_identification.status
-    assert_nil feed_identification.candidates.first["title"]
+    assert_equal "example.com", feed_identification.candidates.first["title"]
   end
 
   test "#identify should fall back to AI extraction when no structured profile matches" do

--- a/test/services/title_extractor/base_test.rb
+++ b/test/services/title_extractor/base_test.rb
@@ -21,4 +21,19 @@ class TitleExtractor::BaseTest < ActiveSupport::TestCase
     end
     assert_equal "Subclasses must implement #title", error.message
   end
+
+  test "#hostname_from_url should return hostname without www prefix" do
+    e = TitleExtractor::Base.new("https://www.example.com/feed.xml")
+    assert_equal "example.com", e.send(:hostname_from_url)
+  end
+
+  test "#hostname_from_url should return hostname as-is when no www prefix" do
+    e = TitleExtractor::Base.new("https://feeds.example.com/rss")
+    assert_equal "feeds.example.com", e.send(:hostname_from_url)
+  end
+
+  test "#hostname_from_url should return nil for invalid URL" do
+    e = TitleExtractor::Base.new("not a url")
+    assert_nil e.send(:hostname_from_url)
+  end
 end

--- a/test/services/title_extractor/rss_title_extractor_test.rb
+++ b/test/services/title_extractor/rss_title_extractor_test.rb
@@ -32,16 +32,16 @@ class TitleExtractor::RssTitleExtractorTest < ActiveSupport::TestCase
     assert_equal "Padded Title", extractor(body).title
   end
 
-  test "#title should return nil for blank response body" do
-    assert_nil extractor("").title
-    assert_nil extractor(nil).title
+  test "#title should fall back to hostname for blank response body" do
+    assert_equal "example.com", extractor("").title
+    assert_equal "example.com", extractor(nil).title
   end
 
-  test "#title should return nil for invalid XML" do
-    assert_nil extractor("not valid xml").title
+  test "#title should fall back to hostname for invalid XML" do
+    assert_equal "example.com", extractor("not valid xml").title
   end
 
-  test "#title should return nil for XML without title" do
+  test "#title should fall back to hostname when feed has no title" do
     body = <<~XML
       <?xml version="1.0"?>
       <rss version="2.0">
@@ -50,17 +50,36 @@ class TitleExtractor::RssTitleExtractorTest < ActiveSupport::TestCase
         </channel>
       </rss>
     XML
-    assert_nil extractor(body).title
+    assert_equal "example.com", extractor(body).title
   end
 
-  test "#title should return nil for non-feed XML" do
+  test "#title should fall back to hostname for non-feed XML" do
     body = <<~XML
       <?xml version="1.0"?>
       <document>
         <title>This is not a feed</title>
       </document>
     XML
-    assert_nil extractor(body).title
+    assert_equal "example.com", extractor(body).title
+  end
+
+  test "#title should extract title from RSS 1.0 (RDF) feed" do
+    body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rdf:RDF
+          xmlns="http://purl.org/rss/1.0/"
+          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <channel rdf:about="https://example.com/feed">
+          <title>My RDF Feed</title>
+        </channel>
+      </rdf:RDF>
+    XML
+    assert_equal "My RDF Feed", extractor(body).title
+  end
+
+  test "#title should fall back to nil when URL has no hostname" do
+    e = TitleExtractor::RssTitleExtractor.new("not-a-url", nil)
+    assert_nil e.title
   end
 
   test "#title should extract title from Atom feed" do

--- a/test/services/title_extractor/rss_title_extractor_test.rb
+++ b/test/services/title_extractor/rss_title_extractor_test.rb
@@ -82,6 +82,12 @@ class TitleExtractor::RssTitleExtractorTest < ActiveSupport::TestCase
     assert_nil e.title
   end
 
+  test "#title should fall back to hostname when XML parser raises SyntaxError" do
+    Nokogiri.stub(:XML, ->(_) { raise Nokogiri::XML::SyntaxError, "bad xml" }) do
+      assert_equal "example.com", extractor("<broken").title
+    end
+  end
+
   test "#title should extract title from Atom feed" do
     body = <<~XML
       <?xml version="1.0" encoding="UTF-8"?>

--- a/test/services/title_extractor/youtube_title_extractor_test.rb
+++ b/test/services/title_extractor/youtube_title_extractor_test.rb
@@ -35,4 +35,11 @@ class TitleExtractor::YoutubeTitleExtractorTest < ActiveSupport::TestCase
   test "#title should swallow invalid URI errors when deriving a handle" do
     assert_nil extractor("https://www.youtube.com/ bad handle").title
   end
+
+  test "#title should swallow XML SyntaxError when parsing atom feed" do
+    url = "https://www.youtube.com/channel/UCabc123def456ghi789jkl"
+    Nokogiri.stub(:XML, ->(_) { raise Nokogiri::XML::SyntaxError, "bad xml" }) do
+      assert_nil extractor(url, "<broken").title
+    end
+  end
 end


### PR DESCRIPTION
Changes:

- Fix RSS 1.0 (RDF) title extraction — `<channel>` and `<title>` are in the `http://purl.org/rss/1.0/` default namespace, so the old unprefixed XPath never matched them
- Add `hostname_from_url` helper to `TitleExtractor::Base` that strips `www.` and returns the host as a fallback title
- Fall back to hostname in `RssTitleExtractor` when feed content yields no title
- Refactor `YoutubeTitleExtractor#atom_title` to extract Atom titles directly, so the hostname fallback doesn't shadow its own `@handle` fallback