### PR TITLE
List menu clipping, post status link, and Sent Emails gating fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-21
 
+- Post status now reads "Reposted: 28m" and links to the feed inside Feeder.
 - Fixed row action menus getting cut off at the bottom of feed, post, access token, and AI credential lists.
 - Access tokens and AI credentials now use the same compact list layout as feeds.
 - Fixed RSS posts attaching the same image twice when it appeared as both a cover and inline image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-21
 
+- Fixed row action menus getting cut off at the bottom of feed, post, access token, and AI credential lists.
 - Access tokens and AI credentials now use the same compact list layout as feeds.
 - Fixed RSS posts attaching the same image twice when it appeared as both a cover and inline image.
 - Improve New feed form layout: keeps source input on top, and labels it "Source URL" or "Source prompt" to match user entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-21
 
-- Post status now reads "Reposted: 28m" and links to the feed inside Feeder.
-- Fixed row action menus getting cut off at the bottom of feed, post, access token, and AI credential lists.
 - Access tokens and AI credentials now use the same compact list layout as feeds.
 - Fixed RSS posts attaching the same image twice when it appeared as both a cover and inline image.
 - Improve New feed form layout: keeps source input on top, and labels it "Source URL" or "Source prompt" to match user entry.

--- a/app/components/list_component.rb
+++ b/app/components/list_component.rb
@@ -1,5 +1,8 @@
 class ListComponent < SlotListComponent
-  DEFAULT_CSS_CLASSES = "overflow-hidden rounded-lg border border-slate-200 bg-white divide-y divide-slate-200"
+  # No `overflow-hidden`: it would clip row dropdown menus that open past the
+  # list's bottom edge. Rows round their own first/last corners instead (see
+  # ListItemComponent), so the rounded container still looks clean.
+  DEFAULT_CSS_CLASSES = "rounded-lg border border-slate-200 bg-white divide-y divide-slate-200"
 
   private
 

--- a/app/components/list_item_component.rb
+++ b/app/components/list_item_component.rb
@@ -42,8 +42,10 @@ class ListItemComponent < ViewComponent::Base
     @css_class
   end
 
+  # Round the outer corners so tinted/hover row backgrounds match the list's
+  # rounded container, which no longer clips them with overflow-hidden.
   def li_class
-    helpers.class_names("px-5 py-3", row_css_class)
+    helpers.class_names("px-5 py-3 first:rounded-t-lg last:rounded-b-lg", row_css_class)
   end
 
   # The second line only hangs under the primary text when there is a leading

--- a/app/components/post_list_item_component.rb
+++ b/app/components/post_list_item_component.rb
@@ -148,10 +148,6 @@ class PostListItemComponent < ListItemComponent
     helpers.icon(status_display[:icon], css_class: "size-4 #{status_display[:color]}")
   end
 
-  # Group the label, colon and the time tag inside a single inline wrapper so
-  # the surrounding flex gap only spaces the icon from the text. Without the
-  # wrapper the time becomes a separate flex item and drifts away from the
-  # label, e.g. "Reposted: 1d" splitting apart.
   def status_label_with_time
     helpers.content_tag(:span, helpers.safe_join([status_display[:label], ": ", helpers.short_time_ago_tag(status_time)]))
   end

--- a/app/components/post_list_item_component.rb
+++ b/app/components/post_list_item_component.rb
@@ -68,9 +68,9 @@ class PostListItemComponent < ListItemComponent
   end
 
   def status_element
-    if status_links_to_freefeed?
-      helpers.link_to(freefeed_url, target: "_blank", rel: "noopener",
-                      class: "transition hover:text-slate-600", data: { key: "post.status" }) { status_label_with_time }
+    if status_url
+      helpers.link_to(status_label_with_time, status_url,
+                      class: "transition hover:text-slate-600", data: { key: "post.status" })
     else
       helpers.tag.span(status_label_with_time, data: { key: "post.status" })
     end
@@ -148,12 +148,12 @@ class PostListItemComponent < ListItemComponent
     helpers.icon(status_display[:icon], css_class: "size-4 #{status_display[:color]}")
   end
 
-  # Group the label, parens and the time tag inside a single inline wrapper so
+  # Group the label, colon and the time tag inside a single inline wrapper so
   # the surrounding flex gap only spaces the icon from the text. Without the
-  # wrapper the parens become separate flex items and the duration drifts away
-  # from them, e.g. "Reposted ( 1d )" instead of "Reposted (1d)".
+  # wrapper the time becomes a separate flex item and drifts away from the
+  # label, e.g. "Reposted: 1d" splitting apart.
   def status_label_with_time
-    helpers.content_tag(:span, helpers.safe_join([status_display[:label], " (", helpers.short_time_ago_tag(status_time), ")"]))
+    helpers.content_tag(:span, helpers.safe_join([status_display[:label], ": ", helpers.short_time_ago_tag(status_time)]))
   end
 
   # The status badge reports when the post reached its current state. For a
