### PR TITLE
Throttle GroupPurgeJob

### DIFF
--- a/app/controllers/feeds/purges_controller.rb
+++ b/app/controllers/feeds/purges_controller.rb
@@ -3,7 +3,7 @@ class Feeds::PurgesController < ApplicationController
     feed = Current.user.feeds.find(params[:feed_id])
     authorize feed, :purge?
 
-    WithdrawAllPostsJob.perform_later(feed.id)
+    WithdrawAllPostsJob.perform_later(feed.id, Current.user.id)
 
     redirect_to feed_path(feed), notice: "Feed purge started for #{feed.target_group}"
   end

--- a/app/controllers/feeds/purges_controller.rb
+++ b/app/controllers/feeds/purges_controller.rb
@@ -3,7 +3,7 @@ class Feeds::PurgesController < ApplicationController
     feed = Current.user.feeds.find(params[:feed_id])
     authorize feed, :purge?
 
-    GroupPurgeJob.perform_later(feed.id)
+    WithdrawAllPostsJob.perform_later(feed.id)
 
     Event.create!(
       type: "group_purge_started",

--- a/app/controllers/feeds/purges_controller.rb
+++ b/app/controllers/feeds/purges_controller.rb
@@ -5,14 +5,6 @@ class Feeds::PurgesController < ApplicationController
 
     WithdrawAllPostsJob.perform_later(feed.id)
 
-    Event.create!(
-      type: "group_purge_started",
-      user: Current.user,
-      subject: feed,
-      level: :info,
-      metadata: { target_group: feed.target_group }
-    )
-
     redirect_to feed_path(feed), notice: "Feed purge started for #{feed.target_group}"
   end
 end

--- a/app/jobs/group_purge_job.rb
+++ b/app/jobs/group_purge_job.rb
@@ -1,6 +1,4 @@
 class GroupPurgeJob < ApplicationJob
-  include RateLimited
-
   queue_as :default
 
   def perform(feed_id)
@@ -11,26 +9,27 @@ class GroupPurgeJob < ApplicationJob
     return unless access_token&.active?
 
     client = access_token.build_client
-
-    # Posts cleared below drop out of this scope, so a rescheduled run (on throttle)
-    # resumes with whatever is left rather than re-deleting.
     posts = feed.posts.where.not(freefeed_post_id: [nil, ""])
 
     posts.find_each do |post|
-      result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
-      return reschedule_for_rate_limit(result.retry_after) unless result.allowed?
+      loop do
+        result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
+        unless result.allowed?
+          sleep(result.retry_after)
+          next
+        end
 
-      begin
-        client.delete_post(post.freefeed_post_id)
-        post.update!(freefeed_post_id: nil)
-      rescue FreefeedClient::Error => e
-        Rails.logger.error("Failed to withdraw post #{post.id} from FreeFeed: #{e.message}")
-        # Continue with next post even if one fails
+        begin
+          client.delete_post(post.freefeed_post_id)
+          post.update!(freefeed_post_id: nil)
+          break
+        rescue RateLimit::Throttled => e
+          sleep(e.retry_after)
+        rescue FreefeedClient::Error => e
+          Rails.logger.error("Failed to withdraw post #{post.id} from FreeFeed: #{e.message}")
+          break
+        end
       end
     end
-  rescue RateLimit::Throttled => e
-    # FreeFeed throttled a DELETE mid-batch; defer the rest. Cleared posts have
-    # dropped out of the scope, so the rescheduled run resumes with the remainder.
-    reschedule_for_rate_limit(e.retry_after)
   end
 end

--- a/app/jobs/group_purge_job.rb
+++ b/app/jobs/group_purge_job.rb
@@ -11,6 +11,8 @@ class GroupPurgeJob < ApplicationJob
     client = access_token.build_client
     posts = feed.posts.where.not(freefeed_post_id: [nil, ""])
 
+    affected_dates = Set.new
+
     posts.find_each do |post|
       loop do
         result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
@@ -21,7 +23,8 @@ class GroupPurgeJob < ApplicationJob
 
         begin
           client.delete_post(post.freefeed_post_id)
-          post.update!(freefeed_post_id: nil)
+          affected_dates << post.reposted_at.to_date if post.reposted_at
+          post.update!(freefeed_post_id: nil, status: :withdrawn)
           break
         rescue RateLimit::Throttled => e
           sleep(e.retry_after)
@@ -31,5 +34,7 @@ class GroupPurgeJob < ApplicationJob
         end
       end
     end
+
+    affected_dates.each { |date| FeedMetric.recompute_published(feed: feed, date: date) }
   end
 end

--- a/app/jobs/group_purge_job.rb
+++ b/app/jobs/group_purge_job.rb
@@ -9,7 +9,7 @@ class GroupPurgeJob < ApplicationJob
     return unless access_token&.active?
 
     client = access_token.build_client
-    posts = feed.posts.where.not(freefeed_post_id: [nil, ""])
+    posts = feed.posts.published
 
     affected_dates = Set.new
 

--- a/app/jobs/withdraw_all_posts_job.rb
+++ b/app/jobs/withdraw_all_posts_job.rb
@@ -1,13 +1,16 @@
 class WithdrawAllPostsJob < ApplicationJob
   queue_as :default
 
-  def perform(feed_id)
+  def perform(feed_id, user_id)
     feed = Feed.find_by(id: feed_id)
     return unless feed
+
+    user = User.find_by(id: user_id)
+    return unless user
 
     access_token = feed.access_token
     return unless access_token&.active?
 
-    WithdrawAllPosts.new(feed).call
+    WithdrawAllPosts.new(feed, user: user).call
   end
 end

--- a/app/jobs/withdraw_all_posts_job.rb
+++ b/app/jobs/withdraw_all_posts_job.rb
@@ -8,37 +8,6 @@ class WithdrawAllPostsJob < ApplicationJob
     access_token = feed.access_token
     return unless access_token&.active?
 
-    client = access_token.build_client
-    posts = feed.posts.published
-
-    affected_dates = Set.new
-
-    posts.find_each do |post|
-      loop do
-        result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { delete: 1 })
-        unless result.allowed?
-          sleep(result.retry_after)
-          next
-        end
-
-        begin
-          client.delete_post(post.freefeed_post_id)
-        rescue RateLimit::Throttled => e
-          sleep(e.retry_after)
-          next
-        rescue FreefeedClient::NotFoundError
-          Rails.logger.warn("FreeFeed post #{post.freefeed_post_id} not found; syncing local record")
-        rescue FreefeedClient::Error => e
-          Rails.logger.error("Failed to withdraw post #{post.id} from FreeFeed: #{e.message}")
-          break
-        end
-
-        affected_dates << post.reposted_at.to_date if post.reposted_at
-        post.update!(freefeed_post_id: nil, status: :withdrawn)
-        break
-      end
-    end
-
-    affected_dates.each { |date| FeedMetric.recompute_published(feed: feed, date: date) }
+    WithdrawAllPosts.new(feed).call
   end
 end

