### PR TITLE
Add Herb as an ERB linter in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,10 @@ jobs:
           erb_lint --lint-all
 
   # Trial run of Herb (https://herb-tools.dev) as a candidate ERB linter.
-  # Non-blocking while we evaluate it against the existing erb_lint job.
+  # Reports findings (log output + inline annotations) without failing the
+  # job, so we can evaluate it against the existing erb_lint job.
   lint_herb:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -158,7 +158,7 @@ jobs:
           node-version: 22
 
       - name: Lint ERB templates with Herb
-        run: npx --yes @herb-tools/linter "app/**/*.erb"
+        run: npx --yes @herb-tools/linter "app/**/*.erb" || true
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,9 +143,8 @@ jobs:
           gem install erb_lint --no-document
           erb_lint --lint-all
 
-  # Trial run of Herb (https://herb-tools.dev) as a candidate ERB linter.
-  # Reports findings (log output + inline annotations) without failing the
-  # job, so we can evaluate it against the existing erb_lint job.
+  # Herb (https://herb-tools.dev) as an HTML-aware ERB linter, complementing
+  # erb_lint. Rule tuning lives in .herb.yml.
   lint_herb:
     runs-on: ubuntu-latest
     steps:
@@ -158,7 +157,7 @@ jobs:
           node-version: 22
 
       - name: Lint ERB templates with Herb
-        run: npx --yes @herb-tools/linter "app/**/*.erb" || true
+        run: npx --yes @herb-tools/linter "app/**/*.erb"
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,23 @@ jobs:
           gem install erb_lint --no-document
           erb_lint --lint-all
 
+  # Trial run of Herb (https://herb-tools.dev) as a candidate ERB linter.
+  # Non-blocking while we evaluate it against the existing erb_lint job.
+  lint_herb:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Lint ERB templates with Herb
+        run: npx --yes @herb-tools/linter "app/**/*.erb"
+
   test:
     runs-on: ubuntu-latest
 

--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,38 @@
+# Herb configuration (https://herb-tools.dev/configuration).
+# Pinned so upgrades don't silently enable new rules.
+version: 0.10.1
+
+linter:
+  enabled: true
+
+  # Dev-only component style guide and demo pages, not shipped views.
+  exclude:
+    - "app/views/development/**/*"
+
+  rules:
+    # ViewComponent slot setters (`<% list.with_item(value: tag.x(...)) %>`) pass
+    # helper output as an argument, not as discarded output. The rule misreads
+    # this common pattern as a silent helper call.
+    actionview-no-silent-helper:
+      enabled: false
+
+    # Cosmetic: hoisting a shared tag out of if/else branches often hurts
+    # readability more than the duplication it removes.
+    erb-no-duplicate-branch-elements:
+      enabled: false
+
+    # Our `href="#"` anchors are Stimulus modal-trigger buttons with no real
+    # navigation target; there's no meaningful href to require.
+    html-anchor-require-href:
+      enabled: false
+
+    # Rails compiles the `<%# locals: %>` magic comment for every template, not
+    # just partials (ActionView::Template#compiled_source), so these are valid
+    # on action views too. The rule's partial-only assumption is outdated here.
+    actionview-strict-locals-partial-only:
+      enabled: false
+    erb-strict-locals-comment-syntax:
+      enabled: false
+
+formatter:
+  enabled: false

--- a/app/components/page_header_component.html.erb
+++ b/app/components/page_header_component.html.erb
@@ -4,10 +4,10 @@
   <% end %>
   <div class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
     <div class="flex flex-col gap-5">
-      <h1 <%= tag.attributes(class: class_names("text-4xl font-semibold mb-0 text-slate-900", "flex items-center gap-3" => title_icon?), data: @title_data) %>>
+      <%= tag.h1(class: class_names("text-4xl font-semibold mb-0 text-slate-900", "flex items-center gap-3" => title_icon?), data: @title_data) do %>
         <%= title_icon if title_icon? %>
         <%= @title %>
-      </h1>
+      <% end %>
       <% if context_paragraphs? %>
         <% context_paragraphs.each do |paragraph| %>
           <p class="text-slate-600"><%= paragraph %></p>

--- a/app/views/feeds/_candidate_chooser.html.erb
+++ b/app/views/feeds/_candidate_chooser.html.erb
@@ -14,11 +14,7 @@
       <% is_first = index.zero? %>
       <label class="flex items-start gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 cursor-pointer hover:border-sky-400 transition"
              data-key="candidate.<%= profile_key %>">
-        <input type="radio"
-               name="feed[feed_profile_key]"
-               value="<%= profile_key %>"
-               <%= "checked" if is_first %>
-               class="mt-1">
+        <%= tag.input type: "radio", name: "feed[feed_profile_key]", value: profile_key, checked: is_first, class: "mt-1" %>
         <span class="flex flex-col gap-1">
           <span class="flex flex-wrap items-center gap-2">
             <span class="font-semibold text-slate-800"><%= display_name %></span>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -78,14 +78,11 @@
       </div>
 
       <div class="mt-2" data-key="form.preview">
-        <button type="button"
-                <%= "disabled" unless feed.can_be_previewed? %>
-                class="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                data-preview-button-target="button"
-                data-action="click->preview-button#open"
-                data-key="preview.open">
-          Preview feed contents
-        </button>
+        <%= tag.button "Preview feed contents",
+              type: "button",
+              disabled: !feed.can_be_previewed?,
+              class: "inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
+              data: { preview_button_target: "button", action: "click->preview-button#open", key: "preview.open" } %>
 
         <%= render ModalComponent.new(title: "Feed preview", modal_id: "feed-preview-modal") do %>
           <%= turbo_frame_tag "feed-preview", data: { preview_button_target: "frame" } do %>


### PR DESCRIPTION
Changes:

- Add a `lint_herb` CI job running Herb (https://herb-tools.dev) over `app/**/*.erb`
- Add a pinned `.herb.yml` that tunes the rule set for this codebase
- Fix the genuine offenses Herb surfaced in production views
- Enforce the job (blocking) now that templates pass clean

Herb is an HTML-aware ERB linter that complements the existing `erb_lint` job. The linter ships as an npm package, so the job uses Node via `npx` rather than a gem (the `herb` gem's `lint` command just delegates to the same npm tool).

Evaluating Herb against the codebase surfaced a mix of genuine issues and rules that don't fit our conventions, so `.herb.yml` disables a few:

- `actionview-no-silent-helper` — false positive on ViewComponent slot setters, where helper output is passed as an argument rather than discarded
- `actionview-strict-locals-partial-only` / `erb-strict-locals-comment-syntax` — Rails compiles the `<%# locals: %>` magic comment for all templates, not just partials, so these are valid on action views here
- `html-anchor-require-href` — our `href="#"` anchors are Stimulus modal triggers with no navigation target
- `erb-no-duplicate-branch-elements` — cosmetic hint that tends to hurt readability

Dev-only style-guide pages under `app/views/development/**` are excluded. The remaining real offenses (conditional bare attributes, a `tag.attributes` cleanup) are fixed in the views.

References:

- Closes #577
