### PR TITLE
Improve AI credentials list UI and default-switching UX

### DIFF
--- a/app/components/ai_credential_card_component.html.erb
+++ b/app/components/ai_credential_card_component.html.erb
@@ -36,40 +36,30 @@
              aria-labelledby="<%= menu_id %>-button">
           <ul class="py-1">
             <li>
-              <%= link_to credential_url,
-                    class: "flex items-center gap-2 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
-                    role: "menuitem" do %>
-                <%= helpers.icon("info", css_class: "size-4") %>
-                Details
-              <% end %>
+              <%= link_to "Details", credential_url,
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem" %>
             </li>
             <li>
-              <%= link_to edit_url,
-                    class: "flex items-center gap-2 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
-                    role: "menuitem" do %>
-                <%= helpers.icon("square-pen", css_class: "size-4") %>
-                Edit
-              <% end %>
+              <%= link_to "Edit", edit_url,
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem" %>
             </li>
             <% unless default? %>
               <li>
-                <%= link_to helpers.ai_credential_default_path(credential),
+                <%= link_to "Make default",
+                      helpers.ai_credential_default_path(credential),
                       data: { turbo_method: :patch },
-                      class: "flex items-center gap-2 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
-                      role: "menuitem" do %>
-                  <%= helpers.icon("star", css_class: "size-4") %>
-                  Make default
-                <% end %>
+                      class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                      role: "menuitem" %>
               </li>
             <% end %>
             <li>
-              <%= link_to helpers.ai_credential_path(credential),
+              <%= link_to "Delete…",
+                    helpers.ai_credential_path(credential),
                     data: { turbo_method: :delete, turbo_confirm: "Delete this AI credential? Feeds using it will be disabled." },
-                    class: "flex items-center gap-2 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
-                    role: "menuitem" do %>
-                <%= helpers.icon("trash-2", css_class: "size-4") %>
-                Delete
-              <% end %>
+                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                    role: "menuitem" %>
             </li>
           </ul>
         </div>

--- a/app/controllers/ai_credentials/defaults_controller.rb
+++ b/app/controllers/ai_credentials/defaults_controller.rb
@@ -3,8 +3,16 @@ class AiCredentials::DefaultsController < ApplicationController
     authorize credential, :update?
 
     credential.make_default!
-    message = "'#{credential.display_name}' is now the default credential."
-    redirect_to ai_credentials_path, success: message
+
+    respond_to do |format|
+      format.turbo_stream do
+        flash.now[:success] = "'#{credential.display_name}' is now the default credential."
+        @ai_credentials = policy_scope(AiCredential).order(created_at: :desc)
+      end
+      format.html do
+        redirect_to ai_credentials_path, success: "'#{credential.display_name}' is now the default credential."
+      end
+    end
   end
 
   private

--- a/app/views/ai_credentials/_show_content.html.erb
+++ b/app/views/ai_credentials/_show_content.html.erb
@@ -50,9 +50,6 @@
                     data: { key: "ai_credential.return-to" } %>
       <% end %>
     <% end %>
-    <%= link_to "Back to credentials",
-                ai_credentials_path,
-                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50" %>
     <% unless ai_credential.default? %>
       <%= button_to "Make default",
                     ai_credential_default_path(ai_credential),
@@ -63,7 +60,7 @@
                 edit_ai_credential_path(ai_credential),
                 class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50",
                 data: { key: "ai_credential.edit" } %>
-    <%= button_to "Delete",
+    <%= button_to "Delete…",
                   ai_credential_path(ai_credential),
                   method: :delete,
                   form: { data: { turbo_confirm: "Delete this AI credential? Feeds using it will be disabled." } },

--- a/app/views/ai_credentials/defaults/update.turbo_stream.erb
+++ b/app/views/ai_credentials/defaults/update.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.replace "ai_credentials_list" do %>
+  <div id="ai_credentials_list">
+    <% if @ai_credentials.any? %>
+      <%= render AiCredentialsListComponent.new(credentials: @ai_credentials) %>
+    <% else %>
+      <%= render EmptyStateComponent.new("No AI credentials yet — add one to use AI-backed feed extraction") %>
+    <% end %>
+  </div>
+<% end %>
+
+<%= turbo_stream.replace "flash-messages", partial: "layouts/flash" %>

--- a/app/views/ai_credentials/index.html.erb
+++ b/app/views/ai_credentials/index.html.erb
@@ -11,9 +11,11 @@
     <% end %>
   <% end %>
 
-  <% if @ai_credentials.any? %>
-    <%= render AiCredentialsListComponent.new(credentials: @ai_credentials) %>
-  <% else %>
-    <%= render EmptyStateComponent.new("No AI credentials yet — add one to use AI-backed feed extraction") %>
-  <% end %>
+  <div id="ai_credentials_list">
+    <% if @ai_credentials.any? %>
+      <%= render AiCredentialsListComponent.new(credentials: @ai_credentials) %>
+    <% else %>
+      <%= render EmptyStateComponent.new("No AI credentials yet — add one to use AI-backed feed extraction") %>
+    <% end %>
+  </div>
 </div>

--- a/test/components/ai_credentials_list_component_test.rb
+++ b/test/components/ai_credentials_list_component_test.rb
@@ -72,7 +72,7 @@ class AiCredentialsListComponentTest < ViewComponent::TestCase
 
   test "#call should render the Delete menu item with default text color" do
     result = render_inline(AiCredentialsListComponent.new(credentials: [credential]))
-    item = result.css("a[role='menuitem']").find { |a| a.text.strip == "Delete" }
+    item = result.css("a[role='menuitem']").find { |a| a.text.strip == "Delete…" }
 
     assert_not_nil item
     assert_includes item["class"], "text-slate-700"

--- a/test/controllers/ai_credentials/defaults_controller_test.rb
+++ b/test/controllers/ai_credentials/defaults_controller_test.rb
@@ -39,6 +39,17 @@ class AiCredentials::DefaultsControllerTest < ActionDispatch::IntegrationTest
     assert_nil other_user.reload.default_ai_credential_id
   end
 
+  test "#update should respond with turbo stream when requested" do
+    sign_in_as(user)
+    credential = create(:ai_credential, user: user, provider: "anthropic")
+
+    patch ai_credential_default_url(credential), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :ok
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_equal credential.id, user.reload.default_ai_credential_id
+  end
+
   test "#update should require authentication" do
     credential = create(:ai_credential, user: user)
     patch ai_credential_default_url(credential)


### PR DESCRIPTION
Changes:

- Redraw the credentials list with Turbo Stream when switching the default (no full-page redirect)
- Drop icons from the card dropdown menu for a cleaner look
- Add ellipsis to the Delete item in the dropdown and the Delete button on the show page
- Remove the "Back to credentials" button from the show page
