### PR TITLE
Show the selected feed type when editing a feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-23
 
+- Editing a feed now shows its feed type, with a clearer note that the source and type stay fixed once a feed is created.
 - Feed and post pages now keep extra actions in a dropdown menu.
 - Settings now shows your permissions right under the page title.
 - The Invites page now shows each invite as a card.

--- a/app/views/feeds/_candidate_chooser.html.erb
+++ b/app/views/feeds/_candidate_chooser.html.erb
@@ -21,10 +21,6 @@
               <span class="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-700"
                     data-key="candidate.recommended-badge">Recommended</span>
             <% end %>
-            <% if uses_ai %>
-              <span class="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700"
-                    data-key="candidate.ai-badge">AI</span>
-            <% end %>
           </span>
           <% if description.present? %>
             <span class="text-slate-600 text-sm"><%= description %></span>

--- a/app/views/feeds/_candidate_chooser.html.erb
+++ b/app/views/feeds/_candidate_chooser.html.erb
@@ -22,9 +22,7 @@
                     data-key="candidate.recommended-badge">Recommended</span>
             <% end %>
           </span>
-          <% if description.present? %>
-            <span class="text-slate-600 text-sm"><%= description %></span>
-          <% end %>
+          <span class="text-slate-600 text-sm"><%= description %></span>
           <% if uses_ai %>
             <span class="text-slate-600 text-sm" data-key="candidate.ai-cost">
               Fetching costs AI tokens — previews and refreshes do too. You'll see your spend on the feed page.

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -34,34 +34,55 @@
     <div class="space-y-10">
       <%# Source stays anchored at the top so the expansion reads as the
           "What do you want to follow?" field staying put while the rest of
-          the form appears below it. %>
+          the form appears below it. The source and feed type are the feed's
+          fixed identity, so they're grouped under one "Source" heading. %>
       <% source_label = feed.source_input_url? ? "Source URL" : "Source prompt" %>
-      <div class="space-y-2">
-        <%= f.label :url, source_label, class: "block font-semibold text-slate-800" %>
-        <%= f.text_field :url_display,
-                         value: feed.source_input,
-                         disabled: true,
-                         class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
-                         aria: { label: "#{source_label} (cannot be changed)" },
-                         data: { key: "form.source-display" } %>
-        <% feed.params&.each do |key, value| %>
-          <%= hidden_field_tag "feed[params][#{key}]", value %>
-        <% end %>
-        <% unless show_chooser %>
-          <p class="text-sm text-slate-500"><%= edit_mode ? "Source and type can't be changed after creation. Start a new feed to follow a different source." : FeedProfile.display_name_for(feed.feed_profile_key).to_s %></p>
-        <% end %>
-      </div>
+      <div>
+        <h2 class="text-xl font-semibold text-slate-900 mb-4">Source</h2>
 
-      <% if show_chooser %>
-        <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.source_input, single: single_candidate %>
-        <%# A disabled radio won't submit its value, so the lone option still
-            needs a hidden field to carry the profile key to the server. %>
-        <% if single_candidate %>
+        <div class="space-y-6">
+          <div class="space-y-2">
+            <%= f.label :url, source_label, class: "block font-semibold text-slate-800" %>
+            <%= f.text_field :url_display,
+                             value: feed.source_input,
+                             disabled: true,
+                             class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
+                             aria: { label: "#{source_label} (cannot be changed)" },
+                             data: { key: "form.source-display" } %>
+            <% feed.params&.each do |key, value| %>
+              <%= hidden_field_tag "feed[params][#{key}]", value %>
+            <% end %>
+          </div>
+
+          <% if show_chooser %>
+            <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.source_input, single: single_candidate %>
+          <% else %>
+            <%# Feed type is fixed once the feed exists, so it's shown read-only
+                as a disabled input matching the source field above it. Like the
+                source field, it's display-only — the controller never reads it. %>
+            <div class="space-y-2">
+              <%= label_tag nil, "Feed type", class: "block font-semibold text-slate-800" %>
+              <%= f.text_field :feed_type_display,
+                               value: candidate_summary(feed.feed_profile_key, feed.source_input),
+                               disabled: true,
+                               class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-lg leading-normal shadow-xs ring-sky-500 transition focus:border-sky-500 focus:outline-none focus:ring-2 disabled:bg-slate-100 disabled:text-slate-500 disabled:border-slate-200 disabled:cursor-not-allowed",
+                               aria: { label: "Feed type (cannot be changed)" },
+                               data: { key: "form.feed-type-display" } %>
+            </div>
+          <% end %>
+        </div>
+
+        <%# A read-only display or a disabled single-option radio won't submit
+            the profile key, so a hidden field carries it whenever the chooser
+            isn't offering a live selection. %>
+        <% if !show_chooser || single_candidate %>
           <%= f.hidden_field :feed_profile_key %>
         <% end %>
