### PR TITLE
Tidy event pages and add admin feeds resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,6 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-20
 
+- Event pages now show stats in a clear, always-visible section.
 - Started keeping a changelog of user-facing changes.
 - New favicon featuring the Feeder mark.

--- a/app/components/admin/event_card_component.rb
+++ b/app/components/admin/event_card_component.rb
@@ -1,0 +1,24 @@
+module Admin
+  # Admin variant of EventCardComponent for the operator log: links feeds and
+  # events to the admin pages, adds the type/user/target footer, and turns the
+  # severity icon into a level drill-down.
+  class EventCardComponent < ::EventCardComponent
+    private
+
+    def description_component_class
+      Admin::EventDescriptionComponent
+    end
+
+    def show_footer?
+      true
+    end
+
+    def severity
+      helpers.link_to(severity_icon,
+                      helpers.admin_events_path(filter: { level: event.level }),
+                      class: "flex w-4 shrink-0 items-center justify-center",
+                      title: "Show #{event.level} events",
+                      data: { key: "events.severity" })
+    end
+  end
+end

--- a/app/components/admin/event_description_component.rb
+++ b/app/components/admin/event_description_component.rb
@@ -1,14 +1,11 @@
 module Admin
   # Admin variant of EventDescriptionComponent: identical rendering, but feed
-  # references point at the operator-facing feed page. The per-type subclasses
-  # mirror the user-facing ones so refresh counts and reason copy still render.
+  # references point at the operator-facing feed page. Reuses the base type
+  # resolution and mixes the admin link behavior into whichever subclass it
+  # returns, so new event-type subclasses are covered automatically.
   class EventDescriptionComponent < ::EventDescriptionComponent
-    include FeedLinks
-
-    SUBCLASSES = {
-      "feed_refresh" => "Admin::FeedRefreshDescriptionComponent",
-      "feed_auto_disabled" => "Admin::FeedAutoDisabledDescriptionComponent",
-      "feed_target_group_unavailable" => "Admin::FeedTargetGroupUnavailableDescriptionComponent"
-    }.freeze
+    def self.for(event)
+      ::EventDescriptionComponent.for(event).extend(FeedLinks)
+    end
   end
 end

--- a/app/components/admin/event_description_component.rb
+++ b/app/components/admin/event_description_component.rb
@@ -1,0 +1,14 @@
+module Admin
+  # Admin variant of EventDescriptionComponent: identical rendering, but feed
+  # references point at the operator-facing feed page. The per-type subclasses
+  # mirror the user-facing ones so refresh counts and reason copy still render.
+  class EventDescriptionComponent < ::EventDescriptionComponent
+    include FeedLinks
+
+    SUBCLASSES = {
+      "feed_refresh" => "Admin::FeedRefreshDescriptionComponent",
+      "feed_auto_disabled" => "Admin::FeedAutoDisabledDescriptionComponent",
+      "feed_target_group_unavailable" => "Admin::FeedTargetGroupUnavailableDescriptionComponent"
+    }.freeze
+  end
+end

--- a/app/components/admin/events_list_component.rb
+++ b/app/components/admin/events_list_component.rb
@@ -1,0 +1,11 @@
+module Admin
+  # Admin variant of EventsListComponent: links each event to the
+  # operator-facing event page instead of the user-facing one.
+  class EventsListComponent < ::EventsListComponent
+    private
+
+    def event_href(event)
+      helpers.admin_event_path(event)
+    end
+  end
+end

--- a/app/components/admin/feed_auto_disabled_description_component.rb
+++ b/app/components/admin/feed_auto_disabled_description_component.rb
@@ -1,5 +1,0 @@
-module Admin
-  class FeedAutoDisabledDescriptionComponent < ::FeedAutoDisabledDescriptionComponent
-    include FeedLinks
-  end
-end

--- a/app/components/admin/feed_auto_disabled_description_component.rb
+++ b/app/components/admin/feed_auto_disabled_description_component.rb
@@ -1,0 +1,5 @@
+module Admin
+  class FeedAutoDisabledDescriptionComponent < ::FeedAutoDisabledDescriptionComponent
+    include FeedLinks
+  end
+end

--- a/app/components/admin/feed_links.rb
+++ b/app/components/admin/feed_links.rb
@@ -1,0 +1,12 @@
+module Admin
+  # Points an event description's feed links at the operator-facing feed page,
+  # so admins can follow them to any user's feed. Mixed into the admin event
+  # description components.
+  module FeedLinks
+    private
+
+    def feed_link_path(feed)
+      helpers.admin_feed_path(feed)
+    end
+  end
+end

--- a/app/components/admin/feed_refresh_description_component.rb
+++ b/app/components/admin/feed_refresh_description_component.rb
@@ -1,0 +1,5 @@
+module Admin
+  class FeedRefreshDescriptionComponent < ::FeedRefreshDescriptionComponent
+    include FeedLinks
+  end
+end

--- a/app/components/admin/feed_refresh_description_component.rb
+++ b/app/components/admin/feed_refresh_description_component.rb
@@ -1,5 +1,0 @@
-module Admin
-  class FeedRefreshDescriptionComponent < ::FeedRefreshDescriptionComponent
-    include FeedLinks
-  end
-end

--- a/app/components/admin/feed_target_group_unavailable_description_component.rb
+++ b/app/components/admin/feed_target_group_unavailable_description_component.rb
@@ -1,0 +1,5 @@
+module Admin
+  class FeedTargetGroupUnavailableDescriptionComponent < ::FeedTargetGroupUnavailableDescriptionComponent
+    include FeedLinks
+  end
+end

--- a/app/components/admin/feed_target_group_unavailable_description_component.rb
+++ b/app/components/admin/feed_target_group_unavailable_description_component.rb
@@ -1,5 +1,0 @@
-module Admin
-  class FeedTargetGroupUnavailableDescriptionComponent < ::FeedTargetGroupUnavailableDescriptionComponent
-    include FeedLinks
-  end
-end