--- a/app/jobs/withdraw_all_posts_job.rb
+++ b/app/jobs/withdraw_all_posts_job.rb
@@ -27,7 +27,7 @@ class WithdrawAllPostsJob < ApplicationJob
           sleep(e.retry_after)
           next
         rescue FreefeedClient::NotFoundError
-          # already deleted from FreeFeed — fall through and sync the record
+          Rails.logger.warn("FreeFeed post #{post.freefeed_post_id} not found; syncing local record")
         rescue FreefeedClient::Error => e
           Rails.logger.error("Failed to withdraw post #{post.id} from FreeFeed: #{e.message}")
           break

--- a/app/jobs/withdraw_all_posts_job.rb
+++ b/app/jobs/withdraw_all_posts_job.rb
@@ -1,4 +1,4 @@
-class GroupPurgeJob < ApplicationJob
+class WithdrawAllPostsJob < ApplicationJob
   queue_as :default
 
   def perform(feed_id)

--- a/app/jobs/withdraw_all_posts_job.rb
+++ b/app/jobs/withdraw_all_posts_job.rb
@@ -23,15 +23,19 @@ class WithdrawAllPostsJob < ApplicationJob
 
         begin
           client.delete_post(post.freefeed_post_id)
-          affected_dates << post.reposted_at.to_date if post.reposted_at
-          post.update!(freefeed_post_id: nil, status: :withdrawn)
-          break
         rescue RateLimit::Throttled => e
           sleep(e.retry_after)
+          next
+        rescue FreefeedClient::NotFoundError
+          # already deleted from FreeFeed — fall through and sync the record
         rescue FreefeedClient::Error => e
           Rails.logger.error("Failed to withdraw post #{post.id} from FreeFeed: #{e.message}")
           break
         end
+
+        affected_dates << post.reposted_at.to_date if post.reposted_at
+        post.update!(freefeed_post_id: nil, status: :withdrawn)
+        break
       end
     end
 

--- a/app/services/withdraw_all_posts.rb
+++ b/app/services/withdraw_all_posts.rb
@@ -6,16 +6,42 @@ class WithdrawAllPosts
   end
 
   def call
+    event = create_event
+    started_at = Time.current
     affected_dates = Set.new
+    deleted_count = 0
 
     @feed.posts.published.find_each do |post|
-      withdraw(post, affected_dates)
+      deleted_count += 1 if withdraw(post, affected_dates)
     end
 
     affected_dates.each { |date| FeedMetric.recompute_published(feed: @feed, date: date) }
+    finalize_event(event, started_at: started_at, deleted_count: deleted_count, affected_dates: affected_dates)
   end
 
   private
+
+  def create_event
+    Event.create!(
+      type: "group_purge_started",
+      user: @feed.user,
+      subject: @feed,
+      level: :info,
+      metadata: { target_group: @feed.target_group }
+    )
+  end
+
+  def finalize_event(event, started_at:, deleted_count:, affected_dates:)
+    stats = {
+      "deleted_count" => deleted_count,
+      "duration_seconds" => (Time.current - started_at).round(1)
+    }
+    if affected_dates.any?
+      stats["dates_from"] = affected_dates.min.iso8601
+      stats["dates_to"] = affected_dates.max.iso8601
+    end
+    event.update!(metadata: event.metadata.merge(stats))
+  end
 
   def withdraw(post, affected_dates)
     loop do
@@ -25,9 +51,9 @@ class WithdrawAllPosts
       when :ok, :not_found
         affected_dates << post.reposted_at.to_date if post.reposted_at
         post.update!(freefeed_post_id: nil, status: :withdrawn)
-        break
+        return true
       when :error
-        break
+        return false
       end
       # :throttled — loop back and re-acquire capacity before retrying
     end

--- a/app/services/withdraw_all_posts.rb
+++ b/app/services/withdraw_all_posts.rb
@@ -1,6 +1,7 @@
 class WithdrawAllPosts
-  def initialize(feed)
+  def initialize(feed, user:)
     @feed = feed
+    @user = user
     @client = feed.access_token.build_client
     @rate_limit_subject = feed.access_token.rate_limit_subject
   end
