### PR TITLE
Fix metrics-proxy basic-auth hash transport

### DIFF
--- a/.github/workflows/deploy-metrics.yml
+++ b/.github/workflows/deploy-metrics.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-      METRICS_PASSWORD_HASH: ${{ secrets.METRICS_PASSWORD_HASH }}
+      METRICS_PASSWORD_HASH_B64: ${{ secrets.METRICS_PASSWORD_HASH_B64 }}
 
     steps:
       - name: Checkout code

--- a/.kamal/secrets-common
+++ b/.kamal/secrets-common
@@ -11,7 +11,10 @@ KAMAL_REGISTRY_PASSWORD=$(printenv GHCR_TOKEN | grep . || { echo "GHCR_TOKEN is 
 IMGPROXY_KEY=$(printenv IMGPROXY_KEY | grep . || { echo "IMGPROXY_KEY is required and must be non-empty" >&2; exit 1; })
 IMGPROXY_SALT=$(printenv IMGPROXY_SALT | grep . || { echo "IMGPROXY_SALT is required and must be non-empty" >&2; exit 1; })
 
-# bcrypt hash of the basic-auth password guarding metrics.fffeeder.com (the
-# standalone metrics-proxy app verifies it). Generate with:
-#   docker run --rm caddy:2.10-alpine caddy hash-password --plaintext <password>
-METRICS_PASSWORD_HASH=$(printenv METRICS_PASSWORD_HASH | grep . || { echo "METRICS_PASSWORD_HASH is required and must be non-empty" >&2; exit 1; })
+# Base64-encoded bcrypt hash of the basic-auth password guarding
+# metrics.fffeeder.com (the metrics-proxy container decodes it). It must be
+# base64: a raw bcrypt hash contains '$', which this dotenv layer interpolates
+# away to an empty string. Generate with:
+#   HASH=$(docker run --rm caddy:2.10-alpine caddy hash-password --plaintext <password>)
+#   printf '%s' "$HASH" | base64 -w0
+METRICS_PASSWORD_HASH_B64=$(printenv METRICS_PASSWORD_HASH_B64 | grep . || { echo "METRICS_PASSWORD_HASH_B64 is required and must be non-empty" >&2; exit 1; })

--- a/config/deploy.metrics.yml
+++ b/config/deploy.metrics.yml
@@ -44,4 +44,7 @@ env:
     # Basic-auth username is not sensitive; only the password hash is a secret.
     METRICS_USER: admin
   secret:
-    - METRICS_PASSWORD_HASH
+    # The bcrypt hash is shipped base64-encoded and decoded by the container
+    # command — bcrypt's '$' chars get mangled by Kamal's dotenv secrets layer
+    # otherwise. See config/metrics-proxy/Dockerfile.
+    - METRICS_PASSWORD_HASH_B64

--- a/config/metrics-proxy/Dockerfile
+++ b/config/metrics-proxy/Dockerfile
@@ -2,3 +2,12 @@
 # in) to the registry and deploy it as a standalone app. Bump the tag to upgrade.
 FROM caddy:2.10-alpine
 COPY Caddyfile /etc/caddy/Caddyfile
+
+# The basic-auth password is bcrypt-hashed, and bcrypt hashes contain '$'. Kamal
+# feeds secrets through a dotenv layer that interpolates '$...' sequences, which
+# silently empties the hash before it reaches the container. So it's transported
+# base64-encoded (base64 has no '$') and decoded here into the env var Caddy
+# reads via the {$METRICS_PASSWORD_HASH} placeholder. Reset the upstream
+# ENTRYPOINT (["caddy"]) so the shell command runs directly.
+ENTRYPOINT []
+CMD ["sh", "-c", "export METRICS_PASSWORD_HASH=\"$(printf %s \"$METRICS_PASSWORD_HASH_B64\" | base64 -d)\"; exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile"]

--- a/docs/deployment-metrics.md
+++ b/docs/deployment-metrics.md
@@ -21,7 +21,8 @@ unlike imgproxy, which is safe to expose because it only serves signed URLs.
 
 - `config/deploy.metrics.yml` — Kamal config for the standalone proxy app.
 - `config/metrics-proxy/Dockerfile` — thin `FROM caddy:<tag>` wrapper that bakes
-  in the Caddyfile.
+  in the Caddyfile; its `CMD` decodes the base64 password hash (see Secret below)
+  into the env var Caddy reads, then execs Caddy.
 - `config/metrics-proxy/Caddyfile` — basic auth + reverse proxy to
   `f2-victoriametrics:8428`; serves `/up` unauthenticated for kamal-proxy's
   health check.
@@ -34,17 +35,25 @@ the stored value is never the plaintext password. The username isn't sensitive
 and lives in `config/deploy.metrics.yml` as a clear env var (`METRICS_USER`,
 default `admin`).
 
-Generate the hash:
+The hash is transported **base64-encoded**. This isn't cosmetic: a bcrypt hash
+contains `$`, and Kamal's dotenv-based secrets layer interpolates `$...`
+sequences, which silently empties the hash before it reaches the container.
+Base64 has no `$`, so it survives; the container command (in
+`config/metrics-proxy/Dockerfile`) decodes it before Caddy reads it.
+
+Generate the base64-encoded hash:
 
 ```bash
-docker run --rm caddy:2.10-alpine caddy hash-password --plaintext <password>
+HASH=$(docker run --rm caddy:2.10-alpine caddy hash-password --plaintext <password>)
+printf '%s' "$HASH" | base64 -w0    # macOS: use `base64` (no -w0)
 ```
 
-Store the result as the GitHub Actions repository secret `METRICS_PASSWORD_HASH`
-(the deploy workflow passes it through). For local deploys, export it first:
+Store the result as the GitHub Actions repository secret
+`METRICS_PASSWORD_HASH_B64` (the deploy workflow passes it through). For local
+deploys, export it first:
 
 ```bash
-export METRICS_PASSWORD_HASH='<hash>'
+export METRICS_PASSWORD_HASH_B64='<base64 string>'
 ```
 
 `.kamal/secrets-common` reads it, so it's available to the proxy app without a


### PR DESCRIPTION
Changes:

- Transport the metrics-proxy basic-auth bcrypt hash base64-encoded and decode it in a container entrypoint, so the credential actually reaches Caddy

A bcrypt hash contains `$`, and Kamal's dotenv-based secrets layer interpolates `$...` sequences — which silently empties the hash before it reaches the container. Caddy then fails to start (`basic_auth: username and password cannot be empty`) and the deploy rolls back. Base64 has no `$`, so the value survives the secrets pipeline; `config/metrics-proxy/entrypoint.sh` decodes it back into the env var Caddy reads. The secret is renamed to `METRICS_PASSWORD_HASH_B64` across the deploy config, secrets, and workflow, with docs updated.

The origin of secrets:

- Github Actions Secrets
  - → Workflow (`.github/workflows/deploy-metrics.yml`)
    - → Kamal  secrets (`.kamal/secrets-common`)
      - → Kamal configuration (`config/deploy.metrics.yml`)
        - → Docker (`config/metrics-proxy/Dockerfile`)
          -  → Application (Victoria Metrics)

References:

- Follow-up to #782
