### PR TITLE
Fix datepicker controller date-fns import

### DIFF
--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import "flowbite"
-import { format } from "date-fns/utc"
+import { format } from "date-fns"
 
 // Attaches the Flowbite datepicker to its input. Flowbite only auto-inits
 // `datepicker` attributes on turbo:load, which never fires for markup

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -11,3 +11,4 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 
 pin "tippy.js", to: "https://esm.sh/tippy.js@6"
+pin "date-fns", to: "https://esm.sh/date-fns@4"


### PR DESCRIPTION
Changes:

- Import `format` from `date-fns` instead of the unpinned `date-fns/utc` specifier
- Pin `date-fns` in the importmap via esm.sh

The datepicker controller failed to register because `date-fns/utc` was a
bare specifier that was never pinned in the importmap, so the browser could
not resolve it. That subpath also doesn't export `format` — it's a top-level
`date-fns` export. Importing from `date-fns` and pinning the package restores
the controller. This preserves the existing local-time formatting behavior.