### PR TITLE
Display available models on AI credential pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-20
 
+- AI credential pages now list the models each key can use.
 - Event pages now show stats in a clear, always-visible section.
 - Started keeping a changelog of user-facing changes.
 - New favicon featuring the Feeder mark.

--- a/app/components/ai_credential_models_component.html.erb
+++ b/app/components/ai_credential_models_component.html.erb
@@ -1,0 +1,13 @@
+<div class="space-y-3" data-key="ai_credential.models">
+  <h2 class="text-lg font-semibold text-slate-900">Available models</h2>
+  <ul class="overflow-hidden rounded-lg border border-slate-200 bg-white divide-y divide-slate-200">
+    <% models.each do |model| %>
+      <li class="space-y-1 p-4" data-key="ai_credential.model">
+        <p class="text-base font-medium text-slate-900" data-key="ai_credential.model.name"><%= model_name(model) %></p>
+        <% if model_details(model).present? %>
+          <p class="text-sm text-slate-500"><%= model_details(model) %></p>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/components/ai_credential_models_component.html.erb
+++ b/app/components/ai_credential_models_component.html.erb
@@ -4,8 +4,8 @@
     <% models.each do |model| %>
       <li class="space-y-1 p-4" data-key="ai_credential.model">
         <p class="text-base font-medium text-slate-900" data-key="ai_credential.model.name"><%= model_name(model) %></p>
-        <% if model_details(model).present? %>
-          <p class="text-sm text-slate-500"><%= model_details(model) %></p>
+        <% if (details = model_details(model)) %>
+          <p class="text-sm text-slate-500"><%= details %></p>
         <% end %>
       </li>
     <% end %>

--- a/app/components/ai_credential_models_component.rb
+++ b/app/components/ai_credential_models_component.rb
@@ -1,0 +1,32 @@
+class AiCredentialModelsComponent < ViewComponent::Base
+  def initialize(ai_credential:)
+    @ai_credential = ai_credential
+  end
+
+  def render?
+    models.present?
+  end
+
+  def models
+    @ai_credential.available_models
+  end
+
+  def model_name(model)
+    model["name"].presence || model["id"]
+  end
+
+  # Compact one-liner of the facts worth scanning: context size and
+  # whatever capabilities the provider reports.
+  def model_details(model)
+    parts = []
+    parts << "#{helpers.number_with_delimiter(model['context_window'])} token context" if model["context_window"].present?
+    parts << capabilities(model).join(", ") if capabilities(model).present?
+    parts.join(" · ")
+  end
+
+  private
+
+  def capabilities(model)
+    Array(model["capabilities"]).map { |capability| capability.to_s.tr("_", " ") }
+  end
+end

--- a/app/components/ai_credential_models_component.rb
+++ b/app/components/ai_credential_models_component.rb
@@ -16,12 +16,14 @@ class AiCredentialModelsComponent < ViewComponent::Base
   end
 
   # Compact one-liner of the facts worth scanning: context size and
-  # whatever capabilities the provider reports.
+  # whatever capabilities the provider reports. Returns nil when there's
+  # nothing to show, so the template can decide with a single call.
   def model_details(model)
     parts = []
     parts << "#{helpers.number_with_delimiter(model['context_window'])} token context" if model["context_window"].present?
-    parts << capabilities(model).join(", ") if capabilities(model).present?
-    parts.join(" · ")
+    capabilities = capabilities(model)
+    parts << capabilities.join(", ") if capabilities.present?
+    parts.join(" · ").presence
   end
 
   private

--- a/app/jobs/ai_credential_validation_job.rb
+++ b/app/jobs/ai_credential_validation_job.rb
@@ -1,15 +1,17 @@
-# Validates an AiCredential against its provider by issuing a cheap
-# health-check call through LlmClient. Mirrors AccessTokenValidationJob:
-# moves the credential through `validating → active | inactive` and records
-# `last_validated_at` / `last_error` on the way.
+# Validates an AiCredential against its provider by fetching its available
+# models through LlmClient. Mirrors AccessTokenValidationJob: moves the
+# credential through `validating → active | inactive` and records
+# `last_validated_at` / `last_error` on the way. A successful fetch both
+# proves the key works and gives us the model list to persist.
 class AiCredentialValidationJob < ApplicationJob
   queue_as :default
 
   def perform(credential)
     credential.validating!
 
-    LlmClient.for(credential).health_check
-    credential.update!(state: :active, last_validated_at: Time.current, last_error: nil)
+    models = LlmClient.for(credential).available_models
+    credential.update!(state: :active, available_models: models,
+                       last_validated_at: Time.current, last_error: nil)
   rescue LlmClient::Error => e
     credential.disable_credential_and_feeds(last_error: e.message)
   end

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -104,12 +104,14 @@ class LlmClient
     Result.new(payload: response.payload, usage_id: usage.id)
   end
 
