### PR TITLE
Show locked chooser for single feed profile

### DIFF
--- a/app/views/feeds/_candidate_chooser.html.erb
+++ b/app/views/feeds/_candidate_chooser.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (candidates: [], input: nil) %>
+<%# locals: (candidates: [], input: nil, single: false) %>
 <% selected_key = candidates.first&.dig("profile_key") %>
 
 <div class="space-y-2"
@@ -12,13 +12,13 @@
       <% description = FeedProfile[profile_key]&.dig(:description) %>
       <% uses_ai = !!candidate["depends_on_ai"] %>
       <% is_first = index.zero? %>
-      <label class="flex items-start gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 cursor-pointer hover:border-sky-400 transition"
+      <label class="flex items-start gap-3 rounded-lg border px-4 py-3 transition <%= single ? "border-sky-300 bg-sky-50 cursor-default" : "border-slate-200 bg-white cursor-pointer hover:border-sky-400" %>"
              data-key="candidate.<%= profile_key %>">
-        <%= tag.input type: "radio", name: "feed[feed_profile_key]", value: profile_key, checked: is_first, class: "mt-1" %>
+        <%= tag.input type: "radio", name: "feed[feed_profile_key]", value: profile_key, checked: is_first, disabled: single, class: "mt-1" %>
         <span class="flex flex-col gap-1">
           <span class="flex flex-wrap items-center gap-2">
             <span class="font-semibold text-slate-800"><%= display_name %></span>
-            <% if is_first %>
+            <% if is_first && !single %>
               <span class="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-700"
                     data-key="candidate.recommended-badge">Recommended</span>
             <% end %>
@@ -34,4 +34,8 @@
       </label>
     <% end %>
   </div>
+
+  <% if single %>
+    <p class="text-sm text-slate-500" data-key="candidate.single-note">This is the only way we can fetch this source, so it's locked in.</p>
+  <% end %>
 </div>

--- a/app/views/feeds/_candidate_chooser.html.erb
+++ b/app/views/feeds/_candidate_chooser.html.erb
@@ -1,5 +1,4 @@
 <%# locals: (candidates: [], input: nil, single: false) %>
-<% selected_key = candidates.first&.dig("profile_key") %>
 
 <div class="space-y-2"
      data-key="candidates">

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -1,9 +1,10 @@
 <%# locals: (edit_mode: false, feed: @feed, candidates: []) %>
 <% active_tokens = Current.user.access_tokens.active.order(:host) %>
-<% multi_candidate = !edit_mode && candidates.size > 1 %>
+<% show_chooser = !edit_mode && candidates.any? %>
+<% single_candidate = show_chooser && candidates.size == 1 %>
 <%
   preview_shapes =
-    if multi_candidate
+    if show_chooser
       candidates.to_h { |c| [c["profile_key"], FeedProfile[c["profile_key"]]&.dig(:input_shape).to_s] }
     else
       { feed.feed_profile_key => feed.source_input_shape }
@@ -31,8 +32,13 @@
                   groups_default_text_value: "The FreeFeed group where posts will be published. Each feed can go to its own group, or you can point multiple feeds at the same one."
                 } do |f| %>
     <div class="space-y-10">
-      <% if multi_candidate %>
-        <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.url %>
+      <% if show_chooser %>
+        <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.url, single: single_candidate %>
+        <%# A disabled radio won't submit its value, so the lone option still
+            needs a hidden field to carry the profile key to the server. %>
+        <% if single_candidate %>
+          <%= f.hidden_field :feed_profile_key %>
+        <% end %>
       <% else %>
         <%= f.hidden_field :feed_profile_key %>
       <% end %>
@@ -56,7 +62,7 @@
         <% feed.params&.each do |key, value| %>
           <%= hidden_field_tag "feed[params][#{key}]", value %>
         <% end %>
-        <% unless multi_candidate %>
+        <% unless show_chooser %>
           <p class="text-sm text-slate-500"><%= edit_mode ? "Source and type can't be changed after creation. Start a new feed to follow a different source." : FeedProfile.display_name_for(feed.feed_profile_key).to_s %></p>
         <% end %>
       </div>

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -503,6 +503,35 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "data-key=\"candidate.ai-badge\""
   end
 
+  test "#show should render a locked single-option chooser when one candidate exists" do
+    sign_in_as(user)
+    url = "http://example.com/feed.xml"
+    feed_identification = FeedIdentification.create!(
+      user: user,
+      input: url,
+      status: :success,
+      candidates: [
+        { "profile_key" => "llm_website_extractor", "title" => "Example", "depends_on_ai" => true, "rank" => 0, "rank_reason" => "ai_fallback" }
+      ]
+    )
+
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    # The chooser shows even with a single option, so the user sees what was picked.
+    assert_select "[data-key='candidates']", count: 1
+    assert_select "[data-key='candidate.llm_website_extractor']", count: 1
+    assert_select "[data-key='candidate.single-note']", count: 1
+    # The only option is preselected and locked.
+    assert_select "input[type=radio][name='feed[feed_profile_key]'][checked][disabled]", count: 1
+    # A disabled radio doesn't submit, so a hidden field carries the value.
+    assert_select "input[type=hidden][name='feed[feed_profile_key]'][value='llm_website_extractor']", count: 1
+    # No "Recommended" badge when there's nothing to compare against.
+    assert_select "[data-key='candidate.recommended-badge']", count: 0
+  ensure
+    feed_identification&.destroy
+  end
+
   test "#show should truncate detected title to Feed::NAME_MAX_LENGTH" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -506,9 +506,11 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
   test "#show should render a locked single-option chooser when one candidate exists" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
-    feed_identification = FeedIdentification.create!(
+    create(
+      :feed_identification,
       user: user,
       input: url,
+      started_at: Time.current,
       status: :success,
       candidates: [
         { "profile_key" => "llm_website_extractor", "title" => "Example", "depends_on_ai" => true, "rank" => 0, "rank_reason" => "ai_fallback" }
@@ -528,8 +530,6 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type=hidden][name='feed[feed_profile_key]'][value='llm_website_extractor']", count: 1
     # No "Recommended" badge when there's nothing to compare against.
     assert_select "[data-key='candidate.recommended-badge']", count: 0
-  ensure
-    feed_identification&.destroy
   end
 
   test "#show should truncate detected title to Feed::NAME_MAX_LENGTH" do

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -310,7 +310,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     # what the fetcher will write when only the llm_website_extractor matches
     # (the AI matcher itself ships in a later PR, so we construct the payload
     # here as a stand-in to exercise the controller payload contract today).
-    feed_identification = FeedIdentification.create!(
+    FeedIdentification.create!(
       user: user,
       input: url,
       status: :success,
@@ -326,14 +326,12 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "llm_website_extractor", payload.first["profile_key"]
     assert_equal true, payload.first["depends_on_ai"]
     assert_equal "ai_fallback", payload.first["rank_reason"]
-  ensure
-    feed_identification&.destroy
   end
 
   test "#show should show the AI cost notice when a non-recommended candidate is AI" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
-    feed_identification = FeedIdentification.create!(
+    FeedIdentification.create!(
       user: user,
       input: url,
       status: :success,
@@ -347,15 +345,13 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-key='ai-cost.notice']", count: 1
-  ensure
-    feed_identification&.destroy
   end
 
   test "#show should preselect the default schedule interval with no blank option" do
     sign_in_as(user)
     create(:access_token, :active, user: user)
     url = "http://example.com/feed.xml"
-    feed_identification = FeedIdentification.create!(
+    FeedIdentification.create!(
       user: user,
       input: url,
       status: :success,
@@ -371,8 +367,6 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "select[name='feed[schedule_interval]'] option[selected='selected']" do |options|
       assert_equal Feed::DEFAULT_SCHEDULE_INTERVAL, options.first["value"]
     end
-  ensure
-    feed_identification&.destroy
   end
 
   test "#show should preselect the first active access token with no blank option" do
@@ -380,7 +374,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     first_token = create(:access_token, :active, user: user, host: "https://aaa.freefeed.net")
     create(:access_token, :active, user: user, host: "https://zzz.freefeed.net")
     url = "http://example.com/feed.xml"
-    feed_identification = FeedIdentification.create!(
+    FeedIdentification.create!(
       user: user,
       input: url,
       status: :success,
@@ -396,8 +390,6 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "select[name='feed[access_token_id]'] option[selected='selected']" do |options|
       assert_equal first_token.id.to_s, options.first["value"]
     end
-  ensure
-    feed_identification&.destroy
   end
 
   test "#show should write the user's input under params[query] for handle inputs" do
@@ -536,7 +528,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     url = "http://example.com/feed.xml"
     long_title = "A" * (Feed::NAME_MAX_LENGTH + 10)
-    feed_identification = FeedIdentification.create!(
+    FeedIdentification.create!(
       user: user,
       input: url,
       status: :success,
@@ -549,8 +541,6 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "input[name='feed[name]'][value='#{"A" * (Feed::NAME_MAX_LENGTH - 3)}...']", count: 1
-  ensure
-    feed_identification&.destroy
   end
 
   private


### PR DESCRIPTION
Changes:

- Render the profile chooser even when detection finds a single compatible profile, with that option preselected and locked
- Carry the profile key through a hidden field, since a disabled radio doesn't submit its value

When detection returns only one viable profile, the user now sees it presented and locked in place rather than having it silently chosen behind the scenes. This keeps the choice transparent and consistent with the multi-candidate flow.
