### PR TITLE
Set initial feed schedule to next cron time to prevent double refresh

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -307,18 +307,31 @@ class Feed < ApplicationRecord
     ).to_a
   end
 
-  # Resets the feed schedule to run immediately
-  # Creates a new schedule if none exists, or updates existing schedule's next_run_at
-  # @return [FeedSchedule] the created or updated schedule
+  # Resets the feed schedule to run immediately (next_run_at = now).
+  # Creates a new schedule if none exists, or updates the existing one.
+  # @return [FeedSchedule]
   def reset_schedule!
     if feed_schedule.present?
       feed_schedule.update!(next_run_at: Time.current)
       feed_schedule
     else
-      create_feed_schedule!(
-        next_run_at: Time.current,
-        last_run_at: Time.current
-      )
+      create_feed_schedule!(next_run_at: Time.current, last_run_at: Time.current)
+    end
+  end
+
+  # Sets next_run_at to the next cron slot without triggering an immediate run.
+  # Use when a job has already been enqueued and the schedule should not fire again right away.
+  # Creates a new schedule if none exists, or updates the existing one.
+  # @return [FeedSchedule]
+  def defer_schedule!
+    if feed_schedule.present?
+      feed_schedule.update!(next_run_at: feed_schedule.calculate_next_run_at)
+      feed_schedule
+    else
+      schedule = build_feed_schedule(last_run_at: Time.current)
+      schedule.next_run_at = schedule.calculate_next_run_at
+      schedule.save!
+      schedule
     end
   end
 
@@ -435,8 +448,6 @@ class Feed < ApplicationRecord
     return unless enabled?
     return if feed_schedule.present?
 
-    schedule = build_feed_schedule(last_run_at: Time.current)
-    schedule.next_run_at = schedule.calculate_next_run_at
-    schedule.save!
+    defer_schedule!
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -435,6 +435,8 @@ class Feed < ApplicationRecord
     return unless enabled?
     return if feed_schedule.present?
 
-    reset_schedule!
+    schedule = build_feed_schedule(last_run_at: Time.current)
+    schedule.next_run_at = schedule.calculate_next_run_at
+    schedule.save!
   end
 end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -926,4 +926,30 @@ class FeedTest < ActiveSupport::TestCase
 
     assert_equal 0, feed.reload.consecutive_failures
   end
+
+  test "#defer_schedule! should create a schedule with next_run_at in the future when none exists" do
+    feed = create(:feed, :enabled, cron_expression: "0 * * * *")
+    feed.feed_schedule&.destroy
+    feed.reload
+
+    freeze_time do
+      schedule = feed.defer_schedule!
+
+      assert_not_nil schedule
+      assert_operator schedule.next_run_at, :>, Time.current
+      assert_not_nil schedule.last_run_at
+    end
+  end
+
+  test "#defer_schedule! should update next_run_at to the future when schedule already exists" do
+    feed = create(:feed, :enabled, cron_expression: "0 * * * *")
+    existing_schedule = feed.feed_schedule || create(:feed_schedule, feed: feed, next_run_at: Time.current)
+
+    freeze_time do
+      returned = feed.defer_schedule!
+
+      assert_equal existing_schedule.id, returned.id
+      assert_operator returned.reload.next_run_at, :>, Time.current
+    end
+  end
 end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -927,6 +927,32 @@ class FeedTest < ActiveSupport::TestCase
     assert_equal 0, feed.reload.consecutive_failures
   end
 
+  test "#reset_schedule! should create a schedule with next_run_at = now when none exists" do
+    feed = create(:feed, :enabled, cron_expression: "0 * * * *")
+    feed.feed_schedule&.destroy
+    feed.reload
+
+    freeze_time do
+      schedule = feed.reset_schedule!
+
+      assert_not_nil schedule
+      assert_equal Time.current, schedule.next_run_at
+      assert_equal Time.current, schedule.last_run_at
+    end
+  end
+
+  test "#reset_schedule! should update next_run_at to now when schedule already exists" do
+    feed = create(:feed, :enabled, cron_expression: "0 * * * *")
+    existing_schedule = feed.feed_schedule || create(:feed_schedule, feed: feed, next_run_at: 1.hour.from_now)
+
+    freeze_time do
+      returned = feed.reset_schedule!
+
+      assert_equal existing_schedule.id, returned.id
+      assert_equal Time.current, returned.reload.next_run_at
+    end
+  end
+
   test "#defer_schedule! should create a schedule with next_run_at in the future when none exists" do
     feed = create(:feed, :enabled, cron_expression: "0 * * * *")
     feed.feed_schedule&.destroy

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -182,12 +182,14 @@ class FeedTest < ActiveSupport::TestCase
 
     assert_nil feed.feed_schedule
 
-    feed.update!(state: :enabled)
+    freeze_time do
+      feed.update!(state: :enabled)
 
-    schedule = feed.reload.feed_schedule
-    assert_not_nil schedule
-    assert_not_nil schedule.next_run_at
-    assert_not_nil schedule.last_run_at
+      schedule = feed.reload.feed_schedule
+      assert_not_nil schedule
+      assert_operator schedule.next_run_at, :>, Time.current, "next_run_at should be in the future so the scheduler does not double-fire"
+      assert_not_nil schedule.last_run_at
+    end
   end
 
   test "should not create duplicate feed_schedule when already exists" do


### PR DESCRIPTION
Changes:

- `create_schedule_on_enable` now sets `next_run_at` to the next cron slot instead of `Time.current`

When a feed is first enabled, the controller enqueues an immediate `FeedRefreshJob`. The old callback used `reset_schedule!`, which sets `next_run_at: Time.current` — making the new feed look immediately due to `FeedSchedulerJob` (which runs every minute). This caused a second refresh within ~60 seconds of the first.

The fix builds the schedule via `FeedSchedule#calculate_next_run_at` so the scheduler won't pick it up until the actual next cron interval. `reset_schedule!` is unchanged — it still resets to `Time.current` for on-demand cases like when the refresh interval is edited.