@@ -24,7 +25,7 @@ class WithdrawAllPosts
   def create_event
     Event.create!(
       type: "group_purge_started",
-      user: @feed.user,
+      user: @user,
       subject: @feed,
       level: :info,
       metadata: { target_group: @feed.target_group }

--- a/app/services/withdraw_all_posts.rb
+++ b/app/services/withdraw_all_posts.rb
@@ -9,8 +9,10 @@ class WithdrawAllPosts
     started_at = Time.current
     affected_dates = Set.new
 
-    deleted_count = published_posts.count do |post|
-      withdraw(post, affected_dates:)
+    deleted_count = 0
+
+    published_posts.each do |post|
+      deleted_count += 1 if withdraw(post, affected_dates:)
     end
 
     recompute_metrics(affected_dates)
@@ -27,7 +29,7 @@ class WithdrawAllPosts
   attr_reader :feed, :user
 
   def published_posts
-    feed.posts.published.order(reposted_at: :asc)
+    feed.posts.published.where.not(freefeed_post_id: [nil, ""]).order(reposted_at: :asc)
   end
 
   def client

--- a/app/services/withdraw_all_posts.rb
+++ b/app/services/withdraw_all_posts.rb
@@ -2,84 +2,145 @@ class WithdrawAllPosts
   def initialize(feed, user:)
     @feed = feed
     @user = user
-    @client = feed.access_token.build_client
-    @rate_limit_subject = feed.access_token.rate_limit_subject
   end
 
   def call
     event = create_event
     started_at = Time.current
     affected_dates = Set.new
-    deleted_count = 0
 
-    @feed.posts.published.order(reposted_at: :asc).each do |post|
-      deleted_count += 1 if withdraw(post, affected_dates)
+    deleted_count = published_posts.count do |post|
+      withdraw(post, affected_dates:)
     end
 
-    affected_dates.each { |date| FeedMetric.recompute_published(feed: @feed, date: date) }
-    finalize_event(event, started_at: started_at, deleted_count: deleted_count,
-                   dates_from: affected_dates.min, dates_to: affected_dates.max)
+    recompute_metrics(affected_dates)
+    finalize_event(
+      event,
+      started_at:,
+      deleted_count:,
+      affected_dates:
+    )
   end
 
   private
 
+  attr_reader :feed, :user
+
+  def published_posts
+    feed.posts.published.order(reposted_at: :asc)
+  end
+
+  def client
+    @client ||= feed.access_token.build_client
+  end
+
+  def rate_limit_subject
+    @rate_limit_subject ||= feed.access_token.rate_limit_subject
+  end
+
   def create_event
     Event.create!(
       type: "group_purge_started",
-      user: @user,
-      subject: @feed,
+      user:,
+      subject: feed,
       level: :info,
-      metadata: { target_group: @feed.target_group }
+      metadata: {
+        target_group: feed.target_group
+      }
     )
   end
 
-  def finalize_event(event, started_at:, deleted_count:, dates_from:, dates_to:)
-    stats = {
-      "deleted_count" => deleted_count,
-      "duration_seconds" => (Time.current - started_at).round(1)
-    }
-    if dates_from
-      stats["dates_from"] = dates_from.iso8601
-      stats["dates_to"] = dates_to.iso8601
+  def withdraw(post, affected_dates:)
+    with_delete_capacity do
+      delete_remote_post(post)
     end
-    event.update!(metadata: event.metadata.merge(stats))
+
+    mark_withdrawn(post)
+    affected_dates << post.reposted_at.to_date if post.reposted_at?
+
+    true
+  rescue FreefeedClient::NotFoundError
+    Rails.logger.warn(
+      "FreeFeed post #{post.freefeed_post_id} not found; syncing local record"
+    )
+
+    mark_withdrawn(post)
+    affected_dates << post.reposted_at.to_date if post.reposted_at?
+
+    true
+  rescue FreefeedClient::Error => e
+    Rails.logger.error(
+      "Failed to withdraw post #{post.id} from FreeFeed: #{e.message}"
+    )
+
+    false
   end
 
-  def withdraw(post, affected_dates)
+  # Sleep rather than reschedule: purging is a one-shot operation;
+  # sleeping holds one worker but avoids re-enqueuing with saved cursor state.
+  def with_delete_capacity
     loop do
       wait_for_capacity
 
-      case attempt_delete(post)
-      when :ok, :not_found
-        affected_dates << post.reposted_at.to_date if post.reposted_at
-        post.update!(freefeed_post_id: nil, status: :withdrawn)
-        return true
-      when :error
-        return false
-      end
-      # :throttled — loop back and re-acquire capacity before retrying
+      yield
+      return
+    rescue RateLimit::Throttled => e
+      sleep(e.retry_after)
     end
   end
 
   def wait_for_capacity
     loop do
-      result = RateLimit.acquire(:freefeed, subject: @rate_limit_subject, cost: { delete: 1 })
-      break if result.allowed?
+      result = RateLimit.acquire(
+        :freefeed,
+        subject: rate_limit_subject,
+        cost: { delete: 1 }
+      )
+
+      return if result.allowed?
+
       sleep(result.retry_after)
     end
   end
 
-  def attempt_delete(post)
-    @client.delete_post(post.freefeed_post_id)
-    :ok
-  rescue RateLimit::Throttled => e
-    sleep(e.retry_after)
-    :throttled
-  rescue FreefeedClient::NotFoundError
-    Rails.logger.warn("FreeFeed post #{post.freefeed_post_id} not found; syncing local record")
-    :not_found
-  rescue FreefeedClient::Error => e
-    Rails.logger.error("Failed to withdraw post #{post.id} from FreeFeed: #{e.message}")
-    :error
+  def delete_remote_post(post)
+    client.delete_post(post.freefeed_post_id)
+  end
+
+  def mark_withdrawn(post)
+    post.update!(
+      freefeed_post_id: nil,
+      status: :withdrawn
+    )
+  end
+
+  def recompute_metrics(dates)
+    dates.each do |date|
+      FeedMetric.recompute_published(feed:, date:)
+    end
+  end
+
+  def finalize_event(event, started_at:, deleted_count:, affected_dates:)
+    event.update!(
+      metadata: event.metadata.merge(
+        event_stats(
+          started_at:,
+          deleted_count:,
+          affected_dates:
+        )
+      )
+    )
+  end
+
+  def event_stats(started_at:, deleted_count:, affected_dates:)
+    {
+      "deleted_count" => deleted_count,
+      "duration_seconds" => (Time.current - started_at).round(1)
+    }.tap do |stats|
+      next if affected_dates.empty?
+
+      stats["dates_from"] = affected_dates.min.iso8601
+      stats["dates_to"] = affected_dates.max.iso8601
+    end
   end
 end

--- a/app/services/withdraw_all_posts.rb
+++ b/app/services/withdraw_all_posts.rb
@@ -12,12 +12,13 @@ class WithdrawAllPosts
     affected_dates = Set.new
     deleted_count = 0
 
-    @feed.posts.published.find_each do |post|
+    @feed.posts.published.order(reposted_at: :asc).each do |post|
       deleted_count += 1 if withdraw(post, affected_dates)
     end
 
     affected_dates.each { |date| FeedMetric.recompute_published(feed: @feed, date: date) }
-    finalize_event(event, started_at: started_at, deleted_count: deleted_count, affected_dates: affected_dates)
+    finalize_event(event, started_at: started_at, deleted_count: deleted_count,
+                   dates_from: affected_dates.min, dates_to: affected_dates.max)
   end
 
   private
@@ -32,14 +33,14 @@ class WithdrawAllPosts
     )
   end
 
-  def finalize_event(event, started_at:, deleted_count:, affected_dates:)
+  def finalize_event(event, started_at:, deleted_count:, dates_from:, dates_to:)
     stats = {
       "deleted_count" => deleted_count,
       "duration_seconds" => (Time.current - started_at).round(1)
     }
