### PR TITLE
Prepare development database on session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -28,6 +28,10 @@ fi
 # the image on first use.
 docker compose up -d
 
-# Prepare the test database inside the app container.
-docker compose exec -T app bin/rails db:test:prepare ||
-  echo "warning: db:test:prepare failed; run it manually once the stack is up" >&2
+# Prepare the databases inside the app container so `bin/rails test` and
+# `bin/rails server` work without a manual step. With DATABASE_URL unset,
+# db:prepare runs against both development and test, so one call creates,
+# migrates, and seeds the dev DB and also creates and loads the test DB.
+# Idempotent on later sessions since pg_data persists across runs.
+docker compose exec -T app bin/rails db:prepare ||
+  echo "warning: db:prepare failed; run it manually once the stack is up" >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,8 @@ References:
 
 ## Testing
 
+> In remote Claude Code environments, prefix every Rails/RuboCop command with `docker compose exec app` (see [Tooling Notes](#tooling-notes)). The bare `bin/rails …` commands below assume local dev.
+
 - Keep tests and code changes together.
 - Add or update tests for any code change.
 - Verify database migrations work both ways (up/down).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ References:
 
 ## Testing
 
-> In remote Claude Code environments, prefix every Rails/RuboCop command with `docker compose exec app` (see [Tooling Notes](#tooling-notes)). The bare `bin/rails …` commands below assume local dev.
+In remote Claude Code environments, prefix every Rails/RuboCop command with `docker compose exec app` (see [Tooling Notes](#tooling-notes)). The bare `bin/rails …` commands below assume local dev.
 
 - Keep tests and code changes together.
 - Add or update tests for any code change.


### PR DESCRIPTION
Changes:

- Replace `db:test:prepare` with `db:prepare` in the session-start hook so both the development and test databases are ready when the dev stack comes up
- Add a pointer at the top of CLAUDE.md's Testing section noting that remote Claude Code environments need the `docker compose exec app` command prefix

Previously the hook prepared only the test database, so a fresh remote environment had no `f2_development` database and `bin/rails server` returned HTTP 500 on every request (`ActiveRecord::NoDatabaseError`). With `DATABASE_URL` unset, `db:prepare` operates on both the development and test environments, so a single call creates, migrates, and seeds the dev DB and also creates and loads the test DB — making the server work out of the box without a separate test-prep step. It stays idempotent on later sessions since `pg_data` persists.