### PR TITLE
Move default credential tracking to user

### DIFF
--- a/app/components/ai_credential_card_component.html.erb
+++ b/app/components/ai_credential_card_component.html.erb
@@ -5,6 +5,7 @@
     <div class="flex min-w-0 items-center gap-2">
       <%= link_to credential.display_name, credential_url,
             class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
+      <%= render status_badge %>
       <% if default? %>
         <%= render BadgeComponent.new(text: "Default", color: :blue, key: "ai_credential.default-badge") %>
       <% end %>
@@ -15,14 +16,9 @@
     <div class="flex items-center gap-3 text-sm text-slate-400">
       <% if provider_name %>
         <span><%= provider_name %></span>
-        <span class="text-slate-300" aria-hidden="true">&bull;</span>
       <% end %>
-      <span>Status: <%= status_label %></span>
     </div>
     <div class="flex items-center gap-3">
-      <% if inactive? %>
-        <p class="text-sm text-red-600">This key didn't work. Open it to add a new one.</p>
-      <% end %>
       <div class="relative">
         <button type="button"
                 id="<%= menu_id %>-button"

--- a/app/components/ai_credential_card_component.rb
+++ b/app/components/ai_credential_card_component.rb
@@ -19,16 +19,16 @@ class AiCredentialCardComponent < ViewComponent::Base
     LlmProvider.find(credential.provider).display_name
   end
 
-  def status_label
-    credential.state.to_s.capitalize
-  end
-
   def default?
-    credential.is_default?
+    credential.default?
   end
 
-  def inactive?
-    credential.inactive?
+  def status_badge
+    case credential.state.to_sym
+    when :pending, :validating then BadgeComponent.new(text: "Checking", color: :gray, key: "ai_credential.status-badge")
+    when :active               then BadgeComponent.new(text: "Active", color: :green, key: "ai_credential.status-badge")
+    when :inactive             then BadgeComponent.new(text: "Inactive", color: :red, key: "ai_credential.status-badge")
+    end
   end
 
   def menu_id

--- a/app/controllers/ai_credentials/defaults_controller.rb
+++ b/app/controllers/ai_credentials/defaults_controller.rb
@@ -3,15 +3,11 @@ class AiCredentials::DefaultsController < ApplicationController
     authorize credential, :update?
 
     credential.make_default!
-    message = "'#{credential.display_name}' is now the default for #{provider_name}."
+    message = "'#{credential.display_name}' is now the default credential."
     redirect_to ai_credentials_path, success: message
   end
 
   private
-
-  def provider_name
-    @provider_name ||= LlmProvider.find(credential.provider).display_name
-  end
 
   def credential
     @credential ||= scope.find(params[:ai_credential_id])

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -28,16 +28,16 @@ class AiCredential < ApplicationRecord
   validate :api_key_present
 
   before_validation :assign_name_if_blank, on: :create
-  before_save :clear_other_defaults_if_promoting
   before_destroy :disable_dependent_feeds
 
   scope :for_provider, ->(provider) { where(provider: provider) }
 
+  def default?
+    user.default_ai_credential_id == id
+  end
+
   def make_default!
-    transaction do
-      self.class.where(user_id: user_id, provider: provider).where.not(id: id).update_all(is_default: false)
-      update!(is_default: true)
-    end
+    user.update!(default_ai_credential: self)
   end
 
   def ruby_llm_context
@@ -73,15 +73,6 @@ class AiCredential < ApplicationRecord
     return if provider.blank?
 
     errors.add(:base, "Enter your API key") if credential_data.blank? || credential_data["api_key"].blank?
-  end
-
-  def clear_other_defaults_if_promoting
-    return unless is_default? && (will_save_change_to_is_default? || new_record?)
-
-    self.class
-      .where(user_id: user_id, provider: provider)
-      .where.not(id: id)
-      .update_all(is_default: false)
   end
 
   # Mirrors AccessToken#disable_associated_feeds: drop the credential

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   has_many :access_tokens, dependent: :destroy
   has_many :ai_credentials, dependent: :destroy
   has_many :llm_usages, dependent: :destroy
