### PR TITLE
Move Enable feed below Advanced options in form

### DIFF
--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -146,21 +146,6 @@
         </div>
       </div>
 
-      <div class="mt-6">
-        <div class="flex items-start">
-          <div class="flex items-center h-6">
-            <%= check_box_tag "enable_feed",
-                              "1",
-                              params[:enable_feed] == "1" || feed.enabled?,
-                              id: "enable_feed" %>
-          </div>
-          <div class="ml-3">
-            <%= label_tag "enable_feed", "Enable feed", class: "block font-semibold text-slate-800 mb-0" %>
-            <p class="text-sm text-slate-500">Start checking for new posts and publish them to FreeFeed.</p>
-          </div>
-        </div>
-      </div>
-
       <%= render CollapsibleSectionComponent.new(title: "Advanced options", open: feed.import_after_enabled, data: { key: "form.advanced-options" }) do %>
         <div class="space-y-6" data-controller="field-toggle">
           <div class="flex items-start">
@@ -223,6 +208,21 @@
           </div>
         </div>
       <% end %>
+
+      <div class="mt-6">
+        <div class="flex items-start">
+          <div class="flex items-center h-6">
+            <%= check_box_tag "enable_feed",
+                              "1",
+                              params[:enable_feed] == "1" || feed.enabled?,
+                              id: "enable_feed" %>
+          </div>
+          <div class="ml-3">
+            <%= label_tag "enable_feed", "Enable feed", class: "block font-semibold text-slate-800 mb-0" %>
+            <p class="text-sm text-slate-500">Start checking for new posts and publish them to FreeFeed.</p>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-slate-600">


### PR DESCRIPTION
Changes:

- Move the "Enable feed" toggle below the "Advanced options" section in the feed form

Placing the enable toggle after the advanced configuration gives the form a more natural flow: users set up the details first, then decide whether to turn the feed on.
