### PR TITLE
Expose VictoriaMetrics at metrics.fffeeder.com

### DIFF
--- a/.github/workflows/deploy-metrics.yml
+++ b/.github/workflows/deploy-metrics.yml
@@ -1,0 +1,53 @@
+name: Deploy metrics proxy
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-metrics
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      METRICS_PASSWORD_HASH: ${{ secrets.METRICS_PASSWORD_HASH }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # The proxy needs no app code, so skip the bundle and install only Kamal.
+      # Pin to the version in Gemfile.lock.
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+
+      - name: Install Kamal
+        run: gem install kamal -v 2.11.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Configure SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan dev.fffeeder.com >> ~/.ssh/known_hosts
+
+      - name: Deploy metrics proxy
+        run: kamal deploy -c config/deploy.metrics.yml

--- a/.kamal/secrets-common
+++ b/.kamal/secrets-common
@@ -10,3 +10,8 @@ KAMAL_REGISTRY_PASSWORD=$(printenv GHCR_TOKEN | grep . || { echo "GHCR_TOKEN is 
 # `openssl rand -hex 64`.
 IMGPROXY_KEY=$(printenv IMGPROXY_KEY | grep . || { echo "IMGPROXY_KEY is required and must be non-empty" >&2; exit 1; })
 IMGPROXY_SALT=$(printenv IMGPROXY_SALT | grep . || { echo "IMGPROXY_SALT is required and must be non-empty" >&2; exit 1; })
+
+# bcrypt hash of the basic-auth password guarding metrics.fffeeder.com (the
+# standalone metrics-proxy app verifies it). Generate with:
+#   docker run --rm caddy:2.10-alpine caddy hash-password --plaintext <password>
+METRICS_PASSWORD_HASH=$(printenv METRICS_PASSWORD_HASH | grep . || { echo "METRICS_PASSWORD_HASH is required and must be non-empty" >&2; exit 1; })

--- a/app/controllers/development/system_status_controller.rb
+++ b/app/controllers/development/system_status_controller.rb
@@ -18,8 +18,17 @@ class Development::SystemStatusController < ApplicationController
       credential_check("imgproxy_endpoint", "imgproxy endpoint present", :imgproxy, :endpoint),
       credential_check("imgproxy_key", "imgproxy signing key present", :imgproxy, :key),
       credential_check("imgproxy_salt", "imgproxy signing salt present", :imgproxy, :salt),
+      metrics_push_check,
       background_jobs_check
     ]
+  end
+
+  # Metrics push is off until METRICS_URL is set (dev/test do nothing). A missing
+  # endpoint isn't an error — it just means this process isn't pushing — so it
+  # shows as neutral, not red.
+  def metrics_push_check
+    status = Metrics.enabled? ? :ok : :neutral
+    { key: "metrics_push", label: "Metrics push enabled", status: status }
   end
 
   # Presence checks for optional credentials. A missing key isn't an error —

--- a/config/deploy.metrics.yml
+++ b/config/deploy.metrics.yml
@@ -1,0 +1,47 @@
+# Standalone Kamal app: a Caddy reverse proxy that exposes the VictoriaMetrics
+# accessory at metrics.fffeeder.com behind HTTP basic auth.
+#
+#   bin/kamal deploy -c config/deploy.metrics.yml
+#
+# VM itself stays an accessory in config/deploy.staging.yml (stateful volume,
+# private push target). This app is just the public, authenticated edge. See
+# docs/deployment-metrics.md for secrets, DNS, and Cloudflare setup.
+service: metrics-proxy
+
+image: dreikanter/metrics-proxy
+
+registry:
+  server: ghcr.io
+  username: dreikanter
+  password:
+    - KAMAL_REGISTRY_PASSWORD
+
+# Caddy ships as a prebuilt public image; config/metrics-proxy/Dockerfile is a
+# thin FROM wrapper that bakes in our Caddyfile so Kamal can retag and push it.
+builder:
+  arch: amd64
+  dockerfile: config/metrics-proxy/Dockerfile
+  context: config/metrics-proxy
+
+servers:
+  web:
+    # The deploy host is the box Kamal SSHes into and where kamal-proxy runs the
+    # ACME challenge, so it must resolve directly to the server — and it must be
+    # the same host as the VM accessory so this app can reach f2-victoriametrics
+    # over the Kamal network. Do NOT use metrics.fffeeder.com here: that name is
+    # Cloudflare-proxied, so SSH and Let's Encrypt would hit the CDN. The public
+    # name is set as proxy.host below.
+    hosts:
+      - dev.fffeeder.com
+
+proxy:
+  ssl: true
+  host: metrics.fffeeder.com
+  app_port: 8080
+
+env:
+  clear:
+    # Basic-auth username is not sensitive; only the password hash is a secret.
+    METRICS_USER: admin
+  secret:
+    - METRICS_PASSWORD_HASH

--- a/config/metrics-proxy/Caddyfile
+++ b/config/metrics-proxy/Caddyfile
@@ -1,0 +1,25 @@
+# Public edge for the VictoriaMetrics accessory. kamal-proxy terminates TLS for
+# metrics.fffeeder.com and forwards plain HTTP here on :8080; Caddy enforces HTTP
+# basic auth and proxies to the VM accessory over the Kamal network.
+{
+	# kamal-proxy already handles TLS; Caddy speaks plain HTTP on the app port.
+	auto_https off
+}
+
+:8080 {
+	# kamal-proxy's health check must not be challenged for credentials.
+	handle /up {
+		respond "OK" 200
+	}
+
+	handle {
+		# Single operator account. The password is stored bcrypt-hashed
+		# (caddy hash-password), so the secret is never a plaintext password.
+		basic_auth {
+			{$METRICS_USER} {$METRICS_PASSWORD_HASH}
+		}
+		# The VM accessory binds localhost on the host but is reachable by
+		# container name over the Kamal docker network.
+		reverse_proxy f2-victoriametrics:8428
+	}
+}

--- a/config/metrics-proxy/Dockerfile
+++ b/config/metrics-proxy/Dockerfile
@@ -1,0 +1,4 @@
+# Thin wrapper so Kamal can tag and push a Caddy image (with our Caddyfile baked
+# in) to the registry and deploy it as a standalone app. Bump the tag to upgrade.
+FROM caddy:2.10-alpine
+COPY Caddyfile /etc/caddy/Caddyfile

--- a/docs/deployment-metrics.md
+++ b/docs/deployment-metrics.md
@@ -1,0 +1,103 @@
+# Deployment: metrics proxy
+
+VictoriaMetrics runs as a Kamal **accessory** (see `docs/victoriametrics.md`):
+it's stateful (the `vmdata` volume), it's the private push target the app reaches
+by container name, and it mounts the scrape/dashboard files. All of that is a
+natural fit for the accessory model, and accessories stay bound to localhost.
+
+The one thing an accessory can't do is get a public HTTPS host — accessories
+aren't routed through kamal-proxy. So the public edge is a separate, tiny
+standalone app: a Caddy reverse proxy that kamal-proxy routes (giving it a
+Let's Encrypt cert for `metrics.fffeeder.com`), enforces HTTP basic auth, and
+forwards to the VM accessory over the Kamal network.
+
+This mirrors the imgproxy setup (`docs/deployment-imgproxy.md`) — a standalone
+app for the public edge — but here it fronts a stateful accessory rather than
+replacing it. VM has no auth of its own (vmui and the full read/write/delete API
+would be wide open), so the proxy's basic auth is what keeps the endpoint safe;
+unlike imgproxy, which is safe to expose because it only serves signed URLs.
+
+## Config layout
+
+- `config/deploy.metrics.yml` — Kamal config for the standalone proxy app.
+- `config/metrics-proxy/Dockerfile` — thin `FROM caddy:<tag>` wrapper that bakes
+  in the Caddyfile.
+- `config/metrics-proxy/Caddyfile` — basic auth + reverse proxy to
+  `f2-victoriametrics:8428`; serves `/up` unauthenticated for kamal-proxy's
+  health check.
+- `.github/workflows/deploy-metrics.yml` — on-demand (`workflow_dispatch`) deploy.
+
+## Secret
+
+Only one secret is needed: the basic-auth password, stored **bcrypt-hashed** so
+the stored value is never the plaintext password. The username isn't sensitive
+and lives in `config/deploy.metrics.yml` as a clear env var (`METRICS_USER`,
+default `admin`).
+
+Generate the hash:
+
+```bash
+docker run --rm caddy:2.10-alpine caddy hash-password --plaintext <password>
+```
+
+Store the result as the GitHub Actions repository secret `METRICS_PASSWORD_HASH`
+(the deploy workflow passes it through). For local deploys, export it first:
+
+```bash
+export METRICS_PASSWORD_HASH='<hash>'
+```
+
+`.kamal/secrets-common` reads it, so it's available to the proxy app without a
+per-destination secrets file.
+
+## DNS and Cloudflare
+
+Same shape as imgproxy — two records with different jobs:
+
+| Record | Cloudflare | Points at | Used for |
+| --- | --- | --- | --- |
+| Deploy host (`dev.fffeeder.com`) | DNS-only (grey) | server IP | Kamal SSH + Let's Encrypt |
+| `metrics.fffeeder.com` | Proxied (orange) | the origin | public endpoint |
+
+The deploy host (`servers.web.hosts`) must resolve **directly** to the server so
+SSH and the ACME challenge reach the origin, not Cloudflare. It must also be the
+**same host as the VM accessory** so the proxy can reach `f2-victoriametrics`
+over the Kamal docker network. `proxy.host` is the public name.
+
+### Let's Encrypt behind Cloudflare
+
+kamal-proxy issues the cert for `metrics.fffeeder.com`, but the ACME challenge
+fails if the record is already proxied. Either deploy with the record **DNS-only
+(grey)** first so the cert is issued, then switch to **proxied (orange)** with
+SSL mode **Full (strict)** (renewals need the same grey window); or install a
+**Cloudflare Origin Certificate** on kamal-proxy and skip Let's Encrypt. See
+`docs/deployment-imgproxy.md` for the same trade-off in more detail.
+
+## Deploy
+
+VM and the proxy change rarely, so deploys are on demand — the workflow does not
+run on push. Trigger the **Deploy metrics proxy** workflow from the Actions tab,
+or deploy locally:
+
+```bash
+bin/kamal deploy -c config/deploy.metrics.yml
+```
+
+The first time on a fresh host, run `setup` instead of `deploy`.
+
+## Upgrade
+
+Bump the tag in `config/metrics-proxy/Dockerfile` and redeploy.
+
+## Verify
+
+```bash
+# Health endpoint bypasses auth (kamal-proxy checks /up).
+curl -I https://metrics.fffeeder.com/up                 # 200
+
+# Unauthenticated UI requests are rejected.
+curl -I https://metrics.fffeeder.com/vmui               # 401
+
+# With credentials, vmui loads.
+curl -I -u admin:<password> https://metrics.fffeeder.com/vmui   # 200
+```

--- a/docs/victoriametrics.md
+++ b/docs/victoriametrics.md
@@ -5,13 +5,18 @@ Staging runs VictoriaMetrics as a Kamal accessory (`config/deploy.staging.yml`) 
 - **Scrape:** VM pulls host OS metrics (CPU, memory, disk, network) from the `node-exporter` accessory, per `config/victoriametrics/scrape.yml`.
 - **Push:** the app sends its own `feeder_*` metrics (counters and gauges, including PostgreSQL sizes) to VM's import endpoint on the configured flush interval — 60 seconds on staging. See `app/services/metrics.rb` and `config/initializers/metrics.rb`.
 
-VM is bound to localhost on the server, so view the UI through an SSH tunnel:
+VM is bound to localhost on the server. There are two ways to reach vmui:
 
-```
-ssh -L 8428:127.0.0.1:8428 dev.fffeeder.com
-```
+- **Public endpoint:** https://metrics.fffeeder.com/vmui, behind HTTP basic auth.
+  A standalone Caddy proxy app fronts the accessory — see
+  `docs/deployment-metrics.md`.
+- **SSH tunnel** (no proxy needed):
 
-Then open http://localhost:8428/vmui.
+  ```
+  ssh -L 8428:127.0.0.1:8428 dev.fffeeder.com
+  ```
+
+  Then open http://localhost:8428/vmui.
 
 ## App push configuration
 

--- a/test/controllers/development/system_status_controller_test.rb
+++ b/test/controllers/development/system_status_controller_test.rb
@@ -44,7 +44,30 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='config.imgproxy_endpoint']", text: /imgproxy endpoint/
     assert_select "[data-key='config.imgproxy_key']", text: /imgproxy signing key/
     assert_select "[data-key='config.imgproxy_salt']", text: /imgproxy signing salt/
+    assert_select "[data-key='config.metrics_push']", text: /Metrics push enabled/
     assert_select "[data-key='config.background_jobs']", text: /Background jobs/
+  end
+
+  test "should flag metrics push as healthy when METRICS_URL is set" do
+    Metrics.stub(:enabled?, true) do
+      login_as(dev_user)
+
+      get development_system_status_path
+    end
+
+    assert_response :success
+    assert_select "[data-key='config.metrics_push'][data-status='ok']"
+  end
+
+  test "should flag metrics push as neutral when METRICS_URL is unset" do
+    Metrics.stub(:enabled?, false) do
+      login_as(dev_user)
+
+      get development_system_status_path
+    end
+
+    assert_response :success
+    assert_select "[data-key='config.metrics_push'][data-status='neutral']"
   end
 
   test "should flag background jobs as healthy when a process is heartbeating" do


### PR DESCRIPTION
Changes:

- Add a standalone Caddy reverse-proxy app (`metrics-proxy`) that exposes the VictoriaMetrics accessory at `metrics.fffeeder.com` behind HTTP basic auth, deployed on demand like imgproxy
- Add a "Metrics push enabled" check to the dev system status page
- Document the setup in `docs/deployment-metrics.md` and note vmui access in `docs/victoriametrics.md`

VM has no auth of its own, so rather than turning it into a standalone app (it's stateful and the private push target), it stays an accessory and a thin kamal-proxy-routed app provides the public, authenticated edge — terminating TLS and forwarding to the VM accessory over the Kamal network. Only the password is a secret, stored bcrypt-hashed; the `/up` endpoint bypasses auth for kamal-proxy's health check.