### PR TITLE
Fix Cancel button not clickable while feed is being checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-06-25
+
+- Fixed the Cancel button not working while a new feed is being checked.
+
 ## 2026-06-23
 
 - A feed you saved without turning on can now be enabled straight from the feed page or the feeds list.

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -1,7 +1,11 @@
+<%# Polling marks its host aria-busy while checking, and the global
+    [aria-busy="true"] rule makes that subtree non-interactive. This card holds
+    the Cancel button, so opt out of the busy state to keep it clickable. %>
 <div id="feed-form"
      class="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 shadow-xs"
      role="status"
      data-controller="polling"
+     data-polling-indicate-busy-value="false"
      data-polling-endpoint-value="<%= feed_identifications_path(input: input) %>"
      data-polling-interval-value="<%= polling_interval_ms %>"
      data-polling-max-polls-value="<%= polling_max_polls %>"


### PR DESCRIPTION
Changes:

- Keep the Cancel button clickable in the "New Feed" loading state.

While a new feed is being checked, the loading card acts as the polling host and gets `aria-busy="true"`. A global CSS rule makes busy regions non-interactive (and dims them), and descendants inherit it, so the Cancel button inside the card couldn't be clicked. Since this card exists only to offer Cancel, it now opts out of the busy state rather than counteracting the dim and pointer-events with extra CSS on the button.