--- a/app/components/event_card_component.html.erb
+++ b/app/components/event_card_component.html.erb
@@ -6,7 +6,7 @@
     </div>
     <%= timestamp_link %>
   </div>
-  <% if extended? %>
+  <% if show_footer? %>
     <div class="truncate border-t <%= divider_border %> px-5 py-2 text-sm text-slate-400" data-key="events.footer">
       <%= safe_join(footer_items, helpers.middot) %>
     </div>

--- a/app/components/event_card_component.html.erb
+++ b/app/components/event_card_component.html.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center gap-3 px-5 py-4">
     <%= severity %>
     <div class="min-w-0 flex-1 truncate text-slate-700" data-key="events.description">
-      <%= render EventDescriptionComponent.for(event) %>
+      <%= render EventDescriptionComponent.for(event, admin: extended?) %>
     </div>
     <%= timestamp_link %>
   </div>

--- a/app/components/event_card_component.html.erb
+++ b/app/components/event_card_component.html.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center gap-3 px-5 py-4">
     <%= severity %>
     <div class="min-w-0 flex-1 truncate text-slate-700" data-key="events.description">
-      <%= render EventDescriptionComponent.for(event, admin: extended?) %>
+      <%= render description %>
     </div>
     <%= timestamp_link %>
   </div>

--- a/app/components/event_card_component.rb
+++ b/app/components/event_card_component.rb
@@ -72,10 +72,12 @@ class EventCardComponent < ViewComponent::Base
   end
 
   def type_link
-    helpers.link_to(event.type,
-                    helpers.admin_events_path(filter: { type: [event.type] }),
-                    class: "font-mono transition hover:text-slate-700",
-                    data: { key: "events.type" })
+    link = helpers.link_to(event.type,
+                           helpers.admin_events_path(filter: { type: [event.type] }),
+                           class: "transition hover:text-slate-700",
+                           data: { key: "events.type" })
+
+    safe_join(["Type: ", link])
   end
 
   # Admins see who an event belongs to; the user links to a filtered log.

--- a/app/components/event_card_component.rb
+++ b/app/components/event_card_component.rb
@@ -13,30 +13,29 @@ class EventCardComponent < ViewComponent::Base
 
   DEFAULT_TINT = { border: "border-slate-200", background: "bg-white hover:bg-slate-50" }.freeze
 
-  # `:simplified` shows just the severity, description and timestamp (status and
-  # feed pages). `:extended` adds a footer with the event type, user and target
-  # for the admin log.
-  def initialize(event:, href:, mode: :simplified)
+  # Shows the severity, description and timestamp. Admin::EventCardComponent
+  # adds a footer with the event type, user and target for the operator log.
+  def initialize(event:, href:)
     @event = event
     @href = href
-    @mode = mode
   end
 
   private
 
-  attr_reader :event, :href, :mode
+  attr_reader :event, :href
 
-  def extended?
-    mode == :extended
-  end
-
-  # The admin log (extended mode) links feeds to the operator-facing feed page.
   def description
     description_component_class.for(event)
   end
 
   def description_component_class
-    extended? ? Admin::EventDescriptionComponent : EventDescriptionComponent
+    EventDescriptionComponent
+  end
+
+  # Whether to render the footer (type/user/target). Admin::EventCardComponent
+  # enables it for the operator log.
+  def show_footer?
+    false
   end
 
   def card_classes
@@ -51,19 +50,9 @@ class EventCardComponent < ViewComponent::Base
     LEVEL_TINTS.fetch(event.level, DEFAULT_TINT)
   end
 
-  # In the admin log the severity icon doubles as a drill-down: clicking it
-  # narrows the log to events of the same level. Elsewhere it is a plain marker.
+  # A plain marker by default. Admin::EventCardComponent turns it into a
+  # drill-down link that narrows the log to events of the same level.
   def severity
-    return severity_marker unless extended?
-
-    helpers.link_to(severity_icon,
-                    helpers.admin_events_path(filter: { level: event.level }),
-                    class: "flex w-4 shrink-0 items-center justify-center",
-                    title: "Show #{event.level} events",
-                    data: { key: "events.severity" })
-  end
-
-  def severity_marker
     helpers.content_tag(:span, severity_icon,
                         class: "flex w-4 shrink-0 items-center justify-center",
                         data: { key: "events.severity" })

--- a/app/components/event_card_component.rb
+++ b/app/components/event_card_component.rb
@@ -30,6 +30,15 @@ class EventCardComponent < ViewComponent::Base
     mode == :extended
   end
 
+  # The admin log (extended mode) links feeds to the operator-facing feed page.
+  def description
+    description_component_class.for(event)
+  end
+
+  def description_component_class
+    extended? ? Admin::EventDescriptionComponent : EventDescriptionComponent
+  end
+
   def card_classes
     helpers.class_names("w-full rounded-lg border shadow-xs transition duration-75", tint[:border], tint[:hover_border], tint[:background])
   end

--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -16,7 +16,7 @@ class EventDescriptionComponent < ViewComponent::Base
   }.freeze
 
   def self.for(event)
-    klass = self::SUBCLASSES[event.type]&.constantize || self
+    klass = SUBCLASSES[event.type]&.constantize || self
     klass.new(event: event)
   end
 

--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -15,13 +15,14 @@ class EventDescriptionComponent < ViewComponent::Base
     "feed_target_group_unavailable" => "FeedTargetGroupUnavailableDescriptionComponent"
   }.freeze
 
-  def self.for(event)
+  def self.for(event, admin: false)
     klass = SUBCLASSES[event.type]&.constantize || self
-    klass.new(event: event)
+    klass.new(event: event, admin: admin)
   end
 
-  def initialize(event:)
+  def initialize(event:, admin: false)
     @event = event
+    @admin = admin
   end
 
   def call
