### PR TITLE
Serve Cloudflare Origin Certificate on staging proxy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,6 +18,8 @@ jobs:
       POSTGRES_PASSWORD_STAGING: ${{ secrets.POSTGRES_PASSWORD_STAGING }}
       IMGPROXY_KEY: ${{ secrets.IMGPROXY_KEY }}
       IMGPROXY_SALT: ${{ secrets.IMGPROXY_SALT }}
+      CF_ORIGIN_CERT: ${{ secrets.CF_ORIGIN_CERT }}
+      CF_ORIGIN_KEY: ${{ secrets.CF_ORIGIN_KEY }}
 
     steps:
       - name: Checkout code
@@ -49,7 +51,7 @@ jobs:
           chmod 700 ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan dev.fffeeder.com >> ~/.ssh/known_hosts
+          ssh-keyscan dev-origin.fffeeder.com >> ~/.ssh/known_hosts
 
       - name: Write Rails master key
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@
 /config/master.key
 /config/credentials/*.key
 
+# Cloudflare Origin Certificate + key served by kamal-proxy (kept out of git;
+# shared via the team password manager). See docs/deployment-setup.md.
+/config/credentials/*.pem
+
 /app/assets/builds/*
 !/app/assets/builds/.keep
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,9 @@
 /config/master.key
 /config/credentials/*.key
 
-# Cloudflare Origin Certificate + key served by kamal-proxy (kept out of git;
-# shared via the team password manager). See docs/deployment-setup.md.
+# Guard against committing a locally-saved Cloudflare Origin Certificate/key.
+# At deploy time these come from the environment, not files. See
+# docs/deployment-setup.md.
 /config/credentials/*.pem
 
 /app/assets/builds/*

--- a/.kamal/secrets.staging
+++ b/.kamal/secrets.staging
@@ -6,3 +6,10 @@ POSTGRES_PASSWORD=$(printenv POSTGRES_PASSWORD_STAGING | grep . || { echo "POSTG
 
 # Rails credentials key for config/credentials/staging.yml.enc.
 RAILS_MASTER_KEY=$(cat config/credentials/staging.key)
+
+# Cloudflare Origin Certificate served by kamal-proxy. dev.fffeeder.com is
+# Cloudflare-proxied, so Let's Encrypt can't issue here; this cert covers the
+# edge↔origin hop under SSL mode Full (strict). The PEM files live under
+# config/credentials/ (gitignored) and are shared via the team password manager.
+CERTIFICATE_PEM=$(cat config/credentials/cf-origin.pem)
+PRIVATE_KEY_PEM=$(cat config/credentials/cf-origin.key)

--- a/.kamal/secrets.staging
+++ b/.kamal/secrets.staging
@@ -9,7 +9,8 @@ RAILS_MASTER_KEY=$(cat config/credentials/staging.key)
 
 # Cloudflare Origin Certificate served by kamal-proxy. dev.fffeeder.com is
 # Cloudflare-proxied, so Let's Encrypt can't issue here; this cert covers the
-# edge↔origin hop under SSL mode Full (strict). The PEM files live under
-# config/credentials/ (gitignored) and are shared via the team password manager.
-CERTIFICATE_PEM=$(cat config/credentials/cf-origin.pem)
-PRIVATE_KEY_PEM=$(cat config/credentials/cf-origin.key)
+# edge↔origin hop under SSL mode Full (strict). Values are multi-line PEM blobs
+# pulled from the environment: GitHub Actions secrets in CI, exported locally
+# for manual deploys (e.g. export CF_ORIGIN_CERT="$(cat cf-origin.pem)").
+CERTIFICATE_PEM=$(printenv CF_ORIGIN_CERT | grep . || { echo "CF_ORIGIN_CERT is required and must be non-empty" >&2; exit 1; })
+PRIVATE_KEY_PEM=$(printenv CF_ORIGIN_KEY | grep . || { echo "CF_ORIGIN_KEY is required and must be non-empty" >&2; exit 1; })

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -1,8 +1,14 @@
 # Deploy to these servers.
+#
+# Hosts here (and accessory hosts below) are SSH targets, so they use the grey
+# DNS-only record dev-origin.fffeeder.com that resolves straight to the box. The
+# public name dev.fffeeder.com is Cloudflare-proxied (orange); using it as an
+# SSH target would route port 22 through Cloudflare and fail. proxy.host stays
+# the public name. See docs/deployment-setup.md.
 servers:
   web:
     hosts:
-      - dev.fffeeder.com
+      - dev-origin.fffeeder.com
     env:
       clear:
         # Gauge sampling runs once in the Puma master process; see
@@ -10,19 +16,27 @@ servers:
         METRICS_GAUGES: "true"
   jobs:
     hosts:
-      - dev.fffeeder.com
+      - dev-origin.fffeeder.com
     cmd: bin/jobs
 
 # Configure proxy for web role.
+#
+# dev.fffeeder.com is Cloudflare-proxied, so kamal-proxy can't use Let's Encrypt
+# here: the ACME HTTP-01 challenge would land on Cloudflare instead of the
+# origin. Instead it serves a Cloudflare Origin Certificate loaded from the
+# CERTIFICATE_PEM/PRIVATE_KEY_PEM secrets. Pair with Cloudflare SSL mode
+# Full (strict). See docs/deployment-setup.md.
 proxy:
-  ssl: true
+  ssl:
+    certificate_pem: CERTIFICATE_PEM
+    private_key_pem: PRIVATE_KEY_PEM
   host: dev.fffeeder.com
 
 # Accessories.
 accessories:
   db:
     image: postgres:18
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     port: "127.0.0.1:5432:5432"
     env:
       clear:
@@ -36,11 +50,11 @@ accessories:
   # Temporary metrics backend for staging. VictoriaMetrics with its built-in
   # web UI (vmui at :8428/vmui). Bound to localhost — the app pushes over the
   # private Kamal network (see METRICS_URL below); view the UI via an SSH
-  # tunnel: ssh -L 8428:127.0.0.1:8428 dev.fffeeder.com → http://localhost:8428/vmui
+  # tunnel: ssh -L 8428:127.0.0.1:8428 dev-origin.fffeeder.com → http://localhost:8428/vmui
   # Remove with: bin/kamal accessory remove victoriametrics -d staging
   victoriametrics:
     image: victoriametrics/victoria-metrics:v1.145.0
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     port: "127.0.0.1:8428:8428"
     cmd: "-retentionPeriod=1 -promscrape.config=/etc/victoriametrics/scrape.yml -vmui.customDashboardsPath=/etc/victoriametrics/dashboards"
     files:
@@ -54,7 +68,7 @@ accessories:
   # (see config/victoriametrics/scrape.yml), so no published port.
   node-exporter:
     image: quay.io/prometheus/node-exporter:v1.11.1
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     cmd: "--path.rootfs=/host"
     volumes:
       - "/:/host:ro,rslave"
@@ -64,7 +78,7 @@ accessories:
   # Remove with: bin/kamal accessory remove vlogs -d staging
   vlogs:
     image: victoriametrics/victoria-logs:v1.51.0
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     port: "127.0.0.1:9428:9428"
     cmd: "-retentionPeriod=2d -storageDataPath=/vlogs"
     directories:
@@ -75,7 +89,7 @@ accessories:
   # Remove with: bin/kamal accessory remove vector -d staging
   vector:
     image: timberio/vector:0.56.0-alpine
-    host: dev.fffeeder.com
+    host: dev-origin.fffeeder.com
     cmd: "--config /etc/vector/vector.yaml"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -82,6 +82,53 @@ ssh root@dev.fffeeder.com "uname -m"   # expected: x86_64
 ssh root@fffeeder.com "uname -m"       # expected: x86_64
 ```
 
+## Cloudflare Origin Certificate (staging)
+
+`dev.fffeeder.com` is Cloudflare-proxied (orange), so kamal-proxy can't get a
+Let's Encrypt certificate: the ACME HTTP-01 challenge lands on Cloudflare, not
+the origin. Instead kamal-proxy serves a **Cloudflare Origin Certificate** and
+Cloudflare runs in SSL mode **Full (strict)**, keeping both hops (browser↔edge
+and edge↔origin) encrypted and validated with no renewal dance.
+
+This needs the deploy host split from the public host. Two DNS records:
+
+| Record | Cloudflare | Used for |
+| --- | --- | --- |
+| `dev-origin.fffeeder.com` | DNS-only (grey) → server IP | Kamal SSH, accessories, cert install |
+| `dev.fffeeder.com` | Proxied (orange) | public `proxy.host` |
+
+`servers.*` and `accessories.*.host` point at the grey record (Cloudflare proxies
+only HTTP/S, so SSH must bypass it); `proxy.host`, `HOSTS`, and
+`ACTION_MAILER_HOST` stay the public name (Cloudflare forwards the original Host
+header, so host routing and Rails host authorization still match).
+
+Setup:
+
+1. Cloudflare → **SSL/TLS → Origin Server → Create Certificate**. Hostnames
+   `dev.fffeeder.com` (or `*.fffeeder.com`), validity 15 years. Save the cert as
+   `config/credentials/cf-origin.pem` and the private key as
+   `config/credentials/cf-origin.key` (both gitignored; share via the team
+   password manager).
+2. Cloudflare → **SSL/TLS → Overview** → set mode **Full (strict)**, and make the
+   `dev.fffeeder.com` DNS record **Proxied (orange)**. Keep `dev-origin` grey.
+3. Deploy. kamal-proxy reads the PEMs from the `CERTIFICATE_PEM` /
+   `PRIVATE_KEY_PEM` secrets (see `.kamal/secrets.staging`).
+
+```bash
+bin/kamal proxy reboot -d staging
+bin/kamal deploy -d staging
+```
+
+Verify the origin actually serves the Cloudflare cert (bypassing the edge):
+
+```bash
+curl -kvI --resolve dev.fffeeder.com:443:<ORIGIN_IP> https://dev.fffeeder.com/up 2>&1 \
+  | grep -i "issuer"   # CloudFlare Origin SSL Certificate Authority
+```
+
+The origin cert is trusted only by Cloudflare, so hitting the origin directly
+shows a browser warning — expected, since real traffic flows through the proxy.
+
 ## Secrets
 
 Kamal destination deploys read:

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -105,14 +105,24 @@ header, so host routing and Rails host authorization still match).
 Setup:
 
 1. Cloudflare → **SSL/TLS → Origin Server → Create Certificate**. Hostnames
-   `dev.fffeeder.com` (or `*.fffeeder.com`), validity 15 years. Save the cert as
-   `config/credentials/cf-origin.pem` and the private key as
-   `config/credentials/cf-origin.key` (both gitignored; share via the team
-   password manager).
-2. Cloudflare → **SSL/TLS → Overview** → set mode **Full (strict)**, and make the
+   `dev.fffeeder.com` (or `*.fffeeder.com`), validity 15 years. Keep the
+   certificate (PEM) and private key blobs handy for the next step.
+2. Provide the cert/key through the environment as multi-line PEM values —
+   the same flow as `IMGPROXY_KEY` and friends. kamal-proxy reads them from the
+   `CERTIFICATE_PEM` / `PRIVATE_KEY_PEM` secrets, which pull from
+   `CF_ORIGIN_CERT` / `CF_ORIGIN_KEY` (see `.kamal/secrets.staging`):
+   - **CI:** add `CF_ORIGIN_CERT` and `CF_ORIGIN_KEY` as GitHub Actions
+     repository secrets (paste the full PEM, including the BEGIN/END lines). The
+     **Deploy Staging** workflow passes them through.
+   - **Local deploys:** export them first, reading from your saved files:
+
+     ```bash
+     export CF_ORIGIN_CERT="$(cat cf-origin.pem)"
+     export CF_ORIGIN_KEY="$(cat cf-origin.key)"
+     ```
+3. Cloudflare → **SSL/TLS → Overview** → set mode **Full (strict)**, and make the
    `dev.fffeeder.com` DNS record **Proxied (orange)**. Keep `dev-origin` grey.
-3. Deploy. kamal-proxy reads the PEMs from the `CERTIFICATE_PEM` /
-   `PRIVATE_KEY_PEM` secrets (see `.kamal/secrets.staging`).
+4. Deploy:
 
 ```bash
 bin/kamal proxy reboot -d staging


### PR DESCRIPTION
Changes:

- Switch the staging `proxy.ssl` from Let's Encrypt to a Cloudflare Origin Certificate, loaded by kamal-proxy from secrets
- Split the deploy host: SSH and accessory hosts use a grey `dev-origin.fffeeder.com` record, while `proxy.host` stays the Cloudflare-proxied public name
- Source the cert/key from `CF_ORIGIN_CERT` / `CF_ORIGIN_KEY` env vars so GitHub Actions secrets drive deploys, matching the existing `IMGPROXY_KEY` flow
- Pass the new secrets through the Deploy Staging workflow and point `ssh-keyscan` at the grey host
- Document the setup in `docs/deployment-setup.md`

Putting `dev.fffeeder.com` behind Cloudflare's proxy breaks the Let's Encrypt HTTP-01 challenge, since it lands on Cloudflare instead of the origin. Serving a Cloudflare Origin Certificate with SSL mode Full (strict) keeps both hops encrypted and validated without any renewal dance. Because Cloudflare only proxies HTTP/S, Kamal's SSH and accessory traffic must bypass it via a separate DNS-only record.