### PR TITLE
Group Settings in user menu and show permission display names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-06-22
+
+- Settings page now shows clearer permission names, like "Developer Tools" instead of "Dev".
+
 ## 2026-06-21
 
 - Access tokens and AI credentials now use the same compact list layout as feeds.

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -20,6 +20,8 @@
             <li>
               <%= link_to "Settings", settings_path, class: "block px-4 py-2 text-sm text-slate-700 hover:bg-slate-100" %>
             </li>
+          </ul>
+          <ul class="py-2">
             <li>
               <%= link_to "Freefeed Access Tokens", access_tokens_path, class: "block px-4 py-2 text-sm text-slate-700 hover:bg-slate-100" %>
             </li>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -31,7 +31,7 @@
       <% if @user.permissions.any? %>
         <% list.with_item(ListComponent::StatItemComponent.new(
           label: "Permissions",
-          value: @user.permissions.map { |permission| permission.name.humanize }.join(", "),
+          value: @user.permissions.map(&:display_name).join(", "),
           key: "settings.permissions"
         )) %>
       <% end %>

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -22,4 +22,12 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
     get settings_url
     assert_redirected_to new_session_path
   end
+
+  test "should show permission display name" do
+    @user = create(:user, :dev)
+    sign_in_user
+    get settings_url
+    assert_response :success
+    assert_select "[data-key='settings.permissions.value']", text: "Developer Tools"
+  end
 end


### PR DESCRIPTION
Changes:

- Show clearer permission names on the settings page (e.g. "Developer Tools" instead of "Dev"), reusing the labels already used on the admin user page
- Group Settings as its own section in the user dropdown menu, with a divider above and below