-    if affected_dates.any?
-      stats["dates_from"] = affected_dates.min.iso8601
-      stats["dates_to"] = affected_dates.max.iso8601
+    if dates_from
+      stats["dates_from"] = dates_from.iso8601
+      stats["dates_to"] = dates_to.iso8601
     end
     event.update!(metadata: event.metadata.merge(stats))
   end

--- a/app/services/withdraw_all_posts.rb
+++ b/app/services/withdraw_all_posts.rb
@@ -1,0 +1,57 @@
+class WithdrawAllPosts
+  def initialize(feed)
+    @feed = feed
+    @client = feed.access_token.build_client
+    @rate_limit_subject = feed.access_token.rate_limit_subject
+  end
+
+  def call
+    affected_dates = Set.new
+
+    @feed.posts.published.find_each do |post|
+      withdraw(post, affected_dates)
+    end
+
+    affected_dates.each { |date| FeedMetric.recompute_published(feed: @feed, date: date) }
+  end
+
+  private
+
+  def withdraw(post, affected_dates)
+    loop do
+      wait_for_capacity
+
+      case attempt_delete(post)
+      when :ok, :not_found
+        affected_dates << post.reposted_at.to_date if post.reposted_at
+        post.update!(freefeed_post_id: nil, status: :withdrawn)
+        break
+      when :error
+        break
+      end
+      # :throttled — loop back and re-acquire capacity before retrying
+    end
+  end
+
+  def wait_for_capacity
+    loop do
+      result = RateLimit.acquire(:freefeed, subject: @rate_limit_subject, cost: { delete: 1 })
+      break if result.allowed?
+      sleep(result.retry_after)
+    end
+  end
+
+  def attempt_delete(post)
+    @client.delete_post(post.freefeed_post_id)
+    :ok
+  rescue RateLimit::Throttled => e
+    sleep(e.retry_after)
+    :throttled
+  rescue FreefeedClient::NotFoundError
+    Rails.logger.warn("FreeFeed post #{post.freefeed_post_id} not found; syncing local record")
+    :not_found
+  rescue FreefeedClient::Error => e
+    Rails.logger.error("Failed to withdraw post #{post.id} from FreeFeed: #{e.message}")
+    :error
+  end
+end

--- a/test/controllers/feeds/purges_controller_test.rb
+++ b/test/controllers/feeds/purges_controller_test.rb
@@ -32,7 +32,7 @@ class Feeds::PurgesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     feed.update!(access_token: access_token)
 
-    assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
+    assert_enqueued_with(job: WithdrawAllPostsJob, args: [feed.id]) do
       assert_difference("Event.count", 1) do
         post feed_purge_path(feed)
       end

--- a/test/controllers/feeds/purges_controller_test.rb
+++ b/test/controllers/feeds/purges_controller_test.rb
@@ -28,24 +28,15 @@ class Feeds::PurgesControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "create schedules job and creates event" do
+  test "create schedules job and redirects" do
     sign_in_as(user)
     feed.update!(access_token: access_token)
 
     assert_enqueued_with(job: WithdrawAllPostsJob, args: [feed.id]) do
-      assert_difference("Event.count", 1) do
-        post feed_purge_path(feed)
-      end
+      post feed_purge_path(feed)
     end
 
     assert_redirected_to feed_path(feed)
     assert_equal "Feed purge started for testgroup", flash[:notice]
-
-    event = Event.last
-    assert_equal "group_purge_started", event.type
-    assert_equal user, event.user
-    assert_equal feed, event.subject
-    assert_equal "info", event.level
-    assert_equal "testgroup", event.metadata["target_group"]
   end
 end

--- a/test/controllers/feeds/purges_controller_test.rb
+++ b/test/controllers/feeds/purges_controller_test.rb
@@ -32,7 +32,7 @@ class Feeds::PurgesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     feed.update!(access_token: access_token)
 
-    assert_enqueued_with(job: WithdrawAllPostsJob, args: [feed.id]) do
+    assert_enqueued_with(job: WithdrawAllPostsJob, args: [feed.id, user.id]) do
       post feed_purge_path(feed)
     end
 

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -45,75 +45,56 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     end
   end
 
-  test ".perform_now should reschedule itself when throttled" do
-    create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
-    subject = access_token.rate_limit_subject
-
-    freeze_time do
-      drain_freefeed(subject, :delete, remaining: 0)
-
-      assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
-        GroupPurgeJob.perform_now(feed.id)
-      end
-    end
-
-    assert_not_requested :delete, "#{access_token.host}/v4/posts/post1"
-  end
-
-  test ".perform_now should keep progress and reschedule the rest when throttled mid-batch" do
+  test ".perform_now should sleep and continue instead of rescheduling when throttled" do
     post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
-    post2 = create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)
-    subject = access_token.rate_limit_subject
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
 
-    freeze_time do
-      # One delete token: the first withdrawal spends it, the second throttles.
-      drain_freefeed(subject, :delete, remaining: 1)
+    # Simulate one denied acquire followed by an allowed one.
+    acquire_call = 0
+    acquire_stub = ->(*args, **kwargs) {
+      acquire_call += 1
+      acquire_call == 1 ? RateLimit::Result.new(allowed: false, retry_after: 5.0)
+                        : RateLimit::Result.new(allowed: true, retry_after: 0.0)
+    }
 
-      assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
-        GroupPurgeJob.perform_now(feed.id)
+    slept = []
+    job = GroupPurgeJob.new(feed.id)
+
+    RateLimit.stub(:acquire, acquire_stub) do
+      job.stub(:sleep, ->(n) { slept << n }) do
+        assert_no_enqueued_jobs(only: GroupPurgeJob) do
+          job.perform_now
+        end
       end
     end
 
-    assert_nil post1.reload.freefeed_post_id
-    assert_equal "post2", post2.reload.freefeed_post_id
+    assert_equal [5.0], slept, "should sleep for the retry_after period"
+    assert_nil post1.reload.freefeed_post_id, "post should be deleted after sleeping for capacity"
   end
 
-  test ".perform_now should reschedule without failing when FreeFeed throttles a DELETE" do
+  test ".perform_now should sleep and retry instead of rescheduling when FreeFeed throttles a DELETE" do
     post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
     stub_request(:delete, "#{access_token.host}/v4/posts/post1")
       .to_return(status: 429, headers: { "Retry-After" => "30" })
