### PR TITLE
Add within-run HTTP cache for feed identification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", github: "rails/rails", branch: "main"
+gem "rails", "~> 8.1.3"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
 # Use postgresql as the database for Active Record
@@ -96,5 +96,5 @@ gem "resend"
 gem "ruby_llm"
 gem "rouge"
 gem "svix"
-gem "heatmap-builder", github: "dreikanter/heatmap-builder"
+gem "heatmap-builder", "~> 0.4.3"
 gem "with_advisory_lock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,74 +1,68 @@
-GIT
-  remote: https://github.com/dreikanter/heatmap-builder.git
-  revision: 7ed1949343a6f2e60eb22919b1871e14409ddc11
+GEM
+  remote: https://rubygems.org/
   specs:
-    heatmap-builder (0.4.3)
-
-GIT
-  remote: https://github.com/rails/rails.git
-  revision: a0b0f0e707246dfed9320006d591b54ec14ff0de
-  branch: main
-  specs:
-    actioncable (8.2.0.alpha)
-      actionpack (= 8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
+    action_text-trix (2.1.19)
+      railties
+    actioncable (8.1.3)
+      actionpack (= 8.1.3)
+      activesupport (= 8.1.3)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
-    actionmailbox (8.2.0.alpha)
-      actionpack (= 8.2.0.alpha)
-      activejob (= 8.2.0.alpha)
-      activerecord (= 8.2.0.alpha)
-      activestorage (= 8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
+    actionmailbox (8.1.3)
+      actionpack (= 8.1.3)
+      activejob (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
       mail (>= 2.8.0)
-    actionmailer (8.2.0.alpha)
-      actionpack (= 8.2.0.alpha)
-      actionview (= 8.2.0.alpha)
-      activejob (= 8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
+    actionmailer (8.1.3)
+      actionpack (= 8.1.3)
+      actionview (= 8.1.3)
+      activejob (= 8.1.3)
+      activesupport (= 8.1.3)
       mail (>= 2.8.0)
       rails-dom-testing (~> 2.2)
-    actionpack (8.2.0.alpha)
-      actionview (= 8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
+    actionpack (8.1.3)
+      actionview (= 8.1.3)
+      activesupport (= 8.1.3)
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
-      rails-html-sanitizer (~> 1.7)
+      rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actiontext (8.2.0.alpha)
-      action_text-trix (~> 2.1.16)
-      actionpack (= 8.2.0.alpha)
-      activerecord (= 8.2.0.alpha)
-      activestorage (= 8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
+    actiontext (8.1.3)
+      action_text-trix (~> 2.1.15)
+      actionpack (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
+    actionview (8.1.3)
+      activesupport (= 8.1.3)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
-      rails-html-sanitizer (~> 1.7)
-    activejob (8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
+      rails-html-sanitizer (~> 1.6)
+    activejob (8.1.3)
+      activesupport (= 8.1.3)
       globalid (>= 0.3.6)
-    activemodel (8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
-    activerecord (8.2.0.alpha)
-      activemodel (= 8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
+    activemodel (8.1.3)
+      activesupport (= 8.1.3)
+    activerecord (8.1.3)
+      activemodel (= 8.1.3)
+      activesupport (= 8.1.3)
       timeout (>= 0.4.0)
-    activestorage (8.2.0.alpha)
-      actionpack (= 8.2.0.alpha)
-      activejob (= 8.2.0.alpha)
-      activerecord (= 8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
+    activestorage (8.1.3)
+      actionpack (= 8.1.3)
+      activejob (= 8.1.3)
+      activerecord (= 8.1.3)
+      activesupport (= 8.1.3)
       marcel (~> 1.0)
-    activesupport (8.2.0.alpha)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -78,39 +72,9 @@ GIT
       json
       logger (>= 1.4.2)
       minitest (>= 5.1)
-      psych (>= 4)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    rails (8.2.0.alpha)
-      actioncable (= 8.2.0.alpha)
-      actionmailbox (= 8.2.0.alpha)
-      actionmailer (= 8.2.0.alpha)
-      actionpack (= 8.2.0.alpha)
-      actiontext (= 8.2.0.alpha)
-      actionview (= 8.2.0.alpha)
-      activejob (= 8.2.0.alpha)
-      activemodel (= 8.2.0.alpha)
-      activerecord (= 8.2.0.alpha)
-      activestorage (= 8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
-      bundler (>= 1.15.0)
-      railties (= 8.2.0.alpha)
-    railties (8.2.0.alpha)
-      actionpack (= 8.2.0.alpha)
-      activesupport (= 8.2.0.alpha)
-      irb (~> 1.13)
-      rackup (>= 1.0.0)
-      rake (>= 12.2)
-      thor (~> 1.0, >= 1.2.2)
-      tsort (>= 0.2)
-      zeitwerk (~> 2.6)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    action_text-trix (2.1.19)
-      railties
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     amazing_print (2.0.0)
@@ -188,6 +152,7 @@ GEM
       activesupport (>= 6.1)
     hana (1.3.7)
     hashdiff (1.2.1)
+    heatmap-builder (0.4.3)
     highline (3.0.1)
     honeybadger (6.9.0)
       logger
@@ -345,6 +310,20 @@ GEM
       rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
+    rails (8.1.3)
+      actioncable (= 8.1.3)
+      actionmailbox (= 8.1.3)
+      actionmailer (= 8.1.3)
+      actionpack (= 8.1.3)
+      actiontext (= 8.1.3)
+      actionview (= 8.1.3)
+      activejob (= 8.1.3)
+      activemodel (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
+      bundler (>= 1.15.0)
+      railties (= 8.1.3)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -356,6 +335,15 @@ GEM
       rack
       railties (>= 5.1)
       semantic_logger (~> 4.16)
+    railties (8.1.3)
+      actionpack (= 8.1.3)
+      activesupport (= 8.1.3)
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
     rbs (4.0.3)
@@ -573,7 +561,7 @@ DEPENDENCIES
   faraday-multipart
   feedjira
   fugit
-  heatmap-builder!
+  heatmap-builder (~> 0.4.3)
   honeybadger
   importmap-rails
   json_schemer
@@ -585,7 +573,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   pundit
-  rails!
+  rails (~> 8.1.3)
   rails_semantic_logger
   resend
   rouge

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -59,8 +59,10 @@ class FeedIdentificationFetcher
     end
   end
 
+  # Cache GETs for the duration of one identification run so matching and
+  # per-candidate testing fetch each source URL at most once.
   def http_client
-    @http_client ||= HttpClient.build(timeout: 15, max_redirects: 5)
+    @http_client ||= HttpClient::Caching.new(HttpClient.build(timeout: 15, max_redirects: 5))
   end
 
   def serialize_candidates(candidates)

--- a/config/initializers/rails_semantic_logger.rb
+++ b/config/initializers/rails_semantic_logger.rb
@@ -5,16 +5,21 @@
 # `require "action_cable/connection/tagged_logger_proxy"` from an after_initialize
 # hook — a LoadError that aborts eager-load boot. Alias the old constant onto the
 # new class so the gem's patch still lands, and seed the stale path into
-# $LOADED_FEATURES so the require is a no-op. The gem loads only on the deployed
+# $LOADED_FEATURES so the require is a no-op. Released Rails still ships the old
+# path, so the shim self-disables there. The gem loads only on the deployed
 # environments (see Gemfile); remove once it targets ActionCable::Server.
 if defined?(RailsSemanticLogger) && defined?(ActionCable)
-  require "action_cable/server/tagged_logger_proxy"
+  begin
+    require "action_cable/server/tagged_logger_proxy"
 
-  module ActionCable
-    module Connection
-      TaggedLoggerProxy = ActionCable::Server::TaggedLoggerProxy unless defined?(TaggedLoggerProxy)
+    module ActionCable
+      module Connection
+        TaggedLoggerProxy = ActionCable::Server::TaggedLoggerProxy unless defined?(TaggedLoggerProxy)
+      end
     end
-  end
 
-  $LOADED_FEATURES << "action_cable/connection/tagged_logger_proxy.rb"
+    $LOADED_FEATURES << "action_cable/connection/tagged_logger_proxy.rb"
+  rescue LoadError
+    # Released Rails keeps ActionCable::Connection::TaggedLoggerProxy; no shim needed.
+  end
 end

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -7,6 +7,7 @@
 #
 require_relative "http_client/base"
 require_relative "http_client/faraday_adapter"
+require_relative "http_client/caching"
 
 module HttpClient
   class Response

--- a/lib/http_client/caching.rb
+++ b/lib/http_client/caching.rb
@@ -1,0 +1,72 @@
+require_relative "base"
+
+module HttpClient
+  # Wraps another HttpClient with a short-lived, in-memory, URL-keyed cache for
+  # GET requests, so a single feed-identification run fetches each source URL at
+  # most once across matching and per-candidate testing.
+  #
+  # Only successful (2xx) responses are cached. Non-2xx responses and raised
+  # errors are never cached, so a transient blip during matching can't poison a
+  # later test or mask a recovery. Entries expire after a short TTL.
+  #
+  # Scoped to one run and held in process memory — deliberately not for
+  # scheduled refreshes, which must always hit the network.
+  class Caching < Base
+    DEFAULT_TTL = 60
+
+    def initialize(client, ttl: DEFAULT_TTL)
+      super()
+      @client = client
+      @ttl = ttl
+      @entries = {}
+      @mutex = Mutex.new
+    end
+
+    def get(url, headers: {}, options: {})
+      cached = read(url)
+      return cached if cached
+
+      response = @client.get(url, headers: headers, options: options)
+      write(url, response) if response.success?
+      response
+    end
+
+    def post(url, body: nil, headers: {}, options: {})
+      @client.post(url, body: body, headers: headers, options: options)
+    end
+
+    def put(url, body: nil, headers: {}, options: {})
+      @client.put(url, body: body, headers: headers, options: options)
+    end
+
+    def delete(url, headers: {}, options: {})
+      @client.delete(url, headers: headers, options: options)
+    end
+
+    private
+
+    def read(url)
+      @mutex.synchronize do
+        entry = @entries[url]
+        next nil if entry.nil?
+
+        if monotonic_now >= entry[:expires_at]
+          @entries.delete(url)
+          next nil
+        end
+
+        entry[:response]
+      end
+    end
+
+    def write(url, response)
+      @mutex.synchronize do
+        @entries[url] = { response: response, expires_at: monotonic_now + @ttl }
+      end
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/test/lib/http_client/caching_test.rb
+++ b/test/lib/http_client/caching_test.rb
@@ -1,0 +1,124 @@
+require "test_helper"
+
+class HttpClient::CachingTest < ActiveSupport::TestCase
+  # Inner client that records how often each GET URL is hit and returns whatever
+  # the supplied block produces. Non-GET verbs return a canned success.
+  class RecordingClient < HttpClient::Base
+    attr_reader :get_calls, :verb_calls
+
+    def initialize(&get_handler)
+      super()
+      @get_handler = get_handler
+      @get_calls = Hash.new(0)
+      @verb_calls = Hash.new(0)
+    end
+
+    def get(url, headers: {}, options: {})
+      @get_calls[url] += 1
+      @get_handler.call(url)
+    end
+
+    def post(url, body: nil, headers: {}, options: {})
+      @verb_calls[:post] += 1
+      HttpClient::Response.new(status: 200, body: "ok")
+    end
+
+    def put(url, body: nil, headers: {}, options: {})
+      @verb_calls[:put] += 1
+      HttpClient::Response.new(status: 200, body: "ok")
+    end
+
+    def delete(url, headers: {}, options: {})
+      @verb_calls[:delete] += 1
+      HttpClient::Response.new(status: 200, body: "ok")
+    end
+  end
+
+  def ok(body = "body", status: 200)
+    HttpClient::Response.new(status: status, body: body)
+  end
+
+  test "#get should cache a successful response and reuse it for the same URL" do
+    inner = RecordingClient.new { ok("hello") }
+    client = HttpClient::Caching.new(inner)
+
+    first = client.get("https://example.com/feed")
+    second = client.get("https://example.com/feed")
+
+    assert_equal "hello", first.body
+    assert_same first, second
+    assert_equal 1, inner.get_calls["https://example.com/feed"]
+  end
+
+  test "#get should cache each URL independently" do
+    inner = RecordingClient.new { |url| ok(url) }
+    client = HttpClient::Caching.new(inner)
+
+    client.get("https://a.example/feed")
+    client.get("https://b.example/feed")
+    client.get("https://a.example/feed")
+
+    assert_equal 1, inner.get_calls["https://a.example/feed"]
+    assert_equal 1, inner.get_calls["https://b.example/feed"]
+  end
+
+  test "#get should not cache non-2xx responses" do
+    inner = RecordingClient.new { ok("error", status: 500) }
+    client = HttpClient::Caching.new(inner)
+
+    client.get("https://example.com/down")
+    client.get("https://example.com/down")
+
+    assert_equal 2, inner.get_calls["https://example.com/down"]
+  end
+
+  test "#get should not cache when the inner client raises" do
+    inner = RecordingClient.new { raise HttpClient::TimeoutError, "boom" }
+    client = HttpClient::Caching.new(inner)
+
+    assert_raises(HttpClient::TimeoutError) { client.get("https://example.com/slow") }
+    assert_raises(HttpClient::TimeoutError) { client.get("https://example.com/slow") }
+
+    assert_equal 2, inner.get_calls["https://example.com/slow"]
+  end
+
+  test "#get should serve from cache within the TTL window" do
+    inner = RecordingClient.new { ok("hello") }
+    client = HttpClient::Caching.new(inner, ttl: 60)
+    clock = [1000.0]
+    client.define_singleton_method(:monotonic_now) { clock[0] }
+
+    client.get("https://example.com/feed")
+    clock[0] += 59
+    client.get("https://example.com/feed")
+
+    assert_equal 1, inner.get_calls["https://example.com/feed"]
+  end
+
+  test "#get should re-fetch after the entry expires" do
+    inner = RecordingClient.new { ok("hello") }
+    client = HttpClient::Caching.new(inner, ttl: 60)
+    clock = [1000.0]
+    client.define_singleton_method(:monotonic_now) { clock[0] }
+
+    client.get("https://example.com/feed")
+    clock[0] += 61
+    client.get("https://example.com/feed")
+
+    assert_equal 2, inner.get_calls["https://example.com/feed"]
+  end
+
+  test "#post, #put and #delete should delegate without caching" do
+    inner = RecordingClient.new { ok }
+    client = HttpClient::Caching.new(inner)
+
+    client.post("https://example.com/x")
+    client.post("https://example.com/x")
+    client.put("https://example.com/x")
+    client.delete("https://example.com/x")
+
+    assert_equal 2, inner.verb_calls[:post]
+    assert_equal 1, inner.verb_calls[:put]
+    assert_equal 1, inner.verb_calls[:delete]
+  end
+end

--- a/test/services/feed_identification_fetcher_test.rb
+++ b/test/services/feed_identification_fetcher_test.rb
@@ -186,6 +186,21 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     assert_equal %w[xkcd rss llm_website_extractor], profile_keys, "xkcd > rss > AI fallback for xkcd.com URLs"
   end
 
+  test "#identify should fetch the input URL once across repeated runs of one fetcher" do
+    url = "http://example.com/feed.xml"
+    rss_content = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0"><channel><title>Example Feed</title></channel></rss>
+    XML
+    stub_request(:get, url).to_return(status: 200, body: rss_content)
+
+    fetcher = FeedIdentificationFetcher.new(user: user, input: url, logger: @logger)
+    fetcher.identify
+    fetcher.identify
+
+    assert_requested :get, url, times: 1
+  end
+
   test "#identify should record the AI fallback as the only candidate when no structured profile matches" do
     url = "http://example.com/page.html"
     stub_request(:get, url).to_return(status: 200, body: "<html><body/></html>")


### PR DESCRIPTION
Changes:

- Add `HttpClient::Caching`, an in-memory, URL-keyed wrapper that caches successful (2xx) GETs for the span of one feed-identification run (~60s TTL). Failures and non-2xx responses are never cached, so a transient blip can't poison a later test or mask a recovery.
- Enable it in `FeedIdentificationFetcher` so a run fetches each source URL at most once across matching and per-candidate testing. Scheduled refreshes keep their own uncached clients and are unaffected.
- Pin Rails (`~> 8.1.3`) and `heatmap-builder` (`~> 0.4.3`) to released gems instead of GitHub git sources, so the bundle resolves without GitHub git access at session start.
- Make the `rails_semantic_logger` Action Cable shim self-disable on released Rails (it depended on an edge-only path).

The cache is the foundation for the feed-detection self-test: matching and the upcoming per-candidate testing reuse one fetch per URL instead of re-fetching the same sources. The dependency pins remove a hard reliance on fetching edge Rails and a private gem over GitHub git, which isn't available in some build/session environments.

References:

- Related: #852