### PR TITLE
Show feed status and hide activity times for drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-06-22
+
+- Feed list rows now show each feed's status, and hide activity times for drafts.
+
 ## 2026-06-21
 
 - Access tokens and AI credentials now use the same compact list layout as feeds.

--- a/app/components/feed_list_item_component.rb
+++ b/app/components/feed_list_item_component.rb
@@ -59,12 +59,24 @@ class FeedListItemComponent < ListItemComponent
   end
 
   def meta_segments
-    segments = [
-      helpers.tag.span(helpers.safe_join(["Latest updated: ", last_refreshed_tag]), data: { key: "feed.#{feed.id}.last_refreshed" }),
-      helpers.tag.span(helpers.safe_join(["Latest post: ", most_recent_post_tag]), data: { key: "feed.#{feed.id}.most_recent_post" })
-    ]
+    segments = [status_segment]
+
+    # Drafts have never run, so their activity times and counts are meaningless.
+    unless draft?
+      segments << helpers.tag.span(helpers.safe_join(["Latest updated: ", last_refreshed_tag]), data: { key: "feed.#{feed.id}.last_refreshed" })
+      segments << helpers.tag.span(helpers.safe_join(["Latest post: ", most_recent_post_tag]), data: { key: "feed.#{feed.id}.most_recent_post" })
+    end
+
     segments << owner_segment if owner
     segments
+  end
+
+  def status_segment
+    helpers.tag.span(status_label, data: { key: "feed.#{feed.id}.status" })
+  end
+
+  def status_label
+    feed.state.capitalize
   end
 
   def owner_segment

--- a/test/components/feed_list_item_component_test.rb
+++ b/test/components/feed_list_item_component_test.rb
@@ -166,6 +166,42 @@ class FeedListItemComponentTest < ViewComponent::TestCase
     assert_includes result.text, "Latest post:"
   end
 
+  test "#render should show plain text status for disabled feeds" do
+    result = render_inline FeedListItemComponent.new(feed: feed)
+
+    status = result.at_css("[data-key='feed.#{feed.id}.status']")
+    assert_not_nil status
+    assert_equal "Disabled", status.text.strip
+  end
+
+  test "#render should show plain text status for enabled feeds" do
+    enabled_feed = create(:feed, :enabled, user: user)
+    result = render_inline FeedListItemComponent.new(feed: enabled_feed)
+
+    status = result.at_css("[data-key='feed.#{enabled_feed.id}.status']")
+    assert_not_nil status
+    assert_equal "Enabled", status.text.strip
+  end
+
+  test "#render should show plain text status for draft feeds" do
+    draft_feed = create(:feed, :draft, user: user)
+    result = render_inline FeedListItemComponent.new(feed: draft_feed)
+
+    status = result.at_css("[data-key='feed.#{draft_feed.id}.status']")
+    assert_not_nil status
+    assert_equal "Draft", status.text.strip
+  end
+
+  test "#render should not show activity times for draft feeds" do
+    draft_feed = create(:feed, :draft, user: user)
+    result = render_inline FeedListItemComponent.new(feed: draft_feed)
+
+    assert_empty result.css("[data-key='feed.#{draft_feed.id}.last_refreshed']")
+    assert_empty result.css("[data-key='feed.#{draft_feed.id}.most_recent_post']")
+    assert_not_includes result.text, "Latest updated:"
+    assert_not_includes result.text, "Latest post:"
+  end
+
   test "#render should link title to admin feed page in admin mode" do
     result = render_inline FeedListItemComponent.new(feed: feed, admin: true)
 


### PR DESCRIPTION
Changes:

- Add a plain-text status (Enabled, Disabled, Draft) to each feed list row's second line, styled like the surrounding muted metadata
- Omit the Latest updated and Latest post segments for draft feeds

Drafts have never run, so their activity times carry no useful information. The row now leads with the feed's status and skips the empty activity metadata for drafts, keeping the list informative without clutter.
