### PR TITLE
Add images-only feed option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-20
 
+- New feed option to import only posts that include images.
 - Event pages now show stats in a clear, always-visible section.
 - Started keeping a changelog of user-facing changes.
 - New favicon featuring the Feeder mark.

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -214,6 +214,7 @@ class FeedsController < ApplicationController
       :import_after_enabled,
       :import_after_date,
       :import_after_time,
+      :images_only,
       # Only the known input-shape keys are accepted. Anything
       # else inside the params hash would otherwise persist into
       # `feeds.params` jsonb undetected. See the profile schemas.
@@ -233,7 +234,7 @@ class FeedsController < ApplicationController
   def update_feed_params
     always_permitted = %i[
       name description target_group access_token_id ai_credential_id schedule_interval
-      import_after_enabled import_after_date import_after_time
+      import_after_enabled import_after_date import_after_time images_only
     ]
     draft_only_permitted = [:url, :feed_profile_key, { params: %i[url query] }]
 

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -8,6 +8,7 @@ class FeedRefreshWorkflow
   step :filter_new_entries
   step :persist_entries
   step :normalize_entries
+  step :reject_posts_without_images
   step :persist_posts
   step :enqueue_publication
   step :finalize_workflow
@@ -125,6 +126,19 @@ class FeedRefreshWorkflow
       feed_entry.update!(status: :processed)
       post
     end
+  end
+
+  # When the feed opts into images-only importing, drop normalized posts that
+  # carry no attachments before they reach persistence, so image-less posts
+  # never publish. Their feed entries and UIDs are already recorded by this
+  # point, so unlike the date threshold this won't re-import them if the option
+  # is later turned off.
+  def reject_posts_without_images(posts)
+    return posts unless feed.images_only?
+
+    with_images, without_images = posts.partition { |post| post.attachment_urls.present? }
+    record_stats(posts_without_images: without_images.size) if without_images.any?
+    with_images
   end
 
   def persist_posts(posts)

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -8,7 +8,6 @@ class FeedRefreshWorkflow
   step :filter_new_entries
   step :persist_entries
   step :normalize_entries
-  step :reject_posts_without_images
   step :persist_posts
   step :enqueue_publication
   step :finalize_workflow
@@ -126,19 +125,6 @@ class FeedRefreshWorkflow
       feed_entry.update!(status: :processed)
       post
     end
-  end
-
-  # When the feed opts into images-only importing, drop normalized posts that
-  # carry no attachments before they reach persistence, so image-less posts
-  # never publish. Their feed entries and UIDs are already recorded by this
-  # point, so unlike the date threshold this won't re-import them if the option
-  # is later turned off.
-  def reject_posts_without_images(posts)
-    return posts unless feed.images_only?
-
-    with_images, without_images = posts.partition { |post| post.attachment_urls.present? }
-    record_stats(posts_without_images: without_images.size) if without_images.any?
-    with_images
   end
 
   def persist_posts(posts)

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -97,7 +97,15 @@ module Normalizer
     def validate_content
       errors = []
       errors << "no_content_or_images" if missing_content_and_images?
+      errors << "no_images" if require_images? && attachment_urls.empty? && content.present?
       errors
+    end
+
+    # Feeds can opt into importing only posts that carry images. Image-less
+    # entries are still saved as rejected posts (rather than dropped) so their
+    # uids stay recorded and they're skipped normally on later refreshes.
+    def require_images?
+      feed_entry.feed.images_only?
     end
 
     def normalize_published_at(published_at)

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -97,15 +97,20 @@ module Normalizer
     def validate_content
       errors = []
       errors << "no_content_or_images" if missing_content_and_images?
-      errors << "no_images" if require_images? && attachment_urls.empty? && content.present?
+      errors.concat(images_only_errors)
       errors
     end
 
     # Feeds can opt into importing only posts that carry images. Image-less
     # entries are still saved as rejected posts (rather than dropped) so their
     # uids stay recorded and they're skipped normally on later refreshes.
