### PR TITLE
Enable ready draft feeds from the feed page and list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-23
 
+- A feed you saved without turning on can now be enabled straight from the feed page or the feeds list.
 - Editing a feed now shows its feed type, with a clearer note that the source and type stay fixed once a feed is created.
 - Feed and post pages now keep extra actions in a dropdown menu.
 - Settings now shows your permissions right under the page title.

--- a/app/components/feed_list_item_component.rb
+++ b/app/components/feed_list_item_component.rb
@@ -98,13 +98,15 @@ class FeedListItemComponent < ListItemComponent
         items << { label: "Continue setup", href: edit_url, data: { key: "feed.#{feed.id}.continue_setup" } }
       else
         items << { label: "Edit", href: edit_url, data: { key: "feed.#{feed.id}.edit" } }
-        if enabled?
-          items << { label: "Disable", href: status_url, method: :patch, params: { status: "disabled" },
-                     data: { key: "feed.#{feed.id}.disable", turbo_confirm: DISABLE_CONFIRM } }
-        elsif can_be_enabled?
-          items << { label: "Enable", href: status_url, method: :patch, params: { status: "enabled" },
-                     data: { key: "feed.#{feed.id}.enable", turbo_confirm: ENABLE_CONFIRM } }
-        end
+      end
+
+      # A ready draft can be enabled straight from the list, same as a paused feed.
+      if enabled?
+        items << { label: "Disable", href: status_url, method: :patch, params: { status: "disabled" },
+                   data: { key: "feed.#{feed.id}.disable", turbo_confirm: DISABLE_CONFIRM } }
+      elsif can_be_enabled?
+        items << { label: "Enable", href: status_url, method: :patch, params: { status: "enabled" },
+                   data: { key: "feed.#{feed.id}.enable", turbo_confirm: ENABLE_CONFIRM } }
       end
 
       if draft?

--- a/app/components/feed_list_item_component.rb
+++ b/app/components/feed_list_item_component.rb
@@ -90,15 +90,18 @@ class FeedListItemComponent < ListItemComponent
   end
 
   def menu_items
-    items = [{ label: "Details", href: feed_url, data: { key: "feed.#{feed.id}.details" } }]
-    items << { label: "Source", href: source_url, target: "_blank", rel: "noopener", data: { key: "feed.#{feed.id}.source" } } if source_url
+    items = []
+
+    # An incomplete draft leads with "Continue setup" and drops "Details" —
+    # there's nothing worth showing on the feed page until it has run.
+    if continue_setup?
+      items << { label: "Continue setup", href: edit_url, data: { key: "feed.#{feed.id}.continue_setup" } }
+    else
+      items << { label: "Details", href: feed_url, data: { key: "feed.#{feed.id}.details" } }
+    end
 
     if management_actions?
-      if draft?
-        items << { label: "Continue setup", href: edit_url, data: { key: "feed.#{feed.id}.continue_setup" } }
-      else
-        items << { label: "Edit", href: edit_url, data: { key: "feed.#{feed.id}.edit" } }
-      end
+      items << { label: "Edit", href: edit_url, data: { key: "feed.#{feed.id}.edit" } } unless draft?
 
       # A ready draft can be enabled straight from the list, same as a paused feed.
       if enabled?
@@ -109,9 +112,7 @@ class FeedListItemComponent < ListItemComponent
                    data: { key: "feed.#{feed.id}.enable", turbo_confirm: ENABLE_CONFIRM } }
       end
 
-      if draft?
-        items << { label: "Discard…", href: feed_url, data: { key: "feed.#{feed.id}.discard", turbo_method: :delete, turbo_confirm: DISCARD_CONFIRM } }
-      end
+      items << { label: "Discard…", href: feed_url, data: { key: "feed.#{feed.id}.discard", turbo_method: :delete, turbo_confirm: DISCARD_CONFIRM } } if draft?
     end
 
     items
@@ -154,18 +155,17 @@ class FeedListItemComponent < ListItemComponent
     !admin
   end
 
