### PR TITLE
Use grey origin DNS record for staging deploys

### DIFF
--- a/.github/workflows/deploy-imgproxy.yml
+++ b/.github/workflows/deploy-imgproxy.yml
@@ -48,7 +48,7 @@ jobs:
           chmod 700 ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan dev.fffeeder.com >> ~/.ssh/known_hosts
+          ssh-keyscan dev-origin.fffeeder.com >> ~/.ssh/known_hosts
 
       - name: Deploy imgproxy
         run: kamal deploy -c config/deploy.imgproxy.yml

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -49,7 +49,7 @@ jobs:
           chmod 700 ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan dev.fffeeder.com >> ~/.ssh/known_hosts
+          ssh-keyscan dev-origin.fffeeder.com >> ~/.ssh/known_hosts
 
       - name: Write Rails master key
         env:

--- a/config/deploy.imgproxy.yml
+++ b/config/deploy.imgproxy.yml
@@ -23,12 +23,13 @@ builder:
 servers:
   web:
     # The deploy host is the box Kamal SSHes into and where kamal-proxy runs the
-    # ACME challenge, so it must resolve directly to the server. Do NOT use
-    # imgproxy.fffeeder.com here: that name is Cloudflare-proxied (the CDN), so
-    # SSH and Let's Encrypt would hit Cloudflare instead of the origin. The
-    # public CDN name is set as proxy.host below.
+    # ACME challenge, so it must resolve directly to the server. Use the grey
+    # dev-origin.fffeeder.com record, not a Cloudflare-proxied name like
+    # imgproxy.fffeeder.com or dev.fffeeder.com: a proxied name resolves to
+    # Cloudflare, so SSH and Let's Encrypt would hit Cloudflare, not the origin.
+    # The public CDN name is set as proxy.host below.
     hosts:
-      - dev.fffeeder.com
+      - dev-origin.fffeeder.com
 
 proxy:
   ssl: true

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -1,8 +1,12 @@
 # Deploy to these servers.
 servers:
   web:
+    # Deploy host: the box Kamal SSHes into and where kamal-proxy runs the ACME
+    # challenge, so it must resolve directly to the server. dev.fffeeder.com is
+    # Cloudflare-proxied (the public name set as proxy.host below); use the grey
+    # dev-origin.fffeeder.com record here so SSH and Let's Encrypt hit the origin.
     hosts:
-      - dev.fffeeder.com
+      - dev-origin.fffeeder.com
     env:
       clear:
         # Gauge sampling runs once in the Puma master process; see
@@ -10,7 +14,7 @@ servers:
         METRICS_GAUGES: "true"
   jobs:
     hosts:
-      - dev.fffeeder.com
+      - dev-origin.fffeeder.com
     cmd: bin/jobs
 
 # Configure proxy for web role.
@@ -22,7 +26,7 @@ proxy:
 accessories:
   db:
     image: postgres:18
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     port: "127.0.0.1:5432:5432"
     env:
       clear:
@@ -36,11 +40,11 @@ accessories:
   # Temporary metrics backend for staging. VictoriaMetrics with its built-in
   # web UI (vmui at :8428/vmui). Bound to localhost — the app pushes over the
   # private Kamal network (see METRICS_URL below); view the UI via an SSH
-  # tunnel: ssh -L 8428:127.0.0.1:8428 dev.fffeeder.com → http://localhost:8428/vmui
+  # tunnel: ssh -L 8428:127.0.0.1:8428 dev-origin.fffeeder.com → http://localhost:8428/vmui
   # Remove with: bin/kamal accessory remove victoriametrics -d staging
   victoriametrics:
     image: victoriametrics/victoria-metrics:v1.145.0
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     port: "127.0.0.1:8428:8428"
     cmd: "-retentionPeriod=1 -promscrape.config=/etc/victoriametrics/scrape.yml -vmui.customDashboardsPath=/etc/victoriametrics/dashboards"
     files:
@@ -54,7 +58,7 @@ accessories:
   # (see config/victoriametrics/scrape.yml), so no published port.
   node-exporter:
     image: quay.io/prometheus/node-exporter:v1.11.1
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     cmd: "--path.rootfs=/host"
     volumes:
       - "/:/host:ro,rslave"
