### PR TITLE
Unify feed list cards across user and admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 - Fixed RSS posts attaching the same image twice when it appeared as both a cover and inline image.
 - Improve New feed form layout: keeps source input on top, and labels it "Source URL" or "Source prompt" to match user entry.
 - Refreshed the favicon with a bold fff ligature on Freefeed-orange tile.
+- Refreshed the feed list with a cleaner, more compact card layout.
 
 ## 2026-06-20
 

--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -1,16 +1,32 @@
-<div id="<%= helpers.dom_id(feed) %>" class="w-full rounded-lg border border-slate-200 bg-white px-5 py-4 shadow-xs transition duration-75 hover:bg-slate-50">
-  <div class="flex items-baseline gap-3">
-    <div class="flex min-w-0 flex-1 items-baseline gap-2">
-      <%= link_to title, feed_url,
-            class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
-      <% if target_group_label %>
-        <% if target_group_url %>
-          <%= link_to target_group_label, target_group_url, target: "_blank", rel: "noopener",
-                class: "truncate text-sm text-slate-400 transition hover:text-slate-600" %>
-        <% else %>
-          <span class="truncate text-sm text-slate-400"><%= target_group_label %></span>
+<div id="<%= helpers.dom_id(feed) %>" class="w-full rounded-lg border border-slate-200 bg-white px-5 py-3 shadow-xs transition duration-75 hover:bg-slate-50">
+  <div class="flex items-start gap-3">
+    <div class="min-w-0 flex-1 space-y-1">
+      <div class="flex items-baseline gap-2">
+        <%= link_to title, feed_url,
+              class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
+        <% if target_group_label %>
+          <% if target_group_url %>
+            <%= link_to target_group_label, target_group_url, target: "_blank", rel: "noopener",
+                  class: "truncate text-sm text-slate-400 transition hover:text-slate-600" %>
+          <% else %>
+            <span class="truncate text-sm text-slate-400"><%= target_group_label %></span>
+          <% end %>
         <% end %>
-      <% end %>
+      </div>
+
+      <div class="truncate text-sm text-slate-400">
+        <span class="inline-flex align-middle" data-key="feed.<%= feed.id %>.status_icon"><%= status_icon %></span>
+        <%= helpers.middot %>
+        <span data-key="feed.<%= feed.id %>.last_refreshed">Latest updated: <%= last_refreshed_tag %></span>
+        <%= helpers.middot %>
+        <span data-key="feed.<%= feed.id %>.most_recent_post">Latest post: <%= most_recent_post_tag %></span>
+        <% if owner %>
+          <%= helpers.middot %>
+          <span data-key="feed.<%= feed.id %>.owner">Owner:
+            <%= link_to owner.email_address, owner_url, class: "transition hover:text-slate-600" %>
+          </span>
+        <% end %>
+      </div>
     </div>
 
     <div class="relative shrink-0">
@@ -92,19 +108,5 @@
         </ul>
       </div>
     </div>
-  </div>
-
-  <div class="mt-1 truncate text-sm text-slate-400">
-    <%= render status_badge %>
-    <%= helpers.middot %>
-    <span data-key="feed.<%= feed.id %>.last_refreshed">Latest updated: <%= last_refreshed_tag %></span>
-    <%= helpers.middot %>
-    <span data-key="feed.<%= feed.id %>.most_recent_post">Latest post: <%= most_recent_post_tag %></span>
-    <% if owner %>
-      <%= helpers.middot %>
-      <span data-key="feed.<%= feed.id %>.owner">Owner:
-        <%= link_to owner.email_address, owner_url, class: "transition hover:text-slate-600" %>
-      </span>
-    <% end %>
   </div>
 </div>

