### PR TITLE
Store sent emails as JSON instead of YAML

### DIFF
--- a/app/services/email_storage/file_system_storage.rb
+++ b/app/services/email_storage/file_system_storage.rb
@@ -1,14 +1,12 @@
-require "active_support/time"
+require "json"
+require "time"
 
 module EmailStorage
   class FileSystemStorage < Base
-    YAML_PERMITTED_CLASSES = [
-      Time,
-      Date,
-      DateTime,
-      ActiveSupport::TimeWithZone,
-      ActiveSupport::TimeZone
-    ].freeze
+    # Times are stored as ISO8601 strings; everything else is a plain JSON
+    # scalar. JSON.parse can only produce basic types, so the writer and reader
+    # are locked to the same format with no allow-list to keep in sync.
+    TIME_KEYS = %w[timestamp date].freeze
 
     def initialize(base_dir = nil)
       @base_dir = base_dir || Rails.root.join("tmp", "sent_emails")
@@ -18,24 +16,19 @@ module EmailStorage
     def list
       return [] unless Dir.exist?(base_dir)
 
-      Dir.glob(base_dir.join("*.yml")).map do |yml_path|
-        filename = File.basename(yml_path, ".yml")
+      Dir.glob(base_dir.join("*.json")).map do |json_path|
+        filename = File.basename(json_path, ".json")
         match = filename.match(/_([0-9a-f\-]+)$/)
         next unless match
 
-        uuid = match[1]
-
-        begin
-          metadata = YAML.safe_load_file(yml_path, permitted_classes: YAML_PERMITTED_CLASSES, aliases: true) || {}
-        rescue Psych::SyntaxError
-          next
-        end
+        metadata = read_metadata(json_path)
+        next unless metadata
 
         {
-          id: uuid,
+          id: match[1],
           subject: metadata["subject"],
-          timestamp: metadata["timestamp"] || File.mtime(yml_path),
-          size: File.size(yml_path)
+          timestamp: parse_time(metadata["timestamp"]) || File.mtime(json_path),
+          size: File.size(json_path)
         }
       end.compact
     end
@@ -44,7 +37,7 @@ module EmailStorage
       filename = find_filename(uuid)
       return nil unless filename
 
-      metadata = load_metadata(filename)
+      metadata = read_metadata(base_dir.join("#{filename}.json"))
       return nil unless metadata
 
       text_content = load_text_content(filename)
@@ -55,7 +48,7 @@ module EmailStorage
         from: metadata["from"],
         to: metadata["to"],
         subject: metadata["subject"],
-        date: metadata["date"],
+        date: parse_time(metadata["date"]),
         multipart: metadata["multipart"] || false,
         body: metadata["multipart"] ? "" : text_content,
         text_part: metadata["multipart"] ? text_content : nil,
@@ -70,7 +63,7 @@ module EmailStorage
       filename = filename_for(uuid, metadata["timestamp"])
       base_path = base_dir.join(filename)
 
-      File.write("#{base_path}.yml", metadata.to_yaml)
+      File.write("#{base_path}.json", JSON.generate(serialize(metadata)))
       File.write("#{base_path}.txt", text_content)
       File.write("#{base_path}.html", html_content) if html_content
 
@@ -81,6 +74,8 @@ module EmailStorage
       find_filename(uuid).present?
     end
 
+    # Wipes the whole directory, so any leftover files (including legacy YAML
+    # captures) are removed regardless of format.
     def purge
       FileUtils.rm_rf(base_dir)
       FileUtils.mkdir_p(base_dir)
@@ -90,6 +85,27 @@ module EmailStorage
 
     attr_reader :base_dir
 
