### PR TITLE
Add a dev sandbox for exercising add-feed states

### DIFF
--- a/app/controllers/development/feed_sandboxes_controller.rb
+++ b/app/controllers/development/feed_sandboxes_controller.rb
@@ -1,0 +1,84 @@
+class Development::FeedSandboxesController < ApplicationController
+  # A made-up source URL for the chooser previews. Only AI-search candidates
+  # interpolate the input and none of the examples use one, so the value is
+  # purely cosmetic.
+  SAMPLE_INPUT = "https://example.com/feed.xml"
+
+  def show
+    authorize :access, :dev?
+    @states = Development::SampleFeedsController::STATES
+    @chooser_input = SAMPLE_INPUT
+    @chooser_examples = chooser_examples
+  end
+
+  private
+
+  # Hand-built candidate lists fed to the real feeds/_candidate_chooser partial
+  # so every detection and self-test verdict can be eyeballed in one place. The
+  # verdict fields (test_status/posts_found) are ignored by the chooser until
+  # the self-test UI lands, at which point these previews light up automatically.
+  def chooser_examples
+    [
+      {
+        title: "Single source, locked in",
+        note: "Only one way to fetch this source, so it's preselected and can't be changed.",
+        single: true,
+        candidates: [candidate("rss", test_status: "passed", posts_found: 5)]
+      },
+      {
+        title: "Working source with an AI fallback",
+        note: "A source that passed its test is recommended; the AI reader is offered as a backup.",
+        candidates: [
+          candidate("rss", test_status: "passed", posts_found: 5),
+          candidate("llm_website_extractor", depends_on_ai: true, test_status: "not_tested")
+        ]
+      },
+      {
+        title: "Works, but nothing to show yet",
+        note: "The test passed but the source has no posts at the moment.",
+        candidates: [
+          candidate("rss", test_status: "passed", posts_found: 0),
+          candidate("llm_website_extractor", depends_on_ai: true, test_status: "not_tested")
+        ]
+      },
+      {
+        title: "Source failed, AI takes over",
+        note: "The structured source couldn't be read, so it's disabled and the AI reader is recommended.",
+        candidates: [
+          candidate("rss", test_status: "failed", posts_found: 0),
+          candidate("llm_website_extractor", depends_on_ai: true, test_status: "not_tested")
+        ]
+      },
+      {
+        title: "Source couldn't be reached",
+        note: "A working source is recommended; the unreachable one stays pickable in case it was a temporary blip.",
+        candidates: [
+          candidate("rss", test_status: "passed", posts_found: 3),
+          candidate("xkcd", test_status: "unreachable")
+        ]
+      },
+      {
+        title: "Every verdict together",
+        note: "Passed, failed, unreachable, and an untested AI option side by side.",
+        candidates: [
+          candidate("rss", test_status: "passed", posts_found: 4),
+          candidate("youtube", test_status: "failed"),
+          candidate("xkcd", test_status: "unreachable"),
+          candidate("llm_website_extractor", depends_on_ai: true, test_status: "not_tested")
+        ]
+      }
+    ]
+  end
+
+  def candidate(profile_key, depends_on_ai: false, test_status: nil, posts_found: 0)
+    {
+      "profile_key" => profile_key,
+      "title" => FeedProfile.display_name_for(profile_key),
+      "depends_on_ai" => depends_on_ai,
+      "test_status" => test_status,
+      "posts_found" => posts_found,
+      "rank" => 0,
+      "rank_reason" => depends_on_ai ? "ai_fallback" : "specific_match"
+    }
+  end
+end