@@ -58,7 +59,7 @@ class EventDescriptionComponent < ViewComponent::Base
   def subject_link
     case event.subject
     when Feed
-      helpers.link_to(event.subject.display_name, helpers.feed_path(event.subject), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
+      helpers.link_to(event.subject.display_name, feed_link_path(event.subject), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     when AccessToken
       helpers.link_to(event.subject.name, helpers.access_tokens_path, class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     when Post
@@ -68,6 +69,12 @@ class EventDescriptionComponent < ViewComponent::Base
     else
       ""
     end
+  end
+
+  # Admin event pages link feeds to the operator-facing feed page so admins can
+  # inspect any user's feed; user-facing pages stay on the owner route.
+  def feed_link_path(feed)
+    @admin ? helpers.admin_feed_path(feed) : helpers.feed_path(feed)
   end
 
   def escaped_message
@@ -87,7 +94,7 @@ class EventDescriptionComponent < ViewComponent::Base
     return "" if disabled_feed_ids.blank?
 
     links = disabled_feeds.map do |feed|
-      helpers.link_to(feed.display_name, helpers.feed_path(feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
+      helpers.link_to(feed.display_name, feed_link_path(feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500")
     end
 
     linked_feeds = helpers.safe_join(links, ", ")

--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -15,14 +15,13 @@ class EventDescriptionComponent < ViewComponent::Base
     "feed_target_group_unavailable" => "FeedTargetGroupUnavailableDescriptionComponent"
   }.freeze
 
-  def self.for(event, admin: false)
-    klass = SUBCLASSES[event.type]&.constantize || self
-    klass.new(event: event, admin: admin)
+  def self.for(event)
+    klass = self::SUBCLASSES[event.type]&.constantize || self
+    klass.new(event: event)
   end
 
-  def initialize(event:, admin: false)
+  def initialize(event:)
     @event = event
-    @admin = admin
   end
 
   def call
@@ -71,10 +70,10 @@ class EventDescriptionComponent < ViewComponent::Base
     end
   end
 
-  # Admin event pages link feeds to the operator-facing feed page so admins can
-  # inspect any user's feed; user-facing pages stay on the owner route.
+  # Feeds link to the owner-facing page. Admin::EventDescriptionComponent
+  # overrides this to point at the operator-facing feed page instead.
   def feed_link_path(feed)
-    @admin ? helpers.admin_feed_path(feed) : helpers.feed_path(feed)
+    helpers.feed_path(feed)
   end
 
   def escaped_message

--- a/app/components/events_list_component.rb
+++ b/app/components/events_list_component.rb
@@ -6,12 +6,11 @@ class EventsListComponent < ViewComponent::Base
 
   # `endpoint` enables polling (first page only). `older_url`/`newer_url` enable
   # cursor pagination links; omit them for an unpaginated list (the status page).
-  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil, admin: false)
+  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil)
     @events = events
     @endpoint = endpoint
     @older_url = older_url
     @newer_url = newer_url
-    @admin = admin
   end
 
   def call
@@ -30,8 +29,10 @@ class EventsListComponent < ViewComponent::Base
     end
   end
 
+  # Events link to the user-facing event page. Admin::EventsListComponent
+  # overrides this to point at the operator-facing event page.
   def event_href(event)
-    @admin ? helpers.admin_event_path(event) : helpers.event_path(event)
+    helpers.event_path(event)
   end
 
   def pagination_nav

--- a/app/components/events_list_component.rb
+++ b/app/components/events_list_component.rb
@@ -6,11 +6,12 @@ class EventsListComponent < ViewComponent::Base
 
   # `endpoint` enables polling (first page only). `older_url`/`newer_url` enable
   # cursor pagination links; omit them for an unpaginated list (the status page).
-  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil)
+  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil, admin: false)
     @events = events
     @endpoint = endpoint
     @older_url = older_url
     @newer_url = newer_url
+    @admin = admin
   end
 
   def call
@@ -25,8 +26,12 @@ class EventsListComponent < ViewComponent::Base
     return render(EmptyStateComponent.new("No events to show yet")) unless @events.any?
 
     content_tag(:div, class: "space-y-2", data: { key: "events.list" }) do
-      safe_join(@events.map { |event| render(EventCardComponent.new(event: event, href: helpers.event_path(event))) })
+      safe_join(@events.map { |event| render(EventCardComponent.new(event: event, href: event_href(event))) })
     end
+  end
+
+  def event_href(event)
+    @admin ? helpers.admin_event_path(event) : helpers.event_path(event)
   end
 
   def pagination_nav

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -4,12 +4,7 @@
       <%= status_icon %>
     </span>
     <div class="flex min-w-0 flex-1 items-center gap-2">
-      <% if interactive %>
-        <%= link_to title, post_url,
-              class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
-      <% else %>
-        <span class="truncate text-base text-slate-900"><%= title %></span>
-      <% end %>
+      <%= title_element %>
       <% if withdrawn? %>
         <%= render BadgeComponent.new(text: "Withdrawn", color: :gray) %>
       <% end %>
@@ -48,7 +43,7 @@
       <% end %>
     </div>
 
-    <% if interactive %>
+    <% if show_actions? %>
     <div class="flex shrink-0 items-center gap-3">
       <div class="relative">
         <button type="button"
@@ -94,7 +89,7 @@
     <% end %>
   </div>
 
-  <% if interactive && delete_allowed? %>
+  <% if show_actions? && delete_allowed? %>
     <%= render PostDeleteModalComponent.new(post: post) %>
   <% end %>
 </div>

--- a/app/components/post_card_component.html.erb
+++ b/app/components/post_card_component.html.erb
@@ -4,8 +4,12 @@
       <%= status_icon %>
     </span>
     <div class="flex min-w-0 flex-1 items-center gap-2">
-      <%= link_to title, post_url,
-            class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
+      <% if interactive %>
+        <%= link_to title, post_url,
+              class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
+      <% else %>
+        <span class="truncate text-base text-slate-900"><%= title %></span>
+      <% end %>
       <% if withdrawn? %>
         <%= render BadgeComponent.new(text: "Withdrawn", color: :gray) %>
       <% end %>
@@ -44,6 +48,7 @@
       <% end %>
     </div>
 
+    <% if interactive %>
     <div class="flex shrink-0 items-center gap-3">
       <div class="relative">
         <button type="button"
@@ -86,9 +91,10 @@
         </div>
       </div>
     </div>
+    <% end %>
   </div>
 
-  <% if delete_allowed? %>
+  <% if interactive && delete_allowed? %>
     <%= render PostDeleteModalComponent.new(post: post) %>
   <% end %>
 </div>

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -8,21 +8,30 @@ class PostCardComponent < ViewComponent::Base
     "withdrawn" => { icon: "trash-2",      color: "text-slate-400",  label: "Withdrawn" }
   }.freeze
 
-  # `interactive: false` renders a read-only card without the title/Details
-  # links or the actions menu. Admin pages reuse this for feeds they don't own,
-  # where the owner-scoped post routes would 404.
-  def initialize(post:, show_feed: false, interactive: true)
+  def initialize(post:, show_feed: false)
     @post = post
     @show_feed = show_feed
-    @interactive = interactive
   end
 
   private
 
-  attr_reader :post, :show_feed, :interactive
+  attr_reader :post, :show_feed
 
   def title
     helpers.post_content_preview(post.content, 160)
+  end
+
+  # The title links to the post page. ReadonlyPostCardComponent overrides this
+  # with plain text where those owner-scoped routes aren't reachable.
+  def title_element
+    helpers.link_to(title, post_url,
+                    class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white")
+  end
+
+  # Whether to render the actions menu (Details/Source/Delete). Disabled by
+  # ReadonlyPostCardComponent.
+  def show_actions?
+    true
   end
 
   def post_url

--- a/app/components/post_card_component.rb
+++ b/app/components/post_card_component.rb
@@ -8,14 +8,18 @@ class PostCardComponent < ViewComponent::Base
     "withdrawn" => { icon: "trash-2",      color: "text-slate-400",  label: "Withdrawn" }
   }.freeze
 
-  def initialize(post:, show_feed: false)
+  # `interactive: false` renders a read-only card without the title/Details
+  # links or the actions menu. Admin pages reuse this for feeds they don't own,
+  # where the owner-scoped post routes would 404.
+  def initialize(post:, show_feed: false, interactive: true)
     @post = post
     @show_feed = show_feed
+    @interactive = interactive
   end
 
   private
 
-  attr_reader :post, :show_feed
+  attr_reader :post, :show_feed, :interactive
 
   def title
     helpers.post_content_preview(post.content, 160)

--- a/app/components/posts_list_component.rb
+++ b/app/components/posts_list_component.rb
@@ -1,13 +1,13 @@
 class PostsListComponent < ViewComponent::Base
-  def initialize(posts:, show_feed: false, interactive: true)
+  def initialize(posts:, show_feed: false, card_component: PostCardComponent)
     @posts = posts
     @show_feed = show_feed
-    @interactive = interactive
+    @card_component = card_component
   end
 
   def call
     content_tag(:div, class: "space-y-4") do
-      safe_join(@posts.map { |post| render(PostCardComponent.new(post: post, show_feed: @show_feed, interactive: @interactive)) })
+      safe_join(@posts.map { |post| render(@card_component.new(post: post, show_feed: @show_feed)) })
     end
   end
 end

--- a/app/components/posts_list_component.rb
+++ b/app/components/posts_list_component.rb
@@ -1,12 +1,13 @@
 class PostsListComponent < ViewComponent::Base
-  def initialize(posts:, show_feed: false)
+  def initialize(posts:, show_feed: false, interactive: true)
     @posts = posts
     @show_feed = show_feed
+    @interactive = interactive
   end
 
   def call
     content_tag(:div, class: "space-y-4") do
-      safe_join(@posts.map { |post| render(PostCardComponent.new(post: post, show_feed: @show_feed)) })
+      safe_join(@posts.map { |post| render(PostCardComponent.new(post: post, show_feed: @show_feed, interactive: @interactive)) })
     end
   end
 end

--- a/app/components/readonly_post_card_component.rb
+++ b/app/components/readonly_post_card_component.rb
@@ -1,0 +1,14 @@
+# A non-interactive PostCardComponent: renders the post as plain text with no
+# title link or actions menu. Used where the owner-scoped post routes aren't
+# reachable, such as the admin feed page showing another user's posts.
+class ReadonlyPostCardComponent < PostCardComponent
+  private
+
+  def title_element
+    helpers.content_tag(:span, title, class: "truncate text-base text-slate-900")
+  end
+
+  def show_actions?
+    false
+  end
+end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -25,7 +25,7 @@ class Admin::EventsController < ApplicationController
   private
 
   def entry_component(event)
-    EventCardComponent.new(event: event, href: admin_event_path(event), mode: :extended)
+    Admin::EventCardComponent.new(event: event, href: admin_event_path(event))
   end
 
   def events_log_path(**params)

--- a/app/controllers/admin/feeds_controller.rb
+++ b/app/controllers/admin/feeds_controller.rb
@@ -1,0 +1,40 @@
+class Admin::FeedsController < ApplicationController
+  include Pagination
+
+  MAX_RECENT_POSTS = 5
+  MAX_RECENT_EVENTS = 10
+
+  def index
+    authorize [:admin, Feed]
+    @feeds = paginate_scope
+  end
+
+  def show
+    @feed = Feed.find(params[:id])
+    authorize [:admin, @feed]
+    @recent_posts = recent_posts(@feed)
+    @recent_events = recent_events(@feed)
+    @has_llm_usages = @feed.llm_usages.exists?
+  end
+
+  private
+
+  def recent_posts(feed)
+    feed
+      .posts
+      .includes(:feed_entry)
+      .preload(feed: :access_token)
+      .order(published_at: :desc)
+      .limit(MAX_RECENT_POSTS)
+  end
+
+  def recent_events(feed)
+    feed.events.recent.limit(MAX_RECENT_EVENTS)
+  end
+
+  def pagination_scope
+    policy_scope([:admin, Feed])
+      .includes(:user, :access_token, :feed_entries, :posts)
+      .order(created_at: :desc)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -124,14 +124,6 @@ module ApplicationHelper
     end
   end
 
-  def highlight_json(json_hash)
-    json_string = JSON.pretty_generate(json_hash)
-    formatter = Rouge::Formatters::HTML.new(wrap: false)
-    lexer = Rouge::Lexers::JSON.new
-    highlighted_code = formatter.format(lexer.lex(json_string))
-    content_tag(:div, highlighted_code.html_safe, class: "highlight")
-  end
-
   def navbar_items
     return [] unless Current.user
 

--- a/app/policies/admin/feed_policy.rb
+++ b/app/policies/admin/feed_policy.rb
@@ -1,0 +1,20 @@
+module Admin
+  # Authorizes the admin-only feed views, where operators inspect any user's
+  # feed. Kept separate from the owner-scoped FeedPolicy so admin access never
+  # leaks into the user-facing feed pages.
+  class FeedPolicy < ApplicationPolicy
+    def index?
+      admin?
+    end
+
+    def show?
+      admin?
+    end
+
+    class Scope < ApplicationPolicy::Scope
+      def resolve
+        admin? ? scope.all : scope.none
+      end
+    end
+  end
+end

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -40,7 +40,7 @@
   )) do |log| %>
     <% @events.each do |event| %>
       <% log.with_entry do %>