@@ -204,12 +204,10 @@ class PostListItemComponent < ListItemComponent
     post.source_url.presence
   end
 
-  def freefeed_url
-    post.freefeed_url
-  end
-
-  def status_links_to_freefeed?
-    reposted? && freefeed_url.present?
+  # The status links to the post's feed page in Feeder, so it's easy to jump
+  # from a post back to the feed that reposted it.
+  def status_url
+    helpers.feed_path(post.feed) if post.feed
   end
 
   def delete_allowed?

--- a/app/components/post_list_item_component.rb
+++ b/app/components/post_list_item_component.rb
@@ -204,8 +204,6 @@ class PostListItemComponent < ListItemComponent
     post.source_url.presence
   end
 
-  # The status links to the post's feed page in Feeder, so it's easy to jump
-  # from a post back to the feed that reposted it.
   def status_url
     helpers.feed_path(post.feed) if post.feed
   end

--- a/app/components/readonly_post_list_item_component.rb
+++ b/app/components/readonly_post_list_item_component.rb
@@ -8,8 +8,6 @@ class ReadonlyPostListItemComponent < PostListItemComponent
     helpers.content_tag(:span, title, class: "truncate text-base text-slate-900")
   end
 
-  # The owner-scoped feed route isn't reachable here, so the status stays plain
-  # text rather than linking to it.
   def status_url
     nil
   end

--- a/app/components/readonly_post_list_item_component.rb
+++ b/app/components/readonly_post_list_item_component.rb
@@ -8,6 +8,12 @@ class ReadonlyPostListItemComponent < PostListItemComponent
     helpers.content_tag(:span, title, class: "truncate text-base text-slate-900")
   end
 
+  # The owner-scoped feed route isn't reachable here, so the status stays plain
+  # text rather than linking to it.
+  def status_url
+    nil
+  end
+
   def show_actions?
     false
   end

--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -1,7 +1,9 @@
 class DevelopmentsController < ApplicationController
   def show
     authorize :access, :dev?
-    @sent_emails_available = ActionMailer::Base.delivery_method == :file ||
-      (ActionMailer::Base.delivery_method == :resend && Resend.api_key.present?)
+    # Only the :file delivery method captures messages into the local store the
+    # Sent Emails page reads from. Other methods (e.g. :resend) actually send the
+    # mail, leaving nothing to browse, so the link stays disabled.
+    @sent_emails_available = ActionMailer::Base.delivery_method == :file
   end
 end

--- a/test/components/list_component_test.rb
+++ b/test/components/list_component_test.rb
@@ -14,6 +14,14 @@ class ListComponentTest < ViewComponent::TestCase
     assert_equal "Trailing slot", result.css('[data-key="stats.custom.value"]').first.text.strip
   end
 
+  test "#render should not clip row dropdowns with overflow-hidden" do
+    component = ListComponent.new
+    component.with_item StubItemComponent.new(body_text: "Body", value: "Value", key: "stats.custom")
+    result = render_inline(component)
+
+    assert_not_includes result.at_css("ul")["class"], "overflow-hidden"
+  end
+
   test "#render should support block-based slot population" do
     result = render_inline(ListComponent.new) do |list|
       list.with_item StubItemComponent.new(body_text: "Block item", value: "Block value", key: "stats.block")

--- a/test/components/list_item_component_test.rb
+++ b/test/components/list_item_component_test.rb
@@ -14,6 +14,16 @@ class ListItemComponentTest < ViewComponent::TestCase
     assert_includes li["class"], "px-5 py-3"
   end
 
+  test "#call should round the first and last row corners" do
+    result = render_inline(ListItemComponent.new(id: "row-1")) do |item|
+      item.with_primary { "Primary".html_safe }
+    end
+
+    li = result.at_css("li#row-1")
+    assert_includes li["class"], "first:rounded-t-lg"
+    assert_includes li["class"], "last:rounded-b-lg"
+  end
+
   test "#call should render every slot when provided" do
     result = render_inline(ListItemComponent.new) do |item|
       item.with_icon { "<svg></svg>".html_safe }

--- a/test/components/post_list_item_component_test.rb
+++ b/test/components/post_list_item_component_test.rb
@@ -63,7 +63,6 @@ class PostListItemComponentTest < ViewComponent::TestCase
     result = render_inline PostListItemComponent.new(post: post, show_feed: false)
 
     assert_nil result.at_css('[data-key="post.group"]')
-    assert_nil result.at_css("a[href*='/feeds/']")
   end
 
   test "#render should show attachment count for reposted posts with attachments" do
@@ -180,39 +179,29 @@ class PostListItemComponentTest < ViewComponent::TestCase
     assert(source_links.all? { |link| link["role"] == "menuitem" })
   end
 