+  belongs_to :default_ai_credential, class_name: "AiCredential", optional: true
   has_many :created_invites, class_name: "Invite", foreign_key: :created_by_user_id, dependent: :destroy
 
   has_one :invite, class_name: "Invite", foreign_key: :invited_user_id, dependent: :nullify

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -45,7 +45,10 @@ class LlmClient
     def default_credential_for(user, provider)
       return nil if provider.blank?
 
-      user.ai_credentials.active.where(provider: provider).order(is_default: :desc, id: :asc).first
+      default = user.default_ai_credential
+      return default if default&.active? && default.provider == provider
+
+      user.ai_credentials.active.where(provider: provider).order(:id).first
     end
   end
 

--- a/app/views/ai_credentials/_show_content.html.erb
+++ b/app/views/ai_credentials/_show_content.html.erb
@@ -53,7 +53,7 @@
     <%= link_to "Back to credentials",
                 ai_credentials_path,
                 class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50" %>
-    <% unless ai_credential.is_default? %>
+    <% unless ai_credential.default? %>
       <%= button_to "Make default",
                     ai_credential_default_path(ai_credential),
                     method: :patch,

--- a/db/migrate/20260617205938_move_default_llm_credential_to_user.rb
+++ b/db/migrate/20260617205938_move_default_llm_credential_to_user.rb
@@ -1,0 +1,41 @@
+class MoveDefaultLlmCredentialToUser < ActiveRecord::Migration[8.2]
+  def up
+    add_reference :users, :default_ai_credential,
+                  foreign_key: { to_table: :ai_credentials, on_delete: :nullify },
+                  null: true
+
+    # Migrate data: for each user pick the first is_default credential (any provider)
+    execute <<~SQL
+      UPDATE users
+      SET default_ai_credential_id = (
+        SELECT id FROM ai_credentials
+        WHERE ai_credentials.user_id = users.id AND is_default = TRUE
+        ORDER BY id ASC
+        LIMIT 1
+      )
+    SQL
+
+    remove_index :ai_credentials, name: "index_ai_credentials_on_user_provider_default"
+    remove_column :ai_credentials, :is_default
+  end
+
+  def down
+    add_column :ai_credentials, :is_default, :boolean, null: false, default: false
+
+    add_index :ai_credentials, [:user_id, :provider],
+              unique: true,
+              where: "is_default = TRUE",
+              name: "index_ai_credentials_on_user_provider_default"
+
+    # Restore is_default from users.default_ai_credential_id
+    execute <<~SQL
+      UPDATE ai_credentials
+      SET is_default = TRUE
+      WHERE id IN (SELECT default_ai_credential_id FROM users WHERE default_ai_credential_id IS NOT NULL)
+    SQL
+
+    remove_reference :users, :default_ai_credential,
+                     foreign_key: { to_table: :ai_credentials },
+                     null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_17_000000) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_17_205938) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -43,14 +43,12 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_17_000000) do
     t.string "provider", null: false
     t.string "display_name", null: false
     t.jsonb "credential_data", default: {}, null: false
-    t.boolean "is_default", default: false, null: false
     t.integer "state", default: 0, null: false
     t.datetime "last_validated_at"
     t.text "last_error"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id", "provider", "display_name"], name: "index_ai_credentials_on_user_id_and_provider_and_display_name", unique: true
-    t.index ["user_id", "provider"], name: "index_ai_credentials_on_user_provider_default", unique: true, where: "(is_default = true)"
     t.index ["user_id", "state"], name: "index_ai_credentials_on_user_id_and_state"
     t.index ["user_id"], name: "index_ai_credentials_on_user_id"
   end
@@ -422,6 +420,8 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_17_000000) do
     t.datetime "suspended_at"
     t.string "unconfirmed_email"
     t.datetime "updated_at", null: false
+    t.bigint "default_ai_credential_id"
+    t.index ["default_ai_credential_id"], name: "index_users_on_default_ai_credential_id"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["email_deactivated_at"], name: "index_users_on_email_deactivated_at"
     t.index ["state"], name: "index_users_on_state"
