### PR TITLE
Harden FreeFeed 403 error handling

### DIFF
--- a/app/controllers/access_tokens/groups_controller.rb
+++ b/app/controllers/access_tokens/groups_controller.rb
@@ -25,7 +25,7 @@ class AccessTokens::GroupsController < ApplicationController
     else
       error_locals(:inactive_token)
     end
-  rescue FreefeedClient::UnauthorizedError => e
+  rescue FreefeedClient::UnauthorizedError, FreefeedClient::ForbiddenError => e
     error_locals(:unauthorized)
   rescue StandardError => e
     error_locals(:api_error)

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -27,7 +27,9 @@ class AccessTokenValidationService
         }
       )
     end
-  rescue FreefeedClient::UnauthorizedError
+  rescue FreefeedClient::UnauthorizedError, FreefeedClient::ForbiddenError
+    # A 401/403 on whoami or managedGroups means the token can't even read its
+    # own account, so it's effectively dead — disable it and its feeds.
     access_token.disable_token_and_feeds
   rescue RateLimit::Throttled
     # Throttling is control flow, not a validation failure: let it propagate so

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -182,28 +182,39 @@ class FreefeedClient
     when 200, 201
       response
     when 401, 403
-      err = (JSON.parse(response.body)["err"] rescue nil)
-      case err
-      when "inactive or expired token"
+      err = parse_error(response)
+      if err == "inactive or expired token"
         raise InvalidTokenError, err
-      when /\AYou can not post to/
-        # FreeFeed rejects the destination, not the token (group went private or
-        # restricted, or the user was removed from it). See PostsController#create
-        # (getDestinationFeeds) in freefeed-server.
-        raise ForbiddenError, err
+      elsif response.status == 403
+        # FreeFeed overloads 403 for both auth problems and "you can't do this
+        # here" (e.g. posting to a group you've lost access to). The token itself
+        # is still valid, so default to ForbiddenError — callers scope the fallout
+        # to the affected resource — rather than UnauthorizedError, which would
+        # disable the whole token and every feed on it.
+        raise ForbiddenError, err || "Forbidden"
       else
         raise UnauthorizedError, err || "Unauthorized"
       end
     when 404
       # Preserve the server's message ("Account '<name>' was not found") so the
       # caller can explain a vanished/renamed target group.
-      err = (JSON.parse(response.body)["err"] rescue nil)
-      raise NotFoundError, err || "Resource not found"
+      raise NotFoundError, parse_error(response) || "Resource not found"
     when 429
       handle_too_many_requests(response)
     else
       raise Error, "HTTP #{response.status}: #{response.body}"
     end
+  end
+
+  # FreeFeed's "err" field from a JSON error body, or nil if the body is absent
+  # or not the expected shape.
+  def parse_error(response)
+    return nil if response.body.blank?
+
+    body = JSON.parse(response.body)
+    body["err"] if body.is_a?(Hash)
+  rescue JSON::ParserError
+    nil
   end
 
   # FreeFeed throttled us. Record the cooldown so later acquires short-circuit,

--- a/test/controllers/access_tokens/groups_controller_test.rb
+++ b/test/controllers/access_tokens/groups_controller_test.rb
@@ -152,6 +152,19 @@ class AccessTokens::GroupsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/Retry/, response.body)
   end
 
+  test "handles forbidden token like unauthorized" do
+    sign_in_as user
+
+    stub_request(:get, "#{active_token.host}/v4/managedGroups")
+      .to_return(status: 403, body: { err: "Forbidden" }.to_json)
+
+    get access_token_groups_path(active_token)
+
+    assert_response :success
+    assert_match(/Unable to load groups/, response.body)
+    assert_no_match(/Retry/, response.body)
+  end
+
   test "handles empty groups list with appropriate message" do
     sign_in_as user
 

--- a/test/lib/freefeed_client_publisher_test.rb
+++ b/test/lib/freefeed_client_publisher_test.rb
@@ -136,11 +136,11 @@ class FreefeedClientPublisherTest < ActiveSupport::TestCase
     assert_equal "post123", result[:id]
   end
 
