### PR TITLE
Show post status icon in card header

### DIFF
--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -1,6 +1,9 @@
 <div id="<%= helpers.dom_id(post) %>" class="<%= card_classes %>">
-  <div class="flex items-start justify-between gap-4 px-4 py-4">
-    <div class="flex min-w-0 items-center gap-2">
+  <div class="flex items-center gap-3 px-4 py-4">
+    <span class="flex w-4 shrink-0 items-center justify-center" data-key="post.status-icon">
+      <%= status_icon %>
+    </span>
+    <div class="flex min-w-0 flex-1 items-center gap-2">
       <%= link_to title, post_url,
             class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
       <% if withdrawn? %>
@@ -15,14 +18,12 @@
           item (group, counts) leads with a middot. %>
       <% if status_links_to_freefeed? %>
         <%= link_to freefeed_url, target: "_blank", rel: "noopener",
-              class: "inline-flex items-center gap-1.5 transition hover:text-slate-600",
+              class: "transition hover:text-slate-600",
               data: { key: "post.status" } do %>
-          <%= status_icon %><%= status_label_with_time %>
+          <%= status_label_with_time %>
         <% end %>
       <% else %>
-        <span class="inline-flex items-center gap-1.5" data-key="post.status">
-          <%= status_icon %><%= status_label_with_time %>
-        </span>
+        <span data-key="post.status"><%= status_label_with_time %></span>
       <% end %>
 
       <% if show_group? %>

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -46,7 +46,7 @@ class PostCardComponent < ViewComponent::Base
   end
 
   def status_icon
-    helpers.icon(status_display[:icon], css_class: "size-3.5 #{status_display[:color]}")
+    helpers.icon(status_display[:icon], css_class: "size-4 #{status_display[:color]}")
   end
 
   # Group the label, parens and the time tag inside a single inline wrapper so

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -178,7 +178,7 @@ class PostCardComponentTest < ViewComponent::TestCase
     status_link = result.at_css("a[href='#{published_post.freefeed_url}']")
     assert_not_nil status_link
     assert_includes status_link.text.gsub(/\s+/, " "), "Reposted (10h)"
-    assert_not_empty status_link.css("svg.text-green-600")
+    assert_not_empty result.css('[data-key="post.status-icon"] svg.text-green-600')
   end
 
   test "#render should keep the duration tight against its parentheses" do
@@ -211,6 +211,6 @@ class PostCardComponentTest < ViewComponent::TestCase
 
     status = result.at_css('[data-key="post.status"]')
     assert_includes status.text.gsub(/\s+/, " "), "Failed (10h)"
-    assert_not_empty status.css("svg.text-red-600")
+    assert_not_empty result.css('[data-key="post.status-icon"] svg.text-red-600')
   end
 end


### PR DESCRIPTION
Changes:

- Move the status icon to the top section of each post card, alongside the title
- Remove the icon from the bottom footer (text label + timestamp remain)
- Bump icon size from 3.5 to 4 to match the event severity icon

The post card header now mirrors the event card pattern — a fixed-width colored icon at the left gives the post's state an immediate visual signal when scanning the list, without duplicating it in the footer.