### PR TITLE
Add CachingAdapter for memoizing successful GET responses

### DIFF
--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -7,6 +7,7 @@
 #
 require_relative "http_client/base"
 require_relative "http_client/faraday_adapter"
+require_relative "http_client/caching_adapter"
 
 module HttpClient
   class Response

--- a/lib/http_client/caching_adapter.rb
+++ b/lib/http_client/caching_adapter.rb
@@ -4,16 +4,18 @@ module HttpClient
   # A FaradayAdapter that memoizes successful (2xx) GET responses by URL.
   #
   # Built for a single feed-identification run, where matching and per-candidate
-  # testing fetch the same source URLs repeatedly: each URL hits the network
-  # once and the response is reused for the rest of the run. Select it through
-  # the usual seam — `HttpClient.build(adapter: HttpClient::CachingAdapter)`.
+  # testing fetch the same source URLs repeatedly. This adapter allows to reuse
+  # downloaded web content multiple times in a row, rather than fetching it again.
+  # 
+  # Do NOT use this adapter when you need HTTP-headers drived cache. It is build
+  # for a different use case.
   #
   # Only 2xx GETs are cached. Non-2xx responses and raised errors fall through
   # to a live request every time, so a transient blip can't poison the cache or
   # mask a recovery. POST/PUT/DELETE are never cached (inherited unchanged).
   #
   # Keyed on URL alone, which is lossless here: within one run each URL is
-  # fetched the same way. Not thread-safe — a cache belongs to one run.
+  # fetched the same way. Not thread-safe, a cache belongs to one run.
   class CachingAdapter < FaradayAdapter
     DEFAULT_TTL = 60
 

--- a/lib/http_client/caching_adapter.rb
+++ b/lib/http_client/caching_adapter.rb
@@ -6,7 +6,7 @@ module HttpClient
   # Built for a single feed-identification run, where matching and per-candidate
   # testing fetch the same source URLs repeatedly. This adapter allows to reuse
   # downloaded web content multiple times in a row, rather than fetching it again.
-  # 
+  #
   # Do NOT use this adapter when you need HTTP-headers drived cache. It is build
   # for a different use case.
   #

