### PR TITLE
Handle target group becoming unavailable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,12 @@ Controllers:
 
 - Eliminate blank action methods.
 
+Comments:
+
+- Comment only when the code can't speak for itself; never restate the obvious.
+- Explain the why (intent, trade-offs, non-obvious constraints), not the what.
+- Keep comments compact and focused.
+
 ## UI Text Writing
 
 When writing user-facing text in views, keep it approachable and practical:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Comments:
 
 - Comment only when the code can't speak for itself; never restate the obvious.
 - Explain the why (intent, trade-offs, non-obvious constraints), not the what.
+- Don't describe what the code doesn't do.
 - Keep comments compact and focused.
 
 ## UI Text Writing

--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -11,7 +11,8 @@ class EventDescriptionComponent < ViewComponent::Base
   # fall back to this base component, which renders the plain description.
   SUBCLASSES = {
     "feed_refresh" => "FeedRefreshDescriptionComponent",
-    "feed_auto_disabled" => "FeedAutoDisabledDescriptionComponent"
+    "feed_auto_disabled" => "FeedAutoDisabledDescriptionComponent",
+    "feed_target_group_unavailable" => "FeedTargetGroupUnavailableDescriptionComponent"
   }.freeze
 
   def self.for(event)

--- a/app/components/feed_target_group_unavailable_description_component.rb
+++ b/app/components/feed_target_group_unavailable_description_component.rb
@@ -2,7 +2,10 @@
 # event metadata. Unknown or missing codes fall back to generic copy.
 class FeedTargetGroupUnavailableDescriptionComponent < EventDescriptionComponent
   # Reason codes we have specific copy for. Anything else uses the default line.
