### PR TITLE
Improve Settings navigation and tidy AI credential page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-22
 
+- Settings now has quick links to Access Tokens, AI Credentials, and Invites, and each of those pages links back to Settings.
 - AI credential pages list available models in alphabetical order by provider and name.
 
 ## 2026-06-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-06-22
+
+- AI credential pages list available models in alphabetical order by provider and name.
+
 ## 2026-06-21
 
 - Access tokens and AI credentials now use the same compact list layout as feeds.

--- a/app/components/ai_credential_models_component.rb
+++ b/app/components/ai_credential_models_component.rb
@@ -7,9 +7,6 @@ class AiCredentialModelsComponent < ViewComponent::Base
     models.present?
   end
 
-  # Provider returns names like "Google: Nano Banana 2 (Gemini 3.1 Flash
-  # Image)", so sorting alphabetically on the displayed title groups by
-  # provider first and then by model name.
   def models
     @ai_credential.available_models.sort_by { |model| model_name(model).downcase }
   end

--- a/app/components/ai_credential_models_component.rb
+++ b/app/components/ai_credential_models_component.rb
@@ -7,8 +7,11 @@ class AiCredentialModelsComponent < ViewComponent::Base
     models.present?
   end
 
+  # Provider returns names like "Google: Nano Banana 2 (Gemini 3.1 Flash
+  # Image)", so sorting alphabetically on the displayed title groups by
+  # provider first and then by model name.
   def models
-    @ai_credential.available_models
+    @ai_credential.available_models.sort_by { |model| model_name(model).downcase }
   end
 
   def model_name(model)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,7 @@ module ApplicationHelper
     "clipboard"      => '<rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>',
     "external-link"  => '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>',
     "key"            => '<path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4"/><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/>',
+    "sparkles"       => '<path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275z"/><path d="M5 3v4"/><path d="M19 17v4"/><path d="M3 5h4"/><path d="M17 19h4"/>',
     "refresh-ccw"    => '<path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 16h5v5"/>',
     "loader-circle"  => '<path d="M21 12a9 9 0 1 1-6.219-8.56"/>',
     "menu"           => '<path d="M4 5h16"/><path d="M4 12h16"/><path d="M4 19h16"/>',

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -9,10 +9,6 @@
 
   <% unless access_token.pending? || access_token.validating? %>
     <% header.with_action_button do %>
-      <%= link_to "Back to Tokens", access_tokens_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
-    <% end %>
-
-    <% header.with_action_button do %>
       <%= link_to "Edit", edit_access_token_path(access_token), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>
     <% end %>
 

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -2,6 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Freefeed Access Tokens") do |header| %>
+    <% header.with_breadcrumb(label: "Settings", url: settings_path) %>
     <% header.with_context_paragraph("Manage your FreeFeed API tokens used for reposting content.") %>
     <% header.with_action_button do %>
       <%= link_to "New Token", new_access_token_path, class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1") %>

--- a/app/views/ai_credentials/_show_content.html.erb
+++ b/app/views/ai_credentials/_show_content.html.erb
@@ -2,6 +2,19 @@
 <div class="space-y-6" data-key="ai_credential.show">
   <%= render PageHeaderComponent.new(title: ai_credential.display_name) do |header| %>
     <% header.with_breadcrumb(label: "AI credentials", url: ai_credentials_path) %>
+    <% header.with_action_button do %>
+      <%= link_to "Edit",
+                  edit_ai_credential_path(ai_credential),
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50",
+                  data: { key: "ai_credential.edit" } %>
+    <% end %>
+    <% header.with_action_button do %>
+      <%= button_to "Delete…",
+                    ai_credential_path(ai_credential),
+                    method: :delete,
+                    form: { data: { turbo_confirm: "Delete this AI credential? Feeds using it will be disabled." } },
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
+    <% end %>
   <% end %>
 
   <% case ai_credential.state %>
