### PR TITLE
Polish admin user page and UI consistency

### DIFF
--- a/app/components/admin/user_details_component.rb
+++ b/app/components/admin/user_details_component.rb
@@ -24,7 +24,7 @@ class Admin::UserDetailsComponent < ViewComponent::Base
   def permissions_value
     return helpers.tag.span("None", class: "text-slate-500") if @user.permissions.empty?
 
-    @user.permissions.map { |p| Permission.display_name(p.name) }.join(", ")
+    @user.permissions.map(&:display_name).join(", ")
   end
 
   def optional_time(time)

--- a/app/components/admin/user_details_component.rb
+++ b/app/components/admin/user_details_component.rb
@@ -8,8 +8,8 @@ class Admin::UserDetailsComponent < ViewComponent::Base
     render(DescriptionListComponent.new) do |list|
       list.with_item(stat_item("Email", @user.email_address))
       list.with_item(stat_item("Permissions", permissions_value))
-      list.with_item(stat_item("Created", time_value(@user.created_at)))
-      list.with_item(stat_item("Updated", time_value(@user.updated_at)))
+      list.with_item(stat_item("Created", helpers.datetime_with_duration_tag(@user.created_at)))
+      list.with_item(stat_item("Updated", helpers.datetime_with_duration_tag(@user.updated_at)))
       list.with_item(stat_item("Password Updated", optional_time(@user.password_updated_at)))
       list.with_item(stat_item("Last Seen", optional_time(@stats.last_session&.updated_at)))
     end
@@ -24,18 +24,10 @@ class Admin::UserDetailsComponent < ViewComponent::Base
   def permissions_value
     return helpers.tag.span("None", class: "text-slate-500") if @user.permissions.empty?
 
-    @user.permissions.pluck(:name).join(", ")
+    @user.permissions.map { |p| Permission.display_name(p.name) }.join(", ")
   end
 
   def optional_time(time)
-    time.present? ? time_value(time) : helpers.tag.span("Never", class: "text-slate-500")
-  end
-
-  def time_value(time)
-    helpers.tag.time(
-      "#{time.to_date.to_fs(:long)} (#{helpers.short_time_ago(time)})",
-      datetime: time.iso8601,
-      title: time.to_fs(:long)
-    )
+    time.present? ? helpers.datetime_with_duration_tag(time) : helpers.tag.span("Never", class: "text-slate-500")
   end
 end

--- a/app/components/page_header_component.html.erb
+++ b/app/components/page_header_component.html.erb
@@ -1,6 +1,6 @@
 <header class="flex flex-col gap-5">
   <% if breadcrumb? %>
-    <div><%= breadcrumb %></div>
+    <nav aria-label="Breadcrumb"><%= breadcrumb %></nav>
   <% end %>
   <div class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
     <div class="flex flex-col gap-5">

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -17,7 +17,7 @@
     <% end %>
 
     <% header.with_action_button do %>
-      <%= link_to "Delete",
+      <%= link_to "Delete...",
                   "#",
                   class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1"),
                   data: { controller: "modal-trigger", modal_trigger_modal_id_value: "delete-token-modal", action: "click->modal-trigger#open" } %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -26,7 +26,7 @@
                 class: "h-4 w-4 rounded border-slate-300 text-sky-600 focus:ring-sky-500 disabled:opacity-50 disabled:cursor-not-allowed",
                 data: { key: "permissions.#{perm}" } %>
             </div>
-            <div class="text-sm leading-6">
+            <div class="leading-6">
               <%= label_tag "permission_#{perm}", label[:display_name], class: "font-semibold text-slate-800" %>
               <p class="text-slate-500"><%= label[:description] %></p>
             </div>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -56,6 +56,7 @@
       so the markup can be copied straight into a new view. %>
   <div class="min-w-0 space-y-12">
     <%= render PageHeaderComponent.new(title: "UI Elements") do |header| %>