--- a/app/components/feed_card_component.html.erb
+++ b/app/components/feed_card_component.html.erb
@@ -1,30 +1,16 @@
-<div id="<%= helpers.dom_id(feed) %>" class="w-full rounded-lg border border-slate-200 bg-white shadow-xs transition duration-75 hover:bg-slate-50">
-  <div class="flex items-start gap-4 px-5 py-4">
-    <div class="flex min-w-0 items-center gap-2">
+<div id="<%= helpers.dom_id(feed) %>" class="w-full rounded-lg border border-slate-200 bg-white px-5 py-4 shadow-xs transition duration-75 hover:bg-slate-50">
+  <div class="flex items-baseline gap-3">
+    <div class="flex min-w-0 flex-1 items-baseline gap-2">
       <%= link_to title, feed_url,
             class: "truncate text-base text-slate-900 transition hover:text-slate-700 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white" %>
-      <%= render status_badge %>
-    </div>
-  </div>
-
-  <div class="flex items-center justify-between gap-4 border-t border-slate-200 px-5 py-2">
-    <div class="min-w-0 flex-1 truncate text-sm text-slate-400">
       <% if target_group_label %>
         <% if target_group_url %>
           <%= link_to target_group_label, target_group_url, target: "_blank", rel: "noopener",
-                class: "mr-3 transition hover:text-slate-600" %>
+                class: "truncate text-sm text-slate-400 transition hover:text-slate-600" %>
         <% else %>
-          <span class="mr-3"><%= target_group_label %></span>
+          <span class="truncate text-sm text-slate-400"><%= target_group_label %></span>
         <% end %>
       <% end %>
-      <span class="inline-flex items-center gap-1 mr-3">
-        Updated:
-        <%= last_refreshed_tag %>
-      </span>
-      <span class="inline-flex items-center gap-1">
-        Post:
-        <%= most_recent_post_tag %>
-      </span>
     </div>
 
     <div class="relative shrink-0">
@@ -57,52 +43,68 @@
                     data: { key: "feed.#{feed.id}.source" } %>
             </li>
           <% end %>
-          <% if draft? %>
-            <li>
-              <%= link_to "Continue setup", edit_url,
-                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
-                    role: "menuitem",
-                    data: { key: "feed.#{feed.id}.continue_setup" } %>
-            </li>
-          <% else %>
-            <li>
-              <%= link_to "Edit", edit_url,
-                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
-                    role: "menuitem",
-                    data: { key: "feed.#{feed.id}.edit" } %>
-            </li>
-            <% if enabled? %>
+          <% if management_actions? %>
+            <% if draft? %>
               <li>
-                <%= button_to "Disable", status_url,
-                      method: :patch,
-                      params: { status: "disabled" },
-                      class: "block w-full px-4 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50",
+                <%= link_to "Continue setup", edit_url,
+                      class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
                       role: "menuitem",
-                      data: { key: "feed.#{feed.id}.disable", turbo_confirm: DISABLE_CONFIRM },
-                      form: { class: "block" } %>
+                      data: { key: "feed.#{feed.id}.continue_setup" } %>
               </li>
-            <% elsif can_be_enabled? %>
+            <% else %>
               <li>
-                <%= button_to "Enable", status_url,
-                      method: :patch,
-                      params: { status: "enabled" },
-                      class: "block w-full px-4 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50",
+                <%= link_to "Edit", edit_url,
+                      class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
                       role: "menuitem",
-                      data: { key: "feed.#{feed.id}.enable", turbo_confirm: ENABLE_CONFIRM },
-                      form: { class: "block" } %>
+                      data: { key: "feed.#{feed.id}.edit" } %>
+              </li>
+              <% if enabled? %>
+                <li>
+                  <%= button_to "Disable", status_url,
+                        method: :patch,
+                        params: { status: "disabled" },
+                        class: "block w-full px-4 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50",
+                        role: "menuitem",
+                        data: { key: "feed.#{feed.id}.disable", turbo_confirm: DISABLE_CONFIRM },
+                        form: { class: "block" } %>
+                </li>
+              <% elsif can_be_enabled? %>
+                <li>
+                  <%= button_to "Enable", status_url,
+                        method: :patch,
+                        params: { status: "enabled" },
+                        class: "block w-full px-4 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50",
+                        role: "menuitem",
+                        data: { key: "feed.#{feed.id}.enable", turbo_confirm: ENABLE_CONFIRM },
+                        form: { class: "block" } %>
+                </li>
+              <% end %>
+            <% end %>
+            <% if draft? %>
+              <li>
+                <%= link_to "Discard…", feed_url,
+                      class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
+                      role: "menuitem",
+                      data: { key: "feed.#{feed.id}.discard", turbo_method: :delete, turbo_confirm: DISCARD_CONFIRM } %>
               </li>
             <% end %>