-        <%= render EventCardComponent.new(event: event, href: admin_event_path(event), mode: :extended) %>
+        <%= render Admin::EventCardComponent.new(event: event, href: admin_event_path(event)) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 
   <%= render AlertComponent.new(variant: @event.alert_variant) do %>
-    <%= render EventDescriptionComponent.for(@event) %>
+    <%= render EventDescriptionComponent.for(@event, admin: true) %>
   <% end %>
 
   <%= render EventDetailsComponent.for(@event, admin: true) %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -36,10 +36,17 @@
     </section>
   <% end %>
 
-  <% if @event.metadata.present? && @event.metadata != {} %>
-    <section class="space-y-4">
-      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Metadata</h2>
-      <pre class="overflow-auto rounded-lg border border-slate-200 bg-slate-50 p-4 font-mono text-sm"><%= highlight_json(@event.metadata) %></pre>
+  <% if (stats = @event.metadata&.fetch("stats", nil)).present? %>
+    <section class="space-y-4" data-key="events.stats">
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900"><%= t("events.metadata.stats.section_title") %></h2>
+      <%= render ListComponent.new do |list| %>
+        <% stats.each do |key, value| %>
+          <% list.with_item(ListComponent::StatItemComponent.new(
+            label: t("events.metadata.stats.#{key}", default: key.humanize),
+            value: format_stat_value(key, value)
+          )) %>
+        <% end %>
+      <% end %>
     </section>
   <% end %>
 </div>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 
   <%= render AlertComponent.new(variant: @event.alert_variant) do %>