+      .then.to_return(status: 200)
 
+    slept = []
     reported = []
-    assert_enqueued_with(job: GroupPurgeJob, args: [feed.id]) do
-      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
-        GroupPurgeJob.perform_now(feed.id)
-      end
-    end
-
-    assert_empty reported, "a handled mid-batch throttle must not be reported as a fault"
-    assert_equal "post1", post1.reload.freefeed_post_id, "a throttled DELETE must leave the post untouched"
-  end
-
-  test ".perform_now should report and stop when throttle retries are exhausted" do
-    post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
-    subject = access_token.rate_limit_subject
     job = GroupPurgeJob.new(feed.id)
-    job.executions = RateLimited::MAX_ATTEMPTS
 
-    reported = []
-    freeze_time do
-      drain_freefeed(subject, :delete, remaining: 0)
-
-      Rails.error.stub(:report, ->(error, **) { reported << error }) do
-        assert_no_enqueued_jobs(only: GroupPurgeJob) { job.perform_now }
+    # Advance time inside sleep so the penalty block expires before the retry acquire.
+    job.stub(:sleep, ->(n) { slept << n; travel(n.ceil.seconds + 1) }) do
+      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
+        assert_no_enqueued_jobs(only: GroupPurgeJob) do
+          job.perform_now
+        end
       end
     end
 
-    assert_equal 1, reported.size
-    assert_instance_of RateLimit::Throttled, reported.first
-    assert_equal "post1", post1.reload.freefeed_post_id, "nothing is deleted when out of capacity"
+    assert_empty reported, "throttling must not be reported as a fault"
+    assert_not_empty slept, "should sleep when FreeFeed throttles a DELETE"
+    assert_nil post1.reload.freefeed_post_id, "post should be deleted after sleeping and retrying"
   end
 
   test ".perform_now should continue on error and log failure" do

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -13,10 +13,10 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     @feed ||= create(:feed, user: user, access_token: access_token, target_group: "testgroup")
   end
 
-  test ".perform_now should withdraw all posts with freefeed_post_id from feed" do
-    post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
-    post2 = create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)
-    post3 = create(:post, feed: feed, freefeed_post_id: nil, status: :withdrawn)
+  test ".perform_now should delete FreeFeed posts and mark them withdrawn" do
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    post2 = create(:post, :published, feed: feed, freefeed_post_id: "post2")
+    post3 = create(:post, feed: feed, freefeed_post_id: nil)
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
     stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
@@ -24,8 +24,21 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     GroupPurgeJob.perform_now(feed.id)
 
     assert_nil post1.reload.freefeed_post_id
+    assert_predicate post1.reload, :withdrawn?
     assert_nil post2.reload.freefeed_post_id
-    assert_nil post3.reload.freefeed_post_id
+    assert_predicate post2.reload, :withdrawn?
+    assert_not_predicate post3.reload, :withdrawn?, "posts without a FreeFeed ID are not touched"
+  end
+
+  test ".perform_now should recompute published metrics for affected dates" do
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    metric = create(:feed_metric, :with_published_posts, feed: feed, date: post1.reposted_at.to_date)
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
+
+    GroupPurgeJob.perform_now(feed.id)
+
+    assert_equal 0, metric.reload.published_posts_count
   end
 
   test ".perform_now should reserve one delete per post" do
@@ -98,8 +111,8 @@ class GroupPurgeJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should continue on error and log failure" do
-    post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
-    post2 = create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    post2 = create(:post, :published, feed: feed, freefeed_post_id: "post2")
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 500)
     stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
@@ -107,7 +120,9 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     GroupPurgeJob.perform_now(feed.id)
 
     assert_equal "post1", post1.reload.freefeed_post_id
+    assert_predicate post1.reload, :published?, "status unchanged when DELETE fails"
     assert_nil post2.reload.freefeed_post_id
+    assert_predicate post2.reload, :withdrawn?
   end
 
   test ".perform_now should exit gracefully if feed not found" do

--- a/test/jobs/group_purge_job_test.rb
+++ b/test/jobs/group_purge_job_test.rb
@@ -42,8 +42,8 @@ class GroupPurgeJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should reserve one delete per post" do
-    create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
-    create(:post, feed: feed, freefeed_post_id: "post2", status: :withdrawn)
+    create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    create(:post, :published, feed: feed, freefeed_post_id: "post2")
     subject = access_token.rate_limit_subject
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
@@ -59,7 +59,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should sleep and continue instead of rescheduling when throttled" do
-    post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
 
@@ -87,7 +87,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should sleep and retry instead of rescheduling when FreeFeed throttles a DELETE" do
-    post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
     stub_request(:delete, "#{access_token.host}/v4/posts/post1")
       .to_return(status: 429, headers: { "Retry-After" => "30" })
       .then.to_return(status: 200)
@@ -133,8 +133,8 @@ class GroupPurgeJobTest < ActiveJob::TestCase
 
   test ".perform_now should process posts for specified feed only" do
     other_feed = create(:feed, user: user, access_token: access_token, target_group: "othergroup")
-    post1 = create(:post, feed: feed, freefeed_post_id: "post1", status: :withdrawn)
-    post2 = create(:post, feed: other_feed, freefeed_post_id: "post2", status: :withdrawn)
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    post2 = create(:post, :published, feed: other_feed, freefeed_post_id: "post2")
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
 

--- a/test/jobs/withdraw_all_posts_job_test.rb
+++ b/test/jobs/withdraw_all_posts_job_test.rb
@@ -14,26 +14,34 @@ class WithdrawAllPostsJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should delegate to WithdrawAllPosts" do
-    called_with = nil
+    called_with_feed = nil
+    called_with_user = nil
     fake = Struct.new(:call).new(nil)
-    WithdrawAllPosts.stub(:new, ->(f) { called_with = f; fake }) do
-      WithdrawAllPostsJob.perform_now(feed.id)
+    WithdrawAllPosts.stub(:new, ->(f, user:) { called_with_feed = f; called_with_user = user; fake }) do
+      WithdrawAllPostsJob.perform_now(feed.id, user.id)
     end
 
-    assert_equal feed, called_with
+    assert_equal feed, called_with_feed
+    assert_equal user, called_with_user
   end
 
   test ".perform_now should exit gracefully if feed not found" do
     assert_nothing_raised do
