### PR TITLE
Set up prebuilt dev container for Claude Code remote environments

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,22 +1,33 @@
 #!/bin/bash
 set -euo pipefail
 
+# Only run in Claude Code remote environments; local dev uses mise + a native setup.
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-RUBY_BIN="/opt/rbenv/versions/3.3.6/bin"
-export PATH="$RUBY_BIN:$PATH"
-echo "export PATH=\"$RUBY_BIN:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+cd "$CLAUDE_PROJECT_DIR"
 
-# Start PostgreSQL
-service postgresql start
+# Start the Docker daemon if it isn't running. The init script trips on a ulimit
+# call in this sandbox, so launch dockerd directly and wait for the socket.
+if ! docker info >/dev/null 2>&1; then
+  nohup dockerd >/tmp/dockerd.log 2>&1 &
+  for _ in $(seq 1 30); do
+    docker info >/dev/null 2>&1 && break
+    sleep 1
+  done
+fi
 
-# Ensure root pg role exists
-su -c "createuser -s root" postgres 2>/dev/null || true
+if ! docker info >/dev/null 2>&1; then
+  echo "warning: Docker daemon did not start; see /tmp/dockerd.log" >&2
+  exit 0
+fi
 
-# Install gems (idempotent)
-bundle install
+# Bring up the dev stack (app + postgres). The image is prebuilt and cached by the
+# environment setup script (see docs/claude-remote-env.md); without it, this pulls
+# the image on first use.
+docker compose up -d
 
-# Prepare test database
-bin/rails db:test:prepare
+# Prepare the test database inside the app container.
+docker compose exec -T app bin/rails db:test:prepare ||
+  echo "warning: db:test:prepare failed; run it manually once the stack is up" >&2

--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -1,0 +1,54 @@
+name: Build dev image
+
+# Builds the Claude Code remote-env dev image (Dockerfile.dev) and pushes it to
+# GHCR. Triggered when the toolchain or dependencies change, or on demand.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - Dockerfile.dev
+      - Gemfile
+      - Gemfile.lock
+      - package.json
+      - yarn.lock
+      - .github/workflows/build-dev-image.yml
+  workflow_dispatch:
+
+concurrency:
+  group: build-dev-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dev
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/f2-dev:latest
+            ghcr.io/${{ github.repository_owner }}/f2-dev:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,15 @@ References:
 ## Tooling Notes
 
 - Use mise for managing Ruby and Node runtimes (local dev).