@@ -38,34 +51,27 @@
     <%= render AiCredentialDetailsComponent.new(ai_credential: ai_credential) %>
   <% end %>
 
-  <div class="flex flex-wrap gap-3">
-    <% if feed_id.present? %>
-      <% if ai_credential.active? %>
-        <%= link_to "Continue setting up your feed",
-                    edit_feed_path(feed_id),
-                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500",
-                    data: { key: "ai_credential.return-to" } %>
-      <% else %>
-        <%= link_to "Back to your feed",
-                    edit_feed_path(feed_id),
-                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50",
-                    data: { key: "ai_credential.return-to" } %>
+  <% if feed_id.present? || !ai_credential.default? %>
+    <div class="flex flex-wrap gap-3">
+      <% if feed_id.present? %>
+        <% if ai_credential.active? %>
+          <%= link_to "Continue setting up your feed",
+                      edit_feed_path(feed_id),
+                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-sky-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-sky-500",
+                      data: { key: "ai_credential.return-to" } %>
+        <% else %>
+          <%= link_to "Back to your feed",
+                      edit_feed_path(feed_id),
+                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50",
+                      data: { key: "ai_credential.return-to" } %>
+        <% end %>
       <% end %>
-    <% end %>
-    <% unless ai_credential.default? %>
-      <%= button_to "Make default",
-                    ai_credential_default_path(ai_credential),
-                    method: :patch,
-                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
-    <% end %>
-    <%= link_to "Edit",
-                edit_ai_credential_path(ai_credential),
-                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50",
-                data: { key: "ai_credential.edit" } %>
-    <%= button_to "Delete…",
-                  ai_credential_path(ai_credential),
-                  method: :delete,
-                  form: { data: { turbo_confirm: "Delete this AI credential? Feeds using it will be disabled." } },
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-red-200 bg-white px-4 py-2 text-base font-semibold text-red-700 shadow-sm transition hover:bg-red-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
-  </div>
+      <% unless ai_credential.default? %>
+        <%= button_to "Make default",
+                      ai_credential_default_path(ai_credential),
+                      method: :patch,
+                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/ai_credentials/index.html.erb
+++ b/app/views/ai_credentials/index.html.erb
@@ -2,6 +2,7 @@
 
 <div class="space-y-8" data-key="ai_credentials.index">
   <%= render PageHeaderComponent.new(title: "AI Credentials") do |header| %>
+    <% header.with_breadcrumb(label: "Settings", url: settings_path) %>
     <% header.with_context_paragraph("Connect your AI provider keys to use AI-backed feed extraction.") %>
     <% header.with_action_button do %>
       <%= link_to "New Credential",

--- a/app/views/invites/index.html.erb
+++ b/app/views/invites/index.html.erb
@@ -2,6 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Invites") do |header| %>
+    <% header.with_breadcrumb(label: "Settings", url: settings_path) %>
     <% header.with_context_paragraph do %>
       <span id="invite-stats"><%= render "summary", **@invite_stats %></span>
     <% end %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -38,4 +38,35 @@
     <% end %>
   </section>
 
+  <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <%= render CardComponent.new(href: access_tokens_path) do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("key", css_class: "size-5") %>
+          <span>Freefeed Access Tokens</span>
+        </h2>
+        <p class="text-slate-600">Manage the tokens used for reposting to FreeFeed</p>
+      </div>
+    <% end %>
+
+    <%= render CardComponent.new(href: ai_credentials_path) do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("sparkles", css_class: "size-5") %>
+          <span>AI Credentials</span>
+        </h2>
+        <p class="text-slate-600">Connect AI provider keys for AI-backed feed extraction</p>
+      </div>
+    <% end %>
+
+    <%= render CardComponent.new(href: invites_path) do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("mail", css_class: "size-5") %>
+          <span>Invites</span>
+        </h2>
+        <p class="text-slate-600">Invite people to join Feeder</p>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/test/components/ai_credential_models_component_test.rb
+++ b/test/components/ai_credential_models_component_test.rb
@@ -39,6 +39,20 @@ class AiCredentialModelsComponentTest < ViewComponent::TestCase
     assert_includes result.css('[data-key="ai_credential.model.name"]').first.text, "some-model"
   end
 
