### PR TITLE
Disable refresh for draft and disabled feeds

### DIFF
--- a/app/policies/feed_policy.rb
+++ b/app/policies/feed_policy.rb
@@ -20,7 +20,7 @@ class FeedPolicy < ApplicationPolicy
   end
 
   def refresh?
-    owner?
+    owner? && record.enabled?
   end
 
   def purge?

--- a/app/views/feeds/_header.html.erb
+++ b/app/views/feeds/_header.html.erb
@@ -14,11 +14,17 @@
       <% end %>
     <% end %>
     <% header.with_action_button do %>
-      <%= form_with url: feed_refresh_path(feed), method: :post, class: "inline-block", data: {
-            controller: "loading-button",
-            action: "turbo:submit-start->loading-button#start turbo:submit-end->loading-button#end"
-          } do %>
-        <%= render RefreshButtonComponent.new(title: "Refresh now", type: "submit") %>
+      <% if feed.enabled? %>
+        <%= form_with url: feed_refresh_path(feed), method: :post, class: "inline-block", data: {
+              controller: "loading-button",
+              action: "turbo:submit-start->loading-button#start turbo:submit-end->loading-button#end"
+            } do %>
+          <%= render RefreshButtonComponent.new(title: "Refresh now", type: "submit") %>
+        <% end %>
+      <% elsif feed.draft? %>
+        <%= render RefreshButtonComponent.new(title: "Finish setting up this feed first", disabled: true) %>
+      <% else %>
+        <%= render RefreshButtonComponent.new(title: "Enable this feed to refresh it", disabled: true) %>
       <% end %>
     <% end %>
     <% header.with_action_button do %>

--- a/test/controllers/feeds/refreshes_controller_test.rb
+++ b/test/controllers/feeds/refreshes_controller_test.rb
@@ -10,7 +10,15 @@ class Feeds::RefreshesControllerTest < ActionDispatch::IntegrationTest
   end
 
   def feed
-    @feed ||= create(:feed, user: user)
+    @feed ||= create(:feed, :enabled, user: user)
+  end
+
+  def disabled_feed
+    @disabled_feed ||= create(:feed, :disabled, user: user)
+  end
+
+  def draft_feed
+    @draft_feed ||= create(:feed, :draft, user: user)
   end
 
   test "create requires authentication" do
@@ -22,6 +30,18 @@ class Feeds::RefreshesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(other_user)
     post feed_refresh_path(feed)
     assert_response :not_found
+  end
+
+  test "create is not allowed for disabled feeds" do
+    sign_in_as(user)
+    post feed_refresh_path(disabled_feed)
+    assert_redirected_to root_path
+  end
+
+  test "create is not allowed for draft feeds" do
+    sign_in_as(user)
+    post feed_refresh_path(draft_feed)
+    assert_redirected_to root_path
   end
 
   test "create schedules refresh job" do

--- a/test/policies/feed_policy_test.rb
+++ b/test/policies/feed_policy_test.rb
@@ -95,6 +95,29 @@ class FeedPolicyTest < ActiveSupport::TestCase
     assert_not policy.purge?
   end
 
+  test "#refresh? should allow refresh for owner of enabled feed" do
+    enabled_feed = create(:feed, :enabled, user: user)
+    policy = policy_for_user(user, enabled_feed)
+    assert policy.refresh?
+  end
+
+  test "#refresh? should deny refresh for owner of disabled feed" do
+    policy = policy_for_user(user, feed)
+    assert_not policy.refresh?
+  end
+
+  test "#refresh? should deny refresh for owner of draft feed" do
+    draft_feed = create(:feed, :draft, user: user)
+    policy = policy_for_user(user, draft_feed)
+    assert_not policy.refresh?
+  end
+
+  test "#refresh? should deny refresh for non-owner" do
+    enabled_feed = create(:feed, :enabled, user: user)
+    policy = policy_for_user(other_user, enabled_feed)
+    assert_not policy.refresh?
+  end
+
   test "should handle nil user gracefully" do
     policy = FeedPolicy.new(nil, feed)
 


### PR DESCRIPTION
Changes:

- Restrict `FeedPolicy#refresh?` to enabled feeds only
- Show a disabled refresh button with contextual tooltip for draft and disabled feeds
- Add policy and controller tests covering all feed states