### PR TITLE
Align alert icon with text baseline

### DIFF
--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -16,7 +16,7 @@ class AlertComponent < ViewComponent::Base
   end
 
   def call
-    icon_html = @icon.present? ? helpers.icon(@icon, css_class: "size-5") : "".html_safe
+    icon_html = @icon.present? ? helpers.icon(@icon, css_class: "size-5 mt-0.5") : "".html_safe
     body_html = content_tag(:div, content, class: "space-y-1")
     content_tag(:div, icon_html + body_html, merged_options)
   end


### PR DESCRIPTION
Changes:

- Add `mt-0.5` to alert component icons so they visually align with the text baseline