+  # A draft still being set up leads with "Continue setup" instead of "Details".
+  def continue_setup?
+    management_actions? && draft?
+  end
+
   def status_icon
     helpers.feed_status_icon(feed)
   end
 
   def menu_id
     "feed-menu-#{feed.id}"
-  end
-
-  # Query-shaped profiles (AI search) have no URL to open, so the menu only
-  # offers a source link when the feed's input is an actual URL.
-  def source_url
-    feed.source_input.presence if feed.source_input_shape == "url"
   end
 
   def target_group_label

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -15,6 +15,7 @@ module FeedHelper
   def feed_missing_enablement_parts(feed)
     missing_parts = []
     missing_parts << "source" unless feed.source_input.present?
+    missing_parts << "name" unless feed.name.present?
     missing_parts << "feed profile" unless feed.feed_profile_present?
     missing_parts << "active access token" unless feed.access_token&.active?
     missing_parts << "target group" unless feed.target_group.present?

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -214,7 +214,7 @@ class Feed < ApplicationRecord
   end
 
   def can_be_enabled?
-    access_token&.active? && target_group.present? && feed_profile_present? && cron_expression.present?
+    name.present? && access_token&.active? && target_group.present? && feed_profile_present? && cron_expression.present?
   end
 
   # Promote the feed to enabled, running the enabled-state validators. If

--- a/app/views/feeds/_header.html.erb
+++ b/app/views/feeds/_header.html.erb
@@ -24,7 +24,7 @@
                       class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"),
                       form: { class: "inline-block" } %>
       <% end %>
-    <% elsif feed.disabled? && feed.can_be_enabled? %>
+    <% elsif feed.can_be_enabled? %>
       <% header.with_action_button do %>
         <%= button_to "Enable",
                       feed_status_path(feed),

--- a/test/components/feed_list_item_component_test.rb
+++ b/test/components/feed_list_item_component_test.rb
@@ -140,8 +140,19 @@ class FeedListItemComponentTest < ViewComponent::TestCase
     end
   end
 
-  test "#render should not show status toggle for draft feeds" do
+  test "#render should show Enable action for ready draft feeds" do
     draft_feed = create(:feed, :draft, user: user)
+
+    with_request_url("/feeds") do
+      result = render_inline FeedListItemComponent.new(feed: draft_feed)
+
+      assert_not_empty result.css("[data-key='feed.#{draft_feed.id}.enable']")
+      assert_empty result.css("[data-key='feed.#{draft_feed.id}.disable']")
+    end
+  end
+
+  test "#render should not show status toggle for incomplete draft feeds" do
+    draft_feed = create(:feed, :without_access_token, :draft, user: user)
 
     with_request_url("/feeds") do
       result = render_inline FeedListItemComponent.new(feed: draft_feed)

--- a/test/components/feed_list_item_component_test.rb
+++ b/test/components/feed_list_item_component_test.rb
@@ -56,14 +56,16 @@ class FeedListItemComponentTest < ViewComponent::TestCase
     assert_includes result.text, "@testgroup"
   end
 
-  test "#render should show Continue setup and Discard in dropdown for draft feeds" do
+  test "#render should lead with Continue setup and hide Details for draft feeds" do
     draft_feed = create(:feed, :draft, user: user)
 
     with_request_url("/feeds") do
       result = render_inline FeedListItemComponent.new(feed: draft_feed)
 
-      assert_not_empty result.css("[data-key='feed.#{draft_feed.id}.continue_setup']")
+      menu_keys = result.css("[role='menuitem']").map { |item| item["data-key"] }
+      assert_equal "feed.#{draft_feed.id}.continue_setup", menu_keys.first
       assert_not_empty result.css("[data-key='feed.#{draft_feed.id}.discard']")
+      assert_empty result.css("[data-key='feed.#{draft_feed.id}.details']")
     end
   end
 
@@ -76,7 +78,7 @@ class FeedListItemComponentTest < ViewComponent::TestCase
     end
   end
 
-  test "#render should show Details action for every feed" do
+  test "#render should show Details action for non-draft feeds" do
     with_request_url("/feeds") do
       result = render_inline FeedListItemComponent.new(feed: feed)
 