-      <% else %>
-        <%= f.hidden_field :feed_profile_key %>
-      <% end %>
+
+        <% if edit_mode %>
+          <p class="mt-3 text-sm text-slate-500" data-key="form.source-locked-note">The source and feed type are locked in when a feed is created. To follow a different source, just start a new feed.</p>
+        <% end %>
+      </div>
 
       <div class="space-y-2">
         <%= f.label :name, "Feed Name", class: "block font-semibold text-slate-800" %>

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -537,6 +537,9 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "data-key=\"candidates\""
     assert_includes response.body, "data-key=\"candidate.rss\""
     assert_includes response.body, "data-key=\"candidate.llm_website_extractor\""
+    # While the user can still pick, the field asks how to fetch; it only
+    # switches to the static "Feed type" label once the choice is frozen.
+    assert_select "label", text: "How should we fetch posts?"
     # The AI option already names its dependency ("AI page reader"), so there's
     # no redundant AI badge — the cost note carries that signal instead.
     assert_not_includes response.body, "data-key=\"candidate.ai-badge\""

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -537,7 +537,9 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "data-key=\"candidates\""
     assert_includes response.body, "data-key=\"candidate.rss\""
     assert_includes response.body, "data-key=\"candidate.llm_website_extractor\""
-    assert_includes response.body, "data-key=\"candidate.ai-badge\""
+    # The AI option already names its dependency ("AI page reader"), so there's
+    # no redundant AI badge — the cost note carries that signal instead.
+    assert_not_includes response.body, "data-key=\"candidate.ai-badge\""
   end
 
   test "#show should label a query source as a prompt and pass it to the chooser" do

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -551,8 +551,11 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     get edit_feed_url(feed)
     assert_response :success
+    assert_select "h2", text: "Source"
     assert_select "label", text: "Source URL"
-    assert_select "p.text-slate-500", text: "Source and type can't be changed after creation. Start a new feed to follow a different source."
+    assert_select "label", text: "Feed type"
+    assert_select "input[data-key='form.feed-type-display'][value=?][disabled]", "RSS Feed"
+    assert_select "[data-key='form.source-locked-note']", text: "The source and feed type are locked in when a feed is created. To follow a different source, just start a new feed."
   end
 
   test "#edit should label the source as a prompt for a query-shaped feed" do


### PR DESCRIPTION
Changes:

- Group the source URL/prompt and feed type under a "Source" heading, matching the "Reposting Settings" section, to frame them as the feed's fixed identity
- Show the feed type as a read-only field (labeled "Feed type") once the source and type are frozen, so the edit form makes the selected type visible instead of hiding it behind a vague note
- Keep the interactive "How should we fetch posts?" prompt while the type can still be chosen on a new feed
- Reword the locked-fields note to sit below both fields and read clearly for non-technical users: "The source and feed type are locked in when a feed is created. To follow a different source, just start a new feed."
- Drop the redundant "AI" badge from the chooser — the AI options already name the dependency ("AI page reader", "AI search") and the cost note explains the spend
- Update tests to cover the "Source" heading, the read-only feed type display, both label states, and the badge removal

Editing a feed previously showed only the source URL and a "can't be changed" note, leaving the chosen feed type invisible. Surfacing it as a read-only field paired with the disabled source input makes the boundary between the feed's frozen identity and its editable settings obvious before and after saving.