@@ -455,4 +455,5 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_17_000000) do
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "users", "ai_credentials", column: "default_ai_credential_id", on_delete: :nullify
 end

--- a/test/components/ai_credentials_list_component_test.rb
+++ b/test/components/ai_credentials_list_component_test.rb
@@ -25,7 +25,7 @@ class AiCredentialsListComponentTest < ViewComponent::TestCase
   end
 
   test "#call should show default badge for the default credential" do
-    credential.make_default!
+    user.update!(default_ai_credential: credential)
     result = render_inline(AiCredentialsListComponent.new(credentials: [credential]))
 
     assert_not_nil result.css("[data-key='ai_credential.default-badge']").first
@@ -37,23 +37,21 @@ class AiCredentialsListComponentTest < ViewComponent::TestCase
     assert_empty result.css("[data-key='ai_credential.default-badge']")
   end
 
-  test "#call should show inactive note for inactive credentials" do
+  test "#call should show inactive status badge for inactive credentials" do
     inactive = create(:ai_credential, :inactive, user: user)
     result = render_inline(AiCredentialsListComponent.new(credentials: [inactive]))
 
-    assert_includes result.text, "This key didn't work"
+    badge = result.css("[data-key='ai_credential.status-badge']").first
+    assert_not_nil badge
+    assert_equal "Inactive", badge.text.strip
   end
 
-  test "#call should not show inactive note for active credentials" do
+  test "#call should show active status badge for active credentials" do
     result = render_inline(AiCredentialsListComponent.new(credentials: [credential]))
 
-    assert_not_includes result.text, "This key didn't work"
-  end
-
-  test "#call should show capitalized status" do
-    result = render_inline(AiCredentialsListComponent.new(credentials: [credential]))
-
-    assert_includes result.text, "Status: Active"
+    badge = result.css("[data-key='ai_credential.status-badge']").first
+    assert_not_nil badge
+    assert_equal "Active", badge.text.strip
   end
 
   test "#call should render a Details menu item linking to the show page" do

--- a/test/controllers/ai_credentials/defaults_controller_test.rb
+++ b/test/controllers/ai_credentials/defaults_controller_test.rb
@@ -9,7 +9,7 @@ class AiCredentials::DefaultsControllerTest < ActionDispatch::IntegrationTest
     @other_user ||= create(:user)
   end
 
-  test "#update should set the credential as default and un-default siblings" do
+  test "#update should set the credential as the user's default" do
     sign_in_as(user)
     first = create(:ai_credential, :default, user: user, provider: "anthropic", display_name: "first")
     second = create(:ai_credential, user: user, provider: "anthropic", display_name: "second")
@@ -17,8 +17,7 @@ class AiCredentials::DefaultsControllerTest < ActionDispatch::IntegrationTest
     patch ai_credential_default_url(second)
 
     assert_redirected_to ai_credentials_path
-    assert second.reload.is_default?
-    refute first.reload.is_default?
+    assert_equal second.id, user.reload.default_ai_credential_id
   end
 
   test "#update should set default when no other default exists" do
@@ -27,7 +26,7 @@ class AiCredentials::DefaultsControllerTest < ActionDispatch::IntegrationTest
 
     patch ai_credential_default_url(credential)
 
-    assert credential.reload.is_default?
+    assert_equal credential.id, user.reload.default_ai_credential_id
   end
 
   test "#update should 404 for another user's credential" do
@@ -37,7 +36,7 @@ class AiCredentials::DefaultsControllerTest < ActionDispatch::IntegrationTest
     patch ai_credential_default_url(other)
 
     assert_response :not_found
-    refute other.reload.is_default?
+    assert_nil other_user.reload.default_ai_credential_id
   end
 
   test "#update should require authentication" do

--- a/test/factories/ai_credentials.rb
+++ b/test/factories/ai_credentials.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     provider { "anthropic" }
     sequence(:display_name) { |n| "Claude credential #{n}" }
     credential_data { { "api_key" => "sk-ant-#{SecureRandom.hex(16)}" } }