-    def require_images?
-      feed_entry.feed.images_only?
+    # Returned as a list so subclasses that build their own error set can
+    # concat it without duplicating the rule (e.g. LlmNormalizer).
+    def images_only_errors
+      return [] unless feed_entry.feed.images_only?
+      return [] unless attachment_urls.empty? && content.present?
+
+      ["no_images"]
     end
 
     def normalize_published_at(published_at)

--- a/app/services/normalizer/llm_normalizer.rb
+++ b/app/services/normalizer/llm_normalizer.rb
@@ -44,6 +44,7 @@ module Normalizer
       errors = []
       errors << "missing source_url" if normalize_source_url.blank?
       errors << "missing content" if normalize_content.blank?
+      errors.concat(images_only_errors)
       errors
     end
   end

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -157,7 +157,6 @@
       <div class="mt-6">
         <h3 class="text-base font-semibold text-slate-900 mb-4">Advanced options</h3>
 
-        <div class="space-y-6">
         <%= render PanelComponent.new(data: { controller: "field-toggle", key: "form.advanced-options" }) do %>
           <div class="flex items-start">
             <div class="flex h-6 items-center">
@@ -222,7 +221,7 @@
           </div>
         <% end %>
 
-        <%= render PanelComponent.new(data: { key: "form.images-only" }) do %>
+        <%= render PanelComponent.new(class: "mt-6", data: { key: "form.images-only" }) do %>
           <div class="flex items-start">
             <div class="flex h-6 items-center">
               <%= f.check_box :images_only, data: { key: "form.images-only-checkbox" } %>
@@ -233,7 +232,6 @@
             </div>
           </div>
         <% end %>
-        </div>
       </div>
 
       <div class="mt-6">

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -157,6 +157,7 @@
       <div class="mt-6">
         <h3 class="text-base font-semibold text-slate-900 mb-4">Advanced options</h3>
 
+        <div class="space-y-6">
         <%= render PanelComponent.new(data: { controller: "field-toggle", key: "form.advanced-options" }) do %>
           <div class="flex items-start">
             <div class="flex h-6 items-center">
@@ -220,6 +221,19 @@
             <p class="text-sm text-slate-500">Posts published before this moment will be skipped. We'll use the current date and time if you leave these blank. Time is UTC.</p>
           </div>
         <% end %>
+
+        <%= render PanelComponent.new(data: { key: "form.images-only" }) do %>
+          <div class="flex items-start">
+            <div class="flex h-6 items-center">
+              <%= f.check_box :images_only, data: { key: "form.images-only-checkbox" } %>
+            </div>
+            <div class="ml-3">
+              <%= f.label :images_only, "Only posts with images", class: "block font-semibold text-slate-800 mb-0" %>
+              <p class="text-sm text-slate-500">Skip posts that don't include any image attachments.</p>
+            </div>
+          </div>
+        <% end %>
+        </div>
       </div>
 
       <div class="mt-6">

--- a/db/migrate/20260620230000_add_images_only_to_feeds.rb
+++ b/db/migrate/20260620230000_add_images_only_to_feeds.rb
@@ -1,0 +1,5 @@
+class AddImagesOnlyToFeeds < ActiveRecord::Migration[8.2]
+  def change
+    add_column :feeds, :images_only, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_17_205938) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_20_230000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -171,6 +171,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_17_205938) do
     t.bigint "user_id", null: false
     t.bigint "ai_credential_id"
     t.integer "consecutive_failures", default: 0, null: false
+    t.boolean "images_only", default: false, null: false
     t.index ["access_token_id"], name: "index_feeds_on_access_token_id"
     t.index ["ai_credential_id"], name: "index_feeds_on_ai_credential_id"
     t.index ["user_id"], name: "index_feeds_on_user_id"

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -604,6 +604,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select '[data-key="form.import-after-fields"].hidden'
     assert_select 'input[name="feed[import_after_enabled]"][type=checkbox][checked]', false
     assert_select 'input[data-key="form.import-after-time"][value="00:00"]'
+    assert_select 'input[name="feed[images_only]"][type=checkbox][checked]', false
   end
 
   test "#edit should show import threshold fields when one is set" do