-- **Remote Claude Code environments** don't have mise. The session-start hook (`.claude/hooks/session-start.sh`) sets up Ruby via rbenv, starts PostgreSQL, and installs gems automatically. Run binstubs directly after that.
-- Run Rails binstubs directly: `bin/rails test`, `bin/rubocop -f github`.
+- Run Rails binstubs directly in local dev: `bin/rails test`, `bin/rubocop -f github`.
+- **Remote Claude Code environments** don't have mise. They run a prebuilt dev
+  container instead: the session-start hook (`.claude/hooks/session-start.sh`)
+  starts the Docker daemon and brings up the `app` + `db` stack from `compose.yaml`.
+  In these environments, run Rails commands **inside the container**, e.g.
+  `docker compose exec app bin/rails test` or
+  `docker compose exec app bin/rubocop -f github`. See
+  [`docs/claude-remote-env.md`](docs/claude-remote-env.md) for the image build,
+  GHCR publishing, and caching setup.
 
 ## Testing
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1
+# check=error=true
+
+# Development image for Claude Code remote environments (and local container dev).
+# It is prebuilt and published to GHCR by .github/workflows/build-dev-image.yml, so
+# the remote-env setup script can pull it instead of reinstalling dependencies each
+# session. For PRODUCTION images, use the top-level Dockerfile with Kamal instead.
+
+# Keep RUBY_VERSION in sync with .ruby-version.
+ARG RUBY_VERSION=4.0.3
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim
+
+# Build and runtime dependencies for native gems and node modules.
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      curl \
+      git \
+      libffi-dev \
+      libpq-dev \
+      libyaml-dev \
+      pkg-config \
+      postgresql-client \
+      python-is-python3 \
+      zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# Install Node and Yarn. Keep NODE_VERSION in sync with .tool-versions.
+ARG NODE_VERSION=24.15.0
+ARG YARN_VERSION=1.22.21
+ENV PATH=/usr/local/node/bin:$PATH
+RUN ARCH="$(dpkg --print-architecture)" && \
+    case "$ARCH" in \
+      amd64) NODEARCH=x64 ;; \
+      arm64) NODEARCH=arm64 ;; \
+      *) echo "unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODEARCH}.tar.xz" -o /tmp/node.tar.xz && \
+    mkdir -p /usr/local/node && \
+    tar -xJf /tmp/node.tar.xz -C /usr/local/node --strip-components=1 && \
+    rm /tmp/node.tar.xz && \
+    npm install -g "yarn@${YARN_VERSION}"
+
+# Keep gems outside the app directory so the compose bind mount doesn't shadow them.
+ENV BUNDLE_PATH=/usr/local/bundle \
+    BUNDLE_JOBS=4 \
+    LANG=C.UTF-8
+
+WORKDIR /rails
+
+# Install gems (all groups, including development and test).
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+# Install node modules. Baked into the image; compose mounts a named volume over
+# /rails/node_modules so the host bind mount doesn't shadow them. Lenient install
+# (like the production Dockerfile) since the committed yarn.lock can lag package.json.
+COPY package.json yarn.lock ./
+RUN yarn install
+
+CMD ["bash"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,55 @@
+# Development stack for Claude Code remote environments (and local container dev).
+#
+# The `app` image is prebuilt and published to GHCR by
+# .github/workflows/build-dev-image.yml; the remote-env setup script pulls it so
+# dependencies aren't reinstalled each session. See docs/claude-remote-env.md.
+#
+# For PRODUCTION images, use the top-level Dockerfile with Kamal instead.
+name: f2-dev
+
+services:
+  app:
+    image: ghcr.io/dreikanter/f2-dev:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    # Keep the container alive so commands run via `docker compose exec app ...`.
+    command: sleep infinity
+    tty: true
+    volumes:
+      - .:/rails
+      # Preserve the image's node_modules instead of letting the bind mount shadow them.
+      - node_modules:/rails/node_modules
+    environment:
+      # Standard libpq vars supply host + credentials for the `db` service.
+      # config/database.yml supplies the database names (f2_development, f2_test),
+      # so connections work in every Rails env. RAILS_ENV is intentionally unset so
+      # `bin/rails server` defaults to development and `bin/rails test` to test,
+      # same as a normal dev machine.
+      PGHOST: db
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    # Pinned to match CI and the production accessory (config/deploy.yml).
+    image: postgres:18
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - pg_data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  node_modules:
+  pg_data:

--- a/docs/claude-remote-env.md
+++ b/docs/claude-remote-env.md
@@ -1,0 +1,142 @@
+# Claude Code remote environment (prebuilt dev container)
+
+Claude Code on the web runs each session in a fresh Anthropic-managed VM. The base
+image ships Ruby 3.1–3.3 only, but this project needs Ruby 4.0.3, so installing the
+toolchain from scratch every session is slow. Instead we keep a **prebuilt dev
+image** in GitHub Container Registry (GHCR) and run Rails inside it.
+
+Replacing the VM's base image isn't supported, but Docker is available and **pulled
+images are saved in the cached environment snapshot**, so each new session has the
+image on disk without re-pulling. That gives us a reusable, cached image without
+reinstalling dependencies each time.
+
+## How the pieces fit together
+
+| Piece | Where | Role |
+| :--- | :--- | :--- |
+| `Dockerfile.dev` | repo | Defines the dev image: Ruby 4.0.3 + gems + Node + yarn modules. |
+| `.github/workflows/build-dev-image.yml` | repo | Builds the image and pushes it to `ghcr.io/dreikanter/f2-dev` on dependency changes (or on demand). |
+| `compose.yaml` | repo | The dev stack: `app` (the image) + `db` (postgres:18). |
+| Environment **setup script** | Claude web UI | Starts dockerd and `docker pull`s the image. Its result is cached into the environment snapshot. |
+| `.claude/hooks/session-start.sh` | repo | Per session: starts dockerd, `docker compose up -d`, prepares the test DB. |
+
+The setup script runs **once** per environment cache (re-runs roughly weekly or when
+you edit it); the session-start hook runs **every** session. The image must be pulled
+in the setup script for it to land in the cached snapshot — the hook only starts
+containers from it.
+
+## One-time setup
+
+### 1. Publish the image
+
+Merge this branch to `main`. The `Build dev image` workflow builds `Dockerfile.dev`
+and pushes `ghcr.io/dreikanter/f2-dev:latest`. To build before merging, trigger the
+workflow manually from the Actions tab (**Run workflow** → your branch).
+
+After deps change later, the workflow rebuilds automatically when `Dockerfile.dev`,
+`Gemfile.lock`, `package.json`, or `yarn.lock` change on `main`.
+
+### 2. Make the package public
+
+GHCR packages are private by default. Once the first build finishes, open the package
+at `https://github.com/users/dreikanter/packages/container/f2-dev/settings` and set
+**Visibility → Public**. A public image needs no auth in the sandbox.
+
+> Prefer to keep it private? See [Private image](#private-image-alternative) below.
+
+### 3. Add the environment setup script
+
+In the Claude web UI, edit your environment and paste this into the **Setup script**
+field (Network access must be **Trusted** or higher — `ghcr.io` is in the Trusted
+allowlist):
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Start the Docker daemon (the init script fails on a ulimit call in this sandbox).
+if ! docker info >/dev/null 2>&1; then
+  nohup dockerd >/tmp/dockerd.log 2>&1 &
+  for _ in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
+fi
+
+# Pull the prebuilt dev image so it's baked into the cached environment snapshot.
+docker pull ghcr.io/dreikanter/f2-dev:latest
+```
+
+That's it. Start a fresh session and the session-start hook brings up the stack.
+
+## Working in a session
+
+The stack is already up (the hook ran `docker compose up -d`). Run Rails commands
+inside the `app` container:
+
+```bash
+docker compose exec app bin/rails test
+docker compose exec app bin/rails console
+docker compose exec app bin/rubocop -f github
+docker compose exec app bin/rails db:migrate
+```
+
+Rails server (port 3000 is published from the container):
+
+```bash
+docker compose exec app bin/rails server -b 0.0.0.0
+```
+
+Inspect the stack:
+
+```bash
+docker compose ps
+docker compose logs app
+```
+
+## Updating the image
+
+When gems or node modules change, the CI workflow rebuilds `:latest` on merge to
+`main`. To refresh an already-cached environment immediately, re-run the setup script
+(edit and save it in the UI, or start a session in an environment whose cache has
+expired) so it pulls the new `:latest`.
+
+## Local container usage
+
+The same stack works locally without GHCR — Compose builds the image from
+`Dockerfile.dev`:
+
+```bash
+docker compose up -d --build
+docker compose exec app bin/rails test
+```
+
+(Day-to-day local dev can still use mise + native binstubs; the container is optional
+locally.)
+
+## Private image (alternative)
+
+To keep `f2-dev` private:
+
+1. Skip step 2 (leave the package private).
+2. Create a GitHub token with `read:packages` scope (classic) or **Packages: read**
+   (fine-grained), and add it as a `GHCR_TOKEN` environment variable in the Claude
+   environment settings.
+3. Add a login line before the pull in the setup script:
+
+   ```bash
+   echo "$GHCR_TOKEN" | docker login ghcr.io -u dreikanter --password-stdin
+   docker pull ghcr.io/dreikanter/f2-dev:latest
+   ```
+
+Environment variables are visible to anyone who can edit the environment, so treat the
+token accordingly.
+
+## Troubleshooting
+
+- **Daemon won't start:** check `/tmp/dockerd.log`. Start it by hand with
+  `nohup dockerd >/tmp/dockerd.log 2>&1 &`. Use `dockerd` directly — `service docker
+  start` fails on a `ulimit` permission error in the sandbox.
+- **Image re-pulls every session:** the setup script isn't pulling it (only setup-script
+  output is cached, not the session-start hook). Confirm step 3.
+- **`pull access denied` / `denied`:** the package is private and unauthenticated. Make
+  it public (step 2) or configure the token (private-image section).
+- **DB connection refused:** the `db` service may still be starting. `docker compose up
+  -d` waits for its healthcheck; re-run `docker compose exec app bin/rails db:test:prepare`.


### PR DESCRIPTION
Changes:

- Add `Dockerfile.dev` with Ruby 4.0.3, Node 24.15.0, and all development dependencies prebuilt for Claude Code remote environments
- Add `compose.yaml` defining the dev stack (`app` container + PostgreSQL) for both remote and local container development
- Add `.github/workflows/build-dev-image.yml` to build and publish the dev image to GHCR on dependency changes
- Update `.claude/hooks/session-start.sh` to start Docker daemon and bring up the compose stack instead of using rbenv + native PostgreSQL
- Add `docs/claude-remote-env.md` documenting the remote environment setup, image caching strategy, and troubleshooting
- Update `CLAUDE.md` to reflect the new container-based remote environment workflow

The remote environment now pulls a prebuilt image from GHCR and runs the stack in Docker, eliminating the need to reinstall dependencies each session. The image is cached in the environment snapshot after the initial pull, so subsequent sessions start quickly. Local development can optionally use the same container stack or continue with mise + native setup.

References:

- Closes #610