-    is_default { false }
     state { :pending }
 
     trait :active do
@@ -18,7 +17,9 @@ FactoryBot.define do
     end
 
     trait :default do
-      is_default { true }
+      after(:create) do |credential|
+        credential.user.update!(default_ai_credential: credential)
+      end
     end
   end
 end

--- a/test/models/ai_credential_test.rb
+++ b/test/models/ai_credential_test.rb
@@ -53,48 +53,34 @@ class AiCredentialTest < ActiveSupport::TestCase
     assert_equal "sk-ant-secret-12345", credential.reload.credential_data["api_key"]
   end
 
-  test "should un-default sibling credentials when promoting to default" do
-    first = create(:ai_credential, :default, user: user, provider: "anthropic", display_name: "first")
-    second = create(:ai_credential, user: user, provider: "anthropic", display_name: "second")
-
-    second.update!(is_default: true)
-
-    assert second.reload.is_default?
-    refute first.reload.is_default?
+  test "#default? should return true for the user's default credential" do
+    credential = create(:ai_credential, :default, user: user)
+    assert credential.default?
   end
 
-  test "the partial unique index should reject two defaults for the same (user, provider)" do
-    create(:ai_credential, :default, user: user, provider: "anthropic", display_name: "first")
+  test "#default? should return false when another credential is default" do
+    first = create(:ai_credential, :default, user: user, display_name: "first")
+    second = create(:ai_credential, user: user, display_name: "second")
 
-    assert_raises(ActiveRecord::RecordNotUnique) do
-      # Bypass the `before_save` un-default callback so we can observe the
-      # index doing its job as the last-line guard.
-      AiCredential.connection.execute(<<~SQL)
-        INSERT INTO ai_credentials (user_id, provider, display_name, credential_data, is_default, state, created_at, updated_at)
-        VALUES (#{user.id}, 'anthropic', 'second', '{}', TRUE, 0, NOW(), NOW())
-      SQL
-    end
+    refute second.default?
+    assert first.default?
   end
 
-  test "should allow defaults in different providers for the same user" do
-    skip "no second provider registered yet" unless LlmProvider.all.size > 1
-
-    second_provider = (LlmProvider.names - ["anthropic"]).first
-    anthropic = create(:ai_credential, :default, user: user, provider: "anthropic", display_name: "Anthropic default")
-    other = create(:ai_credential, :default, user: user, provider: second_provider, display_name: "Other default")
-
-    assert anthropic.reload.is_default?
-    assert other.reload.is_default?
-  end
-
-  test "#make_default! should atomically promote one credential and un-default siblings" do
-    first = create(:ai_credential, :default, user: user, provider: "anthropic", display_name: "first")
-    second = create(:ai_credential, user: user, provider: "anthropic", display_name: "second")
+  test "#make_default! should set the user's default credential" do
+    first = create(:ai_credential, :default, user: user, display_name: "first")
+    second = create(:ai_credential, user: user, display_name: "second")
 
     second.make_default!
 
-    assert second.reload.is_default?
-    refute first.reload.is_default?
+    assert_equal second.id, user.reload.default_ai_credential_id
+    refute first.reload.default?
+    assert second.reload.default?
+  end
+
+  test "#make_default! should work when no default exists yet" do
+    credential = create(:ai_credential, user: user)
+    credential.make_default!
+    assert_equal credential.id, user.reload.default_ai_credential_id
   end
 
   test "destroy should be a no-op when no feeds reference the credential" do


### PR DESCRIPTION
Changes:

- Drop `is_default` from `llm_credentials`; add `default_llm_credential_id` FK on `users` (nullable, `on_delete: :nullify`)
- Replace per-provider default with a single user-level default credential
- Add `LlmCredential#default?` checking against the user's reference; simplify `make_default!` accordingly
- Remove the `before_save` un-default callback — constraint now handled at the association level
- Update `LlmClient#default_credential_for` to prefer `user.default_llm_credential`, falling back to first active credential for the provider
- Replace the status text and inline inactive alert in the credential card with a status badge in the header, matching the feed card pattern