+    def serialize(metadata)
+      metadata.to_h do |key, value|
+        [key, TIME_KEYS.include?(key) ? format_time(value) : value]
+      end
+    end
+
+    def format_time(value)
+      return value unless value.respond_to?(:iso8601)
+      value.iso8601(3)
+    rescue ArgumentError
+      # Date#iso8601 takes no precision argument; fall back to its bare form.
+      value.iso8601
+    end
+
+    def parse_time(value)
+      return if value.blank?
+      Time.iso8601(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+
     def filename_for(uuid, timestamp)
       timestamp_str = timestamp.strftime("%Y%m%d_%H%M%S_%L")
       "#{timestamp_str}_#{uuid}"
@@ -98,18 +114,16 @@ module EmailStorage
     def find_filename(uuid)
       return nil unless Dir.exist?(base_dir)
 
-      pattern = base_dir.join("*_#{uuid}.yml")
-      matches = Dir.glob(pattern)
+      matches = Dir.glob(base_dir.join("*_#{uuid}.json"))
       return nil if matches.empty?
 
-      File.basename(matches.first, ".yml")
+      File.basename(matches.first, ".json")
     end
 
-    def load_metadata(id)
-      path = base_dir.join("#{id}.yml")
-      return unless File.exist?(path)
-      YAML.safe_load_file(path, permitted_classes: YAML_PERMITTED_CLASSES, aliases: true) || {}
-    rescue Psych::SyntaxError, Errno::ENOENT, IOError => e
+    def read_metadata(path)
+      parsed = JSON.parse(File.read(path))
+      parsed if parsed.is_a?(Hash)
+    rescue JSON::ParserError, Errno::ENOENT, IOError => e
       Rails.logger.error "Failed to load email metadata from #{path}: #{e.message}"
       nil
     end

--- a/app/services/email_storage/in_memory_storage.rb
+++ b/app/services/email_storage/in_memory_storage.rb
@@ -12,7 +12,7 @@ module EmailStorage
             id: email[:id],
             subject: email[:metadata]["subject"],
             timestamp: email[:metadata]["timestamp"],
-            size: email[:metadata].to_yaml.bytesize
+            size: JSON.generate(email[:metadata]).bytesize
           }
         end
       end

--- a/test/services/email_storage/file_system_storage_test.rb
+++ b/test/services/email_storage/file_system_storage_test.rb
@@ -55,8 +55,7 @@ class EmailStorage::FileSystemStorageTest < ActiveSupport::TestCase
 
   test "#ordered_list handles emails with a missing timestamp" do
     uuid = SecureRandom.uuid
-    metadata = { "subject" => "Legacy", "multipart" => false }
-    File.write(storage_dir.join("legacy_#{uuid}.yml"), metadata.to_yaml)
+    File.write(storage_dir.join("legacy_#{uuid}.json"), JSON.generate("subject" => "Legacy", "multipart" => false))
     File.write(storage_dir.join("legacy_#{uuid}.txt"), "Body")
 
     emails = storage.ordered_list
@@ -66,28 +65,60 @@ class EmailStorage::FileSystemStorageTest < ActiveSupport::TestCase
     assert_kind_of Time, emails.first[:timestamp]
   end
 
+  test "#ordered_list falls back to file mtime for an unparseable timestamp" do
+    uuid = SecureRandom.uuid
+    File.write(
+      storage_dir.join("20250101_120000_123_#{uuid}.json"),
+      JSON.generate("subject" => "Bad TS", "timestamp" => "not-a-date")
+    )
+
+    email = storage.ordered_list.first
+    assert_equal "Bad TS", email[:subject]
+    assert_kind_of Time, email[:timestamp]
+  end
+
   test "#ordered_list skips files with invalid filenames" do
     uuid = SecureRandom.uuid
     create_test_email(uuid, "Valid")
-    File.write(storage_dir.join("invalid.yml"), "data")
+    File.write(storage_dir.join("invalid.json"), JSON.generate("subject" => "Nope"))
 
     emails = storage.ordered_list
     assert_equal 1, emails.size
     assert_equal "Valid", emails.first[:subject]
   end
 
-  test "#ordered_list skips files with corrupted YAML" do
+  test "#ordered_list skips files with corrupted JSON" do
     valid_uuid = SecureRandom.uuid
     corrupt_uuid = SecureRandom.uuid
-    valid_id = "20250101_120000_123_#{valid_uuid}"
-    corrupt_id = "20250102_120000_456_#{corrupt_uuid}"
-
-    create_test_email(valid_id, "Valid")
-    File.write(storage_dir.join("#{corrupt_id}.yml"), "invalid: yaml: [")
+    create_test_email("20250101_120000_123_#{valid_uuid}", "Valid")
+    File.write(storage_dir.join("20250102_120000_456_#{corrupt_uuid}.json"), "{not json")
 
     emails = storage.ordered_list
     assert_equal 1, emails.size
     assert_equal "Valid", emails.first[:subject]
+  end
+
+  test "#ordered_list skips JSON files that are not objects" do
+    valid_uuid = SecureRandom.uuid
+    array_uuid = SecureRandom.uuid
+    create_test_email("20250101_120000_123_#{valid_uuid}", "Valid")
+    File.write(storage_dir.join("20250102_120000_456_#{array_uuid}.json"), "[1,2,3]")
+
+    emails = storage.ordered_list
+    assert_equal 1, emails.size
+    assert_equal "Valid", emails.first[:subject]
+  end
+
+  test "#ordered_list ignores legacy YAML files" do
+    json_uuid = SecureRandom.uuid
+    yaml_uuid = SecureRandom.uuid
+    create_test_email("20250101_120000_123_#{json_uuid}", "Current")
+    # A leftover YAML capture from the previous format must not be read.
+    File.write(storage_dir.join("20250102_120000_456_#{yaml_uuid}.yml"), { "subject" => "Old" }.to_yaml)
+
+    emails = storage.ordered_list
+    assert_equal 1, emails.size
+    assert_equal "Current", emails.first[:subject]
   end
 
   test "#load_email returns nil for non-existent email" do