-    <%= render EventDescriptionComponent.for(@event, admin: true) %>
+    <%= render Admin::EventDescriptionComponent.for(@event) %>
   <% end %>
 
   <%= render EventDetailsComponent.for(@event, admin: true) %>

--- a/app/views/admin/feeds/_header.html.erb
+++ b/app/views/admin/feeds/_header.html.erb
@@ -1,0 +1,22 @@
+<%# locals: (feed:) %>
+<%= render PageHeaderComponent.new(title: feed.display_name) do |header| %>
+  <% header.with_breadcrumb(label: "Feeds", url: admin_feeds_path) %>
+  <% header.with_context_paragraph do %>
+    <%= render feed_status_badge(feed) %>
+  <% end %>
+  <% if feed.user %>
+    <% header.with_context_paragraph do %>
+      Owner:
+      <%= link_to feed.user.email_address, admin_user_path(feed.user), class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
+    <% end %>
+  <% end %>
+  <% if feed.target_group_url.present? %>
+    <% header.with_context_paragraph do %>
+      Target group:
+      <%= link_to "#{feed.access_token.host_domain}/#{feed.target_group}",
+                  feed.target_group_url,
+                  class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
+                  target: "_blank", rel: "noopener" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin/feeds/index.html.erb
+++ b/app/views/admin/feeds/index.html.erb
@@ -1,0 +1,58 @@
+<% content_for :title, "Feeds" %>
+
+<div class="space-y-8">
+  <%= render PageHeaderComponent.new(title: "Feeds") do |header| %>
+    <% header.with_breadcrumb(label: "Admin Panel", url: admin_path) %>
+  <% end %>
+
+  <% if @feeds.any? %>
+    <div class="overflow-x-auto rounded-lg border border-slate-200">
+      <table class="w-full text-left text-sm text-slate-700">
+        <thead class="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600">
+          <tr class="hover:bg-slate-50">
+            <th scope="col" class="px-6 py-3">Feed</th>
+            <th scope="col" class="px-6 py-3">Owner</th>
+            <th scope="col" class="px-6 py-3">Status</th>
+            <th scope="col" class="px-6 py-3 text-center">Last Refresh</th>
+            <th scope="col" class="px-6 py-3 text-center">Recent Post</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-200 bg-white">
+          <% @feeds.each do |feed| %>
+            <tr class="hover:bg-slate-50">
+              <td class="px-6 py-4">
+                <%= link_to feed.display_name, admin_feed_path(feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <% if feed.user %>
+                  <%= link_to feed.user.email_address, admin_user_path(feed.user), class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
+                <% else %>
+                  <span class="text-slate-500">—</span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap"><%= render feed_status_badge(feed) %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-center">
+                <% if feed.last_refreshed_at %>
+                  <%= short_time_ago_tag(feed.last_refreshed_at) %>
+                <% else %>
+                  <span class="text-slate-500">Never</span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-center">
+                <% if feed.most_recent_post_date %>
+                  <%= short_time_ago_tag(feed.most_recent_post_date) %>
+                <% else %>
+                  <span class="text-slate-500">None</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <%= render_pagination { |pagination| admin_feeds_path(pagination) } %>
+  <% else %>
+    <%= render EmptyStateComponent.new("No feeds found") %>
+  <% end %>
+</div>

--- a/app/views/admin/feeds/show.html.erb
+++ b/app/views/admin/feeds/show.html.erb
@@ -1,0 +1,60 @@
+<% content_for :title, @feed.display_name %>
+
+<div class="space-y-10">
+  <%= render PageHeaderComponent.new(title: @feed.display_name) do |header| %>
+    <% header.with_breadcrumb(label: "Feeds", url: admin_feeds_path) %>
+    <% header.with_context_paragraph do %>
+      <%= render feed_status_badge(@feed) %>
+    <% end %>
+    <% if @feed.user %>
+      <% header.with_context_paragraph do %>
+        Owner:
+        <%= link_to @feed.user.email_address, admin_user_path(@feed.user), class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
+      <% end %>
+    <% end %>
+    <% if @feed.target_group_url.present? %>
+      <% header.with_context_paragraph do %>
+        Target group:
+        <%= link_to "#{@feed.access_token.host_domain}/#{@feed.target_group}",
+                    @feed.target_group_url,
+                    class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
+                    target: "_blank", rel: "noopener" %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if @recent_posts.any? %>
+    <section class="space-y-4">
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">Stats</h2>
+      <%= render FeedStatsComponent.new(feed: @feed) %>
+      <%= render PostsHeatmapComponent.new(feed: @feed) %>
+    </section>
+  <% end %>
+
+  <% if @has_llm_usages %>
+    <section class="space-y-4">
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900">AI Usage</h2>
+      <%= render FeedLlmStatsComponent.new(feed: @feed) %>
+    </section>
+  <% end %>
+
+  <section class="space-y-4">
+    <div class="flex items-center justify-between">
+      <h2 class="text-2xl font-semibold text-slate-900">Recent Activity</h2>
+      <% if @recent_events.any? %>
+        <%= link_to "View all", admin_events_path(filter: { subject_type: "Feed", subject_id: @feed.id }), class: "text-sm font-semibold text-sky-600 hover:text-sky-500", data: { key: "feed.events.view_all" } %>
+      <% end %>
+    </div>
+    <%= render EventsListComponent.new(events: @recent_events, admin: true) %>
+  </section>
+
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold mb-0 text-slate-900">Recent Posts</h2>
+
+    <% if @recent_posts.any? %>
+      <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false) %>
+    <% else %>
+      <%= render EmptyStateComponent.new("No posts imported yet from this feed") %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/feeds/show.html.erb
+++ b/app/views/admin/feeds/show.html.erb
@@ -32,7 +32,7 @@
     <h2 class="text-2xl font-semibold mb-0 text-slate-900">Recent Posts</h2>
 
     <% if @recent_posts.any? %>
