### PR TITLE
Anchor source at top of feed form, label by input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-06-21
 
 - Fixed RSS posts attaching the same image twice when it appeared as both a cover and inline image.
-- New feed form now keeps your source on top as the rest of the form opens below it, and labels it "Source URL" or "Source prompt" to match what you entered.
+- Improve New feed form layout: keeps source input on top, and labels it "Source URL" or "Source prompt" to match user entry.
 - Refreshed the favicon with a bold fff ligature on Freefeed-orange tile.
 
 ## 2026-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-06-21
 
 - Fixed RSS posts attaching the same image twice when it appeared as both a cover and inline image.
+- New feed form now keeps your source on top as the rest of the form opens below it, and labels it "Source URL" or "Source prompt" to match what you entered.
 - Refreshed the favicon with a bold fff ligature on Freefeed-orange tile.
 
 ## 2026-06-20

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -180,6 +180,13 @@ class Feed < ApplicationRecord
     (FeedProfile[feed_profile_key]&.dig(:input_shape) || :url).to_s
   end
 
+  # Whether the user's source is a URL rather than a free-text prompt.
+  # Decided purely by parsing the input (no profile lookup, no LLM), so the
+  # label stays accurate even when an AI profile is chosen for a URL source.
+  def source_input_url?
+    InputClassifier.classify(source_input) == :url
+  end
+
   def display_name
     name.presence || "Untitled feed"
   end

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -32,8 +32,28 @@
                   groups_default_text_value: "The FreeFeed group where posts will be published. Each feed can go to its own group, or you can point multiple feeds at the same one."
                 } do |f| %>
     <div class="space-y-10">
+      <%# Source stays anchored at the top so the expansion reads as the
+          "What do you want to follow?" field staying put while the rest of
+          the form appears below it. %>
+      <% source_label = feed.source_input_url? ? "Source URL" : "Source prompt" %>
+      <div class="space-y-2">
+        <%= f.label :url, source_label, class: "block font-semibold text-slate-800" %>
+        <%= f.text_field :url_display,
+                         value: feed.source_input,
+                         disabled: true,
+                         class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
+                         aria: { label: "#{source_label} (cannot be changed)" },
+                         data: { key: "form.source-display" } %>
+        <% feed.params&.each do |key, value| %>
+          <%= hidden_field_tag "feed[params][#{key}]", value %>
+        <% end %>
+        <% unless show_chooser %>
+          <p class="text-sm text-slate-500"><%= edit_mode ? "Source and type can't be changed after creation. Start a new feed to follow a different source." : FeedProfile.display_name_for(feed.feed_profile_key).to_s %></p>
+        <% end %>
+      </div>
+
       <% if show_chooser %>
-        <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.url, single: single_candidate %>
+        <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.source_input, single: single_candidate %>
         <%# A disabled radio won't submit its value, so the lone option still
             needs a hidden field to carry the profile key to the server. %>
         <% if single_candidate %>
@@ -50,22 +70,6 @@
           AI fetches cost tokens. Previewing or refreshing a preview spends some too — you'll see your spend on the feed page.
         <% end %>
       <% end %>
-
-      <div class="space-y-2">
-        <%= f.label :url, "Source", class: "block font-semibold text-slate-800" %>
-        <%= f.text_field :url_display,
-                         value: feed.source_input,
-                         disabled: true,
-                         class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
-                         aria: { label: "Source (cannot be changed)" },
-                         data: { key: "form.source-display" } %>
-        <% feed.params&.each do |key, value| %>
-          <%= hidden_field_tag "feed[params][#{key}]", value %>
-        <% end %>
-        <% unless show_chooser %>
-          <p class="text-sm text-slate-500"><%= edit_mode ? "Source and type can't be changed after creation. Start a new feed to follow a different source." : FeedProfile.display_name_for(feed.feed_profile_key).to_s %></p>
-        <% end %>
-      </div>
 
       <div class="space-y-2">
         <%= f.label :name, "Feed Name", class: "block font-semibold text-slate-800" %>

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -495,6 +495,28 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "data-key=\"candidate.ai-badge\""
   end
 
+  test "#show should label a query source as a prompt and pass it to the chooser" do
+    sign_in_as(user)
+    query = "climate change"
+    create(
+      :feed_identification,
+      user: user,
+      input: query,
+      started_at: Time.current,
+      status: :success,
+      candidates: [
+        { "profile_key" => "llm_web_search", "title" => "Climate", "depends_on_ai" => true, "rank" => 0, "rank_reason" => "ai_fallback" }
+      ]
+    )
+
+    get feed_identifications_path, params: { input: query }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "label", text: "Source prompt"
+    assert_select "[data-key='candidate.llm_web_search']",
+                  text: /Follow AI search results for "#{query}"/
+  end
+
   test "#show should render a locked single-option chooser when one candidate exists" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -529,8 +529,18 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     get edit_feed_url(feed)
     assert_response :success
-    assert_select "label", text: "Source"
+    assert_select "label", text: "Source URL"
     assert_select "p.text-slate-500", text: "Source and type can't be changed after creation. Start a new feed to follow a different source."
+  end
+
+  test "#edit should label the source as a prompt for a query-shaped feed" do
+    sign_in_as(user)
+    prompt_feed = create(:feed, user: user, feed_profile_key: "llm_web_search", params: { "query" => "cat pictures" })
+
+    get edit_feed_url(prompt_feed)
+
+    assert_response :success
+    assert_select "label", text: "Source prompt"
   end
 
   test "#edit should render Save feed button and unchecked always-interactable Enable checkbox for a draft" do


### PR DESCRIPTION
Changes:

- Move the source field to the top of the expanded feed form, with the "How should we fetch posts?" chooser below it
- Label the source "Source URL" or "Source prompt" depending on whether the user entered a link or free text

The expansion now reads as the "What do you want to follow?" field staying in place while the rest of the form unfolds below it. The source label is decided by a plain parse of the input — no profile lookup or LLM — so it stays accurate even when an AI profile is picked for a URL.
