### PR TITLE
Disable sent emails card when email capture is not configured

### DIFF
--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -1,6 +1,7 @@
 class DevelopmentsController < ApplicationController
   def show
     authorize :access, :dev?
-    @sent_emails_available = ActionMailer::Base.delivery_method == :file
+    @sent_emails_available = ActionMailer::Base.delivery_method == :file ||
+      (ActionMailer::Base.delivery_method == :resend && Resend.api_key.present?)
   end
 end

--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -1,5 +1,6 @@
 class DevelopmentsController < ApplicationController
   def show
     authorize :access, :dev?
+    @sent_emails_available = ActionMailer::Base.delivery_method == :file
   end
 end

--- a/app/views/developments/show.html.erb
+++ b/app/views/developments/show.html.erb
@@ -34,7 +34,11 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: development_sent_emails_path, target: "_blank", rel: "noopener noreferrer") do %>
+    <%= render CardComponent.new(
+          **(@sent_emails_available \
+            ? { href: development_sent_emails_path, target: "_blank", rel: "noopener noreferrer" } \
+            : { class: "opacity-50 cursor-not-allowed", title: "Email capture is not configured" })
+        ) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("inbox", css_class: "size-5") %>

--- a/test/controllers/developments_controller_test.rb
+++ b/test/controllers/developments_controller_test.rb
@@ -15,7 +15,9 @@ class DevelopmentsControllerTest < ActionDispatch::IntegrationTest
 
   test "should show dev tools when authenticated as dev" do
     sign_in_as(dev_user)
-    get development_url
+    ActionMailer::Base.stub(:delivery_method, :file) do
+      get development_url
+    end
 
     assert_response :success
     assert_select "h1", "Dev Tools"
@@ -24,6 +26,16 @@ class DevelopmentsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{development_email_previews_path}']", count: 1
     assert_select "a[href='#{development_sent_emails_path}']", count: 1
     assert_select "a[href='#{development_components_path}']", count: 1
+  end
+
+  test "should disable sent emails link when email capture is not configured" do
+    sign_in_as(dev_user)
+    ActionMailer::Base.stub(:delivery_method, :smtp) do
+      get development_url
+    end
+
+    assert_response :success
+    assert_select "a[href='#{development_sent_emails_path}']", count: 0
   end
 
   test "should redirect when authenticated as admin without dev permission" do

--- a/test/controllers/developments_controller_test.rb
+++ b/test/controllers/developments_controller_test.rb
@@ -28,6 +28,30 @@ class DevelopmentsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{development_components_path}']", count: 1
   end
 
+  test "should enable sent emails link when resend delivery is configured" do
+    sign_in_as(dev_user)
+    ActionMailer::Base.stub(:delivery_method, :resend) do
+      Resend.stub(:api_key, "re_test_key") do
+        get development_url
+      end
+    end
+
+    assert_response :success
+    assert_select "a[href='#{development_sent_emails_path}']", count: 1
+  end
+
+  test "should disable sent emails link when resend delivery is not configured" do
+    sign_in_as(dev_user)
+    ActionMailer::Base.stub(:delivery_method, :resend) do
+      Resend.stub(:api_key, nil) do
+        get development_url
+      end
+    end
+
+    assert_response :success
+    assert_select "a[href='#{development_sent_emails_path}']", count: 0
+  end
+
   test "should disable sent emails link when email capture is not configured" do
     sign_in_as(dev_user)
     ActionMailer::Base.stub(:delivery_method, :smtp) do


### PR DESCRIPTION
Changes:

- Disable the Sent Emails card on the dev tools page when `ActionMailer` is not configured with `:file` delivery (i.e. on staging/production)
- Show the card with reduced opacity and a tooltip instead of a broken link