@@ -64,7 +68,7 @@ accessories:
   # Remove with: bin/kamal accessory remove vlogs -d staging
   vlogs:
     image: victoriametrics/victoria-logs:v1.51.0
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     port: "127.0.0.1:9428:9428"
     cmd: "-retentionPeriod=2d -storageDataPath=/vlogs"
     directories:
@@ -75,7 +79,7 @@ accessories:
   # Remove with: bin/kamal accessory remove vector -d staging
   vector:
     image: timberio/vector:0.56.0-alpine
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     cmd: "--config /etc/vector/vector.yaml"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"

--- a/docs/deployment-imgproxy.md
+++ b/docs/deployment-imgproxy.md
@@ -52,16 +52,16 @@ Two records with different jobs:
 
 | Record | Cloudflare | Points at | Used for |
 | --- | --- | --- | --- |
-| Deploy host (`dev.fffeeder.com`) | DNS-only (grey) | server IP | Kamal SSH + Let's Encrypt |
+| Deploy host (`dev-origin.fffeeder.com`) | DNS-only (grey) | server IP | Kamal SSH + Let's Encrypt |
 | `imgproxy.fffeeder.com` | Proxied (orange) | the origin | public CDN endpoint |
 
 The deploy host (`servers.web.hosts`) is the box Kamal SSHes into and where
 kamal-proxy runs the ACME challenge, so it must resolve **directly** to the
-server. Don't use `imgproxy.fffeeder.com` as the deploy host: it's
-Cloudflare-proxied, so it resolves to Cloudflare's IPs — SSH (port 22) and the
-Let's Encrypt challenge would hit Cloudflare instead of the origin and fail.
-`proxy.host` is set to `imgproxy.fffeeder.com` (the public name); the deploy host
-stays `dev.fffeeder.com`.
+server. Don't use a Cloudflare-proxied name like `imgproxy.fffeeder.com` (or
+`dev.fffeeder.com`) as the deploy host: it resolves to Cloudflare's IPs — SSH
+(port 22) and the Let's Encrypt challenge would hit Cloudflare instead of the
+origin and fail. `proxy.host` is set to `imgproxy.fffeeder.com` (the public
+name); the deploy host is the shared grey origin record `dev-origin.fffeeder.com`.
 
 To move imgproxy to its own server later without touching this config, give it a
 dedicated grey origin record (e.g. `imgproxy-origin.fffeeder.com`), use that as

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -42,12 +42,15 @@ Run those commands after changing deploy config to catch syntax or merge issues.
 
 The server names in `servers` and `accessories.db.host` must be reachable over SSH from your workstation. Domain names are fine as long as they resolve directly to the server.
 
-For staging:
+Staging splits the deploy host from the public host so `dev.fffeeder.com` can sit behind Cloudflare's orange proxy:
+
+- `dev-origin.fffeeder.com` — DNS-only (grey), points straight at the server. Kamal SSHes into it and kamal-proxy runs the ACME challenge there, so it must resolve directly. Used in `servers` and every `accessories.*.host`.
+- `dev.fffeeder.com` — the public name users hit. Set as `proxy.host` (and in `HOSTS`/`ACTION_MAILER_HOST`). This is the record you put behind Cloudflare's orange proxy.
 
 ```yaml
 servers:
   web:
-    - dev.fffeeder.com
+    - dev-origin.fffeeder.com
 
 proxy:
   ssl: true
@@ -69,17 +72,26 @@ proxy:
 Before the first setup, confirm DNS points to the server so Let's Encrypt can issue certificates:
 
 ```bash
