### PR TITLE
Soften warning event card and fix hover border

### DIFF
--- a/app/components/event_card_component.rb
+++ b/app/components/event_card_component.rb
@@ -1,11 +1,13 @@
 class EventCardComponent < ViewComponent::Base
   include EventLogEntryPresentation
 
-  # Warning and error cards reuse the alert palette so problems stand out while
+  # Warning and error cards lean on the alert palette so problems stand out while
   # scanning the log; routine events stay neutral. The border picks a slightly
-  # darker shade of the background hue, like AlertComponent does.
+  # darker shade of the background hue, like AlertComponent does. Warning stays
+  # gentle, so its border darkens on hover too — otherwise the hover background
+  # would catch up to a static border and the two would read as one flat block.
   LEVEL_TINTS = {
-    "warning" => { border: "border-amber-200", background: "bg-amber-100 hover:bg-amber-200" },
+    "warning" => { border: "border-amber-100", hover_border: "hover:border-amber-200", background: "bg-amber-50 hover:bg-amber-100" },
     "error" => { border: "border-red-200", background: "bg-red-100 hover:bg-red-200" }
   }.freeze
 
@@ -29,7 +31,7 @@ class EventCardComponent < ViewComponent::Base
   end
 
   def card_classes
-    helpers.class_names("w-full rounded-lg border shadow-xs transition duration-75", tint[:border], tint[:background])
+    helpers.class_names("w-full rounded-lg border shadow-xs transition duration-75", tint[:border], tint[:hover_border], tint[:background])
   end
 
   def divider_border

--- a/test/components/event_card_component_test.rb
+++ b/test/components/event_card_component_test.rb
@@ -79,8 +79,10 @@ class EventCardComponentTest < ViewComponent::TestCase
     result = render_card(event)
 
     card = result.css("[data-key='events.entry']").first
-    assert_includes card["class"], "bg-amber-100"
-    assert_includes card["class"], "border-amber-200"
+    assert_includes card["class"], "bg-amber-50"
+    assert_includes card["class"], "border-amber-100"
+    assert_includes card["class"], "hover:bg-amber-100"
+    assert_includes card["class"], "hover:border-amber-200"
   end
 
   test "#call should tint error cards with the alert palette" do


### PR DESCRIPTION
Changes:

- Lighten the warning event card to `border-amber-100 bg-amber-50` so problems still register while scanning the log without shouting.
- Darken the border on hover (`hover:border-amber-200`) alongside the reduced hover background (`hover:bg-amber-100`).

The warning card previously used a static `amber-200` border with an `amber-200` hover background, so on hover the border and background collapsed into a single flat block. Toning the resting colors down and darkening the border on hover keeps the border one step ahead of the background in both states.
