### PR TITLE
Style dropdown menu trigger to match page header buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-23
 
+- The actions menu button on feed and post pages now matches the style of the other buttons in the header.
 - Editing a feed now shows its feed type, with a clearer note that the source and type stay fixed once a feed is created.
 - Feed and post pages now keep extra actions in a dropdown menu.
 - Settings now shows your permissions right under the page title.

--- a/app/components/dropdown_menu_component.html.erb
+++ b/app/components/dropdown_menu_component.html.erb
@@ -3,7 +3,7 @@
           id="<%= menu_id %>-button"
           data-dropdown-toggle="<%= menu_id %>"
           data-dropdown-placement="bottom-end"
-          class="inline-flex size-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+          class="<%= trigger_class %>"
           aria-haspopup="true"
           aria-expanded="false">
     <%= helpers.icon("ellipsis", css_class: "size-4") %>

--- a/app/components/dropdown_menu_component.rb
+++ b/app/components/dropdown_menu_component.rb
@@ -10,12 +10,6 @@
 class DropdownMenuComponent < ViewComponent::Base
   ITEM_CLASS = "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
 
-  # A square, icon-only trigger — here a subtle borderless ellipsis for list rows
-  # and cards. HeaderMenuComponent overrides it to match the bordered action
-  # buttons (Enable, Refresh) it sits beside in a page header.
-  TRIGGER_CLASS = "inline-flex size-7 items-center justify-center rounded text-slate-400 transition " \
-    "hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
-
   def initialize(menu_id:, items:, width: "w-44", label: "More options")
     @menu_id = menu_id
     @items = items.compact
@@ -27,8 +21,12 @@ class DropdownMenuComponent < ViewComponent::Base
 
   attr_reader :menu_id, :items, :width, :label
 
+  # The square, icon-only trigger styling — a subtle borderless ellipsis here.
+  # HeaderMenuComponent overrides it to match the bordered action buttons
+  # (Enable, Refresh) it sits beside in a page header.
   def trigger_class
-    self.class::TRIGGER_CLASS
+    "inline-flex size-7 items-center justify-center rounded text-slate-400 transition " \
+      "hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
   end
 
   def render_item(item)

--- a/app/components/dropdown_menu_component.rb
+++ b/app/components/dropdown_menu_component.rb
@@ -1,5 +1,6 @@
 # An ellipsis "more options" button that toggles a dropdown of actions. Shared
-# by the feed and post list rows, which differ only in their items.
+# by the feed and post list rows and their page headers, which differ in their
+# items and in the trigger's `variant` (see TRIGGER_CLASSES).
 #
 # Each item is a hash; nils are dropped so callers can build the list with inline
 # conditionals. Items with a `method` render as button_to forms (e.g. enable /
@@ -9,16 +10,32 @@
 class DropdownMenuComponent < ViewComponent::Base
   ITEM_CLASS = "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
 
-  def initialize(menu_id:, items:, width: "w-44", label: "More options")
+  # The trigger is a square, icon-only button. In list rows and cards it stays a
+  # subtle borderless ellipsis; in a page header it matches the bordered action
+  # buttons (Enable, Refresh) it sits beside — same height, border, and chrome.
+  TRIGGER_CLASSES = {
+    row: "inline-flex size-7 items-center justify-center rounded text-slate-400 transition " \
+      "hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500",
+    header: "inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 " \
+      "text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 " \
+      "focus:ring-offset-1 cursor-pointer"
+  }.freeze
+
+  def initialize(menu_id:, items:, width: "w-44", label: "More options", variant: :row)
     @menu_id = menu_id
     @items = items.compact
     @width = width
     @label = label
+    @variant = variant
   end
 
   private
 
   attr_reader :menu_id, :items, :width, :label
+
+  def trigger_class
+    TRIGGER_CLASSES.fetch(@variant)
+  end
 
   def render_item(item)
     if item[:method]

--- a/app/components/dropdown_menu_component.rb
+++ b/app/components/dropdown_menu_component.rb
@@ -1,6 +1,6 @@
 # An ellipsis "more options" button that toggles a dropdown of actions. Shared
-# by the feed and post list rows and their page headers, which differ in their
-# items and in the trigger's `variant` (see TRIGGER_CLASSES).
+# by the feed and post list rows and cards, which differ only in their items.
+# HeaderMenuComponent subclasses it for the bordered trigger used in page headers.
 #
 # Each item is a hash; nils are dropped so callers can build the list with inline
 # conditionals. Items with a `method` render as button_to forms (e.g. enable /
