### PR TITLE
Add structured JSON logging to staging with VictoriaLogs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,15 @@ group :development do
   gem "web-console"
 end
 
+# Structured JSON logging on the deployed environments. The app emits JSON to
+# STDOUT and the Vector accessory ships it to VictoriaLogs (config/vector,
+# docs/victorialogs.md). Scoped to production/staging so local dev and tests
+# keep Rails' default human-readable logger. staging.rb inherits production.rb,
+# and Rails.groups loads the matching group in each environment.
+group :production, :staging do
+  gem "rails_semantic_logger"
+end
+
 gem "addressable"
 gem "dotenv"
 gem "faraday"

--- a/Gemfile
+++ b/Gemfile
@@ -70,11 +70,10 @@ group :development do
   gem "web-console"
 end
 
-# Structured JSON logging on the deployed environments. The app emits JSON to
-# STDOUT and the Vector accessory ships it to VictoriaLogs (config/vector,
-# docs/victorialogs.md). Scoped to production/staging so local dev and tests
-# keep Rails' default human-readable logger. staging.rb inherits production.rb,
-# and Rails.groups loads the matching group in each environment.
+# Structured JSON logging for the deployed environments (docs/victorialogs.md).
+# Scoped to production/staging so dev and test keep Rails' default logger.
+# staging.rb inherits production.rb and Rails loads the matching bundler group
+# per environment, so both deployed envs pick it up.
 group :production, :staging do
   gem "rails_semantic_logger"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,6 +344,10 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_semantic_logger (4.20.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
     rainbow (3.1.1)
     rake (13.4.2)
     rbs (4.0.2)
@@ -411,6 +415,8 @@ GEM
     ruby_llm-schema (0.4.0)
     sax-machine (1.3.2)
     securerandom (0.4.1)
+    semantic_logger (4.18.0)
+      concurrent-ruby (~> 1.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -571,6 +577,7 @@ DEPENDENCIES
   puma (>= 5.0)
   pundit
   rails!
+  rails_semantic_logger
   resend
   rouge
   rubocop-rails-omakase

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -59,11 +59,8 @@ accessories:
     volumes:
       - "/:/host:ro,rslave"
 
-  # Self-hosted log storage with a built-in web UI, fed by the vector accessory
-  # below. 2-day retention, bound to localhost — the app never talks to it
-  # directly; view the UI via an SSH tunnel:
-  # ssh -L 9428:127.0.0.1:9428 dev.fffeeder.com → http://localhost:9428/select/vmui/
-  # See docs/victorialogs.md.
+  # Self-hosted log storage with a built-in web UI, fed by the vector accessory.
+  # Bound to localhost — reach the UI via an SSH tunnel (see docs/victorialogs.md).
   # Remove with: bin/kamal accessory remove vlogs -d staging
   vlogs:
     image: victoriametrics/victoria-logs:v1.51.0
@@ -73,9 +70,8 @@ accessories:
     directories:
       - data:/vlogs
 
-  # Reads web/jobs container stdout through the Docker API (read-only socket
-  # mount) and forwards the rails_semantic_logger JSON lines to VictoriaLogs
-  # over the Kamal network. Config in config/vector/vector.yaml.
+  # Reads web/jobs container stdout via the Docker API and forwards the JSON
+  # lines to VictoriaLogs over the Kamal network.
   # Remove with: bin/kamal accessory remove vector -d staging
   vector:
     image: timberio/vector:0.56.0-alpine

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -59,6 +59,33 @@ accessories:
     volumes:
       - "/:/host:ro,rslave"
 
+  # Self-hosted log storage with a built-in web UI, fed by the vector accessory
+  # below. 2-day retention, bound to localhost — the app never talks to it
+  # directly; view the UI via an SSH tunnel:
+  # ssh -L 9428:127.0.0.1:9428 dev.fffeeder.com → http://localhost:9428/select/vmui/
+  # See docs/victorialogs.md.
+  # Remove with: bin/kamal accessory remove vlogs -d staging
+  vlogs:
+    image: victoriametrics/victoria-logs:v1.51.0
+    host: dev.fffeeder.com
+    port: "127.0.0.1:9428:9428"
+    cmd: "-retentionPeriod=2d -storageDataPath=/vlogs"
+    directories:
+      - data:/vlogs
+
+  # Reads web/jobs container stdout through the Docker API (read-only socket
+  # mount) and forwards the rails_semantic_logger JSON lines to VictoriaLogs
+  # over the Kamal network. Config in config/vector/vector.yaml.
+  # Remove with: bin/kamal accessory remove vector -d staging
+  vector:
+    image: timberio/vector:0.56.0-alpine
+    host: dev.fffeeder.com
+    cmd: "--config /etc/vector/vector.yaml"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    files:
+      - config/vector/vector.yaml:/etc/vector/vector.yaml
+
 # Environment variables.
 env:
   clear:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -27,9 +27,8 @@ env:
     - RAILS_MASTER_KEY
     - POSTGRES_PASSWORD
 
-# Cap the json-file log driver so container stdout can't fill the host disk.
-# On staging the vector accessory ships these lines to VictoriaLogs (see
-# config/vector and docs/victorialogs.md); the on-disk copy is just a buffer.
+# Cap the json-file driver so container logs can't fill the host disk. On staging
+# Vector ships these to VictoriaLogs (docs/victorialogs.md); the file is a buffer.
 logging:
   options:
     max-size: 100m

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -27,6 +27,14 @@ env:
     - RAILS_MASTER_KEY
     - POSTGRES_PASSWORD
 
+# Cap the json-file log driver so container stdout can't fill the host disk.
+# On staging the vector accessory ships these lines to VictoriaLogs (see
+# config/vector and docs/victorialogs.md); the on-disk copy is just a buffer.
+logging:
+  options:
+    max-size: 100m
+    max-file: 3
+
 # Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
 # "bin/kamal logs -r jobs" will tail logs from the first server in the jobs section.
 aliases:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,10 +30,9 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
-  # Emit structured JSON logs to STDOUT via rails_semantic_logger so the Vector
-  # accessory can ship them to VictoriaLogs (see docs/victorialogs.md). Kamal
-  # captures STDOUT, so the on-disk file appender is disabled — nothing reads a
-  # log file inside the container. The request id rides along as a named tag.
+  # Structured JSON logs to STDOUT for the Vector accessory to ship to
+  # VictoriaLogs (docs/victorialogs.md). The file appender is off since Kamal
+  # only captures STDOUT; request_id becomes a named tag.
   config.log_tags = [:request_id]
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info").to_sym
   config.rails_semantic_logger.format = :json

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,12 +30,16 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
-  # Log to STDOUT with the current request id as a default log tag.
+  # Emit structured JSON logs to STDOUT via rails_semantic_logger so the Vector
+  # accessory can ship them to VictoriaLogs (see docs/victorialogs.md). Kamal
+  # captures STDOUT, so the on-disk file appender is disabled — nothing reads a
+  # log file inside the container. The request id rides along as a named tag.
   config.log_tags = [:request_id]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
-
-  # Change to "debug" to log everything (including potentially personally-identifiable information!)
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info").to_sym
+  config.rails_semantic_logger.format = :json
+  config.rails_semantic_logger.semantic = true
+  config.rails_semantic_logger.add_file_appender = false
+  config.semantic_logger.add_appender(io: $stdout, level: config.log_level, formatter: :json)
 
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"

--- a/config/initializers/rails_semantic_logger.rb
+++ b/config/initializers/rails_semantic_logger.rb
@@ -1,0 +1,24 @@
+# Edge Rails compatibility shim for rails_semantic_logger 4.20.0.
+#
+# The gem patches Action Cable's TaggedLoggerProxy at its pre-Rails-8 location,
+# ActionCable::Connection::TaggedLoggerProxy. Edge Rails relocated that class to
+# ActionCable::Server::TaggedLoggerProxy, so the gem's
+# `require "action_cable/connection/tagged_logger_proxy"` — run from an
+# after_initialize hook — raises LoadError and aborts production boot under
+# eager_load. The gem only loads on the deployed environments (see Gemfile), so
+# this shim is scoped to them too.
+#
+# Alias the old constant to the relocated class so the gem's patch lands on the
+# real proxy, and mark the stale path as already loaded so the require becomes a
+# no-op. Remove once rails_semantic_logger targets ActionCable::Server.
+if defined?(RailsSemanticLogger) && defined?(ActionCable)
+  require "action_cable/server/tagged_logger_proxy"
+
+  module ActionCable
+    module Connection
+      TaggedLoggerProxy = ActionCable::Server::TaggedLoggerProxy unless defined?(TaggedLoggerProxy)
+    end
+  end
+
+  $LOADED_FEATURES << "action_cable/connection/tagged_logger_proxy.rb"
+end

--- a/config/initializers/rails_semantic_logger.rb
+++ b/config/initializers/rails_semantic_logger.rb
@@ -1,16 +1,12 @@
 # Edge Rails compatibility shim for rails_semantic_logger 4.20.0.
 #
-# The gem patches Action Cable's TaggedLoggerProxy at its pre-Rails-8 location,
-# ActionCable::Connection::TaggedLoggerProxy. Edge Rails relocated that class to
-# ActionCable::Server::TaggedLoggerProxy, so the gem's
-# `require "action_cable/connection/tagged_logger_proxy"` — run from an
-# after_initialize hook — raises LoadError and aborts production boot under
-# eager_load. The gem only loads on the deployed environments (see Gemfile), so
-# this shim is scoped to them too.
-#
-# Alias the old constant to the relocated class so the gem's patch lands on the
-# real proxy, and mark the stale path as already loaded so the require becomes a
-# no-op. Remove once rails_semantic_logger targets ActionCable::Server.
+# Edge Rails moved Action Cable's TaggedLoggerProxy from ActionCable::Connection
+# to ActionCable::Server, but the gem still does
+# `require "action_cable/connection/tagged_logger_proxy"` from an after_initialize
+# hook — a LoadError that aborts eager-load boot. Alias the old constant onto the
+# new class so the gem's patch still lands, and seed the stale path into
+# $LOADED_FEATURES so the require is a no-op. The gem loads only on the deployed
+# environments (see Gemfile); remove once it targets ActionCable::Server.
 if defined?(RailsSemanticLogger) && defined?(ActionCable)
   require "action_cable/server/tagged_logger_proxy"
 

--- a/config/vector/vector.yaml
+++ b/config/vector/vector.yaml
@@ -1,0 +1,59 @@
+# Vector reads the web/jobs container stdout through the Docker API and ships
+# the JSON lines emitted by rails_semantic_logger to the VictoriaLogs accessory.
+# Booted by Kamal as the `vector` accessory (config/deploy.staging.yml).
+# See docs/victorialogs.md.
+
+sources:
+  app:
+    type: docker_logs
+    # Kamal names app containers "<service>-<role>-<destination>-<version>", so
+    # these prefixes match f2-web-staging-* and f2-jobs-staging-*. Accessory
+    # containers (f2-db, f2-vlogs, f2-vector, …) are intentionally left out.
+    include_containers:
+      - f2-web
+      - f2-jobs
+
+transforms:
+  parse:
+    type: remap
+    inputs:
+      - app
+    source: |
+      # Each stdout line is a JSON document from semantic_logger. Parse it and
+      # merge its fields onto the event, keeping the Docker metadata (notably
+      # container_name). Non-JSON lines — early boot, libraries that bypass the
+      # Rails logger — pass through unchanged with .message as the raw text.
+      parsed, err = parse_json(string!(.message))
+      if err == null && is_object(parsed) {
+        . = merge(., object!(parsed))
+
+        # semantic_logger nests request/job details (controller, action, status,
+        # duration, …) under .payload. Hoist them to the top level so they are
+        # directly queryable in VictoriaLogs, e.g. `status:>=500`.
+        if is_object(.payload) {
+          . = merge(., object!(.payload))
+          del(.payload)
+        }
+      }
+
+sinks:
+  vlogs:
+    type: elasticsearch
+    inputs:
+      - parse
+    # Same Kamal docker network, so the VictoriaLogs accessory resolves by name.
+    endpoints:
+      - http://f2-vlogs:9428/insert/elasticsearch/
+    mode: bulk
+    # VictoriaLogs emulates the ES bulk API but not its version handshake, so
+    # pin the version and skip the health probe.
+    api_version: v8
+    compression: gzip
+    healthcheck:
+      enabled: false
+    # Tell VictoriaLogs which fields hold the message and timestamp, and which
+    # low-cardinality fields identify a log stream.
+    query:
+      _msg_field: message
+      _time_field: timestamp
+      _stream_fields: container_name,level

--- a/config/vector/vector.yaml
+++ b/config/vector/vector.yaml
@@ -1,14 +1,11 @@
-# Vector reads the web/jobs container stdout through the Docker API and ships
-# the JSON lines emitted by rails_semantic_logger to the VictoriaLogs accessory.
-# Booted by Kamal as the `vector` accessory (config/deploy.staging.yml).
-# See docs/victorialogs.md.
+# Reads web/jobs container stdout via the Docker API and ships the JSON lines
+# from rails_semantic_logger to the VictoriaLogs accessory. See docs/victorialogs.md.
 
 sources:
   app:
     type: docker_logs
-    # Kamal names app containers "<service>-<role>-<destination>-<version>", so
-    # these prefixes match f2-web-staging-* and f2-jobs-staging-*. Accessory
-    # containers (f2-db, f2-vlogs, f2-vector, …) are intentionally left out.
+    # Kamal names containers "<service>-<role>-<destination>-<version>", so these
+    # prefixes match f2-web-staging-* / f2-jobs-staging-*. Accessories are excluded.
     include_containers:
       - f2-web
       - f2-jobs
@@ -19,17 +16,15 @@ transforms:
     inputs:
       - app
     source: |
-      # Each stdout line is a JSON document from semantic_logger. Parse it and
-      # merge its fields onto the event, keeping the Docker metadata (notably
-      # container_name). Non-JSON lines — early boot, libraries that bypass the
-      # Rails logger — pass through unchanged with .message as the raw text.
+      # Lines are JSON from semantic_logger; merge the parsed fields onto the
+      # event so Docker metadata (container_name) survives. Non-JSON lines pass
+      # through with .message as raw text.
       parsed, err = parse_json(string!(.message))
       if err == null && is_object(parsed) {
         . = merge(., object!(parsed))
 
-        # semantic_logger nests request/job details (controller, action, status,
-        # duration, …) under .payload. Hoist them to the top level so they are
-        # directly queryable in VictoriaLogs, e.g. `status:>=500`.
+        # semantic_logger nests request/job details under .payload; hoist them so
+        # fields like status and controller are queryable directly (status:>=500).
         if is_object(.payload) {
           . = merge(., object!(.payload))
           del(.payload)
@@ -41,7 +36,7 @@ sinks:
     type: elasticsearch
     inputs:
       - parse
-    # Same Kamal docker network, so the VictoriaLogs accessory resolves by name.
+    # Resolves by name over the shared Kamal docker network.
     endpoints:
       - http://f2-vlogs:9428/insert/elasticsearch/
     mode: bulk
@@ -51,8 +46,7 @@ sinks:
     compression: gzip
     healthcheck:
       enabled: false
-    # Tell VictoriaLogs which fields hold the message and timestamp, and which
-    # low-cardinality fields identify a log stream.
+    # _stream_fields must stay low-cardinality.
     query:
       _msg_field: message
       _time_field: timestamp

--- a/docs/victorialogs.md
+++ b/docs/victorialogs.md
@@ -1,0 +1,102 @@
+# VictoriaLogs on Staging
+
+Staging ships structured application and job logs to a self-hosted
+[VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) instance so they
+can be queried by field — status, controller, job class, level — instead of
+grepped. Three pieces work together:
+
+- **App:** `rails_semantic_logger` makes the app emit one JSON object per log
+  line to STDOUT (requests, app logs, and Solid Queue lifecycle). Configured in
+  `config/environments/production.rb`, which `staging.rb` inherits. Scoped to
+  the deployed environments only — local dev and tests keep Rails' default
+  human-readable logger.
+- **Vector** (`vector` accessory): reads the `f2-web` and `f2-jobs` container
+  stdout through the Docker API and forwards the parsed JSON to VictoriaLogs
+  over the private Kamal network. Config in `config/vector/vector.yaml`.
+- **VictoriaLogs** (`vlogs` accessory): stores and serves the logs with a
+  built-in web UI. Two-day retention.
+
+Both accessories live in `config/deploy.staging.yml`. There are no new secrets:
+VictoriaLogs is bound to localhost and only reachable over the Kamal network or
+an SSH tunnel.
+
+## Viewing the UI
+
+VictoriaLogs is bound to localhost on the server, so reach the UI through an SSH
+tunnel:
+
+```
+ssh -L 9428:127.0.0.1:9428 dev.fffeeder.com
+```
+
+Then open http://localhost:9428/select/vmui/.
+
+## Querying
+
+The UI takes [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/).
+Because Vector hoists `semantic_logger`'s `payload` to the top level, request
+and job fields are queryable directly:
+
+```
+level:ERROR
+status:>=500
+container_name:f2-jobs AND level:WARN
+controller:FeedsController duration:>1000
+```
+
+`container_name` distinguishes web (`f2-web-staging-*`) from jobs
+(`f2-jobs-staging-*`), so Solid Queue lines are easy to isolate.
+
+## What gets logged
+
+`semantic_logger` emits `message`, `timestamp`, `level`, `name`, and a `payload`
+of structured fields. Vector maps `message`/`timestamp` to VictoriaLogs'
+`_msg_field`/`_time_field` and streams by `container_name,level`. Non-JSON lines
+(early boot, libraries that bypass the Rails logger) still arrive, with the raw
+text kept as the message.
+
+> Container names carry a `-staging-` segment and a version suffix because Kamal
+> names containers `<service>-<role>-<destination>-<version>`. Vector matches on
+> the `f2-web` / `f2-jobs` prefixes, so it keeps working across deploys. If the
+> service or role names ever change, update `include_containers` in
+> `config/vector/vector.yaml`.
+
+## Applying changes
+
+Like the VictoriaMetrics accessory, these are managed separately from
+`bin/kamal deploy`. The app-side logging format ships with a normal deploy (it's
+just app code), but the accessories and the Vector config do not. After merging,
+from an up-to-date checkout:
+
+```
+bin/kamal accessory boot vlogs -d staging
+bin/kamal accessory boot vector -d staging
+```
+
+Kamal uploads `config/vector/vector.yaml` from your local working tree, so make
+sure you're on the commit you want to ship. To pick up an edited Vector config
+later, reboot just that accessory:
+
+```
+bin/kamal accessory reboot vector -d staging
+```
+
+| Change | Accessory action |
+|---|---|
+| App starts logging a new field | None — appears on the next deploy |
+| `config/vector/vector.yaml` edited | `reboot vector` |
+| Retention or storage flags changed | `reboot vlogs` |
+
+## Safety notes
+
+- Log history survives reboots — it lives in the `data` volume on the host.
+- Rebooting `vlogs` causes a short gap where Vector can't deliver; Vector buffers
+  and retries, so recent lines catch up once it's back.
+- Retention is two days (`-retentionPeriod=2d`); older logs drop automatically.
+- The host's container logs are capped (`logging.max-size`/`max-file` in
+  `config/deploy.yml`), so the json-file driver Vector reads from can't grow
+  unbounded.
+- To tear the whole thing down:
+  `bin/kamal accessory remove vector -d staging` and
+  `bin/kamal accessory remove vlogs -d staging`. The app keeps emitting JSON to
+  STDOUT regardless; that's harmless with nothing collecting it.


### PR DESCRIPTION
Changes:

- Emit structured JSON logs to STDOUT via `rails_semantic_logger`, scoped to production/staging so local dev and tests keep the default logger
- Add a VictoriaLogs accessory on staging for log storage and querying, with a built-in web UI and 2-day retention
- Add a Vector accessory that reads web/jobs container stdout through the Docker API and forwards the JSON to VictoriaLogs over the private Kamal network
- Shim an edge-Rails incompatibility where `rails_semantic_logger` still requires Action Cable's relocated `TaggedLoggerProxy`
- Cap the Docker json-file log driver so container logs can't fill the host disk
- Document the setup, querying, and operations in `docs/victorialogs.md`

The app now emits logs that can be queried by field — status, controller, level, job class — instead of grepped. VictoriaLogs is bound to localhost and needs no new secrets; reach the UI through an SSH tunnel (`ssh -L 9428:127.0.0.1:9428 dev.fffeeder.com` → `http://localhost:9428/select/vmui/`). The JSON logging format ships with a normal `bin/kamal deploy -d staging`; the two accessories are booted separately with `bin/kamal accessory boot`.

References:

- Closes #742