@@ -686,6 +687,46 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_equal Time.zone.parse("2026-01-15 10:30"), Feed.last.import_after
+  end
+
+  test "#update should set images_only from params" do
+    sign_in_as(user)
+
+    patch feed_url(feed), params: { feed: { images_only: "1" } }
+
+    assert_redirected_to feed_path(feed)
+    assert feed.reload.images_only?
+  end
+
+  test "#update should clear images_only when the checkbox is unchecked" do
+    sign_in_as(user)
+    feed.update!(images_only: true)
+
+    patch feed_url(feed), params: { feed: { images_only: "0" } }
+
+    assert_redirected_to feed_path(feed)
+    assert_not feed.reload.images_only?
+  end
+
+  test "#create should accept images_only param" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      url: "http://example.com/feed.xml",
+      name: "Test Feed",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h",
+      images_only: "1"
+    }
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: { feed: feed_params, enable_feed: "0" }
+    end
+
+    assert Feed.last.images_only?
   end
 
   test "#update should show additional message for enabled feeds" do

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -43,6 +43,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       :filter_new_entries,
       :persist_entries,
       :normalize_entries,
+      :reject_posts_without_images,
       :persist_posts,
       :enqueue_publication,
       :finalize_workflow
@@ -242,6 +243,56 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
     assert_equal ["undated-entry"], result.map(&:uid)
     assert_equal 1, workflow.stats[:entries_before_threshold]
+  end
+
+  test "#execute should skip posts without images when the feed is images-only" do
+    test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss", images_only: true)
+
+    sample_rss = <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Test Feed</title>
+          <item>
+            <guid>with-image</guid>
+            <title>Has an image</title>
+            <description>This entry ships an image</description>
+            <link>https://example.com/with-image</link>
+            <enclosure url="https://example.com/photo.jpg" type="image/jpeg" length="1000"/>
+            <pubDate>#{1.hour.ago.rfc822}</pubDate>
+          </item>
+          <item>
+            <guid>without-image</guid>
+            <title>No image here</title>
+            <description>This entry has only text</description>
+            <link>https://example.com/without-image</link>
+            <pubDate>#{2.hours.ago.rfc822}</pubDate>
+          </item>
+        </channel>
+      </rss>
+    RSS
+
+    WebMock.stub_request(:get, test_feed.url).to_return(body: sample_rss, status: 200)
+
+    workflow = FeedRefreshWorkflow.new(test_feed)
+    result = workflow.execute
+
+    assert_equal ["with-image"], result.map(&:uid)
+    assert_equal ["with-image"], Post.where(feed: test_feed).pluck(:uid)
+    assert_equal 1, workflow.stats[:posts_without_images]
+  end
+
+  test "#reject_posts_without_images should keep all posts when images-only is off" do
+    test_feed = create(:feed, images_only: false)
+    workflow = FeedRefreshWorkflow.new(test_feed)
+
+    with_image = Post.new(uid: "a", attachment_urls: ["https://example.com/a.jpg"])
+    without_image = Post.new(uid: "b", attachment_urls: [])
+
+    result = workflow.send(:reject_posts_without_images, [with_image, without_image])
+
+    assert_equal %w[a b], result.map(&:uid)
+    assert_nil workflow.stats[:posts_without_images]
   end
 
   test "#execute should handle HTTP loading errors gracefully" do

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -43,7 +43,6 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       :filter_new_entries,
       :persist_entries,
       :normalize_entries,
-      :reject_posts_without_images,
       :persist_posts,
       :enqueue_publication,
       :finalize_workflow
@@ -245,7 +244,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 1, workflow.stats[:entries_before_threshold]
   end
 
-  test "#execute should skip posts without images when the feed is images-only" do
+  test "#execute should reject image-less posts when the feed is images-only" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss", images_only: true)
 
     sample_rss = <<~RSS
@@ -275,24 +274,19 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, test_feed.url).to_return(body: sample_rss, status: 200)
 
     workflow = FeedRefreshWorkflow.new(test_feed)
-    result = workflow.execute
+    workflow.execute
 
