### PR TITLE
Use alert component on LLM credential show page

### DIFF
--- a/app/components/llm_credential_details_component.rb
+++ b/app/components/llm_credential_details_component.rb
@@ -1,0 +1,38 @@
+class LlmCredentialDetailsComponent < ViewComponent::Base
+  def initialize(llm_credential:)
+    @llm_credential = llm_credential
+  end
+
+  def call
+    render(ListComponent.new) do |list|
+      items.each { list.with_item(ListComponent::StatItemComponent.new(**_1)) }
+    end
+  end
+
+  private
+
+  def items
+    result = [
+      {
+        label: "Provider",
+        value: LlmProvider.find(@llm_credential.provider).display_name,
+        key: "llm_credential.provider"
+      },
+      {
+        label: "Created",
+        value: helpers.datetime_with_duration_tag(@llm_credential.created_at),
+        key: "llm_credential.created"
+      }
+    ]
+
+    if @llm_credential.last_validated_at
+      result << {
+        label: "Last Used",
+        value: helpers.datetime_with_duration_tag(@llm_credential.last_validated_at),
+        key: "llm_credential.last_used"
+      }
+    end
+
+    result
+  end
+end

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -1,8 +1,6 @@
 <%# locals: (llm_credential:, feed_id: nil) %>
 <div class="space-y-6" data-key="llm_credential.show">
-  <%= render PageHeaderComponent.new(title: llm_credential.display_name) do |header| %>
-    <% header.with_context_paragraph(LlmProvider.find(llm_credential.provider).display_name) %>
-  <% end %>
+  <%= render PageHeaderComponent.new(title: llm_credential.display_name) %>
 
   <% case llm_credential.state %>
   <% when "pending", "validating" %>
@@ -17,25 +15,23 @@
       </div>
     </div>
   <% when "active" %>
-    <div class="rounded-lg border border-emerald-200 bg-emerald-50 p-4 space-y-2"
-         data-credential-state="active"
-         data-key="llm_credential.active">
-      <p class="font-semibold text-emerald-900">Credential is active</p>
-      <% if llm_credential.last_validated_at %>
-        <p class="text-sm text-emerald-800">Last checked <%= time_ago_in_words(llm_credential.last_validated_at) %> ago.</p>
-      <% end %>
-    </div>
+    <%= render AlertComponent.new(variant: :success, icon: "circle-check",
+                                  data: { credential_state: "active", key: "llm_credential.active" }) do %>
+      <span>Credential is active</span>
+    <% end %>
+
+    <%= render LlmCredentialDetailsComponent.new(llm_credential: llm_credential) %>
   <% when "inactive" %>
-    <div class="rounded-lg border border-red-200 bg-red-50 p-4 space-y-2"
-         data-credential-state="inactive"
-         data-key="llm_credential.inactive">
-      <p class="font-semibold text-red-900">This key didn't work</p>
+    <%= render AlertComponent.new(variant: :error, icon: "circle-x",
+                                  data: { credential_state: "inactive", key: "llm_credential.inactive" }) do %>
       <% if llm_credential.last_error.present? %>
-        <p class="text-sm text-red-800"><%= llm_credential.last_error %></p>
+        <span><%= llm_credential.last_error %></span>
       <% else %>
-        <p class="text-sm text-red-700">Grab a fresh key from your provider's dashboard and add it again.</p>
+        <span>This key didn't work. Grab a fresh key from your provider's dashboard and add it again.</span>
       <% end %>
-    </div>
+    <% end %>
+
+    <%= render LlmCredentialDetailsComponent.new(llm_credential: llm_credential) %>
   <% end %>
 
   <div class="flex flex-wrap gap-3">

--- a/test/components/llm_credential_details_component_test.rb
+++ b/test/components/llm_credential_details_component_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "view_component/test_case"
+
+class LlmCredentialDetailsComponentTest < ViewComponent::TestCase
+  test "#render should show provider display name" do
+    credential = create(:llm_credential, provider: "openrouter")
+
+    result = render_inline(LlmCredentialDetailsComponent.new(llm_credential: credential))
+
+    assert_includes result.css('[data-key="llm_credential.provider.value"]').first.text, "OpenRouter"
+  end
+
+  test "#render should show created date" do
+    credential = create(:llm_credential)
+
+    result = render_inline(LlmCredentialDetailsComponent.new(llm_credential: credential))
+
+    assert_not_nil result.css('[data-key="llm_credential.created.value"]').first
+  end
+
+  test "#render should show last used when last_validated_at is present" do
+    credential = create(:llm_credential, :active)
+
+    result = render_inline(LlmCredentialDetailsComponent.new(llm_credential: credential))
+
+    assert_not_nil result.css('[data-key="llm_credential.last_used.value"]').first
+  end
+
+  test "#render should not show last used when last_validated_at is absent" do
+    credential = create(:llm_credential, state: :pending)
+
+    result = render_inline(LlmCredentialDetailsComponent.new(llm_credential: credential))
+
+    assert_nil result.css('[data-key="llm_credential.last_used.value"]').first
+  end
+end


### PR DESCRIPTION
Changes:

- Replace hand-rolled status boxes with `AlertComponent` for active and inactive states
- Remove provider context paragraph from the page header
- Add `LlmCredentialDetailsComponent` showing Provider, Created, and Last Used (when persisted)

The show page now follows the same layout as the access token show page: status alert at the top, details list below.
