### PR TITLE
Define email_storage_adapter default for all envs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,9 @@ module F2Rails
 
     # Configure ActiveJob to use SolidQueue
     config.active_job.queue_adapter = :solid_queue
+
+    # Default storage for captured emails. Defined here so the attribute exists
+    # in every environment; environments may override it.
+    config.email_storage_adapter = :file_system
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,8 +44,8 @@ module F2Rails
     # Configure ActiveJob to use SolidQueue
     config.active_job.queue_adapter = :solid_queue
 
-    # Default storage for captured emails. Defined here so the attribute exists
-    # in every environment; environments may override it.
+    # Defined here so the attribute exists in every environment (staging and
+    # production read it too); environments may override it.
     config.email_storage_adapter = :file_system
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,9 +68,6 @@ Rails.application.configure do
   config.active_record.encryption.deterministic_key = "KztQVQFifzXvAVzYZRpYhb4IpbB3LbsN"
   config.active_record.encryption.key_derivation_salt = "VsCuex5mmS3GP4Qu28NpLFEw99NgMVM5"
 
-  # Use filesystem storage for captured emails in development
-  config.email_storage_adapter = :file_system
-
   # Expose developer-only tools (component reference, captured emails).
   config.x.dev_tools.enabled = true
 end

--- a/test/config/email_storage_adapter_test.rb
+++ b/test/config/email_storage_adapter_test.rb
@@ -1,10 +1,27 @@
 require "test_helper"
 
 class EmailStorageAdapterConfigTest < ActiveSupport::TestCase
-  test "email_storage_adapter is defined in every environment" do
-    # The attribute is set in application.rb so reading it never raises
-    # NoMethodError, even in environments that don't override it (staging).
-    assert_nothing_raised { Rails.application.config.email_storage_adapter }
-    assert_not_nil Rails.application.config.email_storage_adapter
+  # Reading config.email_storage_adapter used to raise NoMethodError on staging,
+  # which inherits production and never set the attribute. Defining the default
+  # in application.rb fixes it, but the test environment overrides the value, so
+  # the regression only shows when an environment provides no override. Boot the
+  # production environment in a subprocess to assert the attribute is defined.
+  test "email_storage_adapter is defined without an environment override" do
+    # A marker isolates our value from any gem warnings printed to stdout.
+    script = 'puts "ADAPTER:#{Rails.application.config.email_storage_adapter}"'
+    env = {
+      "RAILS_ENV" => "production",
+      "SECRET_KEY_BASE" => "dummy",
+      "HOSTS" => "example.com",
+      "ACTION_MAILER_HOST" => "example.com"
+    }
+
+    output = nil
+    Dir.chdir(Rails.root) do
+      output = IO.popen(env, ["bin/rails", "runner", script], err: File::NULL, &:read)
+    end
+
+    assert $?.success?, "production environment failed to boot"
+    assert_includes output, "ADAPTER:file_system"
   end
 end

--- a/test/config/email_storage_adapter_test.rb
+++ b/test/config/email_storage_adapter_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class EmailStorageAdapterConfigTest < ActiveSupport::TestCase
+  test "email_storage_adapter is defined in every environment" do
+    # The attribute is set in application.rb so reading it never raises
+    # NoMethodError, even in environments that don't override it (staging).
+    assert_nothing_raised { Rails.application.config.email_storage_adapter }
+    assert_not_nil Rails.application.config.email_storage_adapter
+  end
+end

--- a/test/controllers/development/sent_emails_file_system_test.rb
+++ b/test/controllers/development/sent_emails_file_system_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+# The sent-emails pages run on the :file_system adapter in staging and
+# production, but the main controller test exercises :in_memory. Drive the real
+# controller and views through a FileSystemStorage to cover that path.
+class Development::SentEmailsFileSystemTest < ActionDispatch::IntegrationTest
+  setup do
+    FileUtils.mkdir_p(storage_dir)
+    login_as(dev_user)
+  end
+
+  teardown do
+    FileUtils.rm_rf(storage_dir)
+  end
+
+  def storage_dir
+    @storage_dir ||= Rails.root.join("tmp", "test_sent_emails_#{SecureRandom.hex(8)}")
+  end
+
+  def storage
+    @storage ||= EmailStorage::FileSystemStorage.new(storage_dir)
+  end
+
+  def dev_user
+    @dev_user ||= create(:user, :dev)
+  end
+
+  test "#index should render with no captured emails" do
+    with_file_system_storage do
+      get development_sent_emails_path
+    end
+
+    assert_response :success
+    assert_select '[data-key="development.emails.empty"]', text: /No emails captured yet/
+  end
+
+  test "#index should render captured emails" do
+    save_email("Welcome aboard")
+    save_email("Reset your password")
+
+    with_file_system_storage do
+      get development_sent_emails_path
+    end
+
+    assert_response :success
+    assert_select '[data-key="development.emails.list.item"]', count: 2
+    assert_select '[data-key="development.emails.list.item"] a', text: "Welcome aboard"
+  end
+
+  test "#show should render a captured email" do
+    save_email("Welcome aboard", "Glad you're here")
+    uuid = storage.list.first[:id]
+
+    with_file_system_storage do
+      get development_sent_email_path(id: uuid)
+    end
+
+    assert_response :success
+    assert_select '[data-key="development.emails.subject"]', text: "Welcome aboard"
+    assert_select '[data-key="development.emails.body"]', text: /Glad you're here/
+  end
+
+  test "#purge should clear captured emails" do
+    save_email("Welcome aboard")
+
+    with_file_system_storage do
+      delete purge_development_sent_emails_path
+    end
+
+    assert_redirected_to development_sent_emails_path
+    assert_equal 0, storage.list.count
+  end
+
+  private
+
+  def with_file_system_storage(&block)
+    EmailStorageResolver.stub(:resolve, storage, &block)
+  end
+
+  def save_email(subject, body = "Body text")
+    storage.save_email(
+      metadata: {
+        "message_id" => "<#{SecureRandom.hex(8)}@example.com>",
+        "from" => "sender@example.com",
+        "to" => "recipient@example.com",
+        "subject" => subject,
+        "date" => Time.current,
+        "timestamp" => Time.current,
+        "multipart" => false
+      },
+      text_content: body
+    )
+  end
+
+  def login_as(user)
+    post session_path, params: { email_address: user.email_address, password: "password123" }
+  end
+end


### PR DESCRIPTION
Changes:

- Set `config.email_storage_adapter` default (`:file_system`) in `config/application.rb` so the attribute is defined in every environment
- Drop the now-redundant explicit setting from `config/environments/development.rb`
- Add a regression test asserting the attribute is always defined

The captured-emails dev tool reads `Rails.application.config.email_storage_adapter`, but that attribute was only set in development and test. Staging inherits from production, where it was never defined, so a DEV-permissioned user opening the page hit a `NoMethodError`. Defining the default at the application level keeps it present everywhere while still allowing per-environment overrides.