### PR TITLE
Add breadcrumb slot to PageHeaderComponent

### DIFF
--- a/app/components/page_header_component.html.erb
+++ b/app/components/page_header_component.html.erb
@@ -1,20 +1,25 @@
-<header class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
-  <div class="flex flex-col gap-5">
-    <h1 <%= tag.attributes(class: class_names("text-4xl font-semibold mb-0 text-slate-900", "flex items-center gap-3" => title_icon?), data: @title_data) %>>
-      <%= title_icon if title_icon? %>
-      <%= @title %>
-    </h1>
-    <% if context_paragraphs? %>
-      <% context_paragraphs.each do |paragraph| %>
-        <p class="text-slate-600"><%= paragraph %></p>
-      <% end %>
-    <% end %>
-  </div>
-  <% if action_buttons? %>
-    <div class="flex w-full items-center justify-start gap-3 sm:w-auto sm:justify-end">
-      <% action_buttons.each do |button| %>
-        <%= button %>
+<div class="flex flex-col gap-2">
+  <% if breadcrumb? %>
+    <div><%= breadcrumb %></div>
+  <% end %>
+  <header class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+    <div class="flex flex-col gap-5">
+      <h1 <%= tag.attributes(class: class_names("text-4xl font-semibold mb-0 text-slate-900", "flex items-center gap-3" => title_icon?), data: @title_data) %>>
+        <%= title_icon if title_icon? %>
+        <%= @title %>
+      </h1>
+      <% if context_paragraphs? %>
+        <% context_paragraphs.each do |paragraph| %>
+          <p class="text-slate-600"><%= paragraph %></p>
+        <% end %>
       <% end %>
     </div>
-  <% end %>
-</header>
+    <% if action_buttons? %>
+      <div class="flex w-full items-center justify-start gap-3 sm:w-auto sm:justify-end">
+        <% action_buttons.each do |button| %>
+          <%= button %>
+        <% end %>
+      </div>
+    <% end %>
+  </header>
+</div>

--- a/app/components/page_header_component.html.erb
+++ b/app/components/page_header_component.html.erb
@@ -1,4 +1,4 @@
-<header class="flex flex-col gap-2">
+<header class="flex flex-col gap-5">
   <% if breadcrumb? %>
     <div><%= breadcrumb %></div>
   <% end %>

--- a/app/components/page_header_component.html.erb
+++ b/app/components/page_header_component.html.erb
@@ -1,8 +1,8 @@
-<div class="flex flex-col gap-2">
+<header class="flex flex-col gap-2">
   <% if breadcrumb? %>
     <div><%= breadcrumb %></div>
   <% end %>
-  <header class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+  <div class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
     <div class="flex flex-col gap-5">
       <h1 <%= tag.attributes(class: class_names("text-4xl font-semibold mb-0 text-slate-900", "flex items-center gap-3" => title_icon?), data: @title_data) %>>
         <%= title_icon if title_icon? %>
@@ -21,5 +21,5 @@
         <% end %>
       </div>
     <% end %>
-  </header>
-</div>
+  </div>
+</header>

--- a/app/components/page_header_component.rb
+++ b/app/components/page_header_component.rb
@@ -1,6 +1,10 @@
 class PageHeaderComponent < ViewComponent::Base
   renders_one :title_icon
 
+  renders_one :breadcrumb, ->(label:, url:) do
+    link_to label, url, class: "text-slate-500 hover:text-slate-700 transition-colors"
+  end
+
   renders_many :context_paragraphs, ->(content = nil, &block) do
     content || block.call
   end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -1,5 +1,6 @@
 <%# locals: (access_token:, feed_id: nil) %>
 <%= render PageHeaderComponent.new(title: access_token.name) do |header| %>
+  <% header.with_breadcrumb(label: "Access Tokens", url: access_tokens_path) %>
   <% if feed_id.present? %>
     <% header.with_action_button do %>
       <%= link_to "Back to your feed", edit_feed_path(feed_id), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -2,6 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Events Log") do |header| %>
+    <% header.with_breadcrumb(label: "Admin Panel", url: admin_path) %>
     <% header.with_context_paragraph do %>
       <% if @filter.present? %>
         <span data-key="admin.events.filter-summary">

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -2,6 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Event ##{@event.id}") do |header| %>
+    <% header.with_breadcrumb(label: "Events Log", url: admin_events_path) %>
     <% if @previous_event %>
       <% header.with_action_button do %>
         <%= link_to "← Previous", admin_event_path(@previous_event), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,7 +1,9 @@
 <% content_for :title, "Users" %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Users") %>
+  <%= render PageHeaderComponent.new(title: "Users") do |header| %>
+    <% header.with_breadcrumb(label: "Admin Panel", url: admin_path) %>
+  <% end %>
 
   <% if @users.any? %>
     <div class="overflow-x-auto rounded-lg border border-slate-200">

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -2,9 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: @user.email_address) do |header| %>
-    <% header.with_action_button do %>
-      <%= link_to "Back to Users", admin_users_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
-    <% end %>
+    <% header.with_breadcrumb(label: "Users", url: admin_users_path) %>
   <% end %>
 
   <%= render Admin::UserDetailsComponent.new(user: @user, stats: @stats) %>