-  # Token-free credential check used by AiCredentialValidationJob.
-  # Hits the provider's models endpoint (no inference, no usage row).
-  # Returns true on success, raises a known error class otherwise.
-  def health_check
-    fetch_provider_models
-    true
+  # The provider's available models, as an array of plain hashes ready to
+  # persist on the credential. Doubles as the token-free credential check
+  # used by AiCredentialValidationJob: hitting the models endpoint (no
+  # inference, no usage row) proves the key works, and a successful fetch
+  # is exactly what makes the credential active. Raises a known error
+  # class otherwise.
+  def available_models
+    fetch_provider_models.map { |model| serialize_model(model) }
   rescue RubyLLM::UnauthorizedError, RubyLLM::ForbiddenError, RubyLLM::PaymentRequiredError => e
     raise AuthError, e.message
   rescue RubyLLM::Error, RubyLLM::ConfigurationError => e
@@ -124,6 +126,21 @@ class LlmClient
     RubyLLM::Provider.resolve(credential.provider.to_sym)
                      .new(credential.ruby_llm_context.config)
                      .list_models
+  end
+
+  # Map RubyLLM's Model::Info to a compact, stable hash. We keep only the
+  # fields worth showing or selecting on later; provider-specific noise
+  # (metadata warnings, timestamps) is dropped. String keys so the shape
+  # round-trips through jsonb unchanged.
+  def serialize_model(model)
+    {
+      "id" => model.id,
+      "name" => model.name,
+      "family" => model.family,
+      "context_window" => model.context_window,
+      "max_output_tokens" => model.max_output_tokens,
+      "capabilities" => Array(model.capabilities)
+    }
   end
 
   # Single seam tests stub. Returns a ProviderResponse.

--- a/app/views/ai_credentials/_show_content.html.erb
+++ b/app/views/ai_credentials/_show_content.html.erb
@@ -23,6 +23,8 @@
     <% end %>
 
     <%= render AiCredentialDetailsComponent.new(ai_credential: ai_credential) %>
+
+    <%= render AiCredentialModelsComponent.new(ai_credential: ai_credential) %>
   <% when "inactive" %>
     <%= render AlertComponent.new(variant: :error, icon: "circle-x",
                                   data: { credential_state: "inactive", key: "ai_credential.inactive" }) do %>

--- a/db/migrate/20260620000000_add_available_models_to_ai_credentials.rb
+++ b/db/migrate/20260620000000_add_available_models_to_ai_credentials.rb
@@ -1,0 +1,5 @@
+class AddAvailableModelsToAiCredentials < ActiveRecord::Migration[8.2]
+  def change
+    add_column :ai_credentials, :available_models, :jsonb, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_17_205938) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_20_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_17_205938) do
     t.text "last_error"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "available_models", default: [], null: false
     t.index ["user_id", "provider", "display_name"], name: "index_ai_credentials_on_user_id_and_provider_and_display_name", unique: true
     t.index ["user_id", "state"], name: "index_ai_credentials_on_user_id_and_state"
     t.index ["user_id"], name: "index_ai_credentials_on_user_id"

--- a/test/components/ai_credential_models_component_test.rb
+++ b/test/components/ai_credential_models_component_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+require "view_component/test_case"
+
+class AiCredentialModelsComponentTest < ViewComponent::TestCase
+  def models
+    [
+      {
+        "id" => "claude-sonnet-4-6",
+        "name" => "Claude Sonnet 4.6",
+        "context_window" => 200_000,
+        "capabilities" => ["function_calling"]
+      }
+    ]
+  end
+
+  test "#render should list each available model" do
+    credential = create(:ai_credential, :active, available_models: models)
+
+    result = render_inline(AiCredentialModelsComponent.new(ai_credential: credential))
+
+    assert_includes result.css('[data-key="ai_credential.model.name"]').first.text, "Claude Sonnet 4.6"
+  end
+
+  test "#render should show context size and capabilities" do
+    credential = create(:ai_credential, :active, available_models: models)
+
+    result = render_inline(AiCredentialModelsComponent.new(ai_credential: credential))
+
+    text = result.css('[data-key="ai_credential.model"]').first.text
+    assert_includes text, "200,000 token context"
+    assert_includes text, "function calling"
+  end
+
+  test "#render should fall back to the id when name is blank" do
+    credential = create(:ai_credential, :active, available_models: [{ "id" => "some-model" }])
+
+    result = render_inline(AiCredentialModelsComponent.new(ai_credential: credential))
+
+    assert_includes result.css('[data-key="ai_credential.model.name"]').first.text, "some-model"
+  end
+
+  test "#render should render nothing when there are no models" do
+    credential = create(:ai_credential, :active, available_models: [])
+
+    result = render_inline(AiCredentialModelsComponent.new(ai_credential: credential))
+
+    assert_empty result.css('[data-key="ai_credential.models"]')
+  end
+end

--- a/test/jobs/ai_credential_validation_job_test.rb
+++ b/test/jobs/ai_credential_validation_job_test.rb
@@ -9,7 +9,7 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
     @credential ||= create(:ai_credential, user: user, state: :pending)
   end
 