-      <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false, interactive: false) %>
+      <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false, card_component: ReadonlyPostCardComponent) %>
     <% else %>
       <%= render EmptyStateComponent.new("No posts imported yet from this feed") %>
     <% end %>

--- a/app/views/admin/feeds/show.html.erb
+++ b/app/views/admin/feeds/show.html.erb
@@ -1,27 +1,7 @@
 <% content_for :title, @feed.display_name %>
 
 <div class="space-y-10">
-  <%= render PageHeaderComponent.new(title: @feed.display_name) do |header| %>
-    <% header.with_breadcrumb(label: "Feeds", url: admin_feeds_path) %>
-    <% header.with_context_paragraph do %>
-      <%= render feed_status_badge(@feed) %>
-    <% end %>
-    <% if @feed.user %>
-      <% header.with_context_paragraph do %>
-        Owner:
-        <%= link_to @feed.user.email_address, admin_user_path(@feed.user), class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
-      <% end %>
-    <% end %>
-    <% if @feed.target_group_url.present? %>
-      <% header.with_context_paragraph do %>
-        Target group:
-        <%= link_to "#{@feed.access_token.host_domain}/#{@feed.target_group}",
-                    @feed.target_group_url,
-                    class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500",
-                    target: "_blank", rel: "noopener" %>
-      <% end %>
-    <% end %>
-  <% end %>
+  <%= render "header", feed: @feed %>
 
   <% if @recent_posts.any? %>
     <section class="space-y-4">

--- a/app/views/admin/feeds/show.html.erb
+++ b/app/views/admin/feeds/show.html.erb
@@ -25,7 +25,7 @@
         <%= link_to "View all", admin_events_path(filter: { subject_type: "Feed", subject_id: @feed.id }), class: "text-sm font-semibold text-sky-600 hover:text-sky-500", data: { key: "feed.events.view_all" } %>
       <% end %>
     </div>
-    <%= render EventsListComponent.new(events: @recent_events, admin: true) %>
+    <%= render Admin::EventsListComponent.new(events: @recent_events) %>
   </section>
 
   <section class="space-y-4">

--- a/app/views/admin/feeds/show.html.erb
+++ b/app/views/admin/feeds/show.html.erb
@@ -52,7 +52,7 @@
     <h2 class="text-2xl font-semibold mb-0 text-slate-900">Recent Posts</h2>
 
     <% if @recent_posts.any? %>
-      <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false) %>
+      <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false, interactive: false) %>
     <% else %>
       <%= render EmptyStateComponent.new("No posts imported yet from this feed") %>
     <% end %>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -23,5 +23,15 @@
         <p class="text-slate-600">View system events, logs, and activity</p>
       </div>
     <% end %>