+      <% header.with_breadcrumb(label: "Dev Tools", url: development_path) %>
       <% header.with_context_paragraph do %>
         A living reference of the building blocks used across Feeder — buttons, form
         controls, and components — shown in every state with realistic content. Each
@@ -368,7 +369,7 @@
                   <a href="#" class="block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50" role="menuitem">Edit</a>
                 </li>
                 <li>
-                  <a href="#" class="block px-4 py-2 text-sm text-red-600 transition hover:bg-slate-50" role="menuitem">Delete</a>
+                  <a href="#" class="block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50" role="menuitem">Delete...</a>
                 </li>
               </ul>
             </div>

--- a/app/views/development/sent_emails/index.html.erb
+++ b/app/views/development/sent_emails/index.html.erb
@@ -5,10 +5,10 @@
     <% header.with_breadcrumb(label: "Dev Tools", url: development_path) %>
     <% if @emails.any? %>
       <% header.with_action_button do %>
-        <%= button_to "Purge All",
+        <%= button_to "Purge All...",
                       purge_development_sent_emails_path,
                       method: :delete,
-                      class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50", "text-red-600 hover:text-red-700"),
+                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
                       data: { turbo_confirm: "Are you sure you want to delete all emails?" } %>
       <% end %>
     <% end %>

--- a/app/views/developments/show.html.erb
+++ b/app/views/developments/show.html.erb
@@ -19,6 +19,7 @@
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("hard-hat", css_class: "size-5") %>
           <span>Background Jobs</span>
+          <%= icon("external-link", css_class: "size-4 text-slate-400") %>
         </h2>
         <p class="text-slate-600">Monitor and manage background job queues</p>
       </div>
@@ -48,7 +49,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: development_components_path, target: "_blank", rel: "noopener noreferrer") do %>
+    <%= render CardComponent.new(href: development_components_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <%= icon("layout-grid", css_class: "size-5") %>

--- a/app/views/invites/_table.html.erb
+++ b/app/views/invites/_table.html.erb
@@ -42,7 +42,7 @@
               <% if !invite.invited_user && policy(invite).destroy? %>
                 <%= button_to invite_path(invite),
                               method: :delete,
-                              class: "inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 transition hover:bg-slate-50 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
+                              class: "inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 transition hover:bg-slate-50 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-sky-500 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
                               form: { data: { turbo_confirm: "Are you sure you want to delete this invitation?" } } do %>
                   <%= icon("trash-2", css_class: "size-4") %>
                   <span class="sr-only">Delete invite</span>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -16,7 +16,7 @@
     <% if policy(@post).destroy? %>
       <% header.with_action_button do %>
         <%= link_to "Delete…", "#",
-                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-red-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer",
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer",
                     data: { controller: "modal-trigger", modal_trigger_modal_id_value: PostDeleteModalComponent.modal_id(@post), action: "click->modal-trigger#open" } %>
       <% end %>
     <% end %>

--- a/test/components/admin/user_details_component_test.rb
+++ b/test/components/admin/user_details_component_test.rb
@@ -29,11 +29,11 @@ class Admin::UserDetailsComponentTest < ViewComponent::TestCase
     assert_includes result.text, "None"
   end
 
-  test "#call should list permission names when present" do
+  test "#call should list permission display names when present" do
     create(:permission, user: user, name: "admin")
     result = render_component
 
-    assert_includes result.text, "admin"
+    assert_includes result.text, "Admin"
   end
 
   test "#call should show Never when the user has never been seen" do


### PR DESCRIPTION
Changes:

- Use default font size in the Permissions section on the admin user page
- Show permission display names in user details ("Admin", "Developer Tools")
- Use `datetime_with_duration_tag` for time values in user details, matching the post details page
- Remove red text from Delete/Purge buttons that trigger confirmations; use default slate style
- Add "..." suffix to all confirmation-triggering buttons and menu items
- Add external-link icon to the Background Jobs card on the dev tools page
- Remove new-tab behavior from the UI Reference card
- Add Dev Tools breadcrumb to the UI Elements page