@@ -10,23 +10,17 @@
 class DropdownMenuComponent < ViewComponent::Base
   ITEM_CLASS = "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
 
-  # The trigger is a square, icon-only button. In list rows and cards it stays a
-  # subtle borderless ellipsis; in a page header it matches the bordered action
-  # buttons (Enable, Refresh) it sits beside — same height, border, and chrome.
-  TRIGGER_CLASSES = {
-    row: "inline-flex size-7 items-center justify-center rounded text-slate-400 transition " \
-      "hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500",
-    header: "inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 " \
-      "text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 " \
-      "focus:ring-offset-1 cursor-pointer"
-  }.freeze
+  # A square, icon-only trigger — here a subtle borderless ellipsis for list rows
+  # and cards. HeaderMenuComponent overrides it to match the bordered action
+  # buttons (Enable, Refresh) it sits beside in a page header.
+  TRIGGER_CLASS = "inline-flex size-7 items-center justify-center rounded text-slate-400 transition " \
+    "hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
 
-  def initialize(menu_id:, items:, width: "w-44", label: "More options", variant: :row)
+  def initialize(menu_id:, items:, width: "w-44", label: "More options")
     @menu_id = menu_id
     @items = items.compact
     @width = width
     @label = label
-    @variant = variant
   end
 
   private
@@ -34,7 +28,7 @@ class DropdownMenuComponent < ViewComponent::Base
   attr_reader :menu_id, :items, :width, :label
 
   def trigger_class
-    TRIGGER_CLASSES.fetch(@variant)
+    self.class::TRIGGER_CLASS
   end
 
   def render_item(item)

--- a/app/components/header_menu_component.rb
+++ b/app/components/header_menu_component.rb
@@ -2,7 +2,11 @@
 # matching the height and chrome of the Enable/Refresh buttons it sits beside.
 # The dropdown template and behavior are inherited; only the trigger changes.
 class HeaderMenuComponent < DropdownMenuComponent
-  TRIGGER_CLASS = "inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 " \
-    "text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 " \
-    "focus:ring-offset-1 cursor-pointer"
+  private
+
+  def trigger_class
+    "inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 " \
+      "text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 " \
+      "focus:ring-offset-1 cursor-pointer"
+  end
 end

--- a/app/components/header_menu_component.rb
+++ b/app/components/header_menu_component.rb
@@ -1,0 +1,8 @@
+# DropdownMenuComponent styled for a page header: a square, bordered icon button
+# matching the height and chrome of the Enable/Refresh buttons it sits beside.
+# The dropdown template and behavior are inherited; only the trigger changes.
+class HeaderMenuComponent < DropdownMenuComponent
+  TRIGGER_CLASS = "inline-flex items-center justify-center rounded-md border border-slate-200 bg-white p-3 " \
+    "text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500 " \
+    "focus:ring-offset-1 cursor-pointer"
+end

--- a/app/views/feeds/_header.html.erb
+++ b/app/views/feeds/_header.html.erb
@@ -40,7 +40,7 @@
       <% end %>
     <% end %>
     <% header.with_action_button do %>
-      <%= render DropdownMenuComponent.new(menu_id: "feed-header-menu-#{feed.id}", items: feed_actions_menu_items(feed), width: "w-44", variant: :header) %>
+      <%= render HeaderMenuComponent.new(menu_id: "feed-header-menu-#{feed.id}", items: feed_actions_menu_items(feed), width: "w-44") %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/feeds/_header.html.erb
+++ b/app/views/feeds/_header.html.erb
@@ -40,7 +40,7 @@
       <% end %>
     <% end %>
     <% header.with_action_button do %>
-      <%= render DropdownMenuComponent.new(menu_id: "feed-header-menu-#{feed.id}", items: feed_actions_menu_items(feed), width: "w-44") %>
+      <%= render DropdownMenuComponent.new(menu_id: "feed-header-menu-#{feed.id}", items: feed_actions_menu_items(feed), width: "w-44", variant: :header) %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -18,7 +18,7 @@
                               modal_trigger_modal_id_value: PostDeleteModalComponent.modal_id(@post),
                               action: "click->modal-trigger#open" } } %>
       <% end %>
-      <%= render DropdownMenuComponent.new(menu_id: "post-header-menu-#{@post.id}", items: items, width: "w-40", variant: :header) %>
+      <%= render HeaderMenuComponent.new(menu_id: "post-header-menu-#{@post.id}", items: items, width: "w-40") %>
     <% end %>
   <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -18,7 +18,7 @@
                               modal_trigger_modal_id_value: PostDeleteModalComponent.modal_id(@post),
                               action: "click->modal-trigger#open" } } %>
       <% end %>