+
+    <%= render CardComponent.new(href: admin_feeds_path) do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("layers", css_class: "size-5") %>
+          <span>Feeds</span>
+        </h2>
+        <p class="text-slate-600">Browse feeds across every account</p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -37,7 +37,8 @@
   <% end %>
 
   <% if (stats = @event.metadata&.fetch("stats", nil)).present? %>
-    <%= render CollapsibleSectionComponent.new(title: t("events.metadata.stats.section_title")) do %>
+    <section class="space-y-4" data-key="events.stats">
+      <h2 class="text-2xl font-semibold mb-3 text-slate-900"><%= t("events.metadata.stats.section_title") %></h2>
       <%= render ListComponent.new do |list| %>
         <% stats.each do |key, value| %>
           <% list.with_item(ListComponent::StatItemComponent.new(
@@ -46,6 +47,6 @@
           )) %>
         <% end %>
       <% end %>
-    <% end %>
+    </section>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
     end
 
     resources :events, only: [:index, :show]
+    resources :feeds, only: [:index, :show]
   end
 
   resource :settings, only: :show

--- a/test/components/event_card_component_test.rb
+++ b/test/components/event_card_component_test.rb
@@ -5,9 +5,9 @@ class EventCardComponentTest < ViewComponent::TestCase
     @user ||= create(:user)
   end
 
-  def render_card(event, mode: :simplified, href: nil)
+  def render_card(event, href: nil)
     href ||= "/events/#{event.id}"
-    render_inline(EventCardComponent.new(event: event, href: href, mode: mode))
+    render_inline(EventCardComponent.new(event: event, href: href))
   end
 
   # --- Shared presentation (both modes) ---
@@ -140,7 +140,7 @@ class EventCardComponentTest < ViewComponent::TestCase
   # --- Extended (admin) mode ---
 
   def render_admin_card(event)
-    render_card(event, mode: :extended, href: "/admin/events/#{event.id}")
+    render_inline(Admin::EventCardComponent.new(event: event, href: "/admin/events/#{event.id}"))
   end
 
   test "#call should render a footer with type, user and target in extended mode" do

--- a/test/components/event_card_component_test.rb
+++ b/test/components/event_card_component_test.rb
@@ -187,6 +187,7 @@ class EventCardComponentTest < ViewComponent::TestCase
     link = result.css("a[data-key='events.type']").first
     assert_equal "custom_event", link.text
     assert_includes link["href"], "filter%5Btype%5D%5B%5D=custom_event"
+    assert_includes result.css("[data-key='events.footer']").text, "Type: custom_event"
   end
 
   test "#call should link the user to the admin filter and reveal the email on hover" do

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -31,10 +31,10 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     assert_includes result.to_html, "refreshed"
   end
 
-  test ".for should pick the admin feed refresh subclass in admin mode" do
+  test ".for should preserve the type-specific subclass in admin mode" do
     event = Event.create!(type: "feed_refresh", level: :info, subject: feed, user: user, message: "", metadata: {})
 
-    assert_instance_of Admin::FeedRefreshDescriptionComponent, Admin::EventDescriptionComponent.for(event)
+    assert_kind_of FeedRefreshDescriptionComponent, Admin::EventDescriptionComponent.for(event)
   end
 
   test "#call should link the feed to the admin path in admin mode" do

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -31,6 +31,12 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     assert_includes result.to_html, "refreshed"
   end
 
+  test ".for should pick the admin feed refresh subclass in admin mode" do
+    event = Event.create!(type: "feed_refresh", level: :info, subject: feed, user: user, message: "", metadata: {})
+
+    assert_instance_of Admin::FeedRefreshDescriptionComponent, Admin::EventDescriptionComponent.for(event)
+  end
+
   test "#call should link the feed to the admin path in admin mode" do
     event = Event.create!(
       type: "feed_refresh",
@@ -41,7 +47,7 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
       metadata: {}
     )
 
-    result = render_inline(EventDescriptionComponent.for(event, admin: true))
+    result = render_inline(Admin::EventDescriptionComponent.for(event))
 
     assert_includes result.to_html, "/admin/feeds/#{feed.id}"
     assert_not_includes result.css("a").map { |a| a["href"] }, "/feeds/#{feed.id}"

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -31,6 +31,22 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     assert_includes result.to_html, "refreshed"
   end
 
+  test "#call should link the feed to the admin path in admin mode" do
+    event = Event.create!(
+      type: "feed_refresh",
+      level: :info,
+      subject: feed,
+      user: user,
+      message: "",
+      metadata: {}
+    )
+
+    result = render_inline(EventDescriptionComponent.for(event, admin: true))
+
+    assert_includes result.to_html, "/admin/feeds/#{feed.id}"
+    assert_not_includes result.css("a").map { |a| a["href"] }, "/feeds/#{feed.id}"
+  end
+
   test ".for should pick the feed refresh subclass for refresh events" do
     event = Event.create!(type: "feed_refresh", level: :info, subject: feed, user: user, message: "", metadata: {})
 

--- a/test/components/events_list_component_test.rb
+++ b/test/components/events_list_component_test.rb
@@ -15,6 +15,22 @@ class EventsListComponentTest < ViewComponent::TestCase
     assert_not_nil result.css("[data-key='events.list'] > [data-event-id='#{event2.id}']").first
   end
 
+  test "#call should link events to the user-facing event page" do
+    event = create(:event, user: user)
+
+    result = render_inline(EventsListComponent.new(events: [event]))
+
+    assert_not_nil result.at_css("a[href='#{Rails.application.routes.url_helpers.event_path(event)}']")
+  end
+
+  test "Admin variant should link events to the admin event page" do
+    event = create(:event, user: user)
+
+    result = render_inline(Admin::EventsListComponent.new(events: [event]))
+
+    assert_not_nil result.at_css("a[href='#{Rails.application.routes.url_helpers.admin_event_path(event)}']")
+  end
+
   test "#call should wire up the polling controller when endpoint is given" do
     event = create(:event, user: user)
 

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -28,6 +28,14 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_includes link.text, "Flag Design"
   end
 
