### PR TITLE
Add cov-loupe for CLI coverage inspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@
 bun.lock
 bun.lockb
 /coverage
+# cov-loupe writes a log file here by default.
+/cov_loupe.log
 /.claude/claude_settings_local.json
 .env
 !.env.sample

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,23 @@ def feed
 end
 ```
 
+### Coverage
+
+SimpleCov collects coverage on every test run; pass `COVERAGE=1` to disable
+parallelism for accurate numbers. Results land in `coverage/.resultset.json`.
+
+Inspect coverage from the terminal with [cov-loupe](https://keithrbennett.github.io/cov-loupe/):
+
+```sh
+COVERAGE=1 bin/rails test            # generate the resultset
+bundle exec cov-loupe totals         # project-wide totals
+bundle exec cov-loupe list           # per-file percentages
+bundle exec cov-loupe uncovered app/models/feed.rb  # uncovered lines for a file
+```
+
+cov-loupe needs a UTF-8 locale; prefix with `LANG=C.UTF-8` if it reports an
+encoding error.
+
 ### Test naming convention
 
 Use the format `test "#method should ..."` for unit tests:

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,8 @@ end
 group :test do
   gem "simplecov", require: false
   gem "simplecov-cobertura", require: false
+  # CLI for inspecting SimpleCov coverage [https://keithrbennett.github.io/cov-loupe/]
+  gem "cov-loupe", require: false
   gem "minitest-rails"
   gem "webmock"
   gem "super_diff"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
       railties
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    amazing_print (2.0.0)
     ast (2.4.3)
     attr_extras (7.1.0)
     backport (1.2.0)
@@ -133,6 +134,11 @@ GEM
       highline (~> 3.0.0)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
+    cov-loupe (5.0.0)
+      amazing_print (~> 2.0)
+      logger
+      mcp (~> 0.4)
+      simplecov (>= 0.21, < 1.0)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -237,6 +243,8 @@ GEM
       net-pop
       net-smtp
     marcel (1.2.1)
+    mcp (0.21.0)
+      json_schemer (>= 2.4)
     mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-rails (8.1.0)
@@ -555,6 +563,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman
+  cov-loupe
   cssbundling-rails
   debug
   dotenv


### PR DESCRIPTION
Changes:

- Add the `cov-loupe` gem to the test group for inspecting SimpleCov coverage from the terminal
- Document the coverage workflow in CLAUDE.md (totals, per-file percentages, uncovered lines, and the UTF-8 locale caveat)
- Ignore cov-loupe's default `cov_loupe.log`

SimpleCov already writes `coverage/.resultset.json` on every test run. cov-loupe turns that into terminal-readable reports, so coverage can be checked from the command line without opening the HTML report.

References:

- Closes #321