-  test "#render should label published posts as reposted and link to the freefeed post" do
+  test "#render should label published posts as reposted and link to the feed page" do
     published_post = create(:post, :published, feed: feed,
       published_at: 11.hours.ago, reposted_at: 10.hours.ago)
     result = render_inline PostListItemComponent.new(post: published_post)
 
-    status_link = result.at_css("a[href='#{published_post.freefeed_url}']")
-    assert_not_nil status_link
-    assert_includes status_link.text.gsub(/\s+/, " "), "Reposted (10h)"
+    status_link = result.at_css('[data-key="post.status"]')
+    assert_equal "a", status_link.name
+    assert_equal "/feeds/#{feed.id}", status_link["href"]
+    assert_nil status_link["target"]
+    assert_includes status_link.text.gsub(/\s+/, " "), "Reposted: 10h"
     assert_not_empty result.css('[data-key="post.status-icon"] svg.text-green-600')
   end
 
-  test "#render should keep the duration tight against its parentheses" do
+  test "#render should keep the duration tight against its label" do
     published_post = create(:post, :published, feed: feed,
       published_at: 11.hours.ago, reposted_at: 10.hours.ago)
     result = render_inline PostListItemComponent.new(post: published_post)
 
-    # The label, parens and time tag share one inline wrapper that carries no
-    # flex gap, so the duration cannot drift away from its parentheses.
+    # The label, colon and time tag share one inline wrapper that carries no
+    # flex gap, so the duration cannot drift away from its label.
     wrapper = result.at_css('[data-key="post.status"] time').parent
-    assert_equal "Reposted (10h)", wrapper.text.strip
+    assert_equal "Reposted: 10h", wrapper.text.strip
     assert_not_includes wrapper["class"].to_s, "gap"
-  end
-
-  test "#render should show the reposted status as plain text when freefeed url is missing" do
-    # A purged post stays published but loses its freefeed_post_id (see GroupPurgeJob)
-    purged_post = create(:post, :published, feed: feed, freefeed_post_id: nil,
-      published_at: 11.hours.ago, reposted_at: 10.hours.ago)
-    result = render_inline PostListItemComponent.new(post: purged_post)
-
-    assert_nil purged_post.freefeed_url
-    status = result.at_css('[data-key="post.status"]')
-    assert_includes status.text.gsub(/\s+/, " "), "Reposted (10h)"
-    assert_equal "span", status.name
   end
 
   test "#render should label failed posts as failed with a red icon" do
@@ -220,7 +209,17 @@ class PostListItemComponentTest < ViewComponent::TestCase
     result = render_inline PostListItemComponent.new(post: failed_post)
 
     status = result.at_css('[data-key="post.status"]')
-    assert_includes status.text.gsub(/\s+/, " "), "Failed (10h)"
+    assert_includes status.text.gsub(/\s+/, " "), "Failed: 10h"
     assert_not_empty result.css('[data-key="post.status-icon"] svg.text-red-600')
+  end
+
+  test "#render should show the status as plain text in the readonly variant" do
+    published_post = create(:post, :published, feed: feed,
+      published_at: 11.hours.ago, reposted_at: 10.hours.ago)
+    result = render_inline ReadonlyPostListItemComponent.new(post: published_post)
+
+    status = result.at_css('[data-key="post.status"]')
+    assert_equal "span", status.name
+    assert_includes status.text.gsub(/\s+/, " "), "Reposted: 10h"
   end
 end

--- a/test/controllers/developments_controller_test.rb
+++ b/test/controllers/developments_controller_test.rb
@@ -28,22 +28,10 @@ class DevelopmentsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{development_components_path}']", count: 1
   end
 
-  test "should enable sent emails link when resend delivery is configured" do
+  test "should disable sent emails link when delivery does not capture locally" do
     sign_in_as(dev_user)
     ActionMailer::Base.stub(:delivery_method, :resend) do
       Resend.stub(:api_key, "re_test_key") do
-        get development_url
-      end
-    end
-
-    assert_response :success
-    assert_select "a[href='#{development_sent_emails_path}']", count: 1
-  end
-
-  test "should disable sent emails link when resend delivery is not configured" do
-    sign_in_as(dev_user)
-    ActionMailer::Base.stub(:delivery_method, :resend) do
-      Resend.stub(:api_key, nil) do
         get development_url
       end
     end


### PR DESCRIPTION
Changes:

- Stop the shared list container from clipping row action menus that open past its bottom edge; rows now round their own first/last corners instead of relying on `overflow-hidden`
- Post status now reads "Reposted: 28m" (was "Reposted (28m)") and links to the post's feed page inside Feeder rather than the FreeFeed post; the read-only/admin variant keeps it as plain text
- Enable the dev "Sent Emails" link only for the `:file` delivery method, the only one that captures messages into the local store the page reads from

A few small follow-ups after the list-layout work landed. The biggest is the dropdown clipping fix, which affects every `ListComponent`-based list (feeds, posts, access tokens, AI credentials), not just the newly converted pages.

References:

- Related PR: #823