@@ -87,26 +89,11 @@ class FeedListItemComponentTest < ViewComponent::TestCase
     end
   end
 
-  test "#render should show Source action opening the feed source in a new tab" do
+  test "#render should not show a Source action" do
     with_request_url("/feeds") do
       result = render_inline FeedListItemComponent.new(feed: feed)
 
-      source = result.css("[data-key='feed.#{feed.id}.source']").first
-      assert_not_nil source
-      assert_equal "Source", source.text.strip
-      assert_equal "https://example.com/feed.xml", source["href"]
-      assert_equal "_blank", source["target"]
-    end
-  end
-
-  test "#render should not show Source for query-shaped feeds" do
-    query_feed = create(:feed, user: user, feed_profile_key: "llm_web_search",
-      params: { "query" => "ruby news" })
-
-    with_request_url("/feeds") do
-      result = render_inline FeedListItemComponent.new(feed: query_feed)
-
-      assert_empty result.css("[data-key='feed.#{query_feed.id}.source']")
+      assert_empty result.css("[data-key='feed.#{feed.id}.source']")
     end
   end
 

--- a/test/controllers/feed_statuses_controller_test.rb
+++ b/test/controllers/feed_statuses_controller_test.rb
@@ -22,6 +22,16 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "enabled", feed.state
   end
 
+  test "#update should enable a ready draft feed" do
+    sign_in_as(user)
+    draft = create(:feed, :draft, user: user)
+
+    patch feed_status_path(draft), params: { status: "enabled" }
+
+    assert_redirected_to draft
+    assert_equal "enabled", draft.reload.state
+  end
+
   test "#update should disable feed" do
     sign_in_as(user)
     feed.update!(state: :enabled)

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -496,9 +496,19 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href$='/testgroup']", count: 0
   end
 
-  test "#show should not offer a status toggle for a draft feed" do
+  test "#show should offer an enable toggle for a ready draft feed" do
     sign_in_as(user)
     draft = create(:feed, :draft, user: user)
+
+    get feed_url(draft)
+
+    assert_response :success
+    assert_select "form[action='#{feed_status_path(draft)}'] button", text: "Enable"
+  end
+
+  test "#show should not offer a status toggle for an incomplete draft feed" do
+    sign_in_as(user)
+    draft = create(:feed, :without_access_token, :draft, user: user)
 
     get feed_url(draft)
 

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -41,6 +41,14 @@ class FeedHelperTest < ActionView::TestCase
     assert_equal [], result
   end
 
+  test "#feed_missing_enablement_parts should include name when blank" do
+    access_token = create(:access_token, :active)
+    feed = build(:feed, access_token: access_token, target_group: "test_group", name: "")
+    result = feed_missing_enablement_parts(feed)
+
+    assert_includes result, "name"
+  end
+
   test "#feed_status_icon should render enabled icon" do
     feed = build(:feed, :enabled)
 

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -333,6 +333,14 @@ class FeedTest < ActiveSupport::TestCase
     assert feed.can_be_enabled?
   end
 
+  test "#can_be_enabled? returns false when feed has a blank name" do
+    user = create(:user)
+    access_token = create(:access_token, :active, user: user)
+    feed = create(:feed, user: user, access_token: access_token, target_group: "test_group", name: "")
+
+    assert_not feed.can_be_enabled?
+  end
+
   test "#can_be_enabled? returns false when feed has no access token" do
     feed = create(:feed, :without_access_token)
 


### PR DESCRIPTION
Changes:

- A feed saved without enabling (a "draft") can now be enabled directly from the feed page and the feeds list, instead of only being reachable through "Continue setup"
- The active Enable control is shown for any feed that's ready to enable — draft or paused — while incomplete drafts still route to "Continue setup"
- `can_be_enabled?` now also requires a name (enabling already validates name presence), so a nameless feed can't render an Enable control that would fail on save; "name" is surfaced in the missing-parts message

A feed saved without turning it on lands in the draft state, but the Enable control was gated to paused (disabled) feeds only — so a fully configured draft showed a dead Enable button on its page and offered no Enable action in the list. The control is now available whenever the feed can actually be enabled.