### PR TITLE
Let admins confirm a user's email and see account status

### DIFF
--- a/app/components/admin/user_details_component.rb
+++ b/app/components/admin/user_details_component.rb
@@ -1,4 +1,11 @@
 class Admin::UserDetailsComponent < ViewComponent::Base
+  STATUS_BADGES = {
+    "inactive" => { label: "Pending confirmation", classes: "bg-amber-50 text-amber-700 ring-amber-600/20" },
+    "onboarding" => { label: "Onboarding", classes: "bg-sky-50 text-sky-700 ring-sky-600/20" },
+    "active" => { label: "Active", classes: "bg-emerald-50 text-emerald-700 ring-emerald-600/20" },
+    "suspended" => { label: "Suspended", classes: "bg-red-50 text-red-700 ring-red-600/20" }
+  }.freeze
+
   def initialize(user:, stats:)
     @user = user
     @stats = stats
@@ -7,6 +14,7 @@ class Admin::UserDetailsComponent < ViewComponent::Base
   def call
     render(DescriptionListComponent.new) do |list|
       list.with_item(stat_item("Email", @user.email_address))
+      list.with_item(stat_item("Status", status_badge))
       list.with_item(stat_item("Permissions", permissions_value))
       list.with_item(stat_item("Created", helpers.datetime_with_duration_tag(@user.created_at)))
       list.with_item(stat_item("Updated", helpers.datetime_with_duration_tag(@user.updated_at)))
@@ -19,6 +27,15 @@ class Admin::UserDetailsComponent < ViewComponent::Base
 
   def stat_item(label, value)
     StatListItemComponent.new(label: label, value: value)
+  end
+
+  def status_badge
+    badge = STATUS_BADGES.fetch(@user.state) { { label: @user.state.humanize, classes: "bg-slate-50 text-slate-700 ring-slate-600/20" } }
+    helpers.tag.span(
+      badge[:label],
+      class: "inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset #{badge[:classes]}",
+      data: { key: "user_details.status" }
+    )
   end
 
   def permissions_value

--- a/app/controllers/admin/email_confirmations_controller.rb
+++ b/app/controllers/admin/email_confirmations_controller.rb
@@ -1,0 +1,8 @@
+class Admin::EmailConfirmationsController < ApplicationController
+  def create
+    @user = User.find(params[:user_id])
+    authorize @user, :confirm_email?
+    @user.confirm_email!
+    redirect_to admin_user_path(@user), success: "Email confirmed."
+  end
+end

--- a/app/controllers/registration/email_confirmations_controller.rb
+++ b/app/controllers/registration/email_confirmations_controller.rb
@@ -3,7 +3,7 @@ class Registration::EmailConfirmationsController < ApplicationController
 
   def show
     user = find_user_by_token
-    activate_user(user)
+    user.confirm_email!
     redirect_to new_session_path, success: "Your email is now confirmed. Please sign in to get started."
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     redirect_to new_session_path, alert: "Email confirmation link is invalid or has expired."
@@ -13,9 +13,5 @@ class Registration::EmailConfirmationsController < ApplicationController
 
   def find_user_by_token
     User.find_by_token_for!(:initial_email_confirmation, params[:token])
-  end
-
-  def activate_user(user)
-    user.onboarding! if user.inactive?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,6 +65,14 @@ class User < ApplicationRecord
     update!(state: :active, suspended_at: nil)
   end
 
+  def confirm_email!
+    onboarding! if inactive?
+  end
+
+  def email_confirmed?
+    !inactive?
+  end
+
   def deactivate_email!(reason:)
     update!(
       email_deactivated_at: Time.current,

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -31,6 +31,10 @@ class UserPolicy < ApplicationPolicy
     admin?
   end
 
+  def confirm_email?
+    admin?
+  end
+
   def manage_permissions?
     admin?
   end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -124,6 +124,9 @@
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Actions</h2>
     <div class="flex gap-2">
+      <% unless @user.email_confirmed? %>
+        <%= button_to "Confirm Email", admin_user_email_confirmation_path(@user), method: :post, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", data: { key: "actions.confirm_email" } %>
+      <% end %>
       <%= link_to "Change Email", edit_admin_user_email_update_path(@user), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
       <%= link_to "Reset Password…", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "password-reset-modal-#{@user.id}", action: "click->modal-trigger#open" } %>
       <% if @user.suspended? %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -125,7 +125,7 @@
     <h2 class="text-2xl font-semibold mb-3 text-slate-900">Actions</h2>
     <div class="flex gap-2">
       <% unless @user.email_confirmed? %>
