### PR TITLE
Add ordering dropdown to admin feeds index

### DIFF
--- a/app/controllers/admin/feeds_controller.rb
+++ b/app/controllers/admin/feeds_controller.rb
@@ -1,11 +1,41 @@
 class Admin::FeedsController < ApplicationController
   include Pagination
+  include Sortable
 
   MAX_RECENT_POSTS = 5
   MAX_RECENT_EVENTS = 10
 
+  SORTABLE_FIELDS = {
+    name: {
+      title: "Name",
+      order_by: "LOWER(feeds.name)",
+      direction: :asc
+    },
+    status: {
+      title: "Status",
+      order_by: "CASE feeds.state WHEN #{Feed.states[:draft]} THEN 0 WHEN #{Feed.states[:enabled]} THEN 1 ELSE 2 END",
+      direction: :asc
+    },
+    target_group: {
+      title: "Target Group",
+      order_by: "LOWER(feeds.target_group)",
+      direction: :asc
+    },
+    last_refresh: {
+      title: "Last Refresh",
+      order_by: "(SELECT MAX(created_at) FROM feed_entries WHERE feed_entries.feed_id = feeds.id)",
+      direction: :desc
+    },
+    recent_post: {
+      title: "Recent Post",
+      order_by: "(SELECT MAX(published_at) FROM posts WHERE posts.feed_id = feeds.id)",
+      direction: :desc
+    }
+  }.freeze
+
   def index
     authorize [:admin, Feed]
+    @sortable_presenter = sortable_presenter
     @feeds = paginate_scope
   end
 
@@ -18,6 +48,14 @@ class Admin::FeedsController < ApplicationController
   end
 
   private
+
+  def sortable_fields
+    SORTABLE_FIELDS
+  end
+
+  def sortable_path(sort_params)
+    admin_feeds_path(sort_params)
+  end
 
   def recent_posts(feed)
     feed
@@ -35,6 +73,6 @@ class Admin::FeedsController < ApplicationController
   def pagination_scope
     policy_scope([:admin, Feed])
       .includes(:user, :access_token, :feed_entries, :posts)
-      .order(created_at: :desc)
+      .order(sortable_order)
   end
 end

--- a/app/views/admin/feeds/index.html.erb
+++ b/app/views/admin/feeds/index.html.erb
@@ -3,6 +3,11 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Feeds") do |header| %>
     <% header.with_breadcrumb(label: "Admin Panel", url: admin_path) %>
+    <% if @feeds.any? %>
+      <% header.with_action_button do %>
+        <%= render SortDropdownComponent.new(presenter: @sortable_presenter, menu_id: "admin-feed-sort-menu") %>
+      <% end %>
+    <% end %>
   <% end %>
 
   <% if @feeds.any? %>

--- a/test/controllers/admin/feeds_controller/sortable_test.rb
+++ b/test/controllers/admin/feeds_controller/sortable_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class AdminFeedsControllerSortableTest < ActiveSupport::TestCase
+  test "#sortable_fields should be well formed" do
+    fields = Admin::FeedsController::SORTABLE_FIELDS
+
+    assert_kind_of Hash, fields
+    assert fields.keys.any?, "Expected sortable_fields to contain entries"
+
+    fields.each do |field, config|
+      assert field.present?, "sortable field key must be present"
+      assert_kind_of Hash, config
+      assert config.key?(:title), "sortable field #{field} must define :title"
+      assert config.key?(:order_by), "sortable field #{field} must define :order_by"
+      assert_includes [:asc, :desc, "asc", "desc"], config.fetch(:direction, :desc), "sortable field #{field} has invalid :direction"
+    end
+  end
+end

--- a/test/controllers/admin/feeds_controller_test.rb
+++ b/test/controllers/admin/feeds_controller_test.rb
@@ -70,6 +70,40 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
+  test "should render the sort dropdown on index" do
+    login_as(admin_user)
+    create(:feed, user: create(:user))
+
+    get admin_feeds_path
+
+    assert_response :success
+    assert_select "button[data-dropdown-toggle='admin-feed-sort-menu']", 1
+    assert_select "#admin-feed-sort-menu a", Admin::FeedsController::SORTABLE_FIELDS.size
+  end
+
+  test "should sort feeds by name" do
+    login_as(admin_user)
+    create(:feed, user: create(:user), name: "Z Feed")
+    create(:feed, user: create(:user), name: "A Feed")
+
+    get admin_feeds_path(sort: "name", direction: "asc")
+
+    assert_response :success
+    assert response.body.index("A Feed") < response.body.index("Z Feed"),
+      "Expected A Feed to appear before Z Feed"
+  end
+
+  test "should preserve sort parameters in pagination" do
+    login_as(admin_user)
+    3.times { |i| create(:feed, user: create(:user), name: "Feed #{i}") }
+
+    get admin_feeds_path(sort: "name", direction: "desc", per_page: 2)
+
+    assert_response :success
+    assert_select "nav a[href*='sort=name']"
+    assert_select "nav a[href*='direction=desc']"
+  end
+
   def login_as(user)
     post session_path, params: { email_address: user.email_address, password: "password123" }
   end


### PR DESCRIPTION
Changes:

- Add a sort dropdown to the admin feeds index, matching the one on the main feeds page
- Sort feeds by name, status, target group, last refresh, or recent post
- Preserve the chosen ordering across pagination

The admin feeds list previously used a fixed newest-first order. This reuses
the existing `Sortable` concern and `SortDropdownComponent` so admins get the
same sorting controls already available on `/feeds`.