-      WithdrawAllPostsJob.perform_now(999999)
+      WithdrawAllPostsJob.perform_now(999999, user.id)
+    end
+  end
+
+  test ".perform_now should exit gracefully if user not found" do
+    assert_nothing_raised do
+      WithdrawAllPostsJob.perform_now(feed.id, 999999)
     end
   end
 
   test ".perform_now should exit gracefully if access token is inactive" do
     feed.access_token.update!(status: :inactive)
     service_called = false
-    WithdrawAllPosts.stub(:new, ->(_) { service_called = true }) do
-      WithdrawAllPostsJob.perform_now(feed.id)
+    WithdrawAllPosts.stub(:new, ->(*args, **) { service_called = true }) do
+      WithdrawAllPostsJob.perform_now(feed.id, user.id)
     end
 
     assert_not service_called

--- a/test/jobs/withdraw_all_posts_job_test.rb
+++ b/test/jobs/withdraw_all_posts_job_test.rb
@@ -13,126 +13,14 @@ class WithdrawAllPostsJobTest < ActiveJob::TestCase
     @feed ||= create(:feed, user: user, access_token: access_token, target_group: "testgroup")
   end
 
-  test ".perform_now should delete FreeFeed posts and mark them withdrawn" do
-    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
-    post2 = create(:post, :published, feed: feed, freefeed_post_id: "post2")
-    post3 = create(:post, feed: feed, freefeed_post_id: nil)
-
-    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
-    stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
-
-    WithdrawAllPostsJob.perform_now(feed.id)
-
-    assert_nil post1.reload.freefeed_post_id
-    assert_predicate post1.reload, :withdrawn?
-    assert_nil post2.reload.freefeed_post_id
-    assert_predicate post2.reload, :withdrawn?
-    assert_not_predicate post3.reload, :withdrawn?, "posts without a FreeFeed ID are not touched"
-  end
-
-  test ".perform_now should recompute published metrics for affected dates" do
-    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
-    metric = create(:feed_metric, :with_published_posts, feed: feed, date: post1.reposted_at.to_date)
-
-    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
-
-    WithdrawAllPostsJob.perform_now(feed.id)
-
-    assert_equal 0, metric.reload.published_posts_count
-  end
-
-  test ".perform_now should reserve one delete per post" do
-    create(:post, :published, feed: feed, freefeed_post_id: "post1")
-    create(:post, :published, feed: feed, freefeed_post_id: "post2")
-    subject = access_token.rate_limit_subject
-
-    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
-    stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
-
-    freeze_time do
+  test ".perform_now should delegate to WithdrawAllPosts" do
+    called_with = nil
+    fake = Struct.new(:call).new(nil)
+    WithdrawAllPosts.stub(:new, ->(f) { called_with = f; fake }) do
       WithdrawAllPostsJob.perform_now(feed.id)
-
-      capacity = RateLimit.capacity(:freefeed, :delete)
-      assert_equal capacity - 2, freefeed_tokens_left(subject, :delete),
-        "two withdrawals must spend exactly two delete tokens"
-    end
-  end
-
-  test ".perform_now should sleep and continue instead of rescheduling when throttled" do
-    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
-
-    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
-
-    # Simulate one denied acquire followed by an allowed one.
-    acquire_call = 0
-    acquire_stub = ->(*args, **kwargs) {
-      acquire_call += 1
-      acquire_call == 1 ? RateLimit::Result.new(allowed: false, retry_after: 5.0)
-                        : RateLimit::Result.new(allowed: true, retry_after: 0.0)
-    }
-
-    slept = []
-    job = WithdrawAllPostsJob.new(feed.id)
-
-    RateLimit.stub(:acquire, acquire_stub) do
-      job.stub(:sleep, ->(n) { slept << n }) do
-        assert_no_enqueued_jobs(only: WithdrawAllPostsJob) do
-          job.perform_now
-        end
-      end
     end
 
-    assert_equal [5.0], slept, "should sleep for the retry_after period"
-    assert_nil post1.reload.freefeed_post_id, "post should be deleted after sleeping for capacity"
-  end
-
-  test ".perform_now should sleep and retry instead of rescheduling when FreeFeed throttles a DELETE" do
-    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
-    stub_request(:delete, "#{access_token.host}/v4/posts/post1")
-      .to_return(status: 429, headers: { "Retry-After" => "30" })
-      .then.to_return(status: 200)
-
-    slept = []
-    reported = []
-    job = WithdrawAllPostsJob.new(feed.id)
-
-    # Advance time inside sleep so the penalty block expires before the retry acquire.
-    job.stub(:sleep, ->(n) { slept << n; travel(n.ceil.seconds + 1) }) do
-      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
-        assert_no_enqueued_jobs(only: WithdrawAllPostsJob) do
-          job.perform_now
-        end
-      end
-    end
-
-    assert_empty reported, "throttling must not be reported as a fault"
-    assert_not_empty slept, "should sleep when FreeFeed throttles a DELETE"
-    assert_nil post1.reload.freefeed_post_id, "post should be deleted after sleeping and retrying"
-  end
-
-  test ".perform_now should sync the record when the FreeFeed post is already gone" do
-    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
-    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 404)
-
-    WithdrawAllPostsJob.perform_now(feed.id)
-
-    assert_nil post1.reload.freefeed_post_id
-    assert_predicate post1.reload, :withdrawn?
-  end
-
-  test ".perform_now should continue on error and log failure" do
-    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
-    post2 = create(:post, :published, feed: feed, freefeed_post_id: "post2")
-
-    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 500)
-    stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
-
-    WithdrawAllPostsJob.perform_now(feed.id)
-
-    assert_equal "post1", post1.reload.freefeed_post_id
-    assert_predicate post1.reload, :published?, "status unchanged when DELETE fails"
-    assert_nil post2.reload.freefeed_post_id
-    assert_predicate post2.reload, :withdrawn?
+    assert_equal feed, called_with
   end
 
   test ".perform_now should exit gracefully if feed not found" do
@@ -141,16 +29,13 @@ class WithdrawAllPostsJobTest < ActiveJob::TestCase
     end
   end
 