-          <% end %>
-          <% if draft? %>
-            <li>
-              <%= link_to "Discard…", feed_url,
-                    class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50",
-                    role: "menuitem",
-                    data: { key: "feed.#{feed.id}.discard", turbo_method: :delete, turbo_confirm: DISCARD_CONFIRM } %>
-            </li>
           <% end %>
         </ul>
       </div>
     </div>
+  </div>
+
+  <div class="mt-1 truncate text-sm text-slate-400">
+    <%= render status_badge %>
+    <%= helpers.middot %>
+    <span data-key="feed.<%= feed.id %>.last_refreshed">Latest updated: <%= last_refreshed_tag %></span>
+    <%= helpers.middot %>
+    <span data-key="feed.<%= feed.id %>.most_recent_post">Latest post: <%= most_recent_post_tag %></span>
+    <% if owner %>
+      <%= helpers.middot %>
+      <span data-key="feed.<%= feed.id %>.owner">Owner:
+        <%= link_to owner.email_address, owner_url, class: "transition hover:text-slate-600" %>
+      </span>
+    <% end %>
   </div>
 </div>

--- a/app/components/feed_card_component.rb
+++ b/app/components/feed_card_component.rb
@@ -49,8 +49,8 @@ class FeedCardComponent < ViewComponent::Base
     !admin
   end
 
-  def status_badge
-    helpers.feed_status_badge(feed)
+  def status_icon
+    helpers.feed_status_icon(feed)
   end
 
   def menu_id

--- a/app/components/feed_card_component.rb
+++ b/app/components/feed_card_component.rb
@@ -3,20 +3,23 @@ class FeedCardComponent < ViewComponent::Base
   ENABLE_CONFIRM = "Enable this feed?".freeze
   DISABLE_CONFIRM = "Disable this feed?".freeze
 
-  def initialize(feed:)
+  def initialize(feed:, admin: false)
     @feed = feed
+    @admin = admin
   end
 
   private
 
-  attr_reader :feed
+  attr_reader :feed, :admin
 
   def title
     feed.display_name
   end
 
+  # The admin list points at the operator-facing feed page so admins can open
+  # any user's feed; the regular list stays in the user's own namespace.
   def feed_url
-    helpers.feed_path(feed)
+    admin ? helpers.admin_feed_path(feed) : helpers.feed_path(feed)
   end
 
   def edit_url
@@ -37,6 +40,13 @@ class FeedCardComponent < ViewComponent::Base
 
   def can_be_enabled?
     feed.can_be_enabled?
+  end
+
+  # The admin list spans every user's feeds, where the management actions
+  # (edit, enable/disable, discard) don't apply, so only the read-only links
+  # are offered there.
+  def management_actions?
+    !admin
   end
 
   def status_badge
@@ -61,6 +71,14 @@ class FeedCardComponent < ViewComponent::Base
     return unless feed.access_token && feed.target_group.present?
 
     "#{feed.access_token.host}/#{feed.target_group}"
+  end
+
+  def owner
+    feed.user if admin
+  end
+
+  def owner_url
+    helpers.admin_user_path(owner) if owner
   end
 
   def last_refreshed_tag

--- a/app/components/feeds_list_component.rb
+++ b/app/components/feeds_list_component.rb
@@ -1,11 +1,12 @@
 class FeedsListComponent < ViewComponent::Base
-  def initialize(feeds:)
+  def initialize(feeds:, admin: false)
     @feeds = feeds