@@ -106,6 +137,14 @@ class EmailStorage::FileSystemStorageTest < ActiveSupport::TestCase
     assert_nil email[:text_part]
   end
 
+  test "#load_email parses the date into a time" do
+    uuid = SecureRandom.uuid
+    create_test_email("20250101_120000_123_#{uuid}", "Test")
+
+    email = storage.load_email(uuid)
+    assert_kind_of Time, email[:date]
+  end
+
   test "#load_email loads multipart email" do
     uuid = SecureRandom.uuid
     full_id = "20250101_120000_123_#{uuid}"
@@ -119,10 +158,19 @@ class EmailStorage::FileSystemStorageTest < ActiveSupport::TestCase
     assert_equal "", email[:body]
   end
 
-  test "#load_email returns nil for corrupted YAML" do
+  test "#load_email returns nil for corrupted JSON" do
     uuid = SecureRandom.uuid
     full_id = "20250101_120000_123_#{uuid}"
-    File.write(storage_dir.join("#{full_id}.yml"), "invalid: yaml: [")
+    File.write(storage_dir.join("#{full_id}.json"), "{not json")
+    File.write(storage_dir.join("#{full_id}.txt"), "Content")
+
+    assert_nil storage.load_email(uuid)
+  end
+
+  test "#load_email returns nil for JSON that is not an object" do
+    uuid = SecureRandom.uuid
+    full_id = "20250101_120000_123_#{uuid}"
+    File.write(storage_dir.join("#{full_id}.json"), "[1,2,3]")
     File.write(storage_dir.join("#{full_id}.txt"), "Content")
 
     assert_nil storage.load_email(uuid)
@@ -133,20 +181,17 @@ class EmailStorage::FileSystemStorageTest < ActiveSupport::TestCase
     full_id = "20250101_120000_123_#{uuid}"
     metadata = {
       "message_id" => "<test@example.com>",
-      "from" => "sender@example.com",
-      "to" => "recipient@example.com",
       "subject" => "Test",
-      "date" => Time.now,
-      "timestamp" => Time.parse("2025-01-01T12:00:00+00:00"),
+      "timestamp" => Time.parse("2025-01-01T12:00:00+00:00").iso8601(3),
       "multipart" => false
     }
-    File.write(storage_dir.join("#{full_id}.yml"), metadata.to_yaml)
+    File.write(storage_dir.join("#{full_id}.json"), JSON.generate(metadata))
 
     email = storage.load_email(uuid)
     assert_equal "Test", email[:subject]
   end
 