--- a/app/controllers/development/sample_feeds_controller.rb
+++ b/app/controllers/development/sample_feeds_controller.rb
@@ -1,0 +1,178 @@
+class Development::SampleFeedsController < ApplicationController
+  # A mock feed source for exercising the add-feed detection and self-test
+  # states by hand. Copy development_sample_feed_url(state:) into the add-feed
+  # form to see how each outcome renders; the Feed Sandbox page lists them all.
+  STATES = {
+    "ok" => {
+      summary: "Valid RSS feed with five recent items",
+      outcome: "RSS is detected and the self-test passes with posts"
+    },
+    "empty" => {
+      summary: "Valid RSS feed with no items",
+      outcome: "RSS passes the self-test but is flagged as having no posts yet"
+    },
+    "atom" => {
+      summary: "Valid Atom feed with three entries",
+      outcome: "The feed is detected and the self-test passes"
+    },
+    "malformed" => {
+      summary: "Looks like RSS, but the XML is broken",
+      outcome: "RSS is detected but the self-test fails, so the option is disabled"
+    },
+    "not_feed" => {
+      summary: "An ordinary HTML page with no feed inside",
+      outcome: "Nothing structured matches, so only the AI fallback is offered"
+    },
+    "not_found" => {
+      summary: "Responds with 404 Not Found",
+      outcome: "Identification fails — the source can't be reached"
+    },
+    "forbidden" => {
+      summary: "Responds with 403 Forbidden",
+      outcome: "Identification fails — the source can't be reached"
+    },
+    "unauthorized" => {
+      summary: "Responds with 401 Unauthorized",
+      outcome: "Identification fails — the source can't be reached"
+    },
+    "server_error" => {
+      summary: "Responds with 500 Internal Server Error",
+      outcome: "Identification fails — the source can't be reached"
+    },
+    "slow" => {
+      summary: "Hangs well past the fetch timeout (about 20 seconds)",
+      outcome: "Identification fails — the request times out"
+    },
+    "redirect" => {
+      summary: "Redirects (302) to the valid feed",
+      outcome: "The redirect is followed and the self-test passes"
+    },
+    "redirect_loop" => {
+      summary: "Redirects to itself without end",
+      outcome: "Identification fails — too many redirects"
+    }
+  }.freeze
+
+  DEFAULT_DELAY = 20
+  MAX_DELAY = 30
+
+  def show
+    authorize :access, :dev?
+
+    case params[:state]
+    when "empty" then render_source(empty_rss)
+    when "atom" then render_source(atom_feed, content_type: "application/atom+xml")
+    when "malformed" then render_source(malformed_rss)
+    when "not_feed" then render_source(html_page, content_type: "text/html")
+    when "not_found" then render_status(:not_found)
+    when "forbidden" then render_status(:forbidden)
+    when "unauthorized" then render_status(:unauthorized)
+    when "server_error" then render_status(:internal_server_error)
+    when "slow" then render_slow
+    when "redirect" then redirect_to development_sample_feed_path(state: "ok")
+    when "redirect_loop" then redirect_to development_sample_feed_path(state: "redirect_loop")
+    else render_source(sample_rss)
+    end
+  end
+
+  private
+
+  def render_source(body, content_type: "application/rss+xml")
+    render body: body, content_type: content_type
+  end
+
+  def render_status(status)
+    render plain: "Sample feed mock: simulated #{status.to_s.humanize.downcase} response.", status: status
+  end
+
+  # Holds the connection open past the loader's fetch timeout so detection
+  # surfaces the timeout path. Tests pass delay=0 to skip the wait.
+  def render_slow
+    sleep(params.fetch(:delay, DEFAULT_DELAY).to_i.clamp(0, MAX_DELAY))
+    render_source(sample_rss)
+  end
+
+  def sample_rss
+    items = (1..5).map { |n| rss_item(n) }.join("\n")
+    rss_document("Sample Feed (mock)", items)
+  end
+
+  def empty_rss
+    rss_document("Empty Sample Feed (mock)", "")
+  end
+
+  def rss_document(title, items)
+    <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>#{title}</title>
+          <link>https://example.com</link>
+          <description>A mock RSS feed served by the development sandbox.</description>
+      #{items}
+        </channel>
+      </rss>
+    RSS
+  end
+
+  def rss_item(number)
+    published = (Time.current - number.hours).to_fs(:rfc822)
+    <<~ITEM.chomp
+          <item>
+            <title>Sample post ##{number}</title>
+            <link>https://example.com/posts/#{number}</link>
+            <guid isPermaLink="false">sample-feed-post-#{number}</guid>
+            <pubDate>#{published}</pubDate>
+            <description>Sample post number #{number}, served by the dev mock feed source.</description>
+          </item>
+    ITEM
+  end
+
+  def atom_feed
+    entries = (1..3).map { |n| atom_entry(n) }.join("\n")
+
+    <<~ATOM
+      <?xml version="1.0" encoding="UTF-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Sample Atom Feed (mock)</title>
+        <link href="https://example.com"/>
+        <id>urn:dev:sample-atom-feed</id>
+        <updated>#{Time.current.iso8601}</updated>
+      #{entries}
+      </feed>
+    ATOM
+  end
+
+  def atom_entry(number)
+    updated = (Time.current - number.hours).iso8601
+
+    <<~ENTRY.chomp
+        <entry>
+          <title>Sample entry ##{number}</title>
+          <link href="https://example.com/entries/#{number}"/>
+          <id>urn:dev:sample-atom-entry-#{number}</id>
+          <updated>#{updated}</updated>
+          <summary>Sample Atom entry number #{number}, served by the dev mock feed source.</summary>
+        </entry>
+    ENTRY
+  end
+
+  # Carries the <rss> marker so the RSS profile matches, but the body is not
+  # valid XML, so parsing blows up and the self-test reports it as unreadable.
+  def malformed_rss
+    %(<rss version="2.0"> <<< this is not valid XML &amp & %%% </oops>)
+  end
+
+  def html_page
+    <<~HTML
+      <!DOCTYPE html>
+      <html lang="en">
+        <head><title>Just a web page</title></head>
+        <body>
+          <h1>Hello</h1>
+          <p>An ordinary web page with no syndication markup of any kind.</p>
+        </body>
+      </html>
+    HTML
+  end
+end