-  def stub_health_check(result)
+  def stub_available_models(result)
     LlmClient.stub(:for, ->(_) { fake_client(result) }) do
       yield
     end
@@ -18,7 +18,7 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
   def fake_client(result)
     Class.new do
       def initialize(result) = (@result = result)
-      define_method(:health_check) do
+      define_method(:available_models) do
         case @result
         when Exception then raise @result
         else @result
@@ -27,13 +27,16 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
     end.new(result)
   end
 
-  test "#perform should move credential to active on successful health check" do
-    stub_health_check(true) do
+  test "#perform should move credential to active and persist models on success" do
+    models = [{ "id" => "claude-sonnet-4-6", "name" => "Claude Sonnet 4.6" }]
+
+    stub_available_models(models) do
       AiCredentialValidationJob.perform_now(credential)
     end
 
     credential.reload
     assert_equal "active", credential.state
+    assert_equal models, credential.available_models
     assert_not_nil credential.last_validated_at
     assert_nil credential.last_error
   end
@@ -41,7 +44,7 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
   test "#perform should move credential to inactive and record the error on provider failure" do
     feed = create(:feed, :enabled, user: user, ai_credential: credential)
 
-    stub_health_check(LlmClient::ProviderError.new("invalid api key")) do
+    stub_available_models(LlmClient::ProviderError.new("invalid api key")) do
       AiCredentialValidationJob.perform_now(credential)
     end
 
@@ -54,7 +57,7 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
   end
 
   test "#perform should move credential to inactive on rate-limit during validation" do
-    stub_health_check(LlmClient::RateLimited.new("429")) do
+    stub_available_models(LlmClient::RateLimited.new("429")) do
       AiCredentialValidationJob.perform_now(credential)
     end
 

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -237,30 +237,59 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal "preview", usage.purpose
   end
 
-  test "#health_check should return true when provider models are accessible" do
+  def fake_model(**attrs)
+    defaults = {
+      id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", family: "claude",
+      context_window: 200_000, max_output_tokens: 8_192, capabilities: ["function_calling"]
+    }
+    Struct.new(*defaults.keys, keyword_init: true).new(**defaults.merge(attrs))
+  end
+
+  test "#available_models should return the provider models as compact hashes" do
+    client = LlmClient.new(credential)
+    model = fake_model
+    stub_provider_models(client) { [model] }
+
+    models = client.available_models
+
+    assert_equal(
+      [{
+        "id" => "claude-sonnet-4-6",
+        "name" => "Claude Sonnet 4.6",
+        "family" => "claude",
+        "context_window" => 200_000,
+        "max_output_tokens" => 8_192,
+        "capabilities" => ["function_calling"]
+      }],
+      models
+    )
+    assert_equal 0, LlmUsage.count
+  end
+
+  test "#available_models should return an empty array when the provider lists no models" do
     client = LlmClient.new(credential)
     stub_provider_models(client) { [] }
 
-    assert_equal true, client.health_check
+    assert_equal [], client.available_models
     assert_equal 0, LlmUsage.count
   end
 
-  test "#health_check should raise AuthError when the provider rejects the key" do
+  test "#available_models should raise AuthError when the provider rejects the key" do
     client = LlmClient.new(credential)
     stub_provider_models(client) { raise RubyLLM::UnauthorizedError, "invalid key" }
 
-    assert_raises(LlmClient::AuthError) { client.health_check }
+    assert_raises(LlmClient::AuthError) { client.available_models }
     assert_equal 0, LlmUsage.count
   end
 
-  test "#health_check should raise ProviderError on other provider failures" do
+  test "#available_models should raise ProviderError on other provider failures" do
     client = LlmClient.new(credential)
     stub_provider_models(client) { raise RubyLLM::ServerError, "upstream error" }
 
-    assert_raises(LlmClient::ProviderError) { client.health_check }
+    assert_raises(LlmClient::ProviderError) { client.available_models }
   end
 
-  test "#health_check should call the provider models endpoint with the credential api_key" do
+  test "#available_models should call the provider models endpoint with the credential api_key" do
     client = LlmClient.new(credential)
 
     fake_provider_class = Class.new do
@@ -269,7 +298,7 @@ class LlmClientTest < ActiveSupport::TestCase
     end
 
     RubyLLM::Provider.stub(:resolve, fake_provider_class) do
-      assert_equal true, client.health_check
+      assert_equal [], client.available_models
       assert_equal 0, LlmUsage.count
     end
   end


### PR DESCRIPTION
Changes:

- Persist the provider's available models on each credential and show them on the credential page.
- Fold model discovery into the existing credential validation instead of adding a second provider call.

Credential validation already fetched the provider's model list just to prove the key works, then threw it away. This keeps that list: a successful validation now persists the models on the credential (a new `available_models` jsonb column), so an active credential always carries a fresh model list, refreshed automatically on every re-validation. The credential page gains an "Available models" section. RubyLLM specifics stay contained in `LlmClient`; the job and model don't touch the SDK.