--- a/app/views/development/email_previews/index.html.erb
+++ b/app/views/development/email_previews/index.html.erb
@@ -1,7 +1,9 @@
 <% content_for :title, "Email Previews" %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Email Previews") %>
+  <%= render PageHeaderComponent.new(title: "Email Previews") do |header| %>
+    <% header.with_breadcrumb(label: "Dev Tools", url: development_path) %>
+  <% end %>
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
     <% @previews.each do |preview| %>

--- a/app/views/development/email_previews/show.html.erb
+++ b/app/views/development/email_previews/show.html.erb
@@ -1,7 +1,9 @@
 <% content_for :title, @preview[:label] %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: @preview[:label]) %>
+  <%= render PageHeaderComponent.new(title: @preview[:label]) do |header| %>
+    <% header.with_breadcrumb(label: "Email Previews", url: development_email_previews_path) %>
+  <% end %>
 
   <div class="space-y-6">
     <div class="rounded-lg border border-slate-200 bg-white p-4 space-y-1">
@@ -30,7 +32,5 @@
         <pre class="overflow-auto rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 whitespace-pre-wrap"><%= @text_body %></pre>
       </div>
     <% end %>
-
-    <%= link_to "← All email previews", development_email_previews_path, class: "inline-block text-sm text-slate-500 hover:text-slate-700" %>
   </div>
 </div>

--- a/app/views/development/sent_emails/index.html.erb
+++ b/app/views/development/sent_emails/index.html.erb
@@ -2,6 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Sent Emails") do |header| %>
+    <% header.with_breadcrumb(label: "Dev Tools", url: development_path) %>
     <% if @emails.any? %>
       <% header.with_action_button do %>
         <%= button_to "Purge All",

--- a/app/views/development/sent_emails/show.html.erb
+++ b/app/views/development/sent_emails/show.html.erb
@@ -2,9 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: h(@email[:subject]), title_data: { key: "development.emails.subject" }) do |header| %>
-    <% header.with_action_button do %>
-      <%= link_to "Back to all emails", development_sent_emails_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
-    <% end %>
+    <% header.with_breadcrumb(label: "Sent Emails", url: development_sent_emails_path) %>
   <% end %>
 
   <%= render SentEmailDetailsComponent.new(email: @email) %>

--- a/app/views/development/system_status/show.html.erb
+++ b/app/views/development/system_status/show.html.erb
@@ -11,7 +11,9 @@
 %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "System Status") %>
+  <%= render PageHeaderComponent.new(title: "System Status") do |header| %>
+    <% header.with_breadcrumb(label: "Dev Tools", url: development_path) %>
+  <% end %>
 
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Configuration</h2>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,12 +2,10 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Events Log") do |header| %>
+    <% header.with_breadcrumb(label: "Status", url: status_path) %>
     <% header.with_context_paragraph "Everything Feeder has done on your feeds, newest first." %>
     <% header.with_context_paragraph do %>
       <span data-key="events.offset"><%= events_offset_summary(@offset) %></span>
-    <% end %>
-    <% header.with_action_button do %>
-      <%= link_to "Back to Status", status_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
     <% end %>
     <% if @log_endpoint %>
       <% header.with_action_button do %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,6 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Event ##{@event.id}") do |header| %>
+    <% header.with_breadcrumb(label: "Events Log", url: events_path) %>
     <% if @previous_event %>
       <% header.with_action_button do %>
         <%= link_to "← Previous", event_path(@previous_event), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>

--- a/app/views/feeds/_header.html.erb
+++ b/app/views/feeds/_header.html.erb
@@ -1,6 +1,7 @@
 <%# locals: (feed:) %>
 <div id="<%= dom_id(feed, :header) %>">
   <%= render PageHeaderComponent.new(title: feed.display_name) do |header| %>
+    <% header.with_breadcrumb(label: "Feeds", url: feeds_path) %>
     <% header.with_context_paragraph do %>
       <%= render feed_status_badge(feed) %>
     <% end %>

--- a/app/views/llm_credentials/_show_content.html.erb
+++ b/app/views/llm_credentials/_show_content.html.erb
@@ -1,6 +1,8 @@
 <%# locals: (llm_credential:, feed_id: nil) %>
 <div class="space-y-6" data-key="llm_credential.show">
-  <%= render PageHeaderComponent.new(title: llm_credential.display_name) %>
+  <%= render PageHeaderComponent.new(title: llm_credential.display_name) do |header| %>
+    <% header.with_breadcrumb(label: "AI Credentials", url: llm_credentials_path) %>
+  <% end %>
 
   <% case llm_credential.state %>
   <% when "pending", "validating" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,6 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Post #{@post.id}") do |header| %>
+    <% header.with_breadcrumb(label: "Posts", url: posts_path) %>
     <% header.with_context_paragraph do %>
       <%= render BadgeComponent.new(
         text: @post.status.capitalize,


### PR DESCRIPTION
Changes:

- Add `breadcrumb` slot to `PageHeaderComponent` accepting `label:` and `url:` params
- Render breadcrumb as a muted link above the header row, with hover transition to normal text color
- Add breadcrumb to the Access Tokens show page linking back to the index
- Add breadcrumb to the LLM Credentials show page linking back to the index