-  test "create_post handles API error" do
+  test "create_post raises ForbiddenError on 403" do
     stub_request(:post, "#{@host}/v4/posts")
       .to_return(status: 403, body: "Forbidden")
 
-    assert_raises(FreefeedClient::UnauthorizedError) do
+    assert_raises(FreefeedClient::ForbiddenError) do
       @client.create_post(body: "Test", feeds: ["testgroup"])
     end
   end

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -82,11 +82,20 @@ class FreefeedClientTest < ActiveSupport::TestCase
     end
   end
 
-  test "whoami raises UnauthorizedError on 403" do
+  test "whoami raises ForbiddenError on 403" do
     stub_request(:get, "#{@host}/v4/users/whoami")
       .to_return(status: 403, body: { err: "invalid JWT payload format" }.to_json)
 
-    assert_raises(FreefeedClient::UnauthorizedError) do
+    assert_raises(FreefeedClient::ForbiddenError) do
+      @client.whoami
+    end
+  end
+
+  test "whoami raises InvalidTokenError on 403 with inactive or expired token body" do
+    stub_request(:get, "#{@host}/v4/users/whoami")
+      .to_return(status: 403, body: { err: "inactive or expired token" }.to_json)
+
+    assert_raises(FreefeedClient::InvalidTokenError) do
       @client.whoami
     end
   end
@@ -292,11 +301,20 @@ class FreefeedClientTest < ActiveSupport::TestCase
     assert_not FreefeedClient::ForbiddenError.ancestors.include?(FreefeedClient::UnauthorizedError)
   end
 
-  test "create_post raises UnauthorizedError on 403 with other auth failures" do
+  test "create_post raises ForbiddenError on any non-token 403" do
     stub_request(:post, "#{@host}/v4/posts")
-      .to_return(status: 403, body: { err: "invalid JWT payload format" }.to_json)
+      .to_return(status: 403, body: { err: "some unexpected forbidden reason" }.to_json)
 
-    assert_raises(FreefeedClient::UnauthorizedError) do
+    assert_raises(FreefeedClient::ForbiddenError) do
+      @client.create_post(body: "hi", feeds: ["cats"])
+    end
+  end
+
+  test "create_post raises InvalidTokenError on 403 with inactive or expired token body" do
+    stub_request(:post, "#{@host}/v4/posts")
+      .to_return(status: 403, body: { err: "inactive or expired token" }.to_json)
+
+    assert_raises(FreefeedClient::InvalidTokenError) do
       @client.create_post(body: "hi", feeds: ["cats"])
     end
   end

--- a/test/services/access_token_validation_service_test.rb
+++ b/test/services/access_token_validation_service_test.rb
@@ -154,6 +154,16 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     assert_equal "inactive", access_token.reload.status
   end
 
+  test "#call should deactivate token on forbidden error" do
+    stub_request(:get, "#{access_token.host}/v4/users/whoami")
+      .to_return(status: 403, body: { err: "invalid JWT payload format" }.to_json)
+
+    service = AccessTokenValidationService.new(access_token)
+    service.call
+
+    assert_equal "inactive", access_token.reload.status
+  end
+
   test "#call should not disable token on transient errors" do
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(


### PR DESCRIPTION
Changes:

- Drop the brittle "You can not post to" message match: any 403 that isn't the explicit dead-token body now raises `ForbiddenError` instead of `UnauthorizedError`, so an unrecognized 403 can no longer disable the whole token and all its feeds — the fallout is scoped to the affected resource
- Treat a 403 on `whoami`/`managedGroups` as a dead token, since it means the token can't read its own account (token validation and the groups lookup now handle `ForbiddenError` like `UnauthorizedError`)
- Extract a `parse_error` helper to read the server's error body safely

FreeFeed overloads 403 for both auth failures and "you can't do this here." Previously the client guessed by string-matching the error message, and a wording drift would silently fall through to the most destructive path (disable the token and every feed on it). Defaulting an unmatched 403 to `ForbiddenError` — which callers scope to the one affected feed — removes that fragility while preserving the dead-token behavior where it matters (reading the token's own account).

References:

- Related PR: #791
- Related issue: #486
