### PR TITLE
Send transactional mail from hello@fffeeder.com

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -33,6 +33,11 @@ env:
     RAILS_ENV: production
     HOSTS: fffeeder.com
     ACTION_MAILER_HOST: fffeeder.com
+    # Send from a real, monitored mailbox on the fffeeder.com domain rather than
+    # the blackhole noreply@frf.im default, so replies and bounces to
+    # transactional mail reach a person. Matches staging; requires fffeeder.com
+    # verified in this environment's Resend workspace.
+    MAILER_FROM: hello@fffeeder.com
     # Run Puma in clustered mode with 2 workers x 3 threads to use both CPU
     # cores. Kept conservative because the jobs role and the Postgres accessory
     # share this 2-core host. If memory becomes the binding constraint, drop

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -33,10 +33,6 @@ env:
     RAILS_ENV: production
     HOSTS: fffeeder.com
     ACTION_MAILER_HOST: fffeeder.com
-    # Send from a real, monitored mailbox on the fffeeder.com domain rather than
-    # the blackhole noreply@frf.im default, so replies and bounces to
-    # transactional mail reach a person. Matches staging; requires fffeeder.com
-    # verified in this environment's Resend workspace.
     MAILER_FROM: hello@fffeeder.com
     # Run Puma in clustered mode with 2 workers x 3 threads to use both CPU
     # cores. Kept conservative because the jobs role and the Postgres accessory

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -102,6 +102,10 @@ env:
     RAILS_ENV: staging
     HOSTS: dev.fffeeder.com
     ACTION_MAILER_HOST: dev.fffeeder.com
+    # ApplicationMailer defaults the sender to noreply@frf.im, but that domain
+    # isn't verified in staging's Resend workspace, so every send is rejected.
+    # Send from the verified fffeeder.com domain instead.
+    MAILER_FROM: hello@fffeeder.com
     # Mirror production's clustered Puma (2 workers x 3 threads) so staging
     # exercises the real multi-worker paths: per-worker counter flushing,
     # single-master gauge sampling, and cross-worker Solid Cable broadcast.

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -102,9 +102,6 @@ env:
     RAILS_ENV: staging
     HOSTS: dev.fffeeder.com
     ACTION_MAILER_HOST: dev.fffeeder.com
-    # ApplicationMailer defaults the sender to noreply@frf.im, but that domain
-    # isn't verified in staging's Resend workspace, so every send is rejected.
-    # Send from the verified fffeeder.com domain instead.
     MAILER_FROM: hello@fffeeder.com
     # Mirror production's clustered Puma (2 workers x 3 threads) so staging
     # exercises the real multi-worker paths: per-worker counter flushing,


### PR DESCRIPTION
Changes:

- Set `MAILER_FROM` to `hello@fffeeder.com` in the staging and production deploy configs

Staging was failing every delivery with `Resend::Error` because `ApplicationMailer`
defaults the sender to `noreply@frf.im`, a domain not verified in staging's Resend
workspace. Production was sending from that same blackhole default. Both now send
from a real, monitored mailbox on the `fffeeder.com` domain, so replies and bounces
to transactional mail reach a person instead of vanishing.

Operational note: each environment's Resend workspace must have `fffeeder.com`
verified before deploy, otherwise sends are rejected the same way staging was.