--- a/app/views/development/feed_sandboxes/show.html.erb
+++ b/app/views/development/feed_sandboxes/show.html.erb
@@ -1,0 +1,82 @@
+<% content_for :title, "Feed Sandbox" %>
+
+<div class="space-y-8">
+  <%= render PageHeaderComponent.new(title: "Feed Sandbox") do |header| %>
+    <% header.with_breadcrumb(label: "Dev Tools", url: development_path) %>
+  <% end %>
+
+  <%= render AlertComponent.new(variant: :info, data: { key: "feed_sandbox.intro" }) do %>
+    A place to see how adding a feed reacts to different sources. Use the chooser
+    previews below to eyeball every detection result, or point the add-feed box at
+    the mock source to drive the real pipeline against a controlled response.
+  <% end %>
+
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Chooser states</h2>
+    <p class="text-slate-600">
+      How the “How should we fetch posts?” chooser renders for each detection and
+      self-test result. The test badges appear once the self-test UI is in place.
+    </p>
+
+    <div class="space-y-6">
+      <% @chooser_examples.each_with_index do |example, index| %>
+        <div class="rounded-lg border border-slate-200 bg-white p-4 space-y-3"
+             data-key="chooser-example.<%= index %>">
+          <div class="space-y-1">
+            <h3 class="font-semibold text-slate-800"><%= example[:title] %></h3>
+            <p class="text-sm text-slate-500"><%= example[:note] %></p>
+          </div>
+          <%= render "feeds/candidate_chooser",
+                     candidates: example[:candidates],
+                     input: @chooser_input,
+                     single: example.fetch(:single, false) %>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold mb-3 text-slate-900">Mock feed source</h2>
+    <p class="text-slate-600">
+      Copy one of these links into the add-feed box to see how detection handles it.
+      Each link makes the mock source respond a certain way.
+    </p>
+
+    <div class="overflow-x-auto rounded-lg border border-slate-200">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-left text-slate-600">
+          <tr>
+            <th class="px-4 py-2 font-semibold">State</th>
+            <th class="px-4 py-2 font-semibold">What it returns</th>
+            <th class="px-4 py-2 font-semibold">What you'll see</th>
+            <th class="px-4 py-2 font-semibold">Link</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% @states.each do |state, info| %>
+            <tr class="align-top" data-key="sample-state.<%= state %>">
+              <td class="px-4 py-2"><code class="text-slate-800"><%= state %></code></td>
+              <td class="px-4 py-2 text-slate-700"><%= info[:summary] %></td>
+              <td class="px-4 py-2 text-slate-700"><%= info[:outcome] %></td>
+              <td class="px-4 py-2 whitespace-nowrap">
+                <div class="flex items-center gap-3">
+                  <%= link_to "Open ↗", development_sample_feed_path(state: state),
+                              target: "_blank", rel: "noopener noreferrer",
+                              class: "text-sky-600 hover:text-sky-800",
+                              data: { key: "sample-state.#{state}.open" } %>
+                  <button type="button"
+                          class="text-sky-600 hover:text-sky-800"
+                          data-controller="clipboard"
+                          data-clipboard-text-value="<%= development_sample_feed_url(state: state) %>"
+                          data-action="clipboard#copy"
+                          data-key="sample-state.<%= state %>.copy"
+                          title="Copy feed URL">Copy URL</button>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>

