### PR TITLE
Skip yarn install in dev container test runs

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,11 @@ services:
       PGPORT: "5432"
       PGUSER: postgres
       PGPASSWORD: postgres
+      # Node deps are baked into the image and kept in the node_modules volume, so the
+      # css:build step that `bin/rails test` and `assets:precompile` trigger must not run
+      # `yarn install` — that network call can't reach the registry from inside the
+      # container. Skip it; `yarn build:css` still runs offline against the baked deps.
+      SKIP_YARN_INSTALL: "1"
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
Changes:

- Set `SKIP_YARN_INSTALL=1` on the dev compose `app` service so the `css:build` step that `bin/rails test` and `assets:precompile` trigger no longer runs `yarn install`.

Inside the dev container that `yarn install` can't trust the egress proxy CA, so it aborts before any test runs. The Node dependencies are already baked into the image and preserved in the `node_modules` volume, so the install is unnecessary — `yarn build:css` still runs offline against the baked deps. Dependencies are refreshed by rebuilding the image, not at runtime.