+    @admin = admin
   end
 
   def call
     content_tag(:div, class: "space-y-4") do
-      safe_join(@feeds.map { |feed| render(FeedCardComponent.new(feed: feed)) })
+      safe_join(@feeds.map { |feed| render(FeedCardComponent.new(feed: feed, admin: @admin)) })
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,6 +40,9 @@ module ApplicationHelper
     # Status & indicators
     "circle-check"   => '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>',
     "circle-x"       => '<circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/>',
+    "circle-play"    => '<circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/>',
+    "circle-pause"   => '<circle cx="12" cy="12" r="10"/><line x1="10" x2="10" y1="15" y2="9"/><line x1="14" x2="14" y1="15" y2="9"/>',
+    "circle-dashed"  => '<path d="M10.1 2.18a9.93 9.93 0 0 1 3.8 0"/><path d="M17.6 3.71a9.95 9.95 0 0 1 2.69 2.7"/><path d="M21.82 10.1a9.93 9.93 0 0 1 0 3.8"/><path d="M20.29 17.6a9.95 9.95 0 0 1-2.7 2.69"/><path d="M13.9 21.82a9.94 9.94 0 0 1-3.8 0"/><path d="M6.4 20.29a9.95 9.95 0 0 1-2.69-2.7"/><path d="M2.18 13.9a9.93 9.93 0 0 1 0-3.8"/><path d="M3.71 6.4a9.95 9.95 0 0 1 2.7-2.69"/>',
     "square"         => '<rect width="18" height="18" x="3" y="3" rx="2"/>',
     "square-check-big" => '<path d="M21 10.656V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h12.344"/><path d="m9 11 3 3L22 4"/>',
     "clock"          => '<circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>',

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -24,13 +24,13 @@ module FeedHelper
 
   def feed_status_icon(feed)
     if feed.enabled?