--- a/app/views/developments/show.html.erb
+++ b/app/views/developments/show.html.erb
@@ -58,5 +58,15 @@
         <p class="text-slate-600">Reference for all reusable UI components.</p>
       </div>
     <% end %>
+
+    <%= render CardComponent.new(href: development_feed_sandbox_path) do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <%= icon("layers", css_class: "size-5") %>
+          <span>Feed Sandbox</span>
+        </h2>
+        <p class="text-slate-600">Preview add-feed states and serve mock feeds for manual testing</p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :development do
     resource :components, only: :show
     resource :system_status, only: :show, controller: "system_status"
+    resource :sample_feed, only: :show
     resources :email_previews, only: [:index, :show] do
       resource :test_email, only: :create
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     resource :components, only: :show
     resource :system_status, only: :show, controller: "system_status"
     resource :sample_feed, only: :show
+    resource :feed_sandbox, only: :show
     resources :email_previews, only: [:index, :show] do
       resource :test_email, only: :create
     end

--- a/test/controllers/development/feed_sandboxes_controller_test.rb
+++ b/test/controllers/development/feed_sandboxes_controller_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class Development::FeedSandboxesControllerTest < ActionDispatch::IntegrationTest
+  def dev_user
+    @dev_user ||= create(:user, :dev)
+  end
+
+  def regular_user
+    @regular_user ||= create(:user)
+  end
+
+  test "#show should require authentication" do
+    get development_feed_sandbox_path
+
+    assert_response :redirect
+  end
+
+  test "#show should require dev permission" do
+    sign_in_as(regular_user)
+    get development_feed_sandbox_path
+
+    assert_redirected_to root_path
+    assert_equal "Access denied. You don't have permission to perform this action.", flash[:alert]
+  end
+
+  test "#show should render the chooser previews" do
+    sign_in_as(dev_user)
+    get development_feed_sandbox_path
+
+    assert_response :success
+    assert_select "h1", "Feed Sandbox"
+    assert_select '[data-key="chooser-example.0"]'
+    assert_select '[data-key="candidates"]', minimum: 2
+  end
+
+  test "#show should list every mock source state with a copyable link" do
+    sign_in_as(dev_user)
+    get development_feed_sandbox_path
+
+    assert_response :success
+    Development::SampleFeedsController::STATES.each_key do |state|
+      assert_select %([data-key="sample-state.#{state}"])
+      assert_select %([data-key="sample-state.#{state}.copy"])
+    end
+  end
+end

