### PR TITLE
Add JSON Feed support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-26
 
-- You can now add JSON feeds, alongside RSS and Atom.
+- JSON feeds are now supported, alongside RSS and Atom.
 
 ## 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-06-26
+
+- You can now add JSON feeds, alongside RSS and Atom.
+
 ## 2026-06-25
 
 - When adding a feed, each fetch option now shows its test result.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-06-26
 
-- JSON feeds are now supported, alongside RSS and Atom.
+- JSON feeds are now supported.
 
 ## 2026-06-25
 

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -49,6 +49,26 @@ class FeedProfile
       title_extractor: "TitleExtractor::RssTitleExtractor",
       output_schema: nil
     },
+    "json_feed" => {
+      display_name: "JSON Feed",
+      description: "Posts from a site's JSON feed (jsonfeed.org)",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::JsonFeedProfileMatcher",
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {
+          "url" => { "type" => "string", "format" => "uri" }
+        },
+        "required" => ["url"],
+        "additionalProperties" => false
+      },
+      loader: { class: "Loader::HttpLoader", config: {} },
+      processor: { class: "Processor::JsonFeedProcessor", config: {} },
+      normalizer: { class: "Normalizer::JsonFeedNormalizer", config: {} },
+      title_extractor: "TitleExtractor::JsonFeedTitleExtractor",
+      output_schema: nil
+    },
     "reddit" => {
       display_name: "Reddit",
       description: "Posts from a subreddit or Reddit user page via RSS",

--- a/app/services/json_feed.rb
+++ b/app/services/json_feed.rb
@@ -1,0 +1,21 @@
+# Shared knowledge of the JSON Feed format (https://jsonfeed.org), used by
+# both the profile matcher (sniffing a fetched body) and the processor
+# (recognizing a parsed payload) so the two stay in lockstep.
+module JsonFeed
+  # The `version` field is the spec URL, e.g. https://jsonfeed.org/version/1.1.
+  # Anchored to the canonical host and path so a lookalike like
+  # https://evil.com/jsonfeed.org/version/1 can't slip through.
+  VERSION_URL = %r{\Ahttps?://jsonfeed\.org/version/\d}
+
+  module_function
+
+  # Whether a parsed payload is a JSON Feed: a JSON object whose `version` is
+  # the spec URL and which carries the required `title` (string) and `items`
+  # (array) fields (https://jsonfeed.org/version/1.1).
+  def feed?(data)
+    data.is_a?(Hash) &&
+      data["version"].is_a?(String) && data["version"].match?(VERSION_URL) &&
+      data["title"].is_a?(String) &&
+      data["items"].is_a?(Array)
+  end
+end

--- a/app/services/normalizer/json_feed_normalizer.rb
+++ b/app/services/normalizer/json_feed_normalizer.rb
@@ -1,0 +1,14 @@
+module Normalizer
+  # JSON Feed shares RSS's URL and image handling; only the text source
+  # differs. RSS leads with `summary` because that's where RSS feeds put
+  # the body, but JSON Feed's `summary` is an explicit short blurb and the
+  # full item lives in `content` (content_html/content_text), so prefer it.
+  class JsonFeedNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      text = raw_data["content"].presence || raw_data["summary"].presence || raw_data["title"].presence || ""
+      strip_html(text)
+    end
+  end
+end

--- a/app/services/processor/json_feed_processor.rb
+++ b/app/services/processor/json_feed_processor.rb
@@ -38,15 +38,18 @@ module Processor
       end
     end
 
-    # A real JSON Feed always declares its version and a title; either an
-    # items array or a title means the payload parsed as a genuine feed
-    # rather than unrelated JSON that happened to mention the marker.
+    # Recognize the same canonical structure the matcher checks, so a
+    # manually chosen profile or a refresh can't treat lookalike JSON as a
+    # genuine feed.
     def recognizable?(feed_data)
-      return false unless feed_data["version"].to_s.include?("jsonfeed.org/version/")
-
-      feed_data["items"].is_a?(Array) || feed_data["title"].present?
+      JsonFeed.feed?(feed_data)
     end
 
+    # The spec requires a string `id` and says readers must coerce a numeric
+    # one to a string. We additionally fall back to `url` when `id` is absent
+    # rather than dropping the item — a permalink is a fine stable identifier,
+    # and this matches RssProcessor. Items with neither are dropped downstream
+    # once their uid comes back blank.
     def extract_uid(item)
       id = item["id"]
       id = id.to_s if id.is_a?(Numeric)

--- a/app/services/processor/json_feed_processor.rb
+++ b/app/services/processor/json_feed_processor.rb
@@ -1,0 +1,98 @@
+module Processor
+  # Parses a JSON Feed (https://jsonfeed.org) into FeedEntry objects.
+  #
+  # The emitted raw_data mirrors the shape RssProcessor produces, so the
+  # generic image/URL handling in RssNormalizer applies. JSON Feed's
+  # `image`, `banner_image`, and image-typed `attachments` are folded into
+  # the same `enclosures` array RSS uses.
+  class JsonFeedProcessor < Base
+    def process
+      feed_data = JSON.parse(raw_data)
+      feed_data = {} unless feed_data.is_a?(Hash)
+
+      Result.new(
+        entries: build_entries(feed_data),
+        recognized: recognizable?(feed_data)
+      )
+    end
+
+    private
+
+    def build_entries(feed_data)
+      feed_authors = feed_data["authors"]
+
+      Array(feed_data["items"]).filter_map do |item|
+        next unless item.is_a?(Hash)
+
+        FeedEntry.new(
+          feed: feed,
+          uid: extract_uid(item),
+          # date_published is optional in JSON Feed; fall back to now so
+          # date-less items still import (see PassthroughProcessor).
+          published_at: parse_time(item["date_published"]) || Time.current,
+          status: :pending,
+          raw_data: sanitize_item(item, feed_authors)
+        )
+      end
+    end
+
+    # A real JSON Feed always declares its version and a title; either an
+    # items array or a title means the payload parsed as a genuine feed
+    # rather than unrelated JSON that happened to mention the marker.
+    def recognizable?(feed_data)
+      return false unless feed_data["version"].to_s.include?("jsonfeed.org/version/")
+
+      feed_data["items"].is_a?(Array) || feed_data["title"].present?
+    end
+
+    def extract_uid(item)
+      id = item["id"]
+      id = id.to_s if id.is_a?(Numeric)
+      id.presence || item["url"]
+    end
+
+    def sanitize_item(item, feed_authors)
+      {
+        "id" => item["id"],
+        "title" => item["title"],
+        "url" => item["url"],
+        "link" => item["url"],
+        "external_url" => item["external_url"],
+        "summary" => item["summary"],
+        "content" => item["content_html"].presence || item["content_text"],
+        "published" => parse_time(item["date_published"])&.rfc3339,
+        "updated" => parse_time(item["date_modified"])&.rfc3339,
+        "author" => author_name(item, feed_authors),
+        "categories" => Array(item["tags"]),
+        "enclosures" => extract_enclosures(item)
+      }
+    end
+
+    # JSON Feed 1.1 carries a list of authors; 1.0 a single author object.
+    # An item without its own author inherits the feed-level authors. Either
+    # way each author is an object whose `name` is what we keep.
+    def author_name(item, feed_authors)
+      authors = item["authors"].presence || [item["author"]].compact.presence || feed_authors
+      author = Array(authors).find { |entry| entry.is_a?(Hash) && entry["name"].present? }
+      author&.dig("name")
+    end
+
+    def extract_enclosures(item)
+      images = [item["image"], item["banner_image"]].compact_blank.map { |url| { "url" => url, "type" => nil } }
+      attachments = Array(item["attachments"]).filter_map do |attachment|
+        next unless attachment.is_a?(Hash) && attachment["url"].present?
+
+        { "url" => attachment["url"], "type" => attachment["mime_type"] }
+      end
+      images + attachments
+    end
+
+    def parse_time(value)
+      return nil if value.blank?
+
+      Time.parse(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/services/processor/json_feed_processor.rb
+++ b/app/services/processor/json_feed_processor.rb
@@ -19,7 +19,9 @@ module Processor
     private
 
     def build_entries(feed_data)
-      feed_authors = feed_data["authors"]
+      # JSON Feed 1.1 has a top-level `authors` list; 1.0 a single `author`.
+      # Items without their own author inherit whichever the feed declares.
+      feed_authors = feed_data["authors"].presence || [feed_data["author"]].compact.presence
 
       Array(feed_data["items"]).filter_map do |item|
         next unless item.is_a?(Hash)

--- a/app/services/profile_matcher/json_feed_profile_matcher.rb
+++ b/app/services/profile_matcher/json_feed_profile_matcher.rb
@@ -3,14 +3,15 @@ module ProfileMatcher
     input_shape :url
     match_specificity 10
 
-    # https://jsonfeed.org/version/1.1 — a feed is a JSON object whose
-    # `version` names the spec and which carries the required `title`
-    # (string) and `items` (array) fields. Parsing and checking that
-    # structure rules out HTML pages that merely link to the spec or
-    # unrelated JSON that happens to mention the URL. Parsing also
-    # normalizes any `\/`-escaped slashes, so the marker is matched
-    # against the decoded value.
-    VERSION_MARKER = "jsonfeed.org/version/".freeze
+    # A feed is a JSON object whose `version` is the spec URL (e.g.
+    # "https://jsonfeed.org/version/1.1") and which carries the required
+    # `title` (string) and `items` (array) fields. Parsing and checking
+    # that structure rules out HTML pages that merely link to the spec or
+    # unrelated JSON that happens to mention the URL; parsing also decodes
+    # any `\/`-escaped slashes. The version is anchored to the canonical
+    # host and path so a lookalike like `https://evil.com/jsonfeed.org/...`
+    # or `https://notjsonfeed.org/version/1` can't slip through.
+    VERSION_URL = %r{\Ahttps?://jsonfeed\.org/version/\d}
 
     def match?
       return false if fetched_body.blank?
@@ -18,8 +19,7 @@ module ProfileMatcher
       feed = parse(fetched_body)
       return false unless feed.is_a?(Hash)
 
-      version = feed["version"]
-      version.is_a?(String) && version.include?(VERSION_MARKER) &&
+      feed["version"].is_a?(String) && feed["version"].match?(VERSION_URL) &&
         feed["title"].is_a?(String) &&
         feed["items"].is_a?(Array)
     end

--- a/app/services/profile_matcher/json_feed_profile_matcher.rb
+++ b/app/services/profile_matcher/json_feed_profile_matcher.rb
@@ -1,27 +1,16 @@
 module ProfileMatcher
   class JsonFeedProfileMatcher < Base
     input_shape :url
-    match_specificity 10
-
-    # A feed is a JSON object whose `version` is the spec URL (e.g.
-    # "https://jsonfeed.org/version/1.1") and which carries the required
-    # `title` (string) and `items` (array) fields. Parsing and checking
-    # that structure rules out HTML pages that merely link to the spec or
-    # unrelated JSON that happens to mention the URL; parsing also decodes
-    # any `\/`-escaped slashes. The version is anchored to the canonical
-    # host and path so a lookalike like `https://evil.com/jsonfeed.org/...`
-    # or `https://notjsonfeed.org/version/1` can't slip through.
-    VERSION_URL = %r{\Ahttps?://jsonfeed\.org/version/\d}
+    # Ranks above generic RSS (10): parsing and validating the JSON Feed
+    # structure is a stronger signal than the RSS matcher's regex scan for
+    # XML-like text, which a JSON feed can trip on if an item's HTML body
+    # contains a `<feed>` or `<rss>` substring.
+    match_specificity 20
 
     def match?
       return false if fetched_body.blank?
 
-      feed = parse(fetched_body)
-      return false unless feed.is_a?(Hash)
-
-      feed["version"].is_a?(String) && feed["version"].match?(VERSION_URL) &&
-        feed["title"].is_a?(String) &&
-        feed["items"].is_a?(Array)
+      JsonFeed.feed?(parse(fetched_body))
     end
 
     private

--- a/app/services/profile_matcher/json_feed_profile_matcher.rb
+++ b/app/services/profile_matcher/json_feed_profile_matcher.rb
@@ -3,20 +3,33 @@ module ProfileMatcher
     input_shape :url
     match_specificity 10
 
-    # Every JSON Feed names its spec version, e.g.
-    # "https://jsonfeed.org/version/1.1". JSON may or may not escape the
-    # slashes, so accept both forms. The textual check mirrors how the
-    # RSS matcher sniffs for `<rss`/`<feed`; the processor's recognition
-    # flag is the real gate.
-    JSON_FEED_MARKERS = [
-      "jsonfeed.org/version/",
-      'jsonfeed.org\/version\/'
-    ].freeze
+    # https://jsonfeed.org/version/1.1 — a feed is a JSON object whose
+    # `version` names the spec and which carries the required `title`
+    # (string) and `items` (array) fields. Parsing and checking that
+    # structure rules out HTML pages that merely link to the spec or
+    # unrelated JSON that happens to mention the URL. Parsing also
+    # normalizes any `\/`-escaped slashes, so the marker is matched
+    # against the decoded value.
+    VERSION_MARKER = "jsonfeed.org/version/".freeze
 
     def match?
       return false if fetched_body.blank?
 
-      JSON_FEED_MARKERS.any? { |marker| fetched_body.include?(marker) }
+      feed = parse(fetched_body)
+      return false unless feed.is_a?(Hash)
+
+      version = feed["version"]
+      version.is_a?(String) && version.include?(VERSION_MARKER) &&
+        feed["title"].is_a?(String) &&
+        feed["items"].is_a?(Array)
+    end
+
+    private
+
+    def parse(body)
+      JSON.parse(body)
+    rescue JSON::ParserError
+      nil
     end
   end
 end

--- a/app/services/profile_matcher/json_feed_profile_matcher.rb
+++ b/app/services/profile_matcher/json_feed_profile_matcher.rb
@@ -1,0 +1,22 @@
+module ProfileMatcher
+  class JsonFeedProfileMatcher < Base
+    input_shape :url
+    match_specificity 10
+
+    # Every JSON Feed names its spec version, e.g.
+    # "https://jsonfeed.org/version/1.1". JSON may or may not escape the
+    # slashes, so accept both forms. The textual check mirrors how the
+    # RSS matcher sniffs for `<rss`/`<feed`; the processor's recognition
+    # flag is the real gate.
+    JSON_FEED_MARKERS = [
+      "jsonfeed.org/version/",
+      'jsonfeed.org\/version\/'
+    ].freeze
+
+    def match?
+      return false if fetched_body.blank?
+
+      JSON_FEED_MARKERS.any? { |marker| fetched_body.include?(marker) }
+    end
+  end
+end

--- a/app/services/title_extractor/json_feed_title_extractor.rb
+++ b/app/services/title_extractor/json_feed_title_extractor.rb
@@ -1,0 +1,16 @@
+module TitleExtractor
+  # Extractor for JSON Feed titles (https://jsonfeed.org). The feed's
+  # top-level `title` is required by the spec; fall back to the hostname
+  # when the body is missing, unparseable, or titleless.
+  class JsonFeedTitleExtractor < Base
+    def title
+      return hostname_from_url if fetched_body.blank?
+
+      data = JSON.parse(fetched_body)
+      feed_title = data.is_a?(Hash) ? data["title"].to_s.strip : ""
+      feed_title.presence || hostname_from_url
+    rescue JSON::ParserError
+      hostname_from_url
+    end
+  end
+end

--- a/test/fixtures/files/feeds/json_feed/entries.json
+++ b/test/fixtures/files/feeds/json_feed/entries.json
@@ -1,0 +1,79 @@
+[
+  {
+    "uid": "https://example.com/first-post",
+    "status": "pending",
+    "published_at": "2024-09-12T16:00:00.000Z",
+    "raw_data": {
+      "id": "https://example.com/first-post",
+      "title": "First Post",
+      "url": "https://example.com/first-post",
+      "link": "https://example.com/first-post",
+      "external_url": null,
+      "summary": "A short summary of the first post.",
+      "content": "<p>Hello, world! Here is an <img src=\"https://example.com/inline.jpg\"> inline image.</p>",
+      "published": "2024-09-12T09:00:00-07:00",
+      "updated": null,
+      "author": "Jane Author",
+      "categories": [
+        "news",
+        "intro"
+      ],
+      "enclosures": []
+    }
+  },
+  {
+    "uid": "https://example.com/second-post",
+    "status": "pending",
+    "published_at": "2024-09-11T22:30:00.000Z",
+    "raw_data": {
+      "id": "https://example.com/second-post",
+      "title": "Second Post",
+      "url": "https://example.com/second-post",
+      "link": "https://example.com/second-post",
+      "external_url": "https://other.example.org/article",
+      "summary": null,
+      "content": "This is a plain text post with no HTML markup.",
+      "published": "2024-09-11T15:30:00-07:00",
+      "updated": null,
+      "author": "John Writer",
+      "categories": [],
+      "enclosures": []
+    }
+  },
+  {
+    "uid": "https://example.com/photo-post",
+    "status": "pending",
+    "published_at": "2024-09-10T19:00:00.000Z",
+    "raw_data": {
+      "id": "https://example.com/photo-post",
+      "title": "Photo Post",
+      "url": "https://example.com/photo-post",
+      "link": "https://example.com/photo-post",
+      "external_url": null,
+      "summary": null,
+      "content": "<p>Check out this photo.</p>",
+      "published": "2024-09-10T12:00:00-07:00",
+      "updated": null,
+      "author": "Jane Author",
+      "categories": [],
+      "enclosures": [
+        {
+          "url": "https://example.com/main-photo.jpg",
+          "type": null
+        },
+        {
+          "url": "https://example.com/banner.jpg",
+          "type": null
+        },
+        {
+          "url": "https://example.com/audio.m4a",
+          "type": "audio/x-m4a"
+        },
+        {
+          "url": "https://example.com/gallery.png",
+          "type": "image/png"
+        }
+      ]
+    }
+  }
+]

--- a/test/fixtures/files/feeds/json_feed/feed.json
+++ b/test/fixtures/files/feeds/json_feed/feed.json
@@ -1,0 +1,45 @@
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "Example JSON Feed",
+  "home_page_url": "https://example.com/",
+  "feed_url": "https://example.com/feed.json",
+  "authors": [
+    { "name": "Jane Author", "url": "https://example.com/jane" }
+  ],
+  "icon": "https://example.com/icon.png",
+  "items": [
+    {
+      "id": "https://example.com/first-post",
+      "url": "https://example.com/first-post",
+      "title": "First Post",
+      "content_html": "<p>Hello, world! Here is an <img src=\"https://example.com/inline.jpg\"> inline image.</p>",
+      "summary": "A short summary of the first post.",
+      "date_published": "2024-09-12T09:00:00-07:00",
+      "tags": ["news", "intro"]
+    },
+    {
+      "id": "https://example.com/second-post",
+      "url": "https://example.com/second-post",
+      "external_url": "https://other.example.org/article",
+      "title": "Second Post",
+      "content_text": "This is a plain text post with no HTML markup.",
+      "date_published": "2024-09-11T15:30:00-07:00",
+      "authors": [
+        { "name": "John Writer" }
+      ]
+    },
+    {
+      "id": "https://example.com/photo-post",
+      "url": "https://example.com/photo-post",
+      "title": "Photo Post",
+      "content_html": "<p>Check out this photo.</p>",
+      "image": "https://example.com/main-photo.jpg",
+      "banner_image": "https://example.com/banner.jpg",
+      "attachments": [
+        { "url": "https://example.com/audio.m4a", "mime_type": "audio/x-m4a", "size_in_bytes": 12345 },
+        { "url": "https://example.com/gallery.png", "mime_type": "image/png" }
+      ],
+      "date_published": "2024-09-10T12:00:00-07:00"
+    }
+  ]
+}

--- a/test/fixtures/files/feeds/json_feed/normalized.json
+++ b/test/fixtures/files/feeds/json_feed/normalized.json
@@ -1,0 +1,12 @@
+{
+  "attachment_urls": [
+    "https://example.com/inline.jpg"
+  ],
+  "comments": [],
+  "content": "Hello, world! Here is an inline image. - https://example.com/first-post",
+  "published_at": "2024-09-12T16:00:00.000Z",
+  "source_url": "https://example.com/first-post",
+  "status": "enqueued",
+  "uid": "https://example.com/first-post",
+  "validation_errors": []
+}

--- a/test/integration/smart_feed_creation_json_feed_test.rb
+++ b/test/integration/smart_feed_creation_json_feed_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+# Integration test for the JSON Feed happy path.
+# Walks paste → detection → preview cache → save → enabled feed.
+class SmartFeedCreationJsonFeedTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def access_token
+    @access_token ||= create(:access_token, :active, user: user)
+  end
+
+  def feed_url
+    "http://example.com/feed.json"
+  end
+
+  def json_body
+    @json_body ||= <<~JSON
+      {
+        "version": "https://jsonfeed.org/version/1.1",
+        "title": "Example JSON Feed",
+        "home_page_url": "http://example.com/",
+        "feed_url": "http://example.com/feed.json",
+        "items": [
+          {
+            "id": "http://example.com/post1",
+            "url": "http://example.com/post1",
+            "title": "First post",
+            "content_html": "<p>Hello world</p>",
+            "date_published": "2024-01-01T00:00:00Z"
+          }
+        ]
+      }
+    JSON
+  end
+
+  def with_memory_cache
+    previous = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = previous
+  end
+
+  test "#post should drive JSON Feed happy path: paste, detect, preview, save enabled" do
+    sign_in_as(user)
+    access_token
+    stub_request(:get, feed_url)
+      .to_return(status: 200, body: json_body, headers: { "Content-Type" => "application/feed+json" })
+
+    with_memory_cache do
+      post feed_identifications_path, params: { input: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      assert_response :success
+
+      perform_enqueued_jobs
+
+      get feed_identifications_path, params: { input: feed_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      assert_response :success
+      assert_includes response.body, 'data-identification-state="complete"'
+      assert_includes response.body, "JSON Feed"
+
+      post feed_preview_path(profile_key: "json_feed", "params" => { "url" => feed_url })
+      assert_response :success
+
+      perform_enqueued_jobs
+
+      preview = FeedPreview.last
+      assert_predicate preview, :ready?, "preview should be ready after the job runs"
+
+      assert_difference("Feed.count", 1) do
+        post feeds_path, params: {
+          feed: {
+            url: feed_url,
+            name: "Example JSON Feed",
+            feed_profile_key: "json_feed",
+            access_token_id: access_token.id,
+            target_group: "testgroup",
+            schedule_interval: "1h"
+          },
+          enable_feed: "1"
+        }
+      end
+
+      feed = Feed.last
+      assert_equal "enabled", feed.state
+      assert_equal "json_feed", feed.feed_profile_key
+      assert_equal feed_url, feed.url
+    end
+  end
+end

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -6,6 +6,7 @@ class FeedProfileTest < ActiveSupport::TestCase
       "aerostat",
       "buni",
       "elementy",
+      "json_feed",
       "litterbox",
       "llm_web_search",
       "llm_website_extractor",

--- a/test/services/feed_profile_detector_test.rb
+++ b/test/services/feed_profile_detector_test.rb
@@ -40,6 +40,21 @@ class FeedProfileDetectorTest < ActiveSupport::TestCase
     assert_equal :specific_match, rss.rank_reason
   end
 
+  test ".call should rank json_feed above rss when a JSON feed contains XML-like markup" do
+    # The RSS matcher scans for `<feed`/`<rss` anywhere in the body, so a JSON
+    # feed whose item HTML mentions `<feed>` trips it too. json_feed's stricter
+    # parse-and-validate match must win the ranking.
+    body = '{"version":"https://jsonfeed.org/version/1.1","title":"Feed",' \
+           '"items":[{"id":"1","url":"https://example.com/1","content_html":"<p>The <feed> element</p>"}]}'
+
+    result = FeedProfileDetector.call(input: "https://example.com/feed.json", fetched_body: body)
+    profile_keys = result.candidates.map(&:profile_key)
+
+    assert_equal "json_feed", profile_keys.first, "json_feed (20) should outrank rss (10)"
+    assert_includes profile_keys, "rss"
+    assert_operator profile_keys.index("json_feed"), :<, profile_keys.index("rss")
+  end
+
   test ".call should rank specific matchers above generic ones, with AI fallback last" do
     result = FeedProfileDetector.call(input: "https://xkcd.com/rss.xml", fetched_body: rss_feed_body)
 

--- a/test/services/normalizer/json_feed_normalizer_test.rb
+++ b/test/services/normalizer/json_feed_normalizer_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class Normalizer::JsonFeedNormalizerTest < ActiveSupport::TestCase
+  include FixtureFeedEntries
+
+  def fixture_dir
+    "feeds/json_feed"
+  end
+
+  def fixture_file
+    "feed.json"
+  end
+
+  def processor_class
+    Processor::JsonFeedProcessor
+  end
+
+  test "#normalize should create a valid post from a feed entry" do
+    normalizer = Normalizer::JsonFeedNormalizer.new(feed_entry(0))
+    post = normalizer.normalize
+
+    assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
+  end
+
+  test "#normalize should extract inline content images as attachments" do
+    post = Normalizer::JsonFeedNormalizer.new(feed_entry(0)).normalize
+
+    assert_equal ["https://example.com/inline.jpg"], post.attachment_urls
+    assert_equal "enqueued", post.status
+  end
+
+  test "#normalize should prefer full content over the summary blurb" do
+    post = Normalizer::JsonFeedNormalizer.new(feed_entry(0)).normalize
+
+    assert_includes post.content, "Hello, world!"
+    assert_not_includes post.content, "short summary"
+  end
+
+  test "#normalize should fall back to the summary when content is blank" do
+    entry = create(:feed_entry, raw_data: {
+      "summary" => "Just a blurb.",
+      "content" => "",
+      "link" => "https://example.com/blurb"
+    })
+
+    post = Normalizer::JsonFeedNormalizer.new(entry).normalize
+
+    assert_equal "Just a blurb. - https://example.com/blurb", post.content
+  end
+
+  test "#normalize should attach image and image-typed attachment enclosures" do
+    photo = feed_entries.find { |entry| entry.uid == "https://example.com/photo-post" }
+    photo.save!
+
+    post = Normalizer::JsonFeedNormalizer.new(photo).normalize
+
+    assert_equal [
+      "https://example.com/main-photo.jpg",
+      "https://example.com/banner.jpg",
+      "https://example.com/gallery.png"
+    ], post.attachment_urls
+  end
+
+  test "#normalize should use the item url as the source url" do
+    post = Normalizer::JsonFeedNormalizer.new(feed_entry(0)).normalize
+
+    assert_equal "https://example.com/first-post", post.source_url
+  end
+end

--- a/test/services/processor/json_feed_processor_test.rb
+++ b/test/services/processor/json_feed_processor_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+
+class Processor::JsonFeedProcessorTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, url: "https://example.com/feed.json")
+  end
+
+  def sample_content
+    @sample_content ||= file_fixture("feeds/json_feed/feed.json").read
+  end
+
+  def entries
+    @entries ||= Processor::JsonFeedProcessor.new(feed, sample_content).process.entries
+  end
+
+  test "#process should parse JSON Feed and create FeedEntry objects" do
+    assert_equal 3, entries.length
+    assert entries.all? { |entry| entry.is_a?(FeedEntry) }
+    assert entries.all? { |entry| entry.feed == feed }
+    assert entries.all? { |entry| entry.status == "pending" }
+    assert entries.all?(&:valid?)
+
+    snapshot = entries.map { |entry| entry.as_json(only: %i[uid status published_at raw_data]) }
+    assert_matches_snapshot(snapshot, snapshot: "feeds/json_feed/entries.json")
+  end
+
+  test "#process should prefer content_html and extract inline image fields" do
+    first = entries.first
+
+    assert_equal "https://example.com/first-post", first.uid
+    assert_equal "<p>Hello, world! Here is an <img src=\"https://example.com/inline.jpg\"> inline image.</p>", first.raw_data["content"]
+    assert_equal ["news", "intro"], first.raw_data["categories"]
+  end
+
+  test "#process should fall back to content_text when there is no HTML" do
+    second = entries.find { |entry| entry.uid == "https://example.com/second-post" }
+
+    assert_equal "This is a plain text post with no HTML markup.", second.raw_data["content"]
+    assert_equal "https://other.example.org/article", second.raw_data["external_url"]
+    assert_equal "John Writer", second.raw_data["author"]
+  end
+
+  test "#process should fold image, banner_image, and image attachments into enclosures" do
+    photo = entries.find { |entry| entry.uid == "https://example.com/photo-post" }
+
+    assert_equal [
+      { "url" => "https://example.com/main-photo.jpg", "type" => nil },
+      { "url" => "https://example.com/banner.jpg", "type" => nil },
+      { "url" => "https://example.com/audio.m4a", "type" => "audio/x-m4a" },
+      { "url" => "https://example.com/gallery.png", "type" => "image/png" }
+    ], photo.raw_data["enclosures"]
+  end
+
+  test "#process should read the top-level authors list for the first item" do
+    first = entries.first
+
+    assert_equal "Jane Author", first.raw_data["author"]
+  end
+
+  test "#process should recognize a valid JSON Feed" do
+    assert Processor::JsonFeedProcessor.new(feed, sample_content).process.recognized?
+  end
+
+  test "#process should recognize an empty feed that carries a version and title" do
+    body = '{"version":"https://jsonfeed.org/version/1.1","title":"Empty","items":[]}'
+
+    result = Processor::JsonFeedProcessor.new(feed, body).process
+    assert_empty result.entries
+    assert result.recognized?
+  end
+
+  test "#process should not recognize JSON that lacks the version marker" do
+    body = '{"title":"Not a feed","items":[{"id":"1","url":"https://example.com/1"}]}'
+
+    assert_not Processor::JsonFeedProcessor.new(feed, body).process.recognized?
+  end
+
+  test "#process should raise on unparseable JSON" do
+    assert_raises(JSON::ParserError) do
+      Processor::JsonFeedProcessor.new(feed, "not json at all").process
+    end
+  end
+
+  test "#process should default a missing date_published to now" do
+    body = '{"version":"https://jsonfeed.org/version/1.1","title":"Feed","items":[{"id":"x","url":"https://example.com/x","content_text":"hi"}]}'
+
+    freeze_time do
+      entry = Processor::JsonFeedProcessor.new(feed, body).process.entries.first
+      assert_equal Time.current, entry.published_at
+      assert_nil entry.raw_data["published"]
+    end
+  end
+
+  test "#process should fall back to url when id is missing" do
+    body = '{"version":"https://jsonfeed.org/version/1.1","title":"Feed","items":[{"url":"https://example.com/no-id","content_text":"hi"}]}'
+
+    entry = Processor::JsonFeedProcessor.new(feed, body).process.entries.first
+    assert_equal "https://example.com/no-id", entry.uid
+  end
+
+  test "#process should coerce a numeric id to a string uid" do
+    body = '{"version":"https://jsonfeed.org/version/1.1","title":"Feed","items":[{"id":42,"url":"https://example.com/42","content_text":"hi"}]}'
+
+    entry = Processor::JsonFeedProcessor.new(feed, body).process.entries.first
+    assert_equal "42", entry.uid
+  end
+
+  test "#process should read a single author object (JSON Feed 1.0)" do
+    body = '{"version":"https://jsonfeed.org/version/1","title":"Feed","items":[{"id":"1","url":"https://example.com/1","author":{"name":"Solo Author"},"content_text":"hi"}]}'
+
+    entry = Processor::JsonFeedProcessor.new(feed, body).process.entries.first
+    assert_equal "Solo Author", entry.raw_data["author"]
+  end
+end

--- a/test/services/processor/json_feed_processor_test.rb
+++ b/test/services/processor/json_feed_processor_test.rb
@@ -75,6 +75,22 @@ class Processor::JsonFeedProcessorTest < ActiveSupport::TestCase
     assert_not Processor::JsonFeedProcessor.new(feed, body).process.recognized?
   end
 
+  test "#process should not recognize a version that is not the canonical spec URL" do
+    lookalike = '{"version":"see jsonfeed.org/version/ docs","title":"x","items":[]}'
+    no_scheme = '{"version":"jsonfeed.org/version/1","title":"x","items":[]}'
+
+    assert_not Processor::JsonFeedProcessor.new(feed, lookalike).process.recognized?
+    assert_not Processor::JsonFeedProcessor.new(feed, no_scheme).process.recognized?
+  end
+
+  test "#process should not recognize a feed missing a title or items array" do
+    no_title = '{"version":"https://jsonfeed.org/version/1.1","items":[]}'
+    bad_items = '{"version":"https://jsonfeed.org/version/1.1","title":"x","items":"nope"}'
+
+    assert_not Processor::JsonFeedProcessor.new(feed, no_title).process.recognized?
+    assert_not Processor::JsonFeedProcessor.new(feed, bad_items).process.recognized?
+  end
+
   test "#process should raise on unparseable JSON" do
     assert_raises(JSON::ParserError) do
       Processor::JsonFeedProcessor.new(feed, "not json at all").process
@@ -91,6 +107,8 @@ class Processor::JsonFeedProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  # Pragmatic deviation from the spec (id is required): a permalink is a fine
+  # stable identifier, so we keep id-less items rather than dropping them.
   test "#process should fall back to url when id is missing" do
     body = '{"version":"https://jsonfeed.org/version/1.1","title":"Feed","items":[{"url":"https://example.com/no-id","content_text":"hi"}]}'
 

--- a/test/services/processor/json_feed_processor_test.rb
+++ b/test/services/processor/json_feed_processor_test.rb
@@ -111,4 +111,18 @@ class Processor::JsonFeedProcessorTest < ActiveSupport::TestCase
     entry = Processor::JsonFeedProcessor.new(feed, body).process.entries.first
     assert_equal "Solo Author", entry.raw_data["author"]
   end
+
+  test "#process should inherit the top-level author for an item without one (JSON Feed 1.0)" do
+    body = '{"version":"https://jsonfeed.org/version/1","title":"Feed","author":{"name":"Feed Owner"},"items":[{"id":"1","url":"https://example.com/1","content_text":"hi"}]}'
+
+    entry = Processor::JsonFeedProcessor.new(feed, body).process.entries.first
+    assert_equal "Feed Owner", entry.raw_data["author"]
+  end
+
+  test "#process should prefer an item's own author over the feed-level one" do
+    body = '{"version":"https://jsonfeed.org/version/1","title":"Feed","author":{"name":"Feed Owner"},"items":[{"id":"1","url":"https://example.com/1","author":{"name":"Item Author"},"content_text":"hi"}]}'
+
+    entry = Processor::JsonFeedProcessor.new(feed, body).process.entries.first
+    assert_equal "Item Author", entry.raw_data["author"]
+  end
 end

--- a/test/services/profile_matcher/json_feed_profile_matcher_test.rb
+++ b/test/services/profile_matcher/json_feed_profile_matcher_test.rb
@@ -60,6 +60,20 @@ class ProfileMatcher::JsonFeedProfileMatcherTest < ActiveSupport::TestCase
     assert_not matcher(body).match?
   end
 
+  test "#match? should not match a lookalike host in the version URL" do
+    embedded = '{"version":"https://evil.com/jsonfeed.org/version/1.1","title":"Feed","items":[]}'
+    suffixed = '{"version":"https://notjsonfeed.org/version/1","title":"Feed","items":[]}'
+
+    assert_not matcher(embedded).match?
+    assert_not matcher(suffixed).match?
+  end
+
+  test "#match? should not match a version without a scheme" do
+    body = '{"version":"jsonfeed.org/version/1.1","title":"Feed","items":[]}'
+
+    assert_not matcher(body).match?
+  end
+
   test "#match? should not match a JSON array" do
     body = '[{"version":"https://jsonfeed.org/version/1.1","title":"Feed","items":[]}]'
 

--- a/test/services/profile_matcher/json_feed_profile_matcher_test.rb
+++ b/test/services/profile_matcher/json_feed_profile_matcher_test.rb
@@ -21,20 +21,20 @@ class ProfileMatcher::JsonFeedProfileMatcherTest < ActiveSupport::TestCase
     assert_equal "json_feed", ProfileMatcher::JsonFeedProfileMatcher.profile_key
   end
 
-  test "#match? should match a JSON Feed by its version marker" do
+  test "#match? should match a JSON Feed by its version, title, and items" do
     body = file_fixture("feeds/json_feed/feed.json").read
 
     assert matcher(body).match?
   end
 
-  test "#match? should match version 1.0 feeds" do
+  test "#match? should match version 1.0 feeds with an empty items array" do
     body = '{"version":"https://jsonfeed.org/version/1","title":"Feed","items":[]}'
 
     assert matcher(body).match?
   end
 
   test "#match? should match when slashes are JSON-escaped" do
-    body = '{"version":"https:\/\/jsonfeed.org\/version\/1.1","title":"Feed"}'
+    body = '{"version":"https:\/\/jsonfeed.org\/version\/1.1","title":"Feed","items":[]}'
 
     assert matcher(body).match?
   end
@@ -44,12 +44,45 @@ class ProfileMatcher::JsonFeedProfileMatcherTest < ActiveSupport::TestCase
     assert_not matcher('<feed xmlns="http://www.w3.org/2005/Atom"></feed>').match?
   end
 
-  test "#match? should not match plain JSON without the marker" do
+  test "#match? should not match an HTML page that links to the spec" do
+    body = '<html><body><a href="https://jsonfeed.org/version/1.1">JSON Feed</a></body></html>'
+
+    assert_not matcher(body).match?
+  end
+
+  test "#match? should not match plain JSON without the version marker" do
     assert_not matcher('{"title":"Just some JSON","items":[]}').match?
+  end
+
+  test "#match? should not match when the marker is outside the version field" do
+    body = '{"version":"1.1","description":"Built per https://jsonfeed.org/version/1.1","title":"Feed","items":[]}'
+
+    assert_not matcher(body).match?
+  end
+
+  test "#match? should not match a JSON array" do
+    body = '[{"version":"https://jsonfeed.org/version/1.1","title":"Feed","items":[]}]'
+
+    assert_not matcher(body).match?
+  end
+
+  test "#match? should not match when items is missing or not an array" do
+    assert_not matcher('{"version":"https://jsonfeed.org/version/1.1","title":"Feed"}').match?
+    assert_not matcher('{"version":"https://jsonfeed.org/version/1.1","title":"Feed","items":"nope"}').match?
+  end
+
+  test "#match? should not match when the title is missing" do
+    body = '{"version":"https://jsonfeed.org/version/1.1","items":[]}'
+
+    assert_not matcher(body).match?
   end
 
   test "#match? should handle a blank fetched_body" do
     assert_not matcher("").match?
     assert_not matcher(nil).match?
+  end
+
+  test "#match? should not match malformed JSON" do
+    assert_not matcher('{"version":"https://jsonfeed.org/version/1.1", "title":').match?
   end
 end

--- a/test/services/profile_matcher/json_feed_profile_matcher_test.rb
+++ b/test/services/profile_matcher/json_feed_profile_matcher_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class ProfileMatcher::JsonFeedProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(body)
+    ProfileMatcher::JsonFeedProfileMatcher.new("https://example.com/feed.json", body)
+  end
+
+  test ".input_shape should be :url" do
+    assert_equal :url, ProfileMatcher::JsonFeedProfileMatcher.input_shape
+  end
+
+  test ".match_specificity should be 10" do
+    assert_equal 10, ProfileMatcher::JsonFeedProfileMatcher.match_specificity
+  end
+
+  test ".depends_on_ai should be false" do
+    assert_equal false, ProfileMatcher::JsonFeedProfileMatcher.depends_on_ai
+  end
+
+  test ".profile_key should be json_feed" do
+    assert_equal "json_feed", ProfileMatcher::JsonFeedProfileMatcher.profile_key
+  end
+
+  test "#match? should match a JSON Feed by its version marker" do
+    body = file_fixture("feeds/json_feed/feed.json").read
+
+    assert matcher(body).match?
+  end
+
+  test "#match? should match version 1.0 feeds" do
+    body = '{"version":"https://jsonfeed.org/version/1","title":"Feed","items":[]}'
+
+    assert matcher(body).match?
+  end
+
+  test "#match? should match when slashes are JSON-escaped" do
+    body = '{"version":"https:\/\/jsonfeed.org\/version\/1.1","title":"Feed"}'
+
+    assert matcher(body).match?
+  end
+
+  test "#match? should not match RSS or Atom XML" do
+    assert_not matcher('<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>').match?
+    assert_not matcher('<feed xmlns="http://www.w3.org/2005/Atom"></feed>').match?
+  end
+
+  test "#match? should not match plain JSON without the marker" do
+    assert_not matcher('{"title":"Just some JSON","items":[]}').match?
+  end
+
+  test "#match? should handle a blank fetched_body" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+end

--- a/test/services/profile_matcher/json_feed_profile_matcher_test.rb
+++ b/test/services/profile_matcher/json_feed_profile_matcher_test.rb
@@ -9,8 +9,10 @@ class ProfileMatcher::JsonFeedProfileMatcherTest < ActiveSupport::TestCase
     assert_equal :url, ProfileMatcher::JsonFeedProfileMatcher.input_shape
   end
 
-  test ".match_specificity should be 10" do
-    assert_equal 10, ProfileMatcher::JsonFeedProfileMatcher.match_specificity
+  test ".match_specificity should be 20, above generic RSS" do
+    assert_equal 20, ProfileMatcher::JsonFeedProfileMatcher.match_specificity
+    assert_operator ProfileMatcher::JsonFeedProfileMatcher.match_specificity, :>,
+                    ProfileMatcher::RssProfileMatcher.match_specificity
   end
 
   test ".depends_on_ai should be false" do

--- a/test/services/title_extractor/json_feed_title_extractor_test.rb
+++ b/test/services/title_extractor/json_feed_title_extractor_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class TitleExtractor::JsonFeedTitleExtractorTest < ActiveSupport::TestCase
+  def extractor(body)
+    TitleExtractor::JsonFeedTitleExtractor.new("https://example.com/feed.json", body)
+  end
+
+  test "#title should extract the top-level title from a JSON Feed" do
+    body = file_fixture("feeds/json_feed/feed.json").read
+
+    assert_equal "Example JSON Feed", extractor(body).title
+  end
+
+  test "#title should strip surrounding whitespace" do
+    body = '{"version":"https://jsonfeed.org/version/1.1","title":"  Padded Title  "}'
+
+    assert_equal "Padded Title", extractor(body).title
+  end
+
+  test "#title should fall back to hostname for a blank body" do
+    assert_equal "example.com", extractor("").title
+    assert_equal "example.com", extractor(nil).title
+  end
+
+  test "#title should fall back to hostname for invalid JSON" do
+    assert_equal "example.com", extractor("not valid json").title
+  end
+
+  test "#title should fall back to hostname when the feed has no title" do
+    body = '{"version":"https://jsonfeed.org/version/1.1","items":[]}'
+
+    assert_equal "example.com", extractor(body).title
+  end
+
+  test "#title should fall back to hostname for non-object JSON" do
+    assert_equal "example.com", extractor("[1, 2, 3]").title
+  end
+
+  test "#title should fall back to nil when the URL has no hostname" do
+    e = TitleExtractor::JsonFeedTitleExtractor.new("not-a-url", nil)
+    assert_nil e.title
+  end
+end

--- a/test/support/fixture_feed_entries.rb
+++ b/test/support/fixture_feed_entries.rb
@@ -7,13 +7,18 @@ module FixtureFeedEntries
     raise NotImplementedError, "#{self.class} must implement #processor_class"
   end
 
+  # Source payload filename within fixture_dir; override for non-XML feeds.
+  def fixture_file
+    "feed.xml"
+  end
+
   def feed
     @feed ||= create(:feed)
   end
 
   def processor
-    feed_xml = file_fixture("#{fixture_dir}/feed.xml").read
-    processor_class.new(feed, feed_xml)
+    raw = file_fixture("#{fixture_dir}/#{fixture_file}").read
+    processor_class.new(feed, raw)
   end
 
   def feed_entries


### PR DESCRIPTION
Changes:

- Add JSON Feed (jsonfeed.org) as a feed profile, alongside RSS and Atom
- Detect feeds by their version marker, extract the feed title, and normalize items into posts
- Fold each item's image, banner_image, and image attachments into the shared enclosures handling

JSON Feed slots into the existing detect → preview → save → refresh pipeline, reusing the shared HTTP loader. The processor handles both the 1.0 and 1.1 specs (single vs. list authors, author inheritance, content_html/content_text fallback); the normalizer extends the RSS one and only changes content selection to prefer the full item body over the short summary blurb. Validated against real feeds (jsonfeed.org and Daring Fireball).

References:

- Closes #862