-      icon("circle-check", css_class: "size-4 text-emerald-500",
+      icon("circle-play", css_class: "size-4 text-emerald-500",
                   title: "Enabled", aria_label: "Enabled")
     elsif feed.draft?
-      icon("square-pen", css_class: "size-4 text-amber-500",
+      icon("circle-dashed", css_class: "size-4 text-slate-400",
                   title: "Draft", aria_label: "Draft")
     else
-      icon("circle-x", css_class: "size-4 text-slate-400",
+      icon("circle-pause", css_class: "size-4 text-slate-400",
                   title: "Disabled", aria_label: "Disabled")
     end
   end

--- a/app/views/admin/feeds/index.html.erb
+++ b/app/views/admin/feeds/index.html.erb
@@ -11,50 +11,7 @@
   <% end %>
 
   <% if @feeds.any? %>
-    <div class="overflow-x-auto rounded-lg border border-slate-200">
-      <table class="w-full text-left text-sm text-slate-700">
-        <thead class="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-600">
-          <tr class="hover:bg-slate-50">
-            <th scope="col" class="px-6 py-3">Feed</th>
-            <th scope="col" class="px-6 py-3">Owner</th>
-            <th scope="col" class="px-6 py-3">Status</th>
-            <th scope="col" class="px-6 py-3 text-center">Last Refresh</th>
-            <th scope="col" class="px-6 py-3 text-center">Recent Post</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-slate-200 bg-white">
-          <% @feeds.each do |feed| %>
-            <tr class="hover:bg-slate-50">
-              <td class="px-6 py-4">
-                <%= link_to feed.display_name, admin_feed_path(feed), class: "font-medium text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <% if feed.user %>
-                  <%= link_to feed.user.email_address, admin_user_path(feed.user), class: "text-sky-600 underline underline-offset-4 transition hover:text-sky-500" %>
-                <% else %>
-                  <span class="text-slate-500">—</span>
-                <% end %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap"><%= render feed_status_badge(feed) %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-center">
-                <% if feed.last_refreshed_at %>
-                  <%= short_time_ago_tag(feed.last_refreshed_at) %>
-                <% else %>
-                  <span class="text-slate-500">Never</span>
-                <% end %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-center">
-                <% if feed.most_recent_post_date %>
-                  <%= short_time_ago_tag(feed.most_recent_post_date) %>
-                <% else %>
-                  <span class="text-slate-500">None</span>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+    <%= render FeedsListComponent.new(feeds: @feeds, admin: true) %>
 
     <%= render_pagination { |pagination| admin_feeds_path(pagination) } %>
   <% else %>

--- a/test/components/feed_card_component_test.rb
+++ b/test/components/feed_card_component_test.rb
@@ -162,7 +162,41 @@ class FeedCardComponentTest < ViewComponent::TestCase
   test "#render should label the activity times" do
     result = render_inline FeedCardComponent.new(feed: feed)
 
-    assert_includes result.text, "Updated:"
-    assert_includes result.text, "Post:"
+    assert_includes result.text, "Latest updated:"
+    assert_includes result.text, "Latest post:"
+  end
+
+  test "#render should link title to admin feed page in admin mode" do
+    result = render_inline FeedCardComponent.new(feed: feed, admin: true)
+
+    link = result.at_css("a[href*='/admin/feeds/']")
+    assert_not_nil link
+    assert_includes link.text, "My Feed"
+  end
+
+  test "#render should show owner in admin mode" do
+    result = render_inline FeedCardComponent.new(feed: feed, admin: true)
+
+    owner = result.css("[data-key='feed.#{feed.id}.owner']").first
+    assert_not_nil owner
+    assert_includes owner.text, user.email_address
+  end
+
+  test "#render should not show owner outside admin mode" do
+    result = render_inline FeedCardComponent.new(feed: feed)
+
+    assert_empty result.css("[data-key='feed.#{feed.id}.owner']")
+  end
+
+  test "#render should not show management actions in admin mode" do
+    enabled_feed = create(:feed, :enabled, user: user)
+
+    with_request_url("/admin/feeds") do
+      result = render_inline FeedCardComponent.new(feed: enabled_feed, admin: true)
+
+      assert_empty result.css("[data-key='feed.#{enabled_feed.id}.edit']")
+      assert_empty result.css("[data-key='feed.#{enabled_feed.id}.disable']")
+      assert_not_empty result.css("[data-key='feed.#{enabled_feed.id}.details']")
+    end
   end
 end

--- a/test/components/feed_card_component_test.rb
+++ b/test/components/feed_card_component_test.rb
@@ -24,30 +24,30 @@ class FeedCardComponentTest < ViewComponent::TestCase
     assert_includes link.text, "My Feed"
   end
 
-  test "#render should show Draft badge for draft feeds" do
+  test "#render should show draft status icon for draft feeds" do
     draft_feed = create(:feed, :draft, user: user)
     result = render_inline FeedCardComponent.new(feed: draft_feed)
 
-    badge = result.css("[data-key='feed.#{draft_feed.id}.draft_badge']").first
-    assert_not_nil badge
-    assert_equal "Draft", badge.text.strip
+    icon = result.at_css("[data-key='feed.#{draft_feed.id}.status_icon'] svg")
+    assert_not_nil icon
+    assert_equal "Draft", icon["aria-label"]
   end
 
-  test "#render should show Disabled badge for disabled feeds" do
+  test "#render should show disabled status icon for disabled feeds" do
     result = render_inline FeedCardComponent.new(feed: feed)
 
-    badge = result.css("[data-key='feed.#{feed.id}.disabled_badge']").first
-    assert_not_nil badge
-    assert_equal "Disabled", badge.text.strip
+    icon = result.at_css("[data-key='feed.#{feed.id}.status_icon'] svg")
+    assert_not_nil icon
+    assert_equal "Disabled", icon["aria-label"]
   end
 
-  test "#render should show Enabled badge for enabled feeds" do
+  test "#render should show enabled status icon for enabled feeds" do
     enabled_feed = create(:feed, :enabled, user: user)
     result = render_inline FeedCardComponent.new(feed: enabled_feed)
 
-    badge = result.css("[data-key='feed.#{enabled_feed.id}.enabled_badge']").first
-    assert_not_nil badge
-    assert_equal "Enabled", badge.text.strip
+    icon = result.at_css("[data-key='feed.#{enabled_feed.id}.status_icon'] svg")
+    assert_not_nil icon
+    assert_equal "Enabled", icon["aria-label"]
   end
 
   test "#render should show @group label when target_group present" do

--- a/test/components/feeds_list_component_test.rb
+++ b/test/components/feeds_list_component_test.rb
@@ -44,20 +44,22 @@ class FeedsListComponentTest < ViewComponent::TestCase
     assert_match "Untitled feed", result.text
   end
 
-  test "#call renders draft badge for draft feeds" do
+  test "#call renders draft status icon for draft feeds" do
     feed = create(:feed, :draft, user: user, name: "Draft Feed")
     result = render_inline(FeedsListComponent.new(feeds: [feed]))
 
-    badge = result.css(%([data-key="feed.#{feed.id}.draft_badge"])).first
-    assert_not_nil badge, "Expected to find a draft badge for draft feed"
-    assert_equal "Draft", badge.text.strip
+    icon = result.at_css(%([data-key="feed.#{feed.id}.status_icon"] svg))
+    assert_not_nil icon, "Expected to find a draft status icon for draft feed"
+    assert_equal "Draft", icon["aria-label"]
   end
 
-  test "#call does not render draft badge for non-draft feeds" do
+  test "#call does not render draft status icon for non-draft feeds" do
     feed = create(:feed, :disabled, user: user, name: "Inactive Feed")
     result = render_inline(FeedsListComponent.new(feeds: [feed]))
 
-    assert_empty result.css(%([data-key="feed.#{feed.id}.draft_badge"]))
+    icon = result.at_css(%([data-key="feed.#{feed.id}.status_icon"] svg))
+    assert_not_nil icon
+    assert_equal "Disabled", icon["aria-label"]
   end
 
   test "#call should render Continue setup and Discard affordances for draft rows" do

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -71,7 +71,7 @@ class FeedHelperTest < ActionView::TestCase
     result = feed_status_icon(feed)
 
     assert_includes result, "<svg"
-    assert_includes result, "text-amber-500"
+    assert_includes result, "text-slate-400"
     assert_includes result, 'title="Draft"'
     assert_includes result, 'aria-label="Draft"'
     assert_includes result, 'role="img"'

--- a/test/integration/feed_draft_flow_test.rb
+++ b/test/integration/feed_draft_flow_test.rb
@@ -135,12 +135,12 @@ class FeedDraftFlowTest < ActionDispatch::IntegrationTest
     assert_equal "llm_website_extractor", draft.feed_profile_key, "Profile key should be locked after promotion"
 
     # Step 6: feeds index should show the feed in the enabled bucket of the
-    # 3-bucket summary line, and the row itself should not carry the Draft
-    # badge or draft-only inline actions anymore.
+    # 3-bucket summary line, and the row itself should carry the enabled
+    # status icon rather than draft-only inline actions.
     get feeds_path
     assert_response :success
     assert_select "p", text: /1 active feed/
-    assert_select "[data-key=?]", "feed.#{draft.id}.draft_badge", false
+    assert_select "[data-key=?] svg[aria-label=?]", "feed.#{draft.id}.status_icon", "Enabled"
     assert_select "[data-key=?]", "feed.#{draft.id}.continue_setup", false
     assert_select "a[href=?]", feed_path(draft), text: "No-RSS Blog"
   end


### PR DESCRIPTION
Changes:

- Redesign the feed card into a compact two-row layout: title and `@target-group` with the actions menu on top, status badge and activity times on a muted second line.
- Render the same card on the admin feeds index, replacing the previous table.
- Add an admin mode to the card that uses admin paths, shows the feed owner, and hides owner-only management actions.

The user and admin feed lists now share one card design, so feeds look and behave consistently across both pages. The admin variant stays read-only and keeps owner information that the table previously surfaced.