-  test ".perform_now should process posts for specified feed only" do
-    other_feed = create(:feed, user: user, access_token: access_token, target_group: "othergroup")
-    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
-    post2 = create(:post, :published, feed: other_feed, freefeed_post_id: "post2")
+  test ".perform_now should exit gracefully if access token is inactive" do
+    feed.access_token.update!(status: :inactive)
+    service_called = false
+    WithdrawAllPosts.stub(:new, ->(_) { service_called = true }) do
+      WithdrawAllPostsJob.perform_now(feed.id)
+    end
 
-    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
-
-    WithdrawAllPostsJob.perform_now(feed.id)
-
-    assert_nil post1.reload.freefeed_post_id
-    assert_equal "post2", post2.reload.freefeed_post_id
+    assert_not service_called
   end
 end

--- a/test/jobs/withdraw_all_posts_job_test.rb
+++ b/test/jobs/withdraw_all_posts_job_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class GroupPurgeJobTest < ActiveJob::TestCase
+class WithdrawAllPostsJobTest < ActiveJob::TestCase
   def user
     @user ||= create(:user)
   end
@@ -21,7 +21,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
     stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
 
-    GroupPurgeJob.perform_now(feed.id)
+    WithdrawAllPostsJob.perform_now(feed.id)
 
     assert_nil post1.reload.freefeed_post_id
     assert_predicate post1.reload, :withdrawn?
@@ -36,7 +36,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
 
-    GroupPurgeJob.perform_now(feed.id)
+    WithdrawAllPostsJob.perform_now(feed.id)
 
     assert_equal 0, metric.reload.published_posts_count
   end
@@ -50,7 +50,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
 
     freeze_time do
-      GroupPurgeJob.perform_now(feed.id)
+      WithdrawAllPostsJob.perform_now(feed.id)
 
       capacity = RateLimit.capacity(:freefeed, :delete)
       assert_equal capacity - 2, freefeed_tokens_left(subject, :delete),
@@ -72,11 +72,11 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     }
 
     slept = []
-    job = GroupPurgeJob.new(feed.id)
+    job = WithdrawAllPostsJob.new(feed.id)
 
     RateLimit.stub(:acquire, acquire_stub) do
       job.stub(:sleep, ->(n) { slept << n }) do
-        assert_no_enqueued_jobs(only: GroupPurgeJob) do
+        assert_no_enqueued_jobs(only: WithdrawAllPostsJob) do
           job.perform_now
         end
       end
@@ -94,12 +94,12 @@ class GroupPurgeJobTest < ActiveJob::TestCase
 
     slept = []
     reported = []
-    job = GroupPurgeJob.new(feed.id)
+    job = WithdrawAllPostsJob.new(feed.id)
 
     # Advance time inside sleep so the penalty block expires before the retry acquire.
     job.stub(:sleep, ->(n) { slept << n; travel(n.ceil.seconds + 1) }) do
       Rails.error.stub(:report, ->(*args, **) { reported << args }) do
-        assert_no_enqueued_jobs(only: GroupPurgeJob) do
+        assert_no_enqueued_jobs(only: WithdrawAllPostsJob) do
           job.perform_now
         end
       end
@@ -117,7 +117,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 500)
     stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
 
-    GroupPurgeJob.perform_now(feed.id)
+    WithdrawAllPostsJob.perform_now(feed.id)
 
     assert_equal "post1", post1.reload.freefeed_post_id
     assert_predicate post1.reload, :published?, "status unchanged when DELETE fails"
@@ -127,7 +127,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
 
   test ".perform_now should exit gracefully if feed not found" do
     assert_nothing_raised do
-      GroupPurgeJob.perform_now(999999)
+      WithdrawAllPostsJob.perform_now(999999)
     end
   end
 
@@ -138,7 +138,7 @@ class GroupPurgeJobTest < ActiveJob::TestCase
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
 
-    GroupPurgeJob.perform_now(feed.id)
+    WithdrawAllPostsJob.perform_now(feed.id)
 
     assert_nil post1.reload.freefeed_post_id
     assert_equal "post2", post2.reload.freefeed_post_id

--- a/test/jobs/withdraw_all_posts_job_test.rb
+++ b/test/jobs/withdraw_all_posts_job_test.rb
@@ -110,6 +110,16 @@ class WithdrawAllPostsJobTest < ActiveJob::TestCase
     assert_nil post1.reload.freefeed_post_id, "post should be deleted after sleeping and retrying"
   end
 
+  test ".perform_now should sync the record when the FreeFeed post is already gone" do
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 404)
+
+    WithdrawAllPostsJob.perform_now(feed.id)
+
+    assert_nil post1.reload.freefeed_post_id
+    assert_predicate post1.reload, :withdrawn?
+  end
+
   test ".perform_now should continue on error and log failure" do
     post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
     post2 = create(:post, :published, feed: feed, freefeed_post_id: "post2")

--- a/test/services/withdraw_all_posts_test.rb
+++ b/test/services/withdraw_all_posts_test.rb
@@ -131,6 +131,37 @@ class WithdrawAllPostsTest < ActiveSupport::TestCase
     assert_predicate post2.reload, :withdrawn?
   end
 
+  test "#call should create a group_purge_started event for the feed" do
+    assert_difference("Event.count", 1) do
+      service.call
+    end
+
+    event = Event.last
+    assert_equal "group_purge_started", event.type
+    assert_equal user, event.user
+    assert_equal feed, event.subject
+    assert_equal "info", event.level
+    assert_equal "testgroup", event.metadata["target_group"]
+  end
+
+  test "#call should update the event with completion stats" do
+    date1 = Date.new(2024, 1, 10)
+    date2 = Date.new(2024, 1, 20)
+    create(:post, :published, feed: feed, freefeed_post_id: "post1", reposted_at: date1.to_time)
+    create(:post, :published, feed: feed, freefeed_post_id: "post2", reposted_at: date2.to_time)
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
+    stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
+
+    service.call
+
+    event = Event.last
+    assert_equal 2, event.metadata["deleted_count"]
+    assert_not_nil event.metadata["duration_seconds"]
+    assert_equal "2024-01-10", event.metadata["dates_from"]
+    assert_equal "2024-01-20", event.metadata["dates_to"]
+  end
+
   test "#call should only process posts belonging to the given feed" do
     other_feed = create(:feed, user: user, access_token: access_token, target_group: "othergroup")
     post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")

--- a/test/services/withdraw_all_posts_test.rb
+++ b/test/services/withdraw_all_posts_test.rb
@@ -14,7 +14,7 @@ class WithdrawAllPostsTest < ActiveSupport::TestCase
   end
 
   def service
-    @service ||= WithdrawAllPosts.new(feed)
+    @service ||= WithdrawAllPosts.new(feed, user: user)
   end
 
   test "#call should delete FreeFeed posts and mark them withdrawn" do

--- a/test/services/withdraw_all_posts_test.rb
+++ b/test/services/withdraw_all_posts_test.rb
@@ -1,0 +1,146 @@
+require "test_helper"
+
+class WithdrawAllPostsTest < ActiveSupport::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def access_token
+    @access_token ||= create(:access_token, :active, user: user)
+  end
+
+  def feed
+    @feed ||= create(:feed, user: user, access_token: access_token, target_group: "testgroup")
+  end
+
+  def service
+    @service ||= WithdrawAllPosts.new(feed)
+  end
+
+  test "#call should delete FreeFeed posts and mark them withdrawn" do
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    post2 = create(:post, :published, feed: feed, freefeed_post_id: "post2")
+    post3 = create(:post, feed: feed, freefeed_post_id: nil)
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
+    stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
+
+    service.call
+
+    assert_nil post1.reload.freefeed_post_id
+    assert_predicate post1.reload, :withdrawn?
+    assert_nil post2.reload.freefeed_post_id
+    assert_predicate post2.reload, :withdrawn?
+    assert_not_predicate post3.reload, :withdrawn?, "posts without a FreeFeed ID are not touched"
+  end
+
+  test "#call should recompute published metrics for affected dates" do
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    metric = create(:feed_metric, :with_published_posts, feed: feed, date: post1.reposted_at.to_date)
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
+
+    service.call
+
+    assert_equal 0, metric.reload.published_posts_count
+  end
+
+  test "#call should reserve one delete token per post" do
+    create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    create(:post, :published, feed: feed, freefeed_post_id: "post2")
+    subject = access_token.rate_limit_subject
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
+    stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
+
+    freeze_time do
+      service.call
+
+      capacity = RateLimit.capacity(:freefeed, :delete)
+      assert_equal capacity - 2, freefeed_tokens_left(subject, :delete),
+        "two withdrawals must spend exactly two delete tokens"
+    end
+  end
+
+  test "#call should sleep and continue instead of raising when throttled" do
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
+
+    acquire_call = 0
+    acquire_stub = ->(*args, **kwargs) {
+      acquire_call += 1
+      acquire_call == 1 ? RateLimit::Result.new(allowed: false, retry_after: 5.0)
+                        : RateLimit::Result.new(allowed: true, retry_after: 0.0)
+    }
+
+    slept = []
+
+    RateLimit.stub(:acquire, acquire_stub) do
+      service.stub(:sleep, ->(n) { slept << n }) do
+        service.call
+      end
+    end
+
+    assert_equal [5.0], slept
+    assert_nil post1.reload.freefeed_post_id
+  end
+
+  test "#call should sleep and retry when FreeFeed throttles a DELETE" do
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1")
+      .to_return(status: 429, headers: { "Retry-After" => "30" })
+      .then.to_return(status: 200)
+
+    slept = []
+    reported = []
+
+    service.stub(:sleep, ->(n) { slept << n; travel(n.ceil.seconds + 1) }) do
+      Rails.error.stub(:report, ->(*args, **) { reported << args }) do
+        service.call
+      end
+    end
+
+    assert_empty reported, "throttling must not be reported as a fault"
+    assert_not_empty slept
+    assert_nil post1.reload.freefeed_post_id
+  end
+
+  test "#call should sync the record when the FreeFeed post is already gone" do
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 404)
+
+    service.call
+
+    assert_nil post1.reload.freefeed_post_id
+    assert_predicate post1.reload, :withdrawn?
+  end
+
+  test "#call should skip failed deletes and continue to the next post" do
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    post2 = create(:post, :published, feed: feed, freefeed_post_id: "post2")
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 500)
+    stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
+
+    service.call
+
+    assert_equal "post1", post1.reload.freefeed_post_id
+    assert_predicate post1.reload, :published?, "status unchanged when DELETE fails"
+    assert_nil post2.reload.freefeed_post_id
+    assert_predicate post2.reload, :withdrawn?
+  end
+
+  test "#call should only process posts belonging to the given feed" do
+    other_feed = create(:feed, user: user, access_token: access_token, target_group: "othergroup")
+    post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
+    post2 = create(:post, :published, feed: other_feed, freefeed_post_id: "post2")
+
+    stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
+
+    service.call
+
+    assert_nil post1.reload.freefeed_post_id
+    assert_equal "post2", post2.reload.freefeed_post_id
+  end
+end

--- a/test/services/withdraw_all_posts_test.rb
+++ b/test/services/withdraw_all_posts_test.rb
@@ -21,6 +21,7 @@ class WithdrawAllPostsTest < ActiveSupport::TestCase
     post1 = create(:post, :published, feed: feed, freefeed_post_id: "post1")
     post2 = create(:post, :published, feed: feed, freefeed_post_id: "post2")
     post3 = create(:post, feed: feed, freefeed_post_id: nil)
+    post4 = create(:post, :published, feed: feed, freefeed_post_id: nil)
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
     stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)
@@ -31,7 +32,8 @@ class WithdrawAllPostsTest < ActiveSupport::TestCase
     assert_predicate post1.reload, :withdrawn?
     assert_nil post2.reload.freefeed_post_id
     assert_predicate post2.reload, :withdrawn?
-    assert_not_predicate post3.reload, :withdrawn?, "posts without a FreeFeed ID are not touched"
+    assert_not_predicate post3.reload, :withdrawn?, "non-published posts without a FreeFeed ID are not touched"
+    assert_not_predicate post4.reload, :withdrawn?, "published posts without a FreeFeed ID are not touched"
   end
 
   test "#call should recompute published metrics for affected dates" do


### PR DESCRIPTION
Changes:

- Replace `include RateLimited` in `GroupPurgeJob` with an inline sleep-and-retry loop
- When the rate limit bucket is full, sleep for `retry_after` and retry the same post
- When FreeFeed returns a 429, sleep for the penalty duration and re-enter the acquire loop
- Update tests to verify no rescheduling, no error reporting, and eventual post deletion after sleeping