### PR TITLE
Clarify feed purge confirmation scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-22
 
+- Clarified the feed Purge confirmation: it only removes posts this feed published, not the whole group.
 - Feed list rows now show the number of published posts per feed.
 - Delete actions now consistently end with "…" to signal they'll ask you to confirm first.
 - Removed a redundant "back" button from the access token page — the breadcrumb already links back.

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -55,15 +55,16 @@
 <% if @feed.target_group.present? %>
   <%= render ConfirmationModalComponent.new(
     title: "Confirm Purge",
-    action: "Purge all posts",
+    action: "Purge feed",
     url: feed_purge_path(@feed),
     method: :post,
     modal_id: "purge-modal-#{@feed.id}"
   ) do %>
     <%= render AlertComponent.new(variant: :warning) do %>
-      <p>Every published post in <%= @feed.target_group %> will be withdrawn on FreeFeed.</p>
-      <p>They'll remain visible in Feeder import history, and will not be re-imported during the next feed refresh.</p>
-      <p>This operation can't be undone.</p>
+      <p>This removes only the posts this feed published to <strong><%= @feed.target_group %></strong> on FreeFeed.</p>
+      <p>Other posts in the group, including anything added by other people, aren't affected.</p>
+      <p>Feeder keeps its own record of the removed posts, so they'll still show up here and won't be posted again the next time this feed refreshes.</p>
+      <p>This can't be undone.</p>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Changes:

- Reword the feed purge confirmation so it's clear the action only removes posts this feed published, not the whole group
- Rename the confirm button from "Purge all posts" to "Purge feed" to match that scope

The old wording ("Every published post in [group] will be withdrawn") read as if the entire FreeFeed group would be cleared. The purge actually removes only the posts this feed itself published — other posts in the group, including anyone else's, stay untouched, and Feeder keeps its own record of the removed ones. The copy is also reworded in plainer, non-technical language.