+  test "#render should omit links and the actions menu when not interactive" do
+    result = render_inline PostCardComponent.new(post: post, interactive: false)
+
+    assert_nil result.at_css("a[href*='/posts/']")
+    assert_includes result.text, "Flag Design"
+    assert_nil result.at_css("[id^='post-menu-']")
+  end
+
   test "#render should show the group as a labeled item linking to the feed when show_feed is true" do
     result = render_inline PostCardComponent.new(post: post, show_feed: true)
 

--- a/test/components/post_card_component_test.rb
+++ b/test/components/post_card_component_test.rb
@@ -28,8 +28,8 @@ class PostCardComponentTest < ViewComponent::TestCase
     assert_includes link.text, "Flag Design"
   end
 
-  test "#render should omit links and the actions menu when not interactive" do
-    result = render_inline PostCardComponent.new(post: post, interactive: false)
+  test "ReadonlyPostCardComponent should omit links and the actions menu" do
+    result = render_inline ReadonlyPostCardComponent.new(post: post)
 
     assert_nil result.at_css("a[href*='/posts/']")
     assert_includes result.text, "Flag Design"

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -89,6 +89,17 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
 
+  test "should display stats from event metadata" do
+    login_as(admin_user)
+    event = create(:event, metadata: { "stats" => { "new_posts" => 3 } }, user: create(:user))
+
+    get admin_event_path(event)
+
+    assert_response :success
+    assert_select "[data-key='events.stats']"
+    assert_select "h2", "Stats"
+  end
+
   test "should render the most recent page of events" do
     with_page_size(2) do
       login_as(admin_user)

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -89,6 +89,17 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
 
+  test "should link the event's feed to the admin feed page" do
+    login_as(admin_user)
+    feed = create(:feed)
+    event = create(:event, type: "feed_refresh", subject: feed, user: feed.user)
+
+    get admin_event_path(event)
+
+    assert_response :success
+    assert_select "a[href=?]", admin_feed_path(feed)
+  end
+
   test "should display stats from event metadata" do
     login_as(admin_user)
     event = create(:event, metadata: { "stats" => { "new_posts" => 3 } }, user: create(:user))

--- a/test/controllers/admin/feeds_controller_test.rb
+++ b/test/controllers/admin/feeds_controller_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
+  def admin_user
+    @admin_user ||= begin
+      user = create(:user)
+      create(:permission, user: user, name: "admin")
+      user
+    end
+  end
+
+  def regular_user
+    @regular_user ||= create(:user)
+  end
+
+  test "should redirect non-admin users from index" do
+    login_as(regular_user)
+
+    get admin_feeds_path
+
+    assert_redirected_to root_path
+    assert_equal "Access denied. You don't have permission to perform this action.", flash[:alert]
+  end
+
+  test "should redirect unauthenticated users from index" do
+    get admin_feeds_path
+
+    assert_redirected_to new_session_path
+  end
+
+  test "should list feeds from every user for admins" do
+    login_as(admin_user)
+    feed = create(:feed, user: create(:user))
+
+    get admin_feeds_path
+
+    assert_response :success
+    assert_select "h1", "Feeds"
+    assert_select "a[href=?]", admin_feed_path(feed), text: feed.display_name
+  end
+
+  test "should let admins view another user's feed" do
+    login_as(admin_user)
+    feed = create(:feed, user: create(:user))
+
+    get admin_feed_path(feed)
+
+    assert_response :success
+    assert_select "h1", feed.display_name
+  end
+
+  test "should redirect non-admin users from show" do
+    login_as(regular_user)
+    feed = create(:feed, user: create(:user))
+
+    get admin_feed_path(feed)
+
+    assert_redirected_to root_path
+  end
+
+  def login_as(user)
+    post session_path, params: { email_address: user.email_address, password: "password123" }
+  end
+end

--- a/test/controllers/admin/feeds_controller_test.rb
+++ b/test/controllers/admin/feeds_controller_test.rb
@@ -49,6 +49,18 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", feed.display_name
   end
 
+  test "should show another user's feed posts without owner-only links" do
+    login_as(admin_user)
+    feed = create(:feed, user: create(:user))
+    post = create(:post, :published, feed: feed)
+
+    get admin_feed_path(feed)
+
+    assert_response :success
+    assert_select "##{ActionView::RecordIdentifier.dom_id(post)}"
+    assert_select "a[href=?]", post_path(post), count: 0
+  end
+
   test "should redirect non-admin users from show" do
     login_as(regular_user)
     feed = create(:feed, user: create(:user))

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -181,13 +181,6 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal expected, result
   end
 
-  test "#highlight_json wraps output in highlight div" do
-    json_hash = { "test" => "value" }
-    result = highlight_json(json_hash)
-
-    assert_includes result, "<div class=\"highlight\">"
-  end
-
   test "#navbar_items should return empty array when user is missing" do
     assert_equal [], navbar_items
   end


### PR DESCRIPTION
Changes:

- Show event stats the same way on the user and admin event pages, renaming the admin "Metadata" section to "Stats" and keeping it always expanded on both
- Label the event type in the admin log footer ("Type: …") and drop its monospaced styling
- Add an admin-only feeds resource (`/admin/feeds` index and `/admin/feed/:id` detail) so operators can browse and inspect any account's feeds, reachable from the admin panel
- Link feed references on admin event pages to the admin feed page instead of the owner-only route
- Add a read-only mode to the post card so the admin feed page can list another user's posts without rendering links that 404

Admin feed access lives in a dedicated `Admin::FeedPolicy`, kept separate from the owner-scoped feed pages so the two authorization paths never bleed into each other. The detail page reuses the user-facing feed layout in a read-only form.