### PR TITLE
Handle missing timestamps in email storage

### DIFF
--- a/app/services/email_storage/base.rb
+++ b/app/services/email_storage/base.rb
@@ -5,7 +5,9 @@ module EmailStorage
     end
 
     def ordered_list
-      list.sort_by { |e| e[:timestamp] }.reverse
+      # Fall back to the epoch so emails with a missing timestamp (legacy or
+      # malformed files) sort last instead of raising on a nil comparison.
+      list.sort_by { |e| e[:timestamp] || Time.at(0) }.reverse
     end
 
     def load_email(id)

--- a/app/services/email_storage/file_system_storage.rb
+++ b/app/services/email_storage/file_system_storage.rb
@@ -34,7 +34,7 @@ module EmailStorage
         {
           id: uuid,
           subject: metadata["subject"],
-          timestamp: metadata["timestamp"],
+          timestamp: metadata["timestamp"] || File.mtime(yml_path),
           size: File.size(yml_path)
         }
       end.compact

--- a/test/services/email_storage/base_test.rb
+++ b/test/services/email_storage/base_test.rb
@@ -27,4 +27,21 @@ class EmailStorage::BaseTest < ActiveSupport::TestCase
     storage = EmailStorage::Base.new
     assert_raises(NotImplementedError) { storage.purge }
   end
+
+  test "#ordered_list sorts newest first and tolerates a missing timestamp" do
+    newer = Time.parse("2025-01-02T12:00:00+00:00")
+    older = Time.parse("2025-01-01T12:00:00+00:00")
+    storage = Class.new(EmailStorage::Base) do
+      def list
+        [
+          { id: "a", timestamp: nil },
+          { id: "b", timestamp: Time.parse("2025-01-02T12:00:00+00:00") },
+          { id: "c", timestamp: Time.parse("2025-01-01T12:00:00+00:00") }
+        ]
+      end
+    end.new
+
+    assert_equal %w[b c a], storage.ordered_list.map { |e| e[:id] }
+    assert_equal [newer, older, nil], storage.ordered_list.map { |e| e[:timestamp] }
+  end
 end

--- a/test/services/email_storage/file_system_storage_test.rb
+++ b/test/services/email_storage/file_system_storage_test.rb
@@ -53,6 +53,19 @@ class EmailStorage::FileSystemStorageTest < ActiveSupport::TestCase
     assert_equal time1, emails[1][:timestamp]
   end
 
+  test "#ordered_list handles emails with a missing timestamp" do
+    uuid = SecureRandom.uuid
+    metadata = { "subject" => "Legacy", "multipart" => false }
+    File.write(storage_dir.join("legacy_#{uuid}.yml"), metadata.to_yaml)
+    File.write(storage_dir.join("legacy_#{uuid}.txt"), "Body")
+
+    emails = storage.ordered_list
+    assert_equal 1, emails.size
+    assert_equal "Legacy", emails.first[:subject]
+    # Falls back to the file mtime so the listing can still render a date.
+    assert_kind_of Time, emails.first[:timestamp]
+  end
+
   test "#ordered_list skips files with invalid filenames" do
     uuid = SecureRandom.uuid
     create_test_email(uuid, "Valid")


### PR DESCRIPTION
Changes:

- Sort emails with a missing timestamp last in `EmailStorage::Base#ordered_list` instead of raising on a nil comparison
- Fall back to the file mtime in `EmailStorage::FileSystemStorage#list` so legacy/malformed emails still render a date
- Add tests covering the missing-timestamp case for both adapters

A stored email with a `nil` timestamp (a legacy file from before timestamps
were saved, or a malformed one) made `ordered_list`'s `sort_by` raise, so
`/development/sent_emails` returned a 500. This keeps the listing working and
shows a sensible fallback date for such emails.