### PR TITLE
Dedupe RSS attachment images by URL path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-21
 
+- Fixed RSS posts attaching the same image twice when it appeared as both a cover and inline image.
 - Refreshed the favicon with a bold fff ligature on Freefeed-orange tile.
 
 ## 2026-06-20

--- a/app/services/normalizer/rss_normalizer.rb
+++ b/app/services/normalizer/rss_normalizer.rb
@@ -49,7 +49,15 @@ module Normalizer
     end
 
     def normalize_attachment_urls
-      (image_urls + content_images).uniq
+      dedup_attachment_urls(image_urls + content_images)
+    end
+
+    # The same image often arrives both as an <enclosure> and as an inline
+    # <img>, differing only by a cache-busting query string (e.g. Beehiiv
+    # appends `?t=123` to the in-content copy). Dedupe on the path so it
+    # isn't attached twice; the first-seen URL wins.
+    def dedup_attachment_urls(urls)
+      urls.uniq { |url| url.split("?").first }
     end
 
     def image_urls

--- a/test/services/normalizer/rss_normalizer_test.rb
+++ b/test/services/normalizer/rss_normalizer_test.rb
@@ -67,6 +67,20 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
     ], post.attachment_urls
   end
 
+  test "#normalize should dedupe enclosure and content images differing only by query string" do
+    entry = create(:feed_entry, raw_data: {
+      "summary" => "Photo of the day.",
+      "link" => "https://example.com/photo",
+      "content" => '<div class="image"><img src="https://media.example.com/photo.jpg?t=1781356253"/></div>',
+      "enclosures" => [{ "url" => "https://media.example.com/photo.jpg", "type" => "image/jpeg" }]
+    })
+
+    normalizer = Normalizer::RssNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert_equal ["https://media.example.com/photo.jpg"], post.attachment_urls
+  end
+
   test "#normalize should accept post with URL even when text content is blank" do
     entry = create(:feed_entry, raw_data: {
       "title" => "",


### PR DESCRIPTION
Changes:

- Dedupe RSS post attachment images by URL path instead of exact string

Some RSS feeds (e.g. Beehiiv) reference a post's cover image twice: once as an `<enclosure>` and once as an inline `<img>`, differing only by a cache-busting query string. Exact-string `uniq` missed this, so the same image got attached twice. Deduplicating on the path collapses these into one while keeping the first-seen URL.

References:

- Closes https://github.com/dreikanter/f2/issues/808