-      <%= render DropdownMenuComponent.new(menu_id: "post-header-menu-#{@post.id}", items: items, width: "w-40") %>
+      <%= render DropdownMenuComponent.new(menu_id: "post-header-menu-#{@post.id}", items: items, width: "w-40", variant: :header) %>
     <% end %>
   <% end %>
 

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -36,7 +36,7 @@
     <%= render CardComponent.new(href: access_tokens_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
-          <%= icon("key", css_class: "size-5") %>
+          <%= icon("key-square", css_class: "size-5") %>
           <span>Freefeed Access Tokens</span>
         </h2>
         <p class="text-slate-600">Manage the tokens used for reposting to FreeFeed</p>

--- a/test/components/dropdown_menu_component_test.rb
+++ b/test/components/dropdown_menu_component_test.rb
@@ -16,6 +16,21 @@ class DropdownMenuComponentTest < ViewComponent::TestCase
     assert_includes result.at_css("#m")["class"], "w-40"
   end
 
+  test "#render should use the compact ellipsis trigger by default" do
+    result = render_inline(DropdownMenuComponent.new(menu_id: "m", items: []))
+
+    assert_includes result.at_css("button[data-dropdown-toggle='m']")["class"], "size-7"
+  end
+
+  test "#render should style the header variant trigger like the page-header buttons" do
+    result = render_inline(DropdownMenuComponent.new(menu_id: "m", items: [], variant: :header))
+
+    button_class = result.at_css("button[data-dropdown-toggle='m']")["class"]
+    assert_includes button_class, "border"
+    assert_includes button_class, "p-3"
+    assert_not_includes button_class, "size-7"
+  end
+
   test "#render should render plain items as links carrying their data" do
     result = render_inline(DropdownMenuComponent.new(menu_id: "m", items: [
       { label: "Details", href: "/feeds/1", data: { key: "feed.1.details" } }

--- a/test/components/dropdown_menu_component_test.rb
+++ b/test/components/dropdown_menu_component_test.rb
@@ -16,19 +16,10 @@ class DropdownMenuComponentTest < ViewComponent::TestCase
     assert_includes result.at_css("#m")["class"], "w-40"
   end
 
-  test "#render should use the compact ellipsis trigger by default" do
+  test "#render should use the compact ellipsis trigger" do
     result = render_inline(DropdownMenuComponent.new(menu_id: "m", items: []))
 
     assert_includes result.at_css("button[data-dropdown-toggle='m']")["class"], "size-7"
-  end
-
-  test "#render should style the header variant trigger like the page-header buttons" do
-    result = render_inline(DropdownMenuComponent.new(menu_id: "m", items: [], variant: :header))
-
-    button_class = result.at_css("button[data-dropdown-toggle='m']")["class"]
-    assert_includes button_class, "border"
-    assert_includes button_class, "p-3"
-    assert_not_includes button_class, "size-7"
   end
 
   test "#render should render plain items as links carrying their data" do

--- a/test/components/header_menu_component_test.rb
+++ b/test/components/header_menu_component_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "view_component/test_case"
+
+class HeaderMenuComponentTest < ViewComponent::TestCase
+  test "#render should style the trigger like the page-header buttons" do
+    result = render_inline(HeaderMenuComponent.new(menu_id: "m", items: []))
+
+    button_class = result.at_css("button[data-dropdown-toggle='m']")["class"]
+    assert_includes button_class, "border"
+    assert_includes button_class, "p-3"
+    assert_not_includes button_class, "size-7"
+  end
+
+  test "#render should inherit the dropdown menu and its items" do
+    result = render_inline(HeaderMenuComponent.new(menu_id: "m", items: [
+      { label: "Edit", href: "/feeds/1" }
+    ]))
+
+    assert_not_nil result.at_css("#m[role='menu']")
+    assert_equal "Edit", result.at_css("a[role='menuitem']").text.strip
+  end
+end


### PR DESCRIPTION
Changes:

- Style the page-header "more options" dropdown like the Enable and Refresh buttons beside it — a square, bordered, icon-only button of matching height. List rows and cards keep their compact ellipsis.
- Use the `key-square` icon for the Freefeed Access Tokens card on the Settings page.

The page-header dropdown is a small `HeaderMenuComponent` subclass that inherits the shared dropdown's template and behavior and overrides only the trigger styling, so every other usage is unchanged.