--- a/lib/http_client/caching_adapter.rb
+++ b/lib/http_client/caching_adapter.rb
@@ -1,0 +1,48 @@
+require_relative "faraday_adapter"
+
+module HttpClient
+  # A FaradayAdapter that memoizes successful (2xx) GET responses by URL.
+  #
+  # Built for a single feed-identification run, where matching and per-candidate
+  # testing fetch the same source URLs repeatedly: each URL hits the network
+  # once and the response is reused for the rest of the run. Select it through
+  # the usual seam — `HttpClient.build(adapter: HttpClient::CachingAdapter)`.
+  #
+  # Only 2xx GETs are cached. Non-2xx responses and raised errors fall through
+  # to a live request every time, so a transient blip can't poison the cache or
+  # mask a recovery. POST/PUT/DELETE are never cached (inherited unchanged).
+  #
+  # Keyed on URL alone, which is lossless here: within one run each URL is
+  # fetched the same way. Not thread-safe — a cache belongs to one run.
+  class CachingAdapter < FaradayAdapter
+    DEFAULT_TTL = 60
+
+    CacheEntry = Struct.new(:response, :expires_at) do
+      def expired?
+        expires_at <= Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+    private_constant :CacheEntry
+
+    def initialize(**options)
+      @cache_ttl = options.delete(:cache_ttl) || DEFAULT_TTL
+      @cache = {}
+      super
+    end
+
+    def get(url, headers: {}, options: {})
+      entry = @cache[url]
+      return entry.response if entry && !entry.expired?
+
+      response = super
+      @cache[url] = CacheEntry.new(response, monotonic_time + @cache_ttl) if response.success?
+      response
+    end
+
+    private
+
+    def monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/test/lib/http_client/caching_adapter_test.rb
+++ b/test/lib/http_client/caching_adapter_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class HttpClient::CachingAdapterTest < ActiveSupport::TestCase
+  def client
+    @client ||= HttpClient::CachingAdapter.new(timeout: 5, max_redirects: 5)
+  end
+
+  test "is selectable through HttpClient.build" do
+    built = HttpClient.build(adapter: HttpClient::CachingAdapter)
+
+    assert_instance_of HttpClient::CachingAdapter, built
+    assert_kind_of HttpClient::FaradayAdapter, built
+  end
+
+  test "caches a successful GET and serves repeats from cache" do
+    stub_request(:get, "https://example.com/feed")
+      .to_return(status: 200, body: "feed body")
+
+    first = client.get("https://example.com/feed")
+    second = client.get("https://example.com/feed")
+
+    assert_equal "feed body", first.body
+    assert_same first, second
+    assert_requested :get, "https://example.com/feed", times: 1
+  end
+
+  test "caches each URL independently" do
+    stub_request(:get, "https://example.com/a").to_return(status: 200, body: "A")
+    stub_request(:get, "https://example.com/b").to_return(status: 200, body: "B")
+
+    assert_equal "A", client.get("https://example.com/a").body
+    assert_equal "B", client.get("https://example.com/b").body
+    assert_equal "A", client.get("https://example.com/a").body
+
+    assert_requested :get, "https://example.com/a", times: 1
+    assert_requested :get, "https://example.com/b", times: 1
+  end
+
+  test "does not cache non-2xx responses" do
+    stub_request(:get, "https://example.com/flaky")
+      .to_return(status: 404, body: "missing").then
+      .to_return(status: 200, body: "recovered")
+
+    first = client.get("https://example.com/flaky")
+    second = client.get("https://example.com/flaky")
+
+    assert_equal 404, first.status
+    assert_equal 200, second.status
+    assert_equal "recovered", second.body
+    assert_requested :get, "https://example.com/flaky", times: 2
+  end
+
+  test "does not cache raised errors" do
+    stub_request(:get, "https://example.com/blip")
+      .to_raise(SocketError.new("getaddrinfo failed")).then
+      .to_return(status: 200, body: "back online")
+
+    assert_raises(HttpClient::ConnectionError) { client.get("https://example.com/blip") }
+
+    recovered = client.get("https://example.com/blip")
+
+    assert_equal 200, recovered.status
+    assert_equal "back online", recovered.body
+  end
+
+  test "re-fetches after the cache entry expires" do
+    expiring = HttpClient::CachingAdapter.new(cache_ttl: 0)
+
+    stub_request(:get, "https://example.com/feed")
+      .to_return(status: 200, body: "first").then
+      .to_return(status: 200, body: "second")
+
+    assert_equal "first", expiring.get("https://example.com/feed").body
+    assert_equal "second", expiring.get("https://example.com/feed").body
+    assert_requested :get, "https://example.com/feed", times: 2
+  end
+
+  test "does not cache POST requests" do
+    stub_request(:post, "https://example.com/submit")
+      .to_return(status: 200, body: "one").then
+      .to_return(status: 200, body: "two")
+
+    assert_equal "one", client.post("https://example.com/submit").body
+    assert_equal "two", client.post("https://example.com/submit").body
+  end
+
+  test "still follows redirects like the Faraday adapter" do
+    stub_request(:get, "https://example.com/redirect")
+      .to_return(status: 302, headers: { "Location" => "https://example.com/final" })
+    stub_request(:get, "https://example.com/final")
+      .to_return(status: 200, body: "final destination")
+
+    response = client.get("https://example.com/redirect")
+
+    assert_equal 200, response.status
+    assert_equal "final destination", response.body
+  end
+end


### PR DESCRIPTION
Changes:

- Add `HttpClient::CachingAdapter`, a `FaradayAdapter` subclass that memoizes successful (2xx) GET responses by URL for the life of the client
- Select it via the existing `HttpClient.build(adapter:)` seam; the scheduled-refresh path doesn't opt in and stays on live responses
- Errors and non-2xx responses are never cached; POST/PUT/DELETE pass through unchanged

Within a single feed-identification run, matching and per-candidate testing fetch the same source URLs repeatedly. This adapter lets each URL hit the network once and reuses the response for the rest of the run, while keeping a transient blip from poisoning the cache or masking a recovery. This lands the cache primitive only; wiring it into the identification path comes with the matching/testing workflow.

References:

- Related to #852
- Closes #852