-dig +short dev.fffeeder.com
+dig +short dev-origin.fffeeder.com   # must return the server IP, not Cloudflare's
 dig +short fffeeder.com
 ```
 
-If a domain is proxied by Cloudflare and SSH does not work through it, use a direct DNS name or the server IP in `servers` and `accessories.db.host`. Keep `proxy.host` set to the public app domain.
+If a domain is proxied by Cloudflare and SSH does not work through it, use a direct DNS name or the server IP in `servers` and `accessories.db.host`. Keep `proxy.host` set to the public app domain. This is exactly why staging deploys against the grey `dev-origin.fffeeder.com` while serving the orange `dev.fffeeder.com`.
+
+### Let's Encrypt behind Cloudflare
+
+kamal-proxy issues a Let's Encrypt certificate for `proxy.host` (`dev.fffeeder.com`) via an HTTP-01 challenge on port 80. If that record is already proxied (orange), the challenge lands on Cloudflare instead of the origin and fails. So before enabling the orange proxy:
+
+- Deploy with `dev.fffeeder.com` **DNS-only (grey)** first so the cert is issued, then switch it to **proxied (orange)** with SSL mode **Full (strict)**. Renewals need the same grey window.
+- Or skip Let's Encrypt and install a **Cloudflare Origin Certificate** on kamal-proxy (via Kamal's custom-cert secrets) with SSL mode **Full (strict)**. This avoids the renewal dance and is the better long-term setup.
+
+Keep `dev-origin.fffeeder.com` grey at all times — it's the SSH and ACME path. See [deployment-imgproxy.md](deployment-imgproxy.md) for the same pattern applied to the imgproxy CDN host.
 
 Confirm the host architecture matches the configured builder architecture:
 
 ```bash
-ssh root@dev.fffeeder.com "uname -m"   # expected: x86_64
-ssh root@fffeeder.com "uname -m"       # expected: x86_64
+ssh root@dev-origin.fffeeder.com "uname -m"   # expected: x86_64
+ssh root@fffeeder.com "uname -m"              # expected: x86_64
 ```
 
 ## Secrets
@@ -159,7 +171,7 @@ test -n "$GHCR_TOKEN" && echo "GHCR_TOKEN set"
 test -n "$POSTGRES_PASSWORD_STAGING" && echo "POSTGRES_PASSWORD_STAGING set"
 test -f config/credentials/staging.key
 
-ssh root@dev.fffeeder.com "uname -m"   # expected: x86_64
+ssh root@dev-origin.fffeeder.com "uname -m"   # expected: x86_64
 bin/kamal config -d staging
 ```
 
@@ -256,8 +268,8 @@ bin/kamal accessory details db -d staging
 If the app container exited before Kamal can find it, inspect containers directly on the host:
 
 ```bash
-ssh root@dev.fffeeder.com 'docker ps -a --filter label=service=f2 --filter label=destination=staging'
-ssh root@dev.fffeeder.com 'docker logs --timestamps --tail 200 <container-id-or-name>'
+ssh root@dev-origin.fffeeder.com 'docker ps -a --filter label=service=f2 --filter label=destination=staging'
+ssh root@dev-origin.fffeeder.com 'docker logs --timestamps --tail 200 <container-id-or-name>'
 ```
 
 Common issues:

--- a/docs/victorialogs.md
+++ b/docs/victorialogs.md
@@ -26,7 +26,7 @@ VictoriaLogs is bound to localhost on the server, so reach the UI through an SSH
 tunnel:
 
 ```
-ssh -L 9428:127.0.0.1:9428 dev.fffeeder.com
+ssh -L 9428:127.0.0.1:9428 dev-origin.fffeeder.com
 ```
 
 Then open http://localhost:9428/select/vmui/.

--- a/docs/victoriametrics.md
+++ b/docs/victoriametrics.md
@@ -8,7 +8,7 @@ Staging runs VictoriaMetrics as a Kamal accessory (`config/deploy.staging.yml`) 
 VM is bound to localhost on the server, so view the UI through an SSH tunnel:
 
 ```
-ssh -L 8428:127.0.0.1:8428 dev.fffeeder.com
+ssh -L 8428:127.0.0.1:8428 dev-origin.fffeeder.com
 ```
 
 Then open http://localhost:8428/vmui.


### PR DESCRIPTION
Changes:

- Point the staging and imgproxy deploy hosts at the grey `dev-origin.fffeeder.com` record (Kamal SSH, accessories, and the ACME challenge)
- Keep `dev.fffeeder.com` as the public name (`proxy.host`, `HOSTS`, `ACTION_MAILER_HOST`) so it can sit behind Cloudflare's orange proxy
- Update SSH/tunnel commands in the workflows and deployment docs, and document the grey-origin/orange-public split plus the Let's Encrypt-behind-Cloudflare caveat

Splitting the deploy host from the public host lets the dev domain go behind Cloudflare while Kamal keeps reaching the origin directly for SSH and certificate issuance — a name that's Cloudflare-proxied resolves to Cloudflare's IPs, so SSH and the ACME challenge would otherwise fail. This mirrors the pattern already used for the imgproxy CDN host.