### PR TITLE
Fail candidate self-test on unreadable payloads

### DIFF
--- a/app/services/candidate_tester.rb
+++ b/app/services/candidate_tester.rb
@@ -4,8 +4,9 @@
 #
 #   status:
 #     :passed      — readable: at least one sampled entry produced a valid post,
-#                    or the source is empty-but-valid (a new feed with no posts)
-#     :failed      — fetched fine, but nothing normalized into a valid post
+#                    or the processor recognized an empty-but-valid source
+#     :failed      — fetched fine but nothing normalized, or the payload was
+#                    unreadable (the processor didn't recognize it)
 #     :unreachable — couldn't fetch the source (timeout / connection)
 #   posts_found: number of sampled entries that normalized (0 = "no posts yet")
 #
@@ -30,10 +31,9 @@ class CandidateTester
   end
 
   def call
-    entries = process(load)
-    posts_found = entries.first(SAMPLE_SIZE).count { |entry| normalized?(entry) }
-    status = entries.empty? || posts_found.positive? ? :passed : :failed
-    Result.new(status: status, posts_found: posts_found)
+    result = feed.processor_instance(load).process
+    posts_found = result.entries.first(SAMPLE_SIZE).count { |entry| normalized?(entry) }
+    Result.new(status: verdict(result, posts_found), posts_found: posts_found)
   rescue Loader::Error => e
     # Loaders wrap transport errors (timeout/connection), so a transient failure
     # shows up as the cause → unreachable. Any other Loader::Error means we
@@ -51,8 +51,13 @@ class CandidateTester
     feed.loader_instance(loader_options).load
   end
 
-  def process(raw_data)
-    feed.processor_instance(raw_data).process
+  # An empty result passes only if the processor recognized the payload —
+  # otherwise the page was unreadable, not empty-but-valid.
+  def verdict(result, posts_found)
+    return :passed if posts_found.positive?
+    return :passed if result.entries.empty? && result.recognized?
+
+    :failed
   end
 
   # Whether one entry yields a publishable post. The normalizer raises on a

--- a/app/services/feed_preview_workflow.rb
+++ b/app/services/feed_preview_workflow.rb
@@ -60,7 +60,7 @@ class FeedPreviewWorkflow
     raw_data = input[:raw_data]
 
     processor = temp_feed.processor_instance(raw_data)
-    entries = processor.process
+    entries = processor.process.entries
 
     # Limit to most recent entries for preview
     limited_entries = entries.first(FeedPreview::PREVIEW_POSTS_LIMIT)

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -43,7 +43,7 @@ class FeedRefreshWorkflow
   end
 
   def process_feed_contents(raw_data)
-    processed_entries = feed.processor_instance(raw_data).process
+    processed_entries = feed.processor_instance(raw_data).process.entries
     record_stats(total_entries: processed_entries.size)
 
     unidentified_count = processed_entries.count { |entry| entry.uid.blank? }

--- a/app/services/processor/base.rb
+++ b/app/services/processor/base.rb
@@ -1,4 +1,12 @@
 module Processor
+  # The outcome of parsing a payload: the entries it yielded, plus whether the
+  # payload was recognizable as this processor's format. The flag lets callers
+  # tell an empty-but-valid source (a real feed with no posts) from one whose
+  # entries are empty only because the payload was unreadable.
+  Result = Data.define(:entries, :recognized) do
+    def recognized? = recognized
+  end
+
   # Base class for feed processors
   class Base
     # @param feed [Feed] the feed being processed
@@ -8,8 +16,8 @@ module Processor
       @raw_data = raw_data
     end
 
-    # Processes raw feed data into structured entries
-    # @return [Array<Hash>] processed feed entries
+    # Parses raw feed data into a Result (entries plus recognition).
+    # @return [Processor::Result]
     # @abstract Subclasses must implement this method
     def process
       raise NotImplementedError, "Subclasses must implement #process method"