+  test "#render should order models by provider then model name" do
+    unordered = [
+      { "id" => "z", "name" => "OpenAI: GPT-4" },
+      { "id" => "a", "name" => "Google: Gemini Pro" },
+      { "id" => "b", "name" => "Google: Gemini Flash" }
+    ]
+    credential = create(:ai_credential, :active, available_models: unordered)
+
+    result = render_inline(AiCredentialModelsComponent.new(ai_credential: credential))
+
+    names = result.css('[data-key="ai_credential.model.name"]').map { |node| node.text.strip }
+    assert_equal ["Google: Gemini Flash", "Google: Gemini Pro", "OpenAI: GPT-4"], names
+  end
+
   test "#render should render nothing when there are no models" do
     credential = create(:ai_credential, :active, available_models: [])
 

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -20,6 +20,7 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "h1", "Freefeed Access Tokens"
+    assert_select "nav[aria-label='Breadcrumb'] a[href=?]", settings_path, text: "Settings"
   end
 
   test "#index should display empty state" do

--- a/test/controllers/ai_credentials_controller_test.rb
+++ b/test/controllers/ai_credentials_controller_test.rb
@@ -32,6 +32,7 @@ class AiCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "[data-key='ai_credentials.index']"
     assert_select "[data-key='ai_credential.#{credential.id}']"
+    assert_select "nav[aria-label='Breadcrumb'] a[href=?]", settings_path, text: "Settings"
   end
 
   test "#index should show the empty state when the user has no credentials" do

--- a/test/controllers/ai_credentials_controller_test.rb
+++ b/test/controllers/ai_credentials_controller_test.rb
@@ -186,6 +186,17 @@ class AiCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='ai_credential.show']"
   end
 
+  test "#show should place edit and delete actions in the header" do
+    sign_in_as(user)
+    get ai_credential_url(credential)
+
+    assert_response :success
+    assert_select "header [data-key='ai_credential.edit']"
+    assert_select "header form[action=?]", ai_credential_path(credential) do
+      assert_select "button", text: /Delete/
+    end
+  end
+
   test "#show should render the polling shell for a pending credential" do
     sign_in_as(user)
     pending = create(:ai_credential, user: user, state: :pending)

--- a/test/controllers/invites_controller_test.rb
+++ b/test/controllers/invites_controller_test.rb
@@ -26,6 +26,7 @@ class InvitesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as user
     get invites_url
     assert_response :success
+    assert_select "nav[aria-label='Breadcrumb'] a[href=?]", settings_path, text: "Settings"
   end
 
   test "should create invite when user has available invites" do

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -18,6 +18,15 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h2", text: "Feeder Invites", count: 0
   end
 
+  test "should link to settings sections" do
+    sign_in_user
+    get settings_url
+    assert_response :success
+    assert_select "a[href=?]", access_tokens_path
+    assert_select "a[href=?]", ai_credentials_path
+    assert_select "a[href=?]", invites_path
+  end
+
   test "should redirect to login when not authenticated" do
     get settings_url
     assert_redirected_to new_session_path


### PR DESCRIPTION
Changes:

- Add quick-access cards on the Settings page linking to Access Tokens, AI Credentials, and Invites
- Add a Settings breadcrumb to the Access Tokens, AI Credentials, and Invites pages
- Move Edit and Delete into the page header on the AI credential page, and give Delete the same neutral styling as Edit
- Sort the available models list on the AI credential page alphabetically by provider and model name
- Drop the redundant Back to Tokens button from the access token page

These changes make it easier to move between Settings and its related sections, and tidy up the AI credential page so its primary actions live in the header.