-  test "#save_email creates metadata and text files" do
+  test "#save_email creates JSON metadata and text files" do
     metadata = {
       "message_id" => "<test@example.com>",
       "from" => "sender@example.com",
@@ -164,12 +209,52 @@ class EmailStorage::FileSystemStorageTest < ActiveSupport::TestCase
     files = Dir.glob(storage_dir.join("*_#{uuid}.*"))
     assert_equal 2, files.size
 
-    yml_file = files.find { |f| f.end_with?(".yml") }
+    json_file = files.find { |f| f.end_with?(".json") }
     txt_file = files.find { |f| f.end_with?(".txt") }
 
-    assert yml_file
+    assert json_file
     assert txt_file
     assert_equal "Body", File.read(txt_file)
+  end
+
+  test "#save_email stores times as ISO8601 strings" do
+    metadata = {
+      "subject" => "Test",
+      "date" => Time.parse("2025-01-01T12:00:00+00:00"),
+      "timestamp" => Time.parse("2025-01-02T12:00:00+00:00"),
+      "multipart" => false
+    }
+
+    uuid = storage.save_email(metadata: metadata, text_content: "Body")
+    raw = JSON.parse(File.read(Dir.glob(storage_dir.join("*_#{uuid}.json")).first))
+
+    assert_equal "2025-01-01T12:00:00.000+00:00", raw["date"]
+    assert_equal "2025-01-02T12:00:00.000+00:00", raw["timestamp"]
+  end
+
+  test "#save_email does not raise on a Date value" do
+    metadata = {
+      "subject" => "Test",
+      "date" => Date.new(2025, 1, 1),
+      "timestamp" => Time.parse("2025-01-01T12:00:00+00:00"),
+      "multipart" => false
+    }
+
+    assert_nothing_raised do
+      storage.save_email(metadata: metadata, text_content: "Body")
+    end
+  end
+
+  test "#save_email persists metadata that can be read back" do
+    metadata = {
+      "subject" => "Round trip",
+      "timestamp" => Time.parse("2025-01-01T12:00:00+00:00"),
+      "multipart" => false
+    }
+
+    uuid = storage.save_email(metadata: metadata, text_content: "Body")
+
+    assert_equal "Round trip", storage.ordered_list.find { |e| e[:id] == uuid }[:subject]
   end
 
   test "#save_email creates HTML file for multipart" do
@@ -206,52 +291,45 @@ class EmailStorage::FileSystemStorageTest < ActiveSupport::TestCase
     refute storage.email_exists?("nonexistent-uuid")
   end
 
-  test "#purge deletes all emails" do
+  test "#purge deletes all emails regardless of format" do
     uuid1 = SecureRandom.uuid
     uuid2 = SecureRandom.uuid
     create_test_email("20250101_120000_123_#{uuid1}", "First")
-    create_test_email("20250102_120000_456_#{uuid2}", "Second")
-
-    assert_equal 2, storage.ordered_list.size
+    # A leftover YAML capture must be wiped too.
+    File.write(storage_dir.join("20250102_120000_456_#{uuid2}.yml"), { "subject" => "Old" }.to_yaml)
 
     storage.purge
 
     assert_equal 0, storage.ordered_list.size
+    assert_empty Dir.glob(storage_dir.join("*"))
     assert Dir.exist?(storage_dir)
   end
 
   private
 
   def create_test_email(uuid, subject, body = "Body", timestamp: Time.parse("2025-01-01T12:00:00+00:00"))
-    metadata = {
-      "message_id" => "<test@example.com>",
-      "from" => "sender@example.com",
-      "to" => "recipient@example.com",
-      "subject" => subject,
-      "date" => Time.now,
-      "timestamp" => timestamp,
-      "multipart" => false
-    }
-    timestamp_str = timestamp.strftime("%Y%m%d_%H%M%S_%L")
-    filename = "#{timestamp_str}_#{uuid}"
-    File.write(storage_dir.join("#{filename}.yml"), metadata.to_yaml)
+    filename = write_metadata(uuid, subject, timestamp: timestamp, multipart: false)
     File.write(storage_dir.join("#{filename}.txt"), body)
   end
 
   def create_multipart_email(uuid, subject, text, html, timestamp: Time.parse("2025-01-01T12:00:00+00:00"))
+    filename = write_metadata(uuid, subject, timestamp: timestamp, multipart: true)
+    File.write(storage_dir.join("#{filename}.txt"), text)
+    File.write(storage_dir.join("#{filename}.html"), html)
+  end
+
+  def write_metadata(uuid, subject, timestamp:, multipart:)
     metadata = {
       "message_id" => "<test@example.com>",
       "from" => "sender@example.com",
       "to" => "recipient@example.com",
       "subject" => subject,
-      "date" => Time.now,
-      "timestamp" => timestamp,
-      "multipart" => true
+      "date" => timestamp.iso8601(3),
+      "timestamp" => timestamp.iso8601(3),
+      "multipart" => multipart
     }
-    timestamp_str = timestamp.strftime("%Y%m%d_%H%M%S_%L")
-    filename = "#{timestamp_str}_#{uuid}"
-    File.write(storage_dir.join("#{filename}.yml"), metadata.to_yaml)
-    File.write(storage_dir.join("#{filename}.txt"), text)
-    File.write(storage_dir.join("#{filename}.html"), html)
+    filename = "#{timestamp.strftime("%Y%m%d_%H%M%S_%L")}_#{uuid}"
+    File.write(storage_dir.join("#{filename}.json"), JSON.generate(metadata))
+    filename
   end
 end


### PR DESCRIPTION
Changes:

- Persist captured dev emails as JSON instead of YAML; store times as ISO8601 strings and parse them back safely.
- Ignore leftover `.yml` captures (the reader globs only `*.json`), so old files can't break the new code.
- Keep "Purge All" wiping the whole directory, so leftover files are removed regardless of format.

The sent-emails pages returned a 500 when a stored metadata file contained a value outside the YAML safe-load allow-list (e.g. a `Symbol`), raising `Psych::DisallowedClass`. The underlying problem was a writer/reader asymmetry: `to_yaml` serializes any Ruby object, while the reader restricted loads to a permitted-classes list, so the two could drift. JSON removes this structurally — its parser only yields plain scalars, so the writer and reader are locked to the same format with no allow-list to maintain.

References:

- Follow-up to #814