-    assert_equal ["with-image"], result.map(&:uid)
-    assert_equal ["with-image"], Post.where(feed: test_feed).pluck(:uid)
-    assert_equal 1, workflow.stats[:posts_without_images]
-  end
+    # Both entries persist as posts; the image-less one is rejected rather than
+    # dropped, so its uid stays recorded for normal dedup on later refreshes.
+    with_image = Post.find_by(feed: test_feed, uid: "with-image")
+    without_image = Post.find_by(feed: test_feed, uid: "without-image")
 
-  test "#reject_posts_without_images should keep all posts when images-only is off" do
-    test_feed = create(:feed, images_only: false)
-    workflow = FeedRefreshWorkflow.new(test_feed)
+    assert with_image.enqueued?
+    assert without_image.rejected?
+    assert_includes without_image.validation_errors, "no_images"
 
-    with_image = Post.new(uid: "a", attachment_urls: ["https://example.com/a.jpg"])
-    without_image = Post.new(uid: "b", attachment_urls: [])
-
-    result = workflow.send(:reject_posts_without_images, [with_image, without_image])
-
-    assert_equal %w[a b], result.map(&:uid)
-    assert_nil workflow.stats[:posts_without_images]
+    assert_equal 1, workflow.stats[:new_posts]
+    assert_equal 1, workflow.stats[:rejected_posts]
   end
 
   test "#execute should handle HTTP loading errors gracefully" do

--- a/test/services/normalizer/base_test.rb
+++ b/test/services/normalizer/base_test.rb
@@ -54,6 +54,37 @@ class Normalizer::BaseTest < ActiveSupport::TestCase
     assert_equal "short", result.last
   end
 
+  test "#normalize should reject image-less posts for images-only feeds" do
+    subclass = Class.new(Normalizer::Base) do
+      def self.name = "Normalizer::TextOnlyNormalizer"
+      def normalize_source_url = "https://example.com/post"
+      def normalize_content = "Some text without images"
+    end
+    feed = create(:feed, images_only: true)
+    entry = create(:feed_entry, feed: feed)
+
+    post = subclass.new(entry).normalize
+
+    assert post.rejected?
+    assert_includes post.validation_errors, "no_images"
+  end
+
+  test "#normalize should enqueue posts with images for images-only feeds" do
+    subclass = Class.new(Normalizer::Base) do
+      def self.name = "Normalizer::ImageNormalizer"
+      def normalize_source_url = "https://example.com/post"
+      def normalize_content = "Some text"
+      def normalize_attachment_urls = ["https://example.com/photo.jpg"]
+    end
+    feed = create(:feed, images_only: true)
+    entry = create(:feed_entry, feed: feed)
+
+    post = subclass.new(entry).normalize
+
+    assert post.enqueued?
+    assert_empty post.validation_errors
+  end
+
   test "#normalize should raise MissingUidError when the subclass produces a blank uid" do
     subclass = Class.new(Normalizer::Base) do
       def self.name = "Normalizer::NoUidNormalizer"

--- a/test/services/normalizer/llm_normalizer_test.rb
+++ b/test/services/normalizer/llm_normalizer_test.rb
@@ -55,4 +55,12 @@ class Normalizer::LlmNormalizerTest < ActiveSupport::TestCase
     assert_equal "rejected", post.status
     assert_includes post.validation_errors, "missing content"
   end
+
+  test "#normalize should reject image-less posts when the feed is images-only" do
+    feed.update!(images_only: true)
+    post = Normalizer::LlmNormalizer.new(feed_entry("images" => [])).normalize
+
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "no_images"
+  end
 end


### PR DESCRIPTION
Changes:

- Add a feed option to import only posts that include images
- Reject image-less posts during normalization when the option is on
- Add the toggle to the feed form, under the date threshold

Some sources mix image posts with text-only entries, and a user may only care about the former. When enabled, posts that carry no image attachments are saved with a `rejected` status during normalization — alongside the existing content-validation rejections (e.g. `no_content_or_images`) — rather than being published. Keeping them as records means their ids stay known, so they're skipped normally on later refreshes. The rule applies to AI-backed feeds too.

References:

- Closes #809