### PR TITLE
Add Panel container component

### DIFF
--- a/app/components/panel_component.rb
+++ b/app/components/panel_component.rb
@@ -1,0 +1,20 @@
+class PanelComponent < ViewComponent::Base
+  # A borderless container on the same light gray surface as the navbar, used to
+  # set a block of related content apart without the weight of a bordered card.
+  BASE_CLASSES = "w-full rounded-lg bg-slate-100 p-6"
+
+  def initialize(**html_options)
+    @html_options = html_options
+  end
+
+  def call
+    content_tag(:div, content, merged_options)
+  end
+
+  private
+
+  def merged_options
+    classes = helpers.class_names(BASE_CLASSES, @html_options[:class])
+    @html_options.merge(class: classes)
+  end
+end

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -20,6 +20,7 @@
     "Components" => [
       ["badge", "Badge"],
       ["card", "Card"],
+      ["panel", "Panel"],
       ["alert", "Alert"],
       ["empty-state", "Empty state"],
       ["collapsible-section", "Collapsible section"],
@@ -393,6 +394,18 @@
         <% card.with_section do %>
           <p class="text-sm text-slate-500">Next refresh in about an hour.</p>
         <% end %>
+      <% end %>
+    </section>
+
+    <%# Panel %>
+    <section id="panel" class="scroll-mt-6 space-y-4" data-key="section.panel">
+      <h2 class="border-b border-slate-200 pb-2 text-xl font-semibold text-slate-900">Panel</h2>
+      <p class="text-slate-600">A borderless container on a light gray surface. Use it to set a block of related content apart with less weight than a bordered card.</p>
+      <%= render PanelComponent.new do %>
+        <div class="space-y-2">
+          <h3 class="text-lg font-semibold text-slate-900">Skip older posts</h3>
+          <p class="text-slate-700">Group related fields together without competing with the bordered cards around them.</p>
+        </div>
       <% end %>
     </section>
 

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -97,57 +97,61 @@
       <div class="mt-6">
         <h3 class="text-base font-semibold text-slate-900 mb-4">Reposting Settings</h3>
 
-        <div class="space-y-10">
-          <div class="space-y-2">
-            <%= f.label :access_token_id, "Access Token", class: "block font-semibold text-slate-800" %>
-            <% if active_tokens.empty? %>
-              <%= render "feeds/token_gate" %>
-            <% else %>
-              <%= f.select :access_token_id,
-                           options_from_collection_for_select(
-                             active_tokens,
-                             :id,
-                             :display_name,
-                             feed.access_token_id || active_tokens.first&.id
-                           ),
-                           {},
-                           {
-                             class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 pb-2",
-                             data: {
-                               action: "change->groups#refresh",
-                               groups_target: "tokenSelect"
-                             }
-                           } %>
-              <% if f.object.errors[:access_token].any? %>
-                <p class="text-sm text-red-600"><%= f.object.errors[:access_token].first %></p>
+        <div class="space-y-6">
+          <%= render PanelComponent.new do %>
+            <div class="space-y-2">
+              <%= f.label :access_token_id, "Access Token", class: "block font-semibold text-slate-800" %>
+              <% if active_tokens.empty? %>
+                <%= render "feeds/token_gate" %>
+              <% else %>
+                <%= f.select :access_token_id,
+                             options_from_collection_for_select(
+                               active_tokens,
+                               :id,
+                               :display_name,
+                               feed.access_token_id || active_tokens.first&.id
+                             ),
+                             {},
+                             {
+                               class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 pb-2",
+                               data: {
+                                 action: "change->groups#refresh",
+                                 groups_target: "tokenSelect"
+                               }
+                             } %>
+                <% if f.object.errors[:access_token].any? %>
+                  <p class="text-sm text-red-600"><%= f.object.errors[:access_token].first %></p>
+                <% end %>
               <% end %>
-            <% end %>
-          </div>
+            </div>
+          <% end %>
 
-          <%= render "feeds/target_group_selector",
-                     feed: feed,
-                     groups: [],
-                     token: nil %>
-        </div>
-      </div>
+          <%= render PanelComponent.new do %>
+            <%= render "feeds/target_group_selector",
+                       feed: feed,
+                       groups: [],
+                       token: nil %>
+          <% end %>
 
-      <div class="mt-6">
-        <h3 class="text-base font-semibold text-slate-900 mb-4">Refresh Schedule</h3>
-
-        <div class="space-y-2">
-          <%= f.label :schedule_interval, "Check for new posts every", class: "block font-semibold text-slate-800" %>
-          <%= f.select :schedule_interval,
-                       Feed.schedule_intervals_for_select,
-                       { selected: feed.schedule_interval || Feed::DEFAULT_SCHEDULE_INTERVAL },
-                       { class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" } %>
-          <% if f.object.errors[:cron_expression].any? %>
-            <p class="text-sm text-red-600"><%= f.object.errors[:cron_expression].first %></p>
+          <%= render PanelComponent.new do %>
+            <div class="space-y-2">
+              <%= f.label :schedule_interval, "Check for new posts every", class: "block font-semibold text-slate-800" %>
+              <%= f.select :schedule_interval,
+                           Feed.schedule_intervals_for_select,
+                           { selected: feed.schedule_interval || Feed::DEFAULT_SCHEDULE_INTERVAL },
+                           { class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2" } %>
+              <% if f.object.errors[:cron_expression].any? %>
+                <p class="text-sm text-red-600"><%= f.object.errors[:cron_expression].first %></p>
+              <% end %>
+            </div>
           <% end %>
         </div>
       </div>
 
-      <%= render CollapsibleSectionComponent.new(title: "Advanced options", open: feed.import_after_enabled, data: { key: "form.advanced-options" }) do %>
-        <%= render PanelComponent.new(data: { controller: "field-toggle" }) do %>
+      <div class="mt-6">
+        <h3 class="text-base font-semibold text-slate-900 mb-4">Advanced options</h3>
+
+        <%= render PanelComponent.new(data: { controller: "field-toggle", key: "form.advanced-options" }) do %>
           <div class="flex items-start">
             <div class="flex h-6 items-center">
               <%= f.check_box :import_after_enabled,
@@ -210,7 +214,7 @@
             <p class="text-sm text-slate-500">Posts published before this moment will be skipped. We'll use the current date and time if you leave these blank. Time is UTC.</p>
           </div>
         <% end %>
-      <% end %>
+      </div>
 
       <div class="mt-6">
         <div class="flex items-start">

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -148,65 +148,66 @@
 
       <%= render CollapsibleSectionComponent.new(title: "Advanced options", open: feed.import_after_enabled, data: { key: "form.advanced-options" }) do %>
         <%= render PanelComponent.new(data: { controller: "field-toggle" }) do %>
-          <div class="space-y-6">
-            <div class="flex items-start">
-              <div class="flex h-6 items-center">
-                <%= f.check_box :import_after_enabled,
-                                data: {
-                                  field_toggle_target: "checkbox",
-                                  action: "change->field-toggle#toggle",
-                                  key: "form.import-after-enabled"
-                                } %>
-              </div>
-              <div class="ml-3">
-                <%= f.label :import_after_enabled, "Skip older posts", class: "block font-semibold text-slate-800 mb-0" %>
-                <p class="text-sm text-slate-500">Only import posts published after a date you pick.</p>
-              </div>
+          <div class="flex items-start">
+            <div class="flex h-6 items-center">
+              <%= f.check_box :import_after_enabled,
+                              data: {
+                                field_toggle_target: "checkbox",
+                                action: "change->field-toggle#toggle",
+                                key: "form.import-after-enabled"
+                              } %>
             </div>
+            <div class="ml-3">
+              <%= f.label :import_after_enabled, "Skip older posts", class: "block font-semibold text-slate-800 mb-0" %>
+              <p class="text-sm text-slate-500">Only import posts published after a date you pick.</p>
+            </div>
+          </div>
 
-            <div class="space-y-2 <%= "hidden" unless feed.import_after_enabled %>"
-                 data-field-toggle-target="panel"
-                 data-key="form.import-after-fields">
-              <div class="grid gap-4 sm:grid-cols-2">
-                <div class="relative">
-                  <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
-                    <%= icon("calendar", css_class: "size-5 text-slate-400") %>
-                  </div>
-                  <%= f.text_field :import_after_date,
-                                   placeholder: "Pick a date",
-                                   autocomplete: "off",
-                                   class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
-                                   aria: { label: "Import posts published after this date" },
-                                   data: {
-                                     controller: "datepicker",
-                                     action: "field-toggle:enabled@window->datepicker#reset",
-                                     field_toggle_target: "input",
-                                     key: "form.import-after-date"
-                                   } %>
+          <%# mt-6 lives on the toggled panel (not a wrapper space-y) so the gap
+              only appears when the fields are shown — a hidden element renders
+              no margin. %>
+          <div class="mt-6 space-y-2 <%= "hidden" unless feed.import_after_enabled %>"
+               data-field-toggle-target="panel"
+               data-key="form.import-after-fields">
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="relative">
+                <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+                  <%= icon("calendar", css_class: "size-5 text-slate-400") %>
                 </div>
-                <div class="relative">
-                  <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
-                    <%= icon("clock", css_class: "size-5 text-slate-400") %>
-                  </div>
-                  <%# Plain 24-hour text field rather than a native time input: the
-                      native control renders 12h or 24h based on the browser locale,
-                      which we can't override, so we pin the format to HH:MM here. %>
-                  <%= f.text_field :import_after_time,
-                                   value: feed.import_after_time.presence || "00:00",
-                                   inputmode: "numeric",
-                                   placeholder: "HH:MM",
-                                   pattern: "([01][0-9]|2[0-3]):[0-5][0-9]",
-                                   maxlength: 5,
-                                   class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
-                                   aria: { label: "Import posts published after this time (24-hour HH:MM, UTC)" },
-                                   data: {
-                                     field_toggle_target: "input",
-                                     key: "form.import-after-time"
-                                   } %>
-                </div>
+                <%= f.text_field :import_after_date,
+                                 placeholder: "Pick a date",
+                                 autocomplete: "off",
+                                 class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                                 aria: { label: "Import posts published after this date" },
+                                 data: {
+                                   controller: "datepicker",
+                                   action: "field-toggle:enabled@window->datepicker#reset",
+                                   field_toggle_target: "input",
+                                   key: "form.import-after-date"
+                                 } %>
               </div>
-              <p class="text-sm text-slate-500">Posts published before this moment will be skipped. We'll use the current date and time if you leave these blank. Time is UTC.</p>
+              <div class="relative">
+                <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+                  <%= icon("clock", css_class: "size-5 text-slate-400") %>
+                </div>
+                <%# Plain 24-hour text field rather than a native time input: the
+                    native control renders 12h or 24h based on the browser locale,
+                    which we can't override, so we pin the format to HH:MM here. %>
+                <%= f.text_field :import_after_time,
+                                 value: feed.import_after_time.presence || "00:00",
+                                 inputmode: "numeric",
+                                 placeholder: "HH:MM",
+                                 pattern: "([01][0-9]|2[0-3]):[0-5][0-9]",
+                                 maxlength: 5,
+                                 class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                                 aria: { label: "Import posts published after this time (24-hour HH:MM, UTC)" },
+                                 data: {
+                                   field_toggle_target: "input",
+                                   key: "form.import-after-time"
+                                 } %>
+              </div>
             </div>
+            <p class="text-sm text-slate-500">Posts published before this moment will be skipped. We'll use the current date and time if you leave these blank. Time is UTC.</p>
           </div>
         <% end %>
       <% end %>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -147,66 +147,68 @@
       </div>
 
       <%= render CollapsibleSectionComponent.new(title: "Advanced options", open: feed.import_after_enabled, data: { key: "form.advanced-options" }) do %>
-        <div class="space-y-6" data-controller="field-toggle">
-          <div class="flex items-start">
-            <div class="flex h-6 items-center">
-              <%= f.check_box :import_after_enabled,
-                              data: {
-                                field_toggle_target: "checkbox",
-                                action: "change->field-toggle#toggle",
-                                key: "form.import-after-enabled"
-                              } %>
+        <%= render PanelComponent.new(data: { controller: "field-toggle" }) do %>
+          <div class="space-y-6">
+            <div class="flex items-start">
+              <div class="flex h-6 items-center">
+                <%= f.check_box :import_after_enabled,
+                                data: {
+                                  field_toggle_target: "checkbox",
+                                  action: "change->field-toggle#toggle",
+                                  key: "form.import-after-enabled"
+                                } %>
+              </div>
+              <div class="ml-3">
+                <%= f.label :import_after_enabled, "Skip older posts", class: "block font-semibold text-slate-800 mb-0" %>
+                <p class="text-sm text-slate-500">Only import posts published after a date you pick.</p>
+              </div>
             </div>
-            <div class="ml-3">
-              <%= f.label :import_after_enabled, "Skip older posts", class: "block font-semibold text-slate-800 mb-0" %>
-              <p class="text-sm text-slate-500">Only import posts published after a date you pick.</p>
-            </div>
-          </div>
 
-          <div class="space-y-2 <%= "hidden" unless feed.import_after_enabled %>"
-               data-field-toggle-target="panel"
-               data-key="form.import-after-fields">
-            <div class="grid gap-4 sm:grid-cols-2">
-              <div class="relative">
-                <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
-                  <%= icon("calendar", css_class: "size-5 text-slate-400") %>
+            <div class="space-y-2 <%= "hidden" unless feed.import_after_enabled %>"
+                 data-field-toggle-target="panel"
+                 data-key="form.import-after-fields">
+              <div class="grid gap-4 sm:grid-cols-2">
+                <div class="relative">
+                  <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+                    <%= icon("calendar", css_class: "size-5 text-slate-400") %>
+                  </div>
+                  <%= f.text_field :import_after_date,
+                                   placeholder: "Pick a date",
+                                   autocomplete: "off",
+                                   class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                                   aria: { label: "Import posts published after this date" },
+                                   data: {
+                                     controller: "datepicker",
+                                     action: "field-toggle:enabled@window->datepicker#reset",
+                                     field_toggle_target: "input",
+                                     key: "form.import-after-date"
+                                   } %>
                 </div>
-                <%= f.text_field :import_after_date,
-                                 placeholder: "Pick a date",
-                                 autocomplete: "off",
-                                 class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
-                                 aria: { label: "Import posts published after this date" },
-                                 data: {
-                                   controller: "datepicker",
-                                   action: "field-toggle:enabled@window->datepicker#reset",
-                                   field_toggle_target: "input",
-                                   key: "form.import-after-date"
-                                 } %>
-              </div>
-              <div class="relative">
-                <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
-                  <%= icon("clock", css_class: "size-5 text-slate-400") %>
+                <div class="relative">
+                  <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
+                    <%= icon("clock", css_class: "size-5 text-slate-400") %>
+                  </div>
+                  <%# Plain 24-hour text field rather than a native time input: the
+                      native control renders 12h or 24h based on the browser locale,
+                      which we can't override, so we pin the format to HH:MM here. %>
+                  <%= f.text_field :import_after_time,
+                                   value: feed.import_after_time.presence || "00:00",
+                                   inputmode: "numeric",
+                                   placeholder: "HH:MM",
+                                   pattern: "([01][0-9]|2[0-3]):[0-5][0-9]",
+                                   maxlength: 5,
+                                   class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
+                                   aria: { label: "Import posts published after this time (24-hour HH:MM, UTC)" },
+                                   data: {
+                                     field_toggle_target: "input",
+                                     key: "form.import-after-time"
+                                   } %>
                 </div>
-                <%# Plain 24-hour text field rather than a native time input: the
-                    native control renders 12h or 24h based on the browser locale,
-                    which we can't override, so we pin the format to HH:MM here. %>
-                <%= f.text_field :import_after_time,
-                                 value: feed.import_after_time.presence || "00:00",
-                                 inputmode: "numeric",
-                                 placeholder: "HH:MM",
-                                 pattern: "([01][0-9]|2[0-3]):[0-5][0-9]",
-                                 maxlength: 5,
-                                 class: "w-full rounded-md border border-slate-300 bg-white py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2",
-                                 aria: { label: "Import posts published after this time (24-hour HH:MM, UTC)" },
-                                 data: {
-                                   field_toggle_target: "input",
-                                   key: "form.import-after-time"
-                                 } %>
               </div>
+              <p class="text-sm text-slate-500">Posts published before this moment will be skipped. We'll use the current date and time if you leave these blank. Time is UTC.</p>
             </div>
-            <p class="text-sm text-slate-500">Posts published before this moment will be skipped. We'll use the current date and time if you leave these blank. Time is UTC.</p>
           </div>
-        </div>
+        <% end %>
       <% end %>
 
       <div class="mt-6">

--- a/test/components/panel_component_test.rb
+++ b/test/components/panel_component_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+require "view_component/test_case"
+
+class PanelComponentTest < ViewComponent::TestCase
+  test "#call should render a div with default styling" do
+    result = render_inline(PanelComponent.new) { "Panel body" }
+
+    panel = result.at_css("div")
+    assert_not_nil panel
+    assert_equal "Panel body", panel.text.strip
+    assert_includes panel["class"], "bg-slate-100"
+    assert_includes panel["class"], "rounded-lg"
+    assert_includes panel["class"], "p-6"
+    refute_includes panel["class"], "border"
+  end
+
+  test "#call should merge classes and forward html attributes" do
+    result = render_inline(
+      PanelComponent.new(
+        class: "test",
+        role: "status",
+        data: { controller: "polling" },
+        id: "test-panel"
+      )
+    ) { "<p>Polling...</p>".html_safe }
+
+    panel = result.at_css('[role="status"]')
+    assert_not_nil panel
+    assert_equal "polling", panel["data-controller"]
+    assert_equal "test-panel", panel["id"]
+    assert_equal "Polling...", panel.css("p").first.text
+    assert_includes panel["class"], "test"
+  end
+end

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -594,26 +594,26 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "2h", feed.schedule_interval
   end
 
-  test "#edit should render collapsed advanced options when no import threshold is set" do
+  test "#edit should hide import threshold fields when none is set" do
     sign_in_as(user)
 
     get edit_feed_url(feed)
 
     assert_response :success
-    assert_select 'details[data-key="form.advanced-options"]:not([open])'
+    assert_select '[data-key="form.advanced-options"]'
     assert_select '[data-key="form.import-after-fields"].hidden'
     assert_select 'input[name="feed[import_after_enabled]"][type=checkbox][checked]', false
     assert_select 'input[data-key="form.import-after-time"][value="00:00"]'
   end
 
-  test "#edit should expand advanced options when an import threshold is set" do
+  test "#edit should show import threshold fields when one is set" do
     sign_in_as(user)
     feed.update!(import_after: Time.utc(2026, 1, 15, 10, 30))
 
     get edit_feed_url(feed)
 
     assert_response :success
-    assert_select 'details[data-key="form.advanced-options"][open]'
+    assert_select '[data-key="form.import-after-fields"]:not(.hidden)'
     assert_select 'input[name="feed[import_after_enabled]"][type=checkbox][checked]'
     assert_select 'input[data-key="form.import-after-date"][value="2026-01-15"]'
     assert_select 'input[data-key="form.import-after-time"][value="10:30"]'


### PR DESCRIPTION
Changes:

- Add `PanelComponent`, a borderless container on the navbar's light gray surface with the same padding as a single-section card
- Wrap the "Skip older posts" feed form section in a panel to set it apart from the surrounding bordered controls
- Add a Panel specimen to the UI reference page

The panel fills a gap between a plain bordered card and undecorated markup: it groups related fields on a subtle surface without the visual weight of a border or shadow.