--- a/app/services/processor/passthrough_processor.rb
+++ b/app/services/processor/passthrough_processor.rb
@@ -5,7 +5,7 @@ module Processor
   class PassthroughProcessor < Base
     def process
       items = Array(raw_data)
-      items.filter_map do |item|
+      entries = items.filter_map do |item|
         next unless item.is_a?(Hash)
 
         uid = item["uid"].presence || item[:uid].presence
@@ -21,6 +21,7 @@ module Processor
           raw_data: item.deep_stringify_keys
         )
       end
+      Result.new(entries: entries, recognized: true)
     end
 
     private

--- a/app/services/processor/rss_processor.rb
+++ b/app/services/processor/rss_processor.rb
@@ -1,11 +1,14 @@
 module Processor
   class RssProcessor < Base
     def process
-      parsed_feed = Feedjira.parse(raw_data)
+      feed_data = Feedjira.parse(raw_data)
+      Result.new(entries: build_entries(feed_data), recognized: recognizable?(feed_data))
+    end
 
-      return [] unless parsed_feed&.entries
+    private
 
-      parsed_feed.entries.map do |entry|
+    def build_entries(feed_data)
+      Array(feed_data&.entries).map do |entry|
         FeedEntry.new(
           feed: feed,
           uid: extract_uid(entry),
@@ -16,7 +19,13 @@ module Processor
       end
     end
 
-    private
+    # A real feed always carries a title, even when empty; its absence on a
+    # zero-entry result means the textual <rss>/<feed> match hit non-feed content.
+    def recognizable?(feed_data)
+      return false unless feed_data&.entries
+
+      feed_data.entries.any? || feed_data.title.present?
+    end
 
     def extract_uid(entry)
       entry.id || entry.url

--- a/app/services/processor/rss_processor.rb
+++ b/app/services/processor/rss_processor.rb
@@ -2,7 +2,11 @@ module Processor
   class RssProcessor < Base
     def process
       feed_data = Feedjira.parse(raw_data)
-      Result.new(entries: build_entries(feed_data), recognized: recognizable?(feed_data))
+
+      Result.new(
+        entries: build_entries(feed_data),
+        recognized: recognizable?(feed_data)
+      )
     end
 
     private

--- a/app/services/processor/telegram_processor.rb
+++ b/app/services/processor/telegram_processor.rb
@@ -15,7 +15,8 @@ module Processor
     BACKGROUND_IMAGE = /background-image:\s*url\(['"]?(.*?)['"]?\)/i
 
     def process
-      document.css(MESSAGE_SELECTOR).filter_map { |wrap| build_entry(wrap) }
+      entries = document.css(MESSAGE_SELECTOR).filter_map { |wrap| build_entry(wrap) }
+      Result.new(entries: entries, recognized: true)
     end
 
     private

--- a/app/services/processor/twitter_processor.rb
+++ b/app/services/processor/twitter_processor.rb
@@ -6,20 +6,28 @@ module Processor
     TWITTER_FORMAT = "%a %b %d %H:%M:%S %z %Y".freeze
 
     def process
-      timeline_tweets.filter_map { |tweet| build_entry(tweet) }
+      timeline_entries = timeline
+      tweets = Array(timeline_entries).filter_map { |entry| entry.dig("content", "tweet") }
+      # A real timeline page exposes the entries array via __NEXT_DATA__ (empty
+      # for an account with no tweets); anything else isn't a profile feed.
+      Result.new(
+        entries: tweets.filter_map { |tweet| build_entry(tweet) },
+        recognized: !timeline_entries.nil?
+      )
     end
 
     private
 
-    def timeline_tweets
+    # The timeline entries array, or nil when the payload isn't a syndication page.
+    def timeline
       script = Nokogiri::HTML.parse(raw_data, nil, "UTF-8").at_css("script#__NEXT_DATA__")
-      return [] unless script
+      script && parse_entries(script.text)
+    end
 
-      data = JSON.parse(script.text)
-      entries = data.dig("props", "pageProps", "timeline", "entries") || []
-      entries.filter_map { |entry| entry.dig("content", "tweet") }
+    def parse_entries(json)
+      JSON.parse(json).dig("props", "pageProps", "timeline", "entries")
     rescue JSON::ParserError
-      []
+      nil
     end
 
     def build_entry(tweet)

--- a/test/services/candidate_tester_test.rb
+++ b/test/services/candidate_tester_test.rb
@@ -107,6 +107,26 @@ class CandidateTesterTest < ActiveSupport::TestCase
     assert_equal :unreachable, result_for(url).status
   end
 
+  test "#call should fail an RSS page that matched textually but isn't a feed" do
+    # The matcher only checks for a literal `<rss`/`<feed`, so a non-feed page
+    # reaches the RSS processor and parses into an empty, titleless feed.
+    url = "https://example.com/not-really.xml"
+    stub_request(:get, url).to_return(status: 200, body: '<rss version="2.0"><channel></channel></rss>')
+
+    result = result_for(url)
+    assert_equal :failed, result.status
+    assert_equal 0, result.posts_found
+  end
+
+  test "#call should fail a Twitter page with no readable timeline" do
+    # A profile URL whose page has no __NEXT_DATA__ (e.g. a login wall) yields
+    # zero entries but isn't an empty-but-valid timeline.
+    url = "https://syndication.twitter.com/srv/timeline-profile/screen-name/ghost"
+    stub_request(:get, url).to_return(status: 200, body: "<html><body>nothing here</body></html>")
+
+    assert_equal :failed, result_for("ghost", profile_key: "twitter").status
+  end
+
   test "#call should fail when the source is reachable but exposes no feed" do
     # YouTube fetches the page fine, then can't find a feed link — a real
     # compatibility failure, not an unreachable source.

--- a/test/services/normalizer/telegram_normalizer_test.rb
+++ b/test/services/normalizer/telegram_normalizer_test.rb
@@ -7,7 +7,7 @@ class Normalizer::TelegramNormalizerTest < ActiveSupport::TestCase
 
   def posts
     @posts ||= Processor::TelegramProcessor.new(feed, file_fixture("feeds/telegram/channel.html").read)
-      .process
+      .process.entries
       .map { |entry| Normalizer::TelegramNormalizer.new(entry).normalize }
   end
 

--- a/test/services/normalizer/twitter_normalizer_test.rb
+++ b/test/services/normalizer/twitter_normalizer_test.rb
@@ -7,7 +7,7 @@ class Normalizer::TwitterNormalizerTest < ActiveSupport::TestCase
 
   def posts
     @posts ||= Processor::TwitterProcessor.new(feed, file_fixture("feeds/twitter/timeline.html").read)
-      .process
+      .process.entries
       .map { |entry| Normalizer::TwitterNormalizer.new(entry).normalize }
   end
 

--- a/test/services/normalizer/youtube_normalizer_test.rb
+++ b/test/services/normalizer/youtube_normalizer_test.rb
@@ -104,7 +104,7 @@ class Normalizer::YoutubeNormalizerTest < ActiveSupport::TestCase
     sample_feed_xml = file_fixture("feeds/youtube/feed.xml").read
 
     processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
-    processor_entry = processor.process.first
+    processor_entry = processor.process.entries.first
 
     temp_entry = FeedEntry.new(
       uid: processor_entry.uid,

--- a/test/services/processor/aerostat_processor_test.rb
+++ b/test/services/processor/aerostat_processor_test.rb
@@ -14,7 +14,7 @@ class Processor::AerostatProcessorTest < ActiveSupport::TestCase
   end
 
   test "#process should parse feed and create FeedEntry objects" do
-    entries = processor.process
+    entries = processor.process.entries
 
     assert_equal 2, entries.length
     assert entries.all? { |e| e.is_a?(FeedEntry) }
@@ -23,7 +23,7 @@ class Processor::AerostatProcessorTest < ActiveSupport::TestCase
   end
 
   test "#process should extract itunes_image into raw_data" do
-    entry = processor.process.first
+    entry = processor.process.entries.first
 
     assert_equal(
       "https://aerostatbg.ru/sites/default/files/styles/rss_image/public/releases/1094.jpg?itok=IpSaPXdB",
@@ -32,7 +32,7 @@ class Processor::AerostatProcessorTest < ActiveSupport::TestCase
   end
 
   test "#process should extract enclosure_url into raw_data" do
-    entry = processor.process.first
+    entry = processor.process.entries.first
 
     assert_equal "https://aerostats.getmobileup.com/music/1094.mp3", entry.raw_data["enclosure_url"]
   end

--- a/test/services/processor/passthrough_processor_test.rb
+++ b/test/services/processor/passthrough_processor_test.rb
@@ -19,7 +19,7 @@ class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
       { "uid" => "https://example.com/b", "title" => "B" }
     ]
 
-    entries = Processor::PassthroughProcessor.new(feed, items).process
+    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
 
     assert_equal 2, entries.size
     assert_equal "https://example.com/a", entries[0].uid
@@ -33,7 +33,7 @@ class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
       { "uid" => "https://example.com/ok" }
     ]
 
-    entries = Processor::PassthroughProcessor.new(feed, items).process
+    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
 
     assert_equal 1, entries.size
     assert_equal "https://example.com/ok", entries[0].uid
@@ -42,7 +42,7 @@ class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
   test "#process should parse published_at from ISO 8601" do
     items = [{ "uid" => "u1", "published_at" => "2026-04-15T12:30:00Z" }]
 
-    entries = Processor::PassthroughProcessor.new(feed, items).process
+    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
 
     assert_kind_of Time, entries[0].published_at
     assert_equal 2026, entries[0].published_at.year
@@ -51,7 +51,7 @@ class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
   test "#process should default to the current time when published_at is invalid" do
     items = [{ "uid" => "u1", "published_at" => "not a date" }]
 
-    entries = Processor::PassthroughProcessor.new(feed, items).process
+    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
 
     assert_in_delta Time.current.to_f, entries[0].published_at.to_f, 5.0
   end
@@ -59,7 +59,7 @@ class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
   test "#process should accept symbol keys as well as strings" do
     items = [{ uid: "u-sym", title: "Sym" }]
 
-    entries = Processor::PassthroughProcessor.new(feed, items).process
+    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
 
     assert_equal "u-sym", entries[0].uid
     assert_equal "u-sym", entries[0].raw_data["uid"]

--- a/test/services/processor/rss_processor_test.rb
+++ b/test/services/processor/rss_processor_test.rb
@@ -11,7 +11,7 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
 
   test "#process should parse RSS feed and create FeedEntry objects" do
     processor = Processor::RssProcessor.new(feed, sample_rss_content)
-    entries = processor.process
+    entries = processor.process.entries
 
     assert_equal 3, entries.length
     assert entries.all? { |entry| entry.is_a?(FeedEntry) }
@@ -46,9 +46,33 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
     RSS
 
     processor = Processor::RssProcessor.new(feed, empty_rss)
-    entries = processor.process
+    entries = processor.process.entries
 
     assert_equal [], entries
+  end
+
+  test "#process should recognize a feed with entries" do
+    assert Processor::RssProcessor.new(feed, sample_rss_content).process.recognized?
+  end
+
+  test "#process should recognize an empty feed that carries a title" do
+    titled_empty = <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Empty Feed</title>
+        </channel>
+      </rss>
+    RSS
+
+    assert Processor::RssProcessor.new(feed, titled_empty).process.recognized?
+  end
+
+  test "#process should not recognize a titleless payload that only matched textually" do
+    # Matches `<rss` textually but parses into an empty, titleless feed.
+    titleless = '<rss version="2.0"><channel></channel></rss>'
+
+    assert_not Processor::RssProcessor.new(feed, titleless).process.recognized?
   end
 
   def image_feed_content
@@ -56,21 +80,21 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
   end
 
   test "#process should extract RSS enclosure as typed enclosure" do
-    entries = Processor::RssProcessor.new(feed, image_feed_content).process
+    entries = Processor::RssProcessor.new(feed, image_feed_content).process.entries
 
     enclosures = entries.find { |e| e.raw_data["title"] == "Spiral Galaxy Close-Up" }.raw_data["enclosures"]
     assert_equal [{ "url" => "https://example.com/uploads/2024/09/spiral-galaxy.jpg", "type" => "image/jpeg" }], enclosures
   end
 
   test "#process should extract media:thumbnail with nil type" do
-    entries = Processor::RssProcessor.new(feed, image_feed_content).process
+    entries = Processor::RssProcessor.new(feed, image_feed_content).process.entries
 
     enclosures = entries.find { |e| e.raw_data["title"] == "Nebula Formation" }.raw_data["enclosures"]
     assert_equal [{ "url" => "https://example.com/uploads/2024/09/nebula-thumb.jpg", "type" => nil }], enclosures
   end
 
   test "#process should extract all media:content elements including non-image types" do
-    entries = Processor::RssProcessor.new(feed, image_feed_content).process
+    entries = Processor::RssProcessor.new(feed, image_feed_content).process.entries
 
     enclosures = entries.find { |e| e.raw_data["title"] == "Planetary Surface" }.raw_data["enclosures"]
     assert_equal 3, enclosures.length
@@ -80,7 +104,7 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
   end
 
   test "#process should store empty enclosures for entries with no media" do
-    entries = Processor::RssProcessor.new(feed, image_feed_content).process
+    entries = Processor::RssProcessor.new(feed, image_feed_content).process.entries
 
     enclosures = entries.find { |e| e.raw_data["title"] == "Mission Update" }.raw_data["enclosures"]
     assert_equal [], enclosures
@@ -100,7 +124,7 @@ class Processor::RssProcessorTest < ActiveSupport::TestCase
     RSS
 
     processor = Processor::RssProcessor.new(feed, minimal_rss)
-    entries = processor.process
+    entries = processor.process.entries
 
     assert_equal 1, entries.length
     entry = entries.first

--- a/test/services/processor/telegram_processor_test.rb
+++ b/test/services/processor/telegram_processor_test.rb
@@ -10,7 +10,7 @@ class Processor::TelegramProcessorTest < ActiveSupport::TestCase
   end
 
   def entries
-    @entries ||= Processor::TelegramProcessor.new(feed, sample_html).process
+    @entries ||= Processor::TelegramProcessor.new(feed, sample_html).process.entries
   end
 
   test "#process should create a FeedEntry per message with a data-post id" do

--- a/test/services/processor/twitter_processor_test.rb
+++ b/test/services/processor/twitter_processor_test.rb
@@ -10,7 +10,7 @@ class Processor::TwitterProcessorTest < ActiveSupport::TestCase
   end
 
   def entries
-    @entries ||= Processor::TwitterProcessor.new(feed, sample_html).process
+    @entries ||= Processor::TwitterProcessor.new(feed, sample_html).process.entries
   end
 
   test "#process should create a FeedEntry per tweet and skip non-tweet entries" do
@@ -49,6 +49,34 @@ class Processor::TwitterProcessorTest < ActiveSupport::TestCase
   end
 
   test "#process should return an empty array when JSON is missing" do
-    assert_equal [], Processor::TwitterProcessor.new(feed, "<html>no data</html>").process
+    assert_equal [], Processor::TwitterProcessor.new(feed, "<html>no data</html>").process.entries
+  end
+
+  def page_with(next_data)
+    %(<html><body><script id="__NEXT_DATA__" type="application/json">#{next_data}</script></body></html>)
+  end
+
+  test "#process should recognize a real timeline page" do
+    assert Processor::TwitterProcessor.new(feed, sample_html).process.recognized?
+  end
+
+  test "#process should recognize a timeline with no tweets" do
+    html = page_with('{"props":{"pageProps":{"timeline":{"entries":[]}}}}')
+    result = Processor::TwitterProcessor.new(feed, html).process
+
+    assert result.recognized?
+    assert_equal [], result.entries
+  end
+
+  test "#process should not recognize a page where __NEXT_DATA__ is missing" do
+    assert_not Processor::TwitterProcessor.new(feed, "<html>no data</html>").process.recognized?
+  end
+
+  test "#process should not recognize a page with invalid JSON" do
+    assert_not Processor::TwitterProcessor.new(feed, page_with("{not json}")).process.recognized?
+  end
+
+  test "#process should not recognize a page with no timeline structure" do
+    assert_not Processor::TwitterProcessor.new(feed, page_with('{"props":{"pageProps":{}}}')).process.recognized?
   end
 end

--- a/test/services/processor/youtube_processor_test.rb
+++ b/test/services/processor/youtube_processor_test.rb
@@ -14,7 +14,7 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
 
   test "#process should parse YouTube feed and create FeedEntry objects" do
     processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
-    entries = processor.process
+    entries = processor.process.entries
 
     assert_equal 15, entries.length
     assert entries.all? { |entry| entry.is_a?(FeedEntry) }
@@ -24,14 +24,14 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
 
   test "#process should set uid from video id" do
     processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
-    entries = processor.process
+    entries = processor.process.entries
 
     assert_equal "yt:video:#{FIRST_VIDEO_ID}", entries.first.uid
   end
 
   test "#process should include thumbnail in raw_data" do
     processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
-    entry = processor.process.first
+    entry = processor.process.entries.first
     entry.save!
 
     assert_equal "https://i.ytimg.com/vi/#{FIRST_VIDEO_ID}/hqdefault.jpg", entry.raw_data["thumbnail"]
@@ -39,7 +39,7 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
 
   test "#process should include video URL in raw_data" do
     processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
-    entry = processor.process.first
+    entry = processor.process.entries.first
     entry.save!
 
     assert_equal "https://www.youtube.com/watch?v=#{FIRST_VIDEO_ID}", entry.raw_data["url"]
@@ -47,7 +47,7 @@ class Processor::YoutubeProcessorTest < ActiveSupport::TestCase
 
   test "#process should store raw_data with string keys accessible without saving" do
     processor = Processor::YoutubeProcessor.new(feed, sample_feed_xml)
-    entry = processor.process.first
+    entry = processor.process.entries.first
 
     assert_equal "Getting Started with Ruby on Rails", entry.raw_data["title"]
     assert_equal "https://www.youtube.com/watch?v=#{FIRST_VIDEO_ID}", entry.raw_data["url"]

--- a/test/support/fixture_feed_entries.rb
+++ b/test/support/fixture_feed_entries.rb
@@ -17,7 +17,7 @@ module FixtureFeedEntries
   end
 
   def feed_entries
-    @feed_entries ||= processor.process
+    @feed_entries ||= processor.process.entries
   end
 
   def feed_entry(index)


### PR DESCRIPTION
Changes:

- Add a `recognized?` predicate to processors so an empty result can be told apart from an unreadable one — RSS keys it on a parsed feed that carries a title; Twitter on a present `__NEXT_DATA__` timeline structure.
- Key the candidate self-test's empty-but-valid verdict on `recognized?` instead of an empty array, so a reachable-but-unreadable page now fails instead of passing as empty.

`CandidateTester` treated any empty processor result as "empty-but-valid", but several processors return `[]` for unrecognizable payloads too — a non-feed page that matched RSS only textually, or a Twitter page with no timeline. Moving the empty-vs-unreadable decision into processor-level semantics keeps the self-test's guarantee that a `passed` candidate actually reads its source.

References:

- Closes #859
- Related issue: #853
- Related issue: #854