### PR TITLE
Show total feed post count in preview modal

### DIFF
--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -46,6 +46,15 @@ class FeedPreview < ApplicationRecord
     posts_data.size
   end
 
+  # Total items the loader pulled from the source — the full set that will be
+  # enqueued once the feed is enabled, not just the handful shown in the preview.
+  # Falls back to the preview count for older records without recorded stats.
+  def total_entries_count
+    return 0 unless data.present? && ready?
+
+    data.dig("stats", "total_entries") || posts_count
+  end
+
   private
 
   def assign_params_digest

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -46,9 +46,11 @@ class FeedPreview < ApplicationRecord
     posts_data.size
   end
 
-  # Total items the loader pulled from the source — the full set that will be
-  # enqueued once the feed is enabled, not just the handful shown in the preview.
-  # Falls back to the preview count for older records without recorded stats.
+  # Total items found in the source — the full batch the loader pulled, not just
+  # the handful shown in the preview. This is an upper bound on what enabling the
+  # feed enqueues; the refresh later drops duplicates and entries before the
+  # import threshold. Falls back to the preview count for older records without
+  # recorded stats.
   def total_entries_count
     return 0 unless data.present? && ready?
 

--- a/app/views/feed_previews/_ready.html.erb
+++ b/app/views/feed_previews/_ready.html.erb
@@ -8,7 +8,7 @@
     <div class="space-y-1">
       <p class="font-semibold text-slate-800">Here's what we'd post</p>
       <p class="text-sm text-slate-500" data-key="preview.summary">
-        This feed has <%= preview.total_entries_count %> <%= "post".pluralize(preview.total_entries_count) %> ready to enqueue.<% if preview.total_entries_count > preview.posts_count %> Here's a peek at the <%= preview.posts_count %> most recent.<% end %>
+        We found <%= preview.total_entries_count %> <%= "post".pluralize(preview.total_entries_count) %> in this feed.<% if preview.total_entries_count > preview.posts_count %> Here's a peek at the <%= preview.posts_count %> most recent.<% end %>
       </p>
     </div>
     <button type="button"

--- a/app/views/feed_previews/_ready.html.erb
+++ b/app/views/feed_previews/_ready.html.erb
@@ -7,7 +7,9 @@
   <div class="flex flex-wrap items-center justify-between gap-2">
     <div class="space-y-1">
       <p class="font-semibold text-slate-800">Here's what we'd post</p>
-      <p class="text-sm text-slate-500">Showing <%= preview.posts_count %> recent <%= "post".pluralize(preview.posts_count) %>.</p>
+      <p class="text-sm text-slate-500" data-key="preview.summary">
+        This feed has <%= preview.total_entries_count %> <%= "post".pluralize(preview.total_entries_count) %> ready to enqueue.<% if preview.total_entries_count > preview.posts_count %> Here's a peek at the <%= preview.posts_count %> most recent.<% end %>
+      </p>
     </div>
     <button type="button"
             class="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50"

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -46,6 +46,34 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "#show should summarize the total post count for a ready preview" do
+    sign_in_as(user)
+    create(:feed_preview, :completed, user: user, feed_profile_key: "rss",
+                                      params: { "url" => "http://example.com/feed.xml" })
+
+    get feed_preview_url(profile_key: "rss", "params" => { url: "http://example.com/feed.xml" })
+
+    assert_response :success
+    summary = css_select('[data-key="preview.summary"]').text
+    assert_match "We found 1 post in this feed", summary
+    assert_no_match(/peek/, summary)
+  end
+
+  test "#show should note the preview is a subset when total exceeds shown posts" do
+    sign_in_as(user)
+    posts = 10.times.map { |i| { "uid" => "uid-#{i}", "content" => "post #{i}" } }
+    create(:feed_preview, user: user, status: :ready, ready_at: 1.minute.ago,
+                          feed_profile_key: "rss", params: { "url" => "http://example.com/feed.xml" },
+                          data: { "posts" => posts, "stats" => { "total_entries" => 25 } })
+
+    get feed_preview_url(profile_key: "rss", "params" => { url: "http://example.com/feed.xml" })
+
+    assert_response :success
+    summary = css_select('[data-key="preview.summary"]').text
+    assert_match "We found 25 posts in this feed", summary
+    assert_match "peek at the 10 most recent", summary
+  end
+
   test "#show should clear the pane and create nothing when source is blank" do
     sign_in_as(user)
 

--- a/test/models/feed_preview_test.rb
+++ b/test/models/feed_preview_test.rb
@@ -85,6 +85,33 @@ class FeedPreviewTest < ActiveSupport::TestCase
     assert_equal 0, preview.posts_count
   end
 
+  test "#total_entries_count should return recorded total entries" do
+    preview = create(
+      :feed_preview,
+      user: user,
+      status: :ready,
+      data: { "posts" => [{ "uid" => "1" }], "stats" => { "total_entries" => 42 } }
+    )
+
+    assert_equal 42, preview.total_entries_count
+  end
+
+  test "#total_entries_count should fall back to posts_count without stats" do
+    preview = create(
+      :feed_preview,
+      user: user,
+      status: :ready,
+      data: { "posts" => [{ "uid" => "1" }, { "uid" => "2" }] }
+    )
+
+    assert_equal 2, preview.total_entries_count
+  end
+
+  test "#total_entries_count should return 0 when not ready" do
+    preview = create(:feed_preview, user: user, data: nil)
+    assert_equal 0, preview.total_entries_count
+  end
+
   test "#timeout! should transition a processing preview to failed" do
     preview = create(:feed_preview, :processing, user: user)
     preview.timeout!


### PR DESCRIPTION
Changes:

- Display the total number of posts the loader pulled from the source in the preview summary, so it's clear how many posts will be enqueued once the feed is enabled
- Add a `FeedPreview#total_entries_count` reading the already-recorded `total_entries` stat, falling back to the preview post count for records without stats

The preview only renders a handful of recent posts, which made it look like the feed contained just those few. Surfacing the full count sets the right expectation about what enabling the feed will queue up.
