### PR TITLE
Serialize candidates via native Data#as_json

### DIFF
--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -13,7 +13,7 @@ class FeedIdentificationFetcher
     if result.candidates.any?
       feed_identification.update!(
         status: :success,
-        candidates: serialize_candidates(result.candidates),
+        candidates: result.candidates.as_json,
         error: nil
       )
     else
@@ -61,17 +61,5 @@ class FeedIdentificationFetcher
 
   def http_client
     @http_client ||= HttpClient.build(timeout: 15, max_redirects: 5)
-  end
-
-  def serialize_candidates(candidates)
-    candidates.map do |c|
-      {
-        "profile_key" => c.profile_key,
-        "title" => c.title,
-        "depends_on_ai" => c.depends_on_ai,
-        "rank" => c.rank,
-        "rank_reason" => c.rank_reason.to_s
-      }
-    end
   end
 end

--- a/test/services/feed_profile_detector_test.rb
+++ b/test/services/feed_profile_detector_test.rb
@@ -140,6 +140,30 @@ class FeedProfileDetectorTest < ActiveSupport::TestCase
     assert_nil Thread.current[:llm_detection_phase], "flag must be cleared after call"
   end
 
+  # Guards the shape persisted to FeedIdentification#candidates: Rails'
+  # native Data#as_json must keep yielding string keys with rank_reason
+  # stringified, so a future field/type change can't silently break it.
+  test "DetectionCandidate should serialize to the persisted candidate hash" do
+    candidate = FeedProfileDetector::DetectionCandidate.new(
+      profile_key: "rss",
+      title: "Example Blog",
+      depends_on_ai: false,
+      rank: 0,
+      rank_reason: :specific_match
+    )
+
+    assert_equal(
+      {
+        "profile_key" => "rss",
+        "title" => "Example Blog",
+        "depends_on_ai" => false,
+        "rank" => 0,
+        "rank_reason" => "specific_match"
+      },
+      candidate.as_json
+    )
+  end
+
   private
 
   def build_matcher_class(class_name, specificity:, &block)


### PR DESCRIPTION
Changes:

- Replace `FeedIdentificationFetcher`'s hand-rolled `serialize_candidates` with `result.candidates.as_json`
- Add a test pinning the persisted candidate hash

ActiveSupport patches `Data#as_json` to `to_h.as_json`, which already yields the persisted shape — string keys, with `rank_reason` stringified via `Symbol#as_json`. The custom serializer just duplicated that, and was a mild foot-gun: a new `DetectionCandidate` field would silently fail to persist unless the helper was updated in lockstep. The added test guards the persisted candidate hash against future field/type changes.

References:

- Related issue: #853