-  KNOWN_REASONS = %w[posting_denied group_not_found].freeze
+  KNOWN_REASONS = %w[
+    group_not_found
+    posting_denied
+  ].freeze
 
   def call
     I18n.t(

--- a/app/components/feed_target_group_unavailable_description_component.rb
+++ b/app/components/feed_target_group_unavailable_description_component.rb
@@ -1,0 +1,24 @@
+# Renders the reason a feed was turned off when its FreeFeed target group became
+# unavailable. The reason comes from a deterministic code in the event metadata,
+# mapped here to safe copy; an unknown or missing code falls back to a generic
+# line. The raw FreeFeed response (metadata "details") is never rendered.
+class FeedTargetGroupUnavailableDescriptionComponent < EventDescriptionComponent
+  # Reason codes we have specific copy for. Anything else uses the generic line.
+  KNOWN_REASONS = %w[posting_denied group_not_found].freeze
+
+  def call
+    I18n.t(
+      "events.feed_target_group_unavailable.description_html",
+      subject_link: subject_link,
+      reason: reason_text
+    ).html_safe
+  end
+
+  private
+
+  def reason_text
+    code = event.metadata["reason"].to_s
+    key = KNOWN_REASONS.include?(code) ? code : "generic"
+    I18n.t("events.feed_target_group_unavailable.reasons.#{key}")
+  end
+end

--- a/app/components/feed_target_group_unavailable_description_component.rb
+++ b/app/components/feed_target_group_unavailable_description_component.rb
@@ -1,6 +1,5 @@
 # Renders why a feed was turned off, from the deterministic reason code in the
-# event metadata. Unknown or missing codes fall back to generic copy; the raw
-# FreeFeed response (metadata "details") is never rendered.
+# event metadata. Unknown or missing codes fall back to generic copy.
 class FeedTargetGroupUnavailableDescriptionComponent < EventDescriptionComponent
   # Reason codes we have specific copy for. Anything else uses the generic line.
   KNOWN_REASONS = %w[posting_denied group_not_found].freeze

--- a/app/components/feed_target_group_unavailable_description_component.rb
+++ b/app/components/feed_target_group_unavailable_description_component.rb
@@ -1,7 +1,7 @@
 # Renders why a feed was turned off, from the deterministic reason code in the
 # event metadata. Unknown or missing codes fall back to generic copy.
 class FeedTargetGroupUnavailableDescriptionComponent < EventDescriptionComponent
-  # Reason codes we have specific copy for. Anything else uses the generic line.
+  # Reason codes we have specific copy for. Anything else uses the default line.
   KNOWN_REASONS = %w[posting_denied group_not_found].freeze
 
   def call
@@ -16,7 +16,7 @@ class FeedTargetGroupUnavailableDescriptionComponent < EventDescriptionComponent
 
   def reason_text
     code = event.metadata["reason"].to_s
-    key = KNOWN_REASONS.include?(code) ? code : "generic"
+    key = KNOWN_REASONS.include?(code) ? code : "default"
     I18n.t("events.feed_target_group_unavailable.reasons.#{key}")
   end
 end

--- a/app/components/feed_target_group_unavailable_description_component.rb
+++ b/app/components/feed_target_group_unavailable_description_component.rb
@@ -1,7 +1,6 @@
-# Renders the reason a feed was turned off when its FreeFeed target group became
-# unavailable. The reason comes from a deterministic code in the event metadata,
-# mapped here to safe copy; an unknown or missing code falls back to a generic
-# line. The raw FreeFeed response (metadata "details") is never rendered.
+# Renders why a feed was turned off, from the deterministic reason code in the
+# event metadata. Unknown or missing codes fall back to generic copy; the raw
+# FreeFeed response (metadata "details") is never rendered.
 class FeedTargetGroupUnavailableDescriptionComponent < EventDescriptionComponent
   # Reason codes we have specific copy for. Anything else uses the generic line.
   KNOWN_REASONS = %w[posting_denied group_not_found].freeze

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -58,6 +58,11 @@ class PostPublishJob < ApplicationJob
   rescue FreefeedClient::UnauthorizedError
     # Token is no longer valid: disable it and stop the chain.
     feed.access_token&.disable_token_and_feeds
+  rescue FreefeedPublisher::TargetGroupUnavailableError => e
+    # The target group is gone or no longer accepts our posts. The token is fine,
+    # so disable just this feed (with an explanation) and stop the chain; the post
+    # stays enqueued and resumes if the user fixes the target and re-enables.
+    feed.disable_due_to_unavailable_target!(reason: e.message, details: e.server_message)
   rescue FreefeedPublisher::SourceContentError => e
     # Source content is gone (e.g. an attachment 404s). Expected external
     # condition: fail the post and move on, but don't page error tracking.

--- a/app/jobs/post_publish_job.rb
+++ b/app/jobs/post_publish_job.rb
@@ -62,7 +62,7 @@ class PostPublishJob < ApplicationJob
     # The target group is gone or no longer accepts our posts. The token is fine,
     # so disable just this feed (with an explanation) and stop the chain; the post
     # stays enqueued and resumes if the user fixes the target and re-enables.
-    feed.disable_due_to_unavailable_target!(reason: e.message, details: e.server_message)
+    feed.disable_due_to_unavailable_target!(reason: e.reason, details: e.server_message)
   rescue FreefeedPublisher::SourceContentError => e
     # Source content is gone (e.g. an attachment 404s). Expected external
     # condition: fail the post and move on, but don't page error tracking.

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -46,7 +46,11 @@ class Feed < ApplicationRecord
   has_many :llm_usages, dependent: :destroy
   has_many :posts, dependent: :destroy
 
-  enum :state, { draft: 0, disabled: 1, enabled: 2 }, default: :draft
+  enum :state, {
+    draft: 0,
+    disabled: 1,
+    enabled: 2
+  }, default: :draft
 
   # How long a ready FeedPreview is reused before a fresh run is forced.
   PREVIEW_FRESHNESS_WINDOW = 60.minutes
@@ -353,7 +357,11 @@ class Feed < ApplicationRecord
   # maps to safe copy; `details` is the raw FreeFeed response, kept for diagnostics.
   # Mirrors disable_after_repeated_failures!.
   def disable_due_to_unavailable_target!(reason: nil, details: nil)
-    metadata = { reason: reason&.to_s, target_group: target_group, details: details }.compact
+    metadata = {
+      reason: reason&.to_s,
+      target_group: target_group,
+      details: details
+    }.compact
 
     transaction do
       update_columns(state: self.class.states[:disabled], consecutive_failures: 0)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -352,9 +352,13 @@ class Feed < ApplicationRecord
   # to (posting permission was revoked, or the group was deleted/renamed). Unlike
   # a dead token this affects only this one feed, so we disable it alone and record
   # a feed_target_group_unavailable event explaining why, letting the user fix the
-  # target and re-enable. Mirrors disable_after_repeated_failures!. The raw FreeFeed
-  # message is kept in metadata for diagnostics only.
-  def disable_due_to_unavailable_target!(reason:, details: nil)
+  # target and re-enable. Mirrors disable_after_repeated_failures!.
+  #
+  # `reason` is a deterministic code the UI maps to safe copy. `details` is the raw
+  # FreeFeed response, stored for diagnostics only and never shown to users.
+  def disable_due_to_unavailable_target!(reason: nil, details: nil)
+    metadata = { reason: reason&.to_s, target_group: target_group, details: details }.compact
+
     transaction do
       update_columns(state: self.class.states[:disabled], consecutive_failures: 0)
       Event.create!(
@@ -362,8 +366,7 @@ class Feed < ApplicationRecord
         level: :warning,
         subject: self,
         user: user,
-        message: reason,
-        metadata: { target_group: target_group, details: details }.compact
+        metadata: metadata
       )
     end
   end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -350,8 +350,8 @@ class Feed < ApplicationRecord
 
   # Disables just this feed (not the whole token) and logs why, so the user can
   # fix the target group and re-enable. `reason` is a deterministic code the UI
-  # maps to safe copy; `details` is the raw FreeFeed response, kept for diagnostics
-  # and never shown. Mirrors disable_after_repeated_failures!.
+  # maps to safe copy; `details` is the raw FreeFeed response, kept for diagnostics.
+  # Mirrors disable_after_repeated_failures!.
   def disable_due_to_unavailable_target!(reason: nil, details: nil)
     metadata = { reason: reason&.to_s, target_group: target_group, details: details }.compact
 

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -348,14 +348,10 @@ class Feed < ApplicationRecord
     true
   end
 
-  # Turns the feed off because its FreeFeed target group can no longer be posted
-  # to (posting permission was revoked, or the group was deleted/renamed). Unlike
-  # a dead token this affects only this one feed, so we disable it alone and record
-  # a feed_target_group_unavailable event explaining why, letting the user fix the
-  # target and re-enable. Mirrors disable_after_repeated_failures!.
-  #
-  # `reason` is a deterministic code the UI maps to safe copy. `details` is the raw
-  # FreeFeed response, stored for diagnostics only and never shown to users.
+  # Disables just this feed (not the whole token) and logs why, so the user can
+  # fix the target group and re-enable. `reason` is a deterministic code the UI
+  # maps to safe copy; `details` is the raw FreeFeed response, kept for diagnostics
+  # and never shown. Mirrors disable_after_repeated_failures!.
   def disable_due_to_unavailable_target!(reason: nil, details: nil)
     metadata = { reason: reason&.to_s, target_group: target_group, details: details }.compact
 

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -348,6 +348,26 @@ class Feed < ApplicationRecord
     true
   end
 
+  # Turns the feed off because its FreeFeed target group can no longer be posted
+  # to (posting permission was revoked, or the group was deleted/renamed). Unlike
+  # a dead token this affects only this one feed, so we disable it alone and record
+  # a feed_target_group_unavailable event explaining why, letting the user fix the
+  # target and re-enable. Mirrors disable_after_repeated_failures!. The raw FreeFeed
+  # message is kept in metadata for diagnostics only.
+  def disable_due_to_unavailable_target!(reason:, details: nil)
+    transaction do
+      update_columns(state: self.class.states[:disabled], consecutive_failures: 0)
+      Event.create!(
+        type: "feed_target_group_unavailable",
+        level: :warning,
+        subject: self,
+        user: user,
+        message: reason,
+        metadata: { target_group: target_group, details: details }.compact
+      )
+    end
+  end
+
   # Clears the streak after a successful refresh.
   def reset_refresh_failures!
     return if consecutive_failures.zero?

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -9,12 +9,10 @@ class FreefeedPublisher
   # expected external condition, not an app fault: the job fails the post and
   # moves on without paging error tracking. See PostPublishJob.
   class SourceContentError < PublishError; end
-  # The feed's target group can no longer be posted to: the token lost posting
-  # permission (group went private/restricted, user removed) or the group was
-  # deleted/renamed. The token itself is fine, so only this feed is affected; the
-  # job disables it and records why. #reason is a deterministic, UI-safe code (see
-  # REASONS); #server_message keeps FreeFeed's raw text for diagnostics only and
-  # must never be shown to users. See PostPublishJob.
+  # The target group rejected the post (lost access, restricted, or deleted), but
+  # the token still works — so the job disables only this feed, not the token.
+  # #reason is a deterministic, UI-safe code (POSTING_DENIED/GROUP_NOT_FOUND);
+  # #server_message is FreeFeed's raw text, for diagnostics only — never shown.
   class TargetGroupUnavailableError < PublishError
     # Posting was rejected for this destination (lost access / restricted group).
     POSTING_DENIED = :posting_denied

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -12,7 +12,7 @@ class FreefeedPublisher
   # The target group rejected the post (lost access, restricted, or deleted), but
   # the token still works — so the job disables only this feed, not the token.
   # #reason is a deterministic, UI-safe code (POSTING_DENIED/GROUP_NOT_FOUND);
-  # #server_message is FreeFeed's raw text, for diagnostics only — never shown.
+  # #server_message is FreeFeed's raw text, for diagnostics only.
   class TargetGroupUnavailableError < PublishError
     # Posting was rejected for this destination (lost access / restricted group).
     POSTING_DENIED = :posting_denied

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -9,6 +9,19 @@ class FreefeedPublisher
   # expected external condition, not an app fault: the job fails the post and
   # moves on without paging error tracking. See PostPublishJob.
   class SourceContentError < PublishError; end
+  # The feed's target group can no longer be posted to: the token lost posting
+  # permission (group went private/restricted, user removed) or the group was
+  # deleted/renamed. The token itself is fine, so only this feed is affected; the
+  # job disables it and records why. #message is a user-facing reason;
+  # #server_message keeps FreeFeed's raw text for diagnostics. See PostPublishJob.
+  class TargetGroupUnavailableError < PublishError
+    attr_reader :server_message
+
+    def initialize(message = nil, server_message: nil)
+      super(message)
+      @server_message = server_message
+    end
+  end
 
   attr_reader :post
 
@@ -94,6 +107,16 @@ class FreefeedPublisher
     raise
   rescue FreefeedClient::UnauthorizedError
     raise
+  rescue FreefeedClient::ForbiddenError => e
+    raise TargetGroupUnavailableError.new(
+      "you no longer have permission to post to @#{post.feed.target_group}",
+      server_message: e.message
+    )
+  rescue FreefeedClient::NotFoundError => e
+    raise TargetGroupUnavailableError.new(
+      "the group @#{post.feed.target_group} no longer exists or was renamed",
+      server_message: e.message
+    )
   rescue => e
     raise PublishError, "Failed to create FreeFeed post: #{e.message}"
   end

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -12,14 +12,21 @@ class FreefeedPublisher
   # The feed's target group can no longer be posted to: the token lost posting
   # permission (group went private/restricted, user removed) or the group was
   # deleted/renamed. The token itself is fine, so only this feed is affected; the
-  # job disables it and records why. #message is a user-facing reason;
-  # #server_message keeps FreeFeed's raw text for diagnostics. See PostPublishJob.
+  # job disables it and records why. #reason is a deterministic, UI-safe code (see
+  # REASONS); #server_message keeps FreeFeed's raw text for diagnostics only and
+  # must never be shown to users. See PostPublishJob.
   class TargetGroupUnavailableError < PublishError
-    attr_reader :server_message
+    # Posting was rejected for this destination (lost access / restricted group).
+    POSTING_DENIED = :posting_denied
+    # The destination group no longer exists (deleted or renamed).
+    GROUP_NOT_FOUND = :group_not_found
 
-    def initialize(message = nil, server_message: nil)
-      super(message)
+    attr_reader :reason, :server_message
+
+    def initialize(reason:, server_message: nil)
+      @reason = reason
       @server_message = server_message
+      super("Target group unavailable (#{reason})")
     end
   end
 
@@ -109,12 +116,12 @@ class FreefeedPublisher
     raise
   rescue FreefeedClient::ForbiddenError => e
     raise TargetGroupUnavailableError.new(
-      "you no longer have permission to post to @#{post.feed.target_group}",
+      reason: TargetGroupUnavailableError::POSTING_DENIED,
       server_message: e.message
     )
   rescue FreefeedClient::NotFoundError => e
     raise TargetGroupUnavailableError.new(
-      "the group @#{post.feed.target_group} no longer exists or was renamed",
+      reason: TargetGroupUnavailableError::GROUP_NOT_FOUND,
       server_message: e.message
     )
   rescue => e

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -524,7 +524,7 @@
           <%= render EventDescriptionComponent.for(Event.new(type: "access_token_validation_failed", level: :warning, subject: sample_token, metadata: { disabled_feed_ids: Feed.limit(3).pluck(:id) })) %>
         <% end %>
         <%= render AlertComponent.new(variant: :warning) do %>
-          <%= render EventDescriptionComponent.for(Event.new(type: "feed_target_group_unavailable", level: :warning, subject: sample_feed, message: "you no longer have permission to post to @cats", metadata: { target_group: "cats" })) %>
+          <%= render EventDescriptionComponent.for(Event.new(type: "feed_target_group_unavailable", level: :warning, subject: sample_feed, metadata: { reason: "posting_denied", target_group: "cats" })) %>
         <% end %>
       </div>
     </section>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -523,6 +523,9 @@
         <%= render AlertComponent.new(variant: :warning) do %>
           <%= render EventDescriptionComponent.for(Event.new(type: "access_token_validation_failed", level: :warning, subject: sample_token, metadata: { disabled_feed_ids: Feed.limit(3).pluck(:id) })) %>
         <% end %>
+        <%= render AlertComponent.new(variant: :warning) do %>
+          <%= render EventDescriptionComponent.for(Event.new(type: "feed_target_group_unavailable", level: :warning, subject: sample_feed, message: "you no longer have permission to post to @cats", metadata: { target_group: "cats" })) %>
+        <% end %>
       </div>
     </section>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,7 +46,7 @@ en:
       reasons:
         posting_denied: "it lost permission to post to its FreeFeed group"
         group_not_found: "its FreeFeed group no longer exists or was renamed"
-        generic: "its FreeFeed group is no longer available"
+        default: "its FreeFeed group is no longer available"
     feed_refresh:
       name: "Feed refreshed"
       description_html: "%{subject_link} refreshed"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,9 @@ en:
     feed_auto_disabled:
       name: "Feed turned off"
       description_html: "%{subject_link} was turned off after repeated errors"
+    feed_target_group_unavailable:
+      name: "Group unavailable"
+      description_html: "%{subject_link} was turned off because %{message}"
     feed_refresh:
       name: "Feed refreshed"
       description_html: "%{subject_link} refreshed"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,11 @@ en:
       description_html: "%{subject_link} was turned off after repeated errors"
     feed_target_group_unavailable:
       name: "Group unavailable"
-      description_html: "%{subject_link} was turned off because %{message}"
+      description_html: "%{subject_link} was turned off because %{reason}"
+      reasons:
+        posting_denied: "it lost permission to post to its FreeFeed group"
+        group_not_found: "its FreeFeed group no longer exists or was renamed"
+        generic: "its FreeFeed group is no longer available"
     feed_refresh:
       name: "Feed refreshed"
       description_html: "%{subject_link} refreshed"

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -6,6 +6,10 @@ class FreefeedClient
   class Error < StandardError; end
   class UnauthorizedError < Error; end
   class InvalidTokenError < UnauthorizedError; end
+  # The token is valid but isn't allowed to perform this action — e.g. it lost
+  # permission to post to a target group. Deliberately not a subclass of
+  # UnauthorizedError so callers don't mistake it for a dead token and disable it.
+  class ForbiddenError < Error; end
   class NotFoundError < Error; end
 
   USER_AGENT = "FreeFeed-Rails-Client".freeze
@@ -179,13 +183,22 @@ class FreefeedClient
       response
     when 401, 403
       err = (JSON.parse(response.body)["err"] rescue nil)
-      if err == "inactive or expired token"
+      case err
+      when "inactive or expired token"
         raise InvalidTokenError, err
+      when /\AYou can not post to/
+        # FreeFeed rejects the destination, not the token (group went private or
+        # restricted, or the user was removed from it). See PostsController#create
+        # (getDestinationFeeds) in freefeed-server.
+        raise ForbiddenError, err
       else
         raise UnauthorizedError, err || "Unauthorized"
       end
     when 404
-      raise NotFoundError, "Resource not found"
+      # Preserve the server's message ("Account '<name>' was not found") so the
+      # caller can explain a vanished/renamed target group.
+      err = (JSON.parse(response.body)["err"] rescue nil)
+      raise NotFoundError, err || "Resource not found"
     when 429
       handle_too_many_requests(response)
     else

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -49,6 +49,55 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     assert_instance_of EventDescriptionComponent, EventDescriptionComponent.for(event)
   end
 
+  test ".for should pick the target-group-unavailable subclass" do
+    event = Event.create!(type: "feed_target_group_unavailable", level: :warning, subject: feed, user: user, metadata: {})
+
+    assert_instance_of FeedTargetGroupUnavailableDescriptionComponent, EventDescriptionComponent.for(event)
+  end
+
+  test "#call should render specific copy for a known target-group-unavailable reason" do
+    event = Event.create!(
+      type: "feed_target_group_unavailable",
+      level: :warning,
+      subject: feed,
+      user: user,
+      metadata: { reason: "posting_denied", target_group: "cats", details: "You can not post to some of destinations: cats" }
+    )
+
+    result = render_inline(EventDescriptionComponent.for(event)).to_html
+
+    assert_includes result, "Test Feed"
+    assert_includes result, "lost permission to post to its FreeFeed group"
+  end
+
+  test "#call should render generic copy when the reason is missing or unknown" do
+    event = Event.create!(
+      type: "feed_target_group_unavailable",
+      level: :warning,
+      subject: feed,
+      user: user,
+      metadata: { reason: "something_new" }
+    )
+
+    result = render_inline(EventDescriptionComponent.for(event)).to_html
+
+    assert_includes result, "its FreeFeed group is no longer available"
+  end
+
+  test "#call should never expose the raw API response for target-group-unavailable events" do
+    event = Event.create!(
+      type: "feed_target_group_unavailable",
+      level: :warning,
+      subject: feed,
+      user: user,
+      metadata: { reason: "group_not_found", details: "Account 'cats' was not found" }
+    )
+
+    result = render_inline(EventDescriptionComponent.for(event)).to_html
+
+    assert_not_includes result, "Account 'cats' was not found"
+  end
+
   test "#call should render links for multiple feeds from metadata" do
     event = Event.create!(
       type: "access_token_validation_failed",

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -70,7 +70,7 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     assert_includes result, "lost permission to post to its FreeFeed group"
   end
 
-  test "#call should render generic copy when the reason is missing or unknown" do
+  test "#call should render default copy when the reason is missing or unknown" do
     event = Event.create!(
       type: "feed_target_group_unavailable",
       level: :warning,

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -134,7 +134,7 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_equal "warning", event.level
     assert_equal "posting_denied", event.metadata["reason"]
     assert_equal "group", event.metadata["target_group"]
-    # Raw API text is kept for diagnostics but not in the user-facing message.
+    # Raw API text is kept in metadata for diagnostics.
     assert_equal "You can not post to some of destinations: group", event.metadata["details"]
     assert_equal "", event.message
   end

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -132,8 +132,11 @@ class PostPublishJobTest < ActiveJob::TestCase
     event = Event.where(type: "feed_target_group_unavailable", subject: feed).last
     assert_not_nil event
     assert_equal "warning", event.level
-    assert_equal "you no longer have permission to post to @group", event.message
+    assert_equal "posting_denied", event.metadata["reason"]
     assert_equal "group", event.metadata["target_group"]
+    # Raw API text is kept for diagnostics but not in the user-facing message.
+    assert_equal "You can not post to some of destinations: group", event.metadata["details"]
+    assert_equal "", event.message
   end
 
   test ".perform_now should skip without publishing when a chain is already running" do

--- a/test/jobs/post_publish_job_test.rb
+++ b/test/jobs/post_publish_job_test.rb
@@ -116,6 +116,26 @@ class PostPublishJobTest < ActiveJob::TestCase
     assert_equal "enqueued", post.reload.status
   end
 
+  test ".perform_now should disable only this feed and record an event when the group is unavailable" do
+    post = create(:post, :enqueued, feed: feed)
+    stub_request(:post, "#{access_token.host}/v4/posts")
+      .to_return(status: 403, body: { err: "You can not post to some of destinations: group" }.to_json)
+
+    assert_no_enqueued_jobs(only: PostPublishJob) do
+      PostPublishJob.perform_now(feed.id)
+    end
+
+    assert_equal "disabled", feed.reload.state
+    assert_equal "active", access_token.reload.status
+    assert_equal "enqueued", post.reload.status
+
+    event = Event.where(type: "feed_target_group_unavailable", subject: feed).last
+    assert_not_nil event
+    assert_equal "warning", event.level
+    assert_equal "you no longer have permission to post to @group", event.message
+    assert_equal "group", event.metadata["target_group"]
+  end
+
   test ".perform_now should skip without publishing when a chain is already running" do
     create(:post, :enqueued, feed: feed)
     stub_publish_success

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -310,6 +310,39 @@ class FreefeedClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "create_post raises ForbiddenError on 403 when the destination rejects the post" do
+    stub_request(:post, "#{@host}/v4/posts")
+      .to_return(status: 403, body: { err: "You can not post to some of destinations: cats" }.to_json)
+
+    error = assert_raises(FreefeedClient::ForbiddenError) do
+      @client.create_post(body: "hi", feeds: ["cats"])
+    end
+    assert_equal "You can not post to some of destinations: cats", error.message
+  end
+
+  test "create_post ForbiddenError is not an UnauthorizedError" do
+    assert_not FreefeedClient::ForbiddenError.ancestors.include?(FreefeedClient::UnauthorizedError)
+  end
+
+  test "create_post raises UnauthorizedError on 403 with other auth failures" do
+    stub_request(:post, "#{@host}/v4/posts")
+      .to_return(status: 403, body: { err: "invalid JWT payload format" }.to_json)
+
+    assert_raises(FreefeedClient::UnauthorizedError) do
+      @client.create_post(body: "hi", feeds: ["cats"])
+    end
+  end
+
+  test "create_post raises NotFoundError carrying the server message on 404" do
+    stub_request(:post, "#{@host}/v4/posts")
+      .to_return(status: 404, body: { err: "Account 'cats' was not found" }.to_json)
+
+    error = assert_raises(FreefeedClient::NotFoundError) do
+      @client.create_post(body: "hi", feeds: ["cats"])
+    end
+    assert_equal "Account 'cats' was not found", error.message
+  end
+
   test "delete_post raises Error on HTTP client errors" do
     post_id = "post123"
 

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -277,39 +277,7 @@ class FreefeedClientTest < ActiveSupport::TestCase
     assert_equal false, group[:is_restricted]  # Default when field is missing
   end
 
-  # delete_post method tests
-  test "delete_post returns true on success" do
-    post_id = "post123"
-
-    stub_request(:delete, "#{@host}/v4/posts/#{post_id}")
-      .to_return(status: 200)
-
-    result = @client.delete_post(post_id)
-    assert_equal true, result
-  end
-
-  test "delete_post raises InvalidTokenError on 401 with inactive or expired token body" do
-    post_id = "post123"
-
-    stub_request(:delete, "#{@host}/v4/posts/#{post_id}")
-      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
-
-    assert_raises(FreefeedClient::InvalidTokenError) do
-      @client.delete_post(post_id)
-    end
-  end
-
-  test "delete_post raises NotFoundError on 404" do
-    post_id = "post123"
-
-    stub_request(:delete, "#{@host}/v4/posts/#{post_id}")
-      .to_return(status: 404)
-
-    assert_raises(FreefeedClient::NotFoundError) do
-      @client.delete_post(post_id)
-    end
-  end
-
+  # create_post method tests
   test "create_post raises ForbiddenError on 403 when the destination rejects the post" do
     stub_request(:post, "#{@host}/v4/posts")
       .to_return(status: 403, body: { err: "You can not post to some of destinations: cats" }.to_json)
@@ -341,6 +309,39 @@ class FreefeedClientTest < ActiveSupport::TestCase
       @client.create_post(body: "hi", feeds: ["cats"])
     end
     assert_equal "Account 'cats' was not found", error.message
+  end
+
+  # delete_post method tests
+  test "delete_post returns true on success" do
+    post_id = "post123"
+
+    stub_request(:delete, "#{@host}/v4/posts/#{post_id}")
+      .to_return(status: 200)
+
+    result = @client.delete_post(post_id)
+    assert_equal true, result
+  end
+
+  test "delete_post raises InvalidTokenError on 401 with inactive or expired token body" do
+    post_id = "post123"
+
+    stub_request(:delete, "#{@host}/v4/posts/#{post_id}")
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
+
+    assert_raises(FreefeedClient::InvalidTokenError) do
+      @client.delete_post(post_id)
+    end
+  end
+
+  test "delete_post raises NotFoundError on 404" do
+    post_id = "post123"
+
+    stub_request(:delete, "#{@host}/v4/posts/#{post_id}")
+      .to_return(status: 404)
+
+    assert_raises(FreefeedClient::NotFoundError) do
+      @client.delete_post(post_id)
+    end
   end
 
   test "delete_post raises Error on HTTP client errors" do

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -934,7 +934,6 @@ class FeedTest < ActiveSupport::TestCase
     assert_equal "posting_denied", event.metadata["reason"]
     assert_equal "cats", event.metadata["target_group"]
     assert_equal "raw err", event.metadata["details"]
-    # No free-text/API message on the event itself.
     assert_equal "", event.message
   end
 

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -919,10 +919,10 @@ class FeedTest < ActiveSupport::TestCase
     assert_nil Event.find_by(subject: feed, type: "feed_auto_disabled")
   end
 
-  test "#disable_due_to_unavailable_target! should disable the feed and record an explanatory event" do
+  test "#disable_due_to_unavailable_target! should disable the feed and record a deterministic reason" do
     feed = create(:feed, :enabled, target_group: "cats", consecutive_failures: 3)
 
-    feed.disable_due_to_unavailable_target!(reason: "you no longer have permission to post to @cats", details: "raw err")
+    feed.disable_due_to_unavailable_target!(reason: :posting_denied, details: "raw err")
 
     feed.reload
     assert feed.disabled?
@@ -931,18 +931,21 @@ class FeedTest < ActiveSupport::TestCase
     event = Event.find_by(subject: feed, type: "feed_target_group_unavailable")
     assert_not_nil event
     assert_equal "warning", event.level
-    assert_equal "you no longer have permission to post to @cats", event.message
+    assert_equal "posting_denied", event.metadata["reason"]
     assert_equal "cats", event.metadata["target_group"]
     assert_equal "raw err", event.metadata["details"]
+    # No free-text/API message on the event itself.
+    assert_equal "", event.message
   end
 
-  test "#disable_due_to_unavailable_target! should omit details from metadata when not given" do
+  test "#disable_due_to_unavailable_target! should omit reason and details from metadata when not given" do
     feed = create(:feed, :enabled, target_group: "cats")
 
-    feed.disable_due_to_unavailable_target!(reason: "gone")
+    feed.disable_due_to_unavailable_target!
 
     event = Event.find_by(subject: feed, type: "feed_target_group_unavailable")
     assert_not event.metadata.key?("details")
+    assert_not event.metadata.key?("reason")
   end
 
   test "#reset_refresh_failures! should clear the streak" do

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -943,6 +943,7 @@ class FeedTest < ActiveSupport::TestCase
     feed.disable_due_to_unavailable_target!
 
     event = Event.find_by(subject: feed, type: "feed_target_group_unavailable")
+    assert_equal "cats", event.metadata["target_group"]
     assert_not event.metadata.key?("details")
     assert_not event.metadata.key?("reason")
   end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -919,6 +919,32 @@ class FeedTest < ActiveSupport::TestCase
     assert_nil Event.find_by(subject: feed, type: "feed_auto_disabled")
   end
 
+  test "#disable_due_to_unavailable_target! should disable the feed and record an explanatory event" do
+    feed = create(:feed, :enabled, target_group: "cats", consecutive_failures: 3)
+
+    feed.disable_due_to_unavailable_target!(reason: "you no longer have permission to post to @cats", details: "raw err")
+
+    feed.reload
+    assert feed.disabled?
+    assert_equal 0, feed.consecutive_failures
+
+    event = Event.find_by(subject: feed, type: "feed_target_group_unavailable")
+    assert_not_nil event
+    assert_equal "warning", event.level
+    assert_equal "you no longer have permission to post to @cats", event.message
+    assert_equal "cats", event.metadata["target_group"]
+    assert_equal "raw err", event.metadata["details"]
+  end
+
+  test "#disable_due_to_unavailable_target! should omit details from metadata when not given" do
+    feed = create(:feed, :enabled, target_group: "cats")
+
+    feed.disable_due_to_unavailable_target!(reason: "gone")
+
+    event = Event.find_by(subject: feed, type: "feed_target_group_unavailable")
+    assert_not event.metadata.key?("details")
+  end
+
   test "#reset_refresh_failures! should clear the streak" do
     feed = create(:feed, :enabled, consecutive_failures: 4)
 

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -421,6 +421,30 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     end
   end
 
+  test "#publish should raise TargetGroupUnavailableError when the group rejects the post" do
+    post = post_with_content("Test content")
+    stub_request(:post, "#{access_token.host}/v4/posts")
+      .to_return(status: 403, body: { err: "You can not post to some of destinations: testgroup" }.to_json)
+
+    error = assert_raises(FreefeedPublisher::TargetGroupUnavailableError) do
+      FreefeedPublisher.new(post).publish
+    end
+    assert_equal "you no longer have permission to post to @testgroup", error.message
+    assert_equal "You can not post to some of destinations: testgroup", error.server_message
+  end
+
+  test "#publish should raise TargetGroupUnavailableError when the group no longer exists" do
+    post = post_with_content("Test content")
+    stub_request(:post, "#{access_token.host}/v4/posts")
+      .to_return(status: 404, body: { err: "Account 'testgroup' was not found" }.to_json)
+
+    error = assert_raises(FreefeedPublisher::TargetGroupUnavailableError) do
+      FreefeedPublisher.new(post).publish
+    end
+    assert_equal "the group @testgroup no longer exists or was renamed", error.message
+    assert_equal "Account 'testgroup' was not found", error.server_message
+  end
+
   test "#publish should raise error when FreeFeed API fails" do
     post = post_with_content("Test content")
 

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -429,7 +429,7 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     error = assert_raises(FreefeedPublisher::TargetGroupUnavailableError) do
       FreefeedPublisher.new(post).publish
     end
-    assert_equal "you no longer have permission to post to @testgroup", error.message
+    assert_equal FreefeedPublisher::TargetGroupUnavailableError::POSTING_DENIED, error.reason
     assert_equal "You can not post to some of destinations: testgroup", error.server_message
   end
 
@@ -441,7 +441,7 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     error = assert_raises(FreefeedPublisher::TargetGroupUnavailableError) do
       FreefeedPublisher.new(post).publish
     end
-    assert_equal "the group @testgroup no longer exists or was renamed", error.message
+    assert_equal FreefeedPublisher::TargetGroupUnavailableError::GROUP_NOT_FOUND, error.reason
     assert_equal "Account 'testgroup' was not found", error.server_message
   end
 


### PR DESCRIPTION
Changes:

- Distinguish a destination-rejected post (FreeFeed 403 "You can not post to some of destinations" / 404 "Account not found") from a dead token in the FreeFeed client
- Disable only the affected feed when its target group is no longer available, instead of mistaking it for an expired token and disabling every feed on that token
- Record a new `feed_target_group_unavailable` event with a clear, user-facing reason so the user knows what to fix
- Keep the triggering post enqueued so publishing resumes once the target is fixed and the feed is re-enabled

Status code alone can't separate a token-403 from a destination-403, but the `err` body can — following the existing pattern the client already uses to detect dead tokens.

| FreeFeed response (`err`) | Reaction |
|---|---|
| 401/403 `inactive or expired token` | *(unchanged)* mark token inactive, disable **all** its feeds, `access_token_validation_failed` event |
| 403 `You can not post to some of destinations` | disable **only that feed**, `feed_target_group_unavailable` event; post stays enqueued |
| 404 `Account '<group>' was not found` | same — disable just that feed, explanatory event |
| other 401 auth failure | *(unchanged)* treated as a token problem |

Previously the 403 was treated as an invalid token (disabling the token and all its feeds) and the 404 silently failed every post while paging error tracking each refresh cycle. Now the failure is scoped to the one feed and surfaced as an explicit event.

References:

- Closes #486