--- a/test/controllers/development/sample_feeds_controller_test.rb
+++ b/test/controllers/development/sample_feeds_controller_test.rb
@@ -1,0 +1,133 @@
+require "test_helper"
+
+class Development::SampleFeedsControllerTest < ActionDispatch::IntegrationTest
+  def dev_user
+    @dev_user ||= create(:user, :dev)
+  end
+
+  def regular_user
+    @regular_user ||= create(:user)
+  end
+
+  test "#show should require authentication" do
+    get development_sample_feed_path
+
+    assert_response :redirect
+  end
+
+  test "#show should require dev permission" do
+    sign_in_as(regular_user)
+    get development_sample_feed_path
+
+    assert_redirected_to root_path
+    assert_equal "Access denied. You don't have permission to perform this action.", flash[:alert]
+  end
+
+  test "#show should serve a parseable RSS feed with posts by default" do
+    sign_in_as(dev_user)
+    get development_sample_feed_path
+
+    assert_response :success
+    assert_equal "application/rss+xml", @response.media_type
+    assert_equal 5, Feedjira.parse(@response.body).entries.size
+  end
+
+  test "#show should fall back to the sample feed for an unknown state" do
+    sign_in_as(dev_user)
+    get development_sample_feed_path(state: "nonsense")
+
+    assert_response :success
+    assert_equal 5, Feedjira.parse(@response.body).entries.size
+  end
+
+  test "#show should serve a valid but empty feed" do
+    sign_in_as(dev_user)
+    get development_sample_feed_path(state: "empty")
+
+    assert_response :success
+    parsed = Feedjira.parse(@response.body)
+    assert_empty parsed.entries
+    assert parsed.title.present?, "empty feed should still carry a title so it reads as valid"
+  end
+
+  test "#show should serve a parseable Atom feed" do
+    sign_in_as(dev_user)
+    get development_sample_feed_path(state: "atom")
+
+    assert_response :success
+    assert_equal "application/atom+xml", @response.media_type
+    assert_equal 3, Feedjira.parse(@response.body).entries.size
+  end
+
+  test "#show should serve an RSS-looking payload that does not parse for the malformed state" do
+    sign_in_as(dev_user)
+    get development_sample_feed_path(state: "malformed")
+
+    assert_response :success
+    assert_match(/<rss[\s>]/, @response.body)
+
+    parsed = begin
+      Feedjira.parse(@response.body)
+    rescue StandardError
+      nil
+    end
+    assert(
+      parsed.nil? || (parsed.entries.empty? && parsed.title.blank?),
+      "malformed payload should not parse into a recognizable feed"
+    )
+  end
+
+  test "#show should serve a plain HTML page with no feed markup for the not_feed state" do
+    sign_in_as(dev_user)
+    get development_sample_feed_path(state: "not_feed")
+
+    assert_response :success
+    assert_equal "text/html", @response.media_type
+    assert_no_match(/<rss[\s>]|<feed[\s>]|<rdf:RDF/i, @response.body)
+  end
+
+  test "#show should simulate HTTP error statuses" do
+    sign_in_as(dev_user)
+
+    {
+      "not_found" => 404,
+      "forbidden" => 403,
+      "unauthorized" => 401,
+      "server_error" => 500
+    }.each do |state, code|
+      get development_sample_feed_path(state: state)
+      assert_response code, "state #{state} should respond with #{code}"
+    end
+  end
+
+  test "#show should redirect to the valid feed for the redirect state" do
+    sign_in_as(dev_user)
+    get development_sample_feed_path(state: "redirect")
+
+    assert_redirected_to development_sample_feed_path(state: "ok")
+  end
+
+  test "#show should redirect to itself for the redirect_loop state" do
+    sign_in_as(dev_user)
+    get development_sample_feed_path(state: "redirect_loop")
+
+    assert_redirected_to development_sample_feed_path(state: "redirect_loop")
+  end
+
+  test "#show should serve the feed after the configured delay for the slow state" do
+    sign_in_as(dev_user)
+    get development_sample_feed_path(state: "slow", delay: 0)
+
+    assert_response :success
+    assert_equal 5, Feedjira.parse(@response.body).entries.size
+  end
+
+  test "every catalogued state should respond without error" do
+    sign_in_as(dev_user)
+
+    Development::SampleFeedsController::STATES.each_key do |state|
+      get development_sample_feed_path(state: state, delay: 0)
+      assert_includes 200..399, @response.status unless %w[not_found forbidden unauthorized server_error].include?(state)
+    end
+  end
+end

--- a/test/controllers/developments_controller_test.rb
+++ b/test/controllers/developments_controller_test.rb
@@ -26,6 +26,7 @@ class DevelopmentsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{development_email_previews_path}']", count: 1
     assert_select "a[href='#{development_sent_emails_path}']", count: 1
     assert_select "a[href='#{development_components_path}']", count: 1
+    assert_select "a[href='#{development_feed_sandbox_path}']", count: 1
   end
 
   test "should disable sent emails link when delivery does not capture locally" do


### PR DESCRIPTION
Changes:

- Add a development-only mock feed source (`/development/sample_feed?state=…`) that returns a controllable response: a valid RSS or Atom feed, an empty feed, malformed XML, a plain HTML page, common HTTP errors (401/403/404/500), a slow response, and redirect / redirect-loop cases.
- Add a Feed Sandbox dev page that previews the feed-creation chooser across every detection and self-test verdict, and catalogs the mock source states with copyable links to paste into the add-feed box. Linked from Dev Tools.

These give a straightforward way to exercise the add-feed detection and candidate self-test feedback by hand. Point the add-feed box at the mock source to drive the real detection pipeline against a known response, or use the chooser previews to eyeball every UI state at once — including the unreachable and mixed-verdict combinations a single source can't easily produce. The chooser previews render the real partial, so they light up automatically as the self-test UI lands.

References:

- Related PR: #863