-        <%= button_to "Confirm Email", admin_user_email_confirmation_path(@user), method: :post, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer", data: { key: "actions.confirm_email" } %>
+        <%= link_to "Confirm Email…", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", data: { key: "actions.confirm_email", controller: "modal-trigger", modal_trigger_modal_id_value: "confirm-email-modal-#{@user.id}", action: "click->modal-trigger#open" } %>
       <% end %>
       <%= link_to "Change Email", edit_admin_user_email_update_path(@user), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1" %>
       <%= link_to "Reset Password…", "#", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1", data: { controller: "modal-trigger", modal_trigger_modal_id_value: "password-reset-modal-#{@user.id}", action: "click->modal-trigger#open" } %>
@@ -139,6 +139,18 @@
     </div>
   </section>
 </div>
+
+<% unless @user.email_confirmed? %>
+  <%= render ConfirmationModalComponent.new(
+    title: "Confirm Email for #{@user.email_address}",
+    action: "Confirm email",
+    url: admin_user_email_confirmation_path(@user),
+    method: :post,
+    modal_id: "confirm-email-modal-#{@user.id}"
+  ) do %>
+    <p>This marks <%= @user.email_address %> as confirmed and lets them sign in, just as if they'd clicked the confirmation link themselves. Handy when the confirmation email can't reach them.</p>
+  <% end %>
+<% end %>
 
 <%= render ConfirmationModalComponent.new(
   title: "Reset Password for #{@user.email_address}",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       resource :suspension, only: [:create, :destroy]
       resource :available_invites, only: :update
       resource :email_reactivation, only: :create
+      resource :email_confirmation, only: :create
     end
 
     resources :events, only: [:index, :show]

--- a/test/components/admin/user_details_component_test.rb
+++ b/test/components/admin/user_details_component_test.rb
@@ -10,8 +10,8 @@ class Admin::UserDetailsComponentTest < ViewComponent::TestCase
     @stats ||= UserStats.new(user)
   end
 
-  def render_component
-    render_inline(Admin::UserDetailsComponent.new(user: user, stats: stats))
+  def render_component(target = user)
+    render_inline(Admin::UserDetailsComponent.new(user: target, stats: UserStats.new(target)))
   end
 
   test "#call should render core user fields" do
@@ -40,5 +40,23 @@ class Admin::UserDetailsComponentTest < ViewComponent::TestCase
     result = render_component
 
     assert_includes result.text, "Never"
+  end
+
+  test "#call should show a Pending confirmation status for inactive users" do
+    result = render_component(create(:user, :inactive))
+
+    assert_equal "Pending confirmation", result.css('[data-key="user_details.status"]').text
+  end
+
+  test "#call should show an Active status for active users" do
+    result = render_component(create(:user, state: :active))
+
+    assert_equal "Active", result.css('[data-key="user_details.status"]').text
+  end
+
+  test "#call should show a Suspended status for suspended users" do
+    result = render_component(create(:user, :suspended))
+
+    assert_equal "Suspended", result.css('[data-key="user_details.status"]').text
   end
 end

--- a/test/controllers/admin/email_confirmations_controller_test.rb
+++ b/test/controllers/admin/email_confirmations_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Admin::EmailConfirmationsControllerTest < ActionDispatch::IntegrationTest
+  def admin_user
+    @admin_user ||= create(:user, :admin)
+  end
+
+  test "#create should let an admin confirm a pending user's email" do
+    sign_in_as admin_user
+    user = create(:user, :inactive)
+
+    post admin_user_email_confirmation_path(user)
+
+    assert_redirected_to admin_user_path(user)
+    assert user.reload.onboarding?
+    follow_redirect!
+    assert_select "[role=\"alert\"]", text: /Email confirmed/
+  end
+
+  test "#create should leave an already confirmed user untouched" do
+    sign_in_as admin_user
+    user = create(:user, state: :active)
+
+    post admin_user_email_confirmation_path(user)
+
+    assert user.reload.active?
+  end
+
+  test "#create should require admin permission" do
+    sign_in_as create(:user)
+    user = create(:user, :inactive)
+
+    post admin_user_email_confirmation_path(user)
+
+    assert_redirected_to root_path
+    assert user.reload.inactive?
+  end
+end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -66,6 +66,26 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Suspend user…", count: 0
   end
 
+  test "should show confirm email button for a user with a pending email" do
+    login_as(admin_user)
+    user = create(:user, :inactive)
+
+    get admin_user_path(user)
+
+    assert_response :success
+    assert_select "[data-key='actions.confirm_email']", text: "Confirm Email"
+  end
+
+  test "should hide confirm email button once the email is confirmed" do
+    login_as(admin_user)
+    user = create(:user, state: :active)
+
+    get admin_user_path(user)
+
+    assert_response :success
+    assert_select "[data-key='actions.confirm_email']", count: 0
+  end
+
   test "should redirect non-admin users from show" do
     login_as(regular_user)
     user = create(:user)

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -73,7 +73,18 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     get admin_user_path(user)
 
     assert_response :success
-    assert_select "[data-key='actions.confirm_email']", text: "Confirm Email"
+    assert_select "[data-key='actions.confirm_email']", text: "Confirm Email…"
+  end
+
+  test "should confirm email behind a confirmation dialog" do
+    login_as(admin_user)
+    user = create(:user, :inactive)
+
+    get admin_user_path(user)
+
+    assert_response :success
+    assert_select "[data-key='actions.confirm_email'][data-modal-trigger-modal-id-value='confirm-email-modal-#{user.id}']"
+    assert_select "#confirm-email-modal-#{user.id} form[action='#{admin_user_email_confirmation_path(user)}']"
   end
 
   test "should hide confirm email button once the email is confirmed" do
@@ -84,6 +95,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-key='actions.confirm_email']", count: 0
+    assert_select "#confirm-email-modal-#{user.id}", count: 0
   end
 
   test "should redirect non-admin users from show" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -76,6 +76,27 @@ class UserTest < ActiveSupport::TestCase
     assert_nil user.suspended_at
   end
 
+  test "#confirm_email! should move an inactive user to onboarding" do
+    user = create(:user, :inactive)
+    user.confirm_email!
+    assert user.onboarding?
+  end
+
+  test "#confirm_email! should not change the state of an already confirmed user" do
+    user = create(:user, state: :active)
+    user.confirm_email!
+    assert user.active?
+  end
+
+  test "#email_confirmed? should return false for an inactive user" do
+    assert_not create(:user, :inactive).email_confirmed?
+  end
+
+  test "#email_confirmed? should return true once the user is past inactive" do
+    assert create(:user, :onboarding).email_confirmed?
+    assert create(:user, state: :active).email_confirmed?
+  end
+
   test "should have many feeds" do
     user = create(:user)
     feed1 = create(:feed, user: user)

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -124,6 +124,16 @@ class UserPolicyTest < ActiveSupport::TestCase
     assert_not policy.suspend?
   end
 
+  test "#confirm_email? should allow admin users" do
+    policy = policy_for_user(admin_user, other_user)
+    assert policy.confirm_email?
+  end
+
+  test "#confirm_email? should deny regular users" do
+    policy = policy_for_user(user, other_user)
+    assert_not policy.confirm_email?
+  end
+
   test "self_or_admin? returns true for self" do
     policy = policy_for_user(user, user)
     assert policy.send(:self_or_admin?)


### PR DESCRIPTION
Changes:

- Add a "Confirm Email" action to the bottom of the admin user page so an admin can activate a pending account without the user clicking the confirmation link
- Show an account status badge (pending confirmation, onboarding, active, suspended) in the admin user details
- Extract the email-confirmation state transition into `User#confirm_email!`, shared by the registration flow and the new admin action

Sometimes a confirmation email can't reach a user, leaving their account stuck as pending. This gives admins an admin-only way to confirm the email directly, and surfaces each account's status so it's clear when that's needed.