### PR TITLE
Add LLM model capability matrix

### DIFF
--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -1,116 +1,49 @@
 # Curated allowlist of (provider, model) pairs the system will run AI feeds
-# on, annotated with the capabilities each pair satisfies. Code-only and
-# reviewable, parallel to `LlmProvider` and `FeedProfile`.
+# on. Code-only and reviewable, parallel to `LlmProvider` and `FeedProfile`.
 #
-# This is a deliberate gate, not auto-discovery. A model earns a place here
-# only once it's known to deliver what an AI feed needs (structured output
-# plus web access). Callers intersect this list with a credential's live
-# `available_models` so a curated model the provider has since dropped falls
-# out of the picker on its own.
+# Every AI feed needs the same full feature set — structured output, web
+# search, and web fetch — so membership *is* qualification: a pair earns a
+# place here only once it's known to deliver all three. There's no per-entry
+# capability flag; a model that can't do the full set simply isn't listed.
 #
-# Entries describe model-level capability. Whether our adapter wires a given
-# capability for a provider (e.g. Anthropic server tools via RubyLLM) is the
-# adapter's concern, and entries are meant to be qualified empirically by a
-# smoke probe before they land here rather than trusted from docs alone.
+# Callers intersect this list with a credential's live `available_models`, so a
+# curated model the provider has since dropped falls out of the picker on its
+# own. How the adapter wires each provider (Anthropic server tools vs
+# OpenRouter web server tools) is the adapter's concern, and entries are meant
+# to be qualified empirically by a smoke probe before they land here.
 #
+# `tier` records how reliably the pair honors structured output and how far to
+# trust it:
+#   :native       — provider enforces the schema directly (Anthropic). Most
+#                   reliable.
+#   :validated    — works, but enforcement is best-effort (OpenRouter routes
+#                   across upstreams); lean on response healing + validation.
+#   :experimental — staging test candidate whose slug and/or fidelity still
+#                   needs confirmation. With no production yet, the matrix
+#                   doubles as the staging test bench, so candidates may land
+#                   ahead of a qualifying probe.
 class LlmModelCapability
-  STRUCTURED_OUTPUT = :structured_output
-  WEB_SEARCH = :web_search
-  WEB_FETCH = :web_fetch
-
-  # The capabilities a model must satisfy to back an AI feed. Web fetch is a
-  # bonus some models add; web search is the must-have for aggregation.
-  REQUIRED_FOR_AI_FEED = [STRUCTURED_OUTPUT, WEB_SEARCH].freeze
-
-  # `tier` records how reliably the pair honors structured output and how far
-  # to trust it:
-  #   :native       — provider enforces the schema directly (Anthropic). Most
-  #                   reliable.
-  #   :validated    — schema and web access work, but enforcement is best-effort
-  #                   (OpenRouter routes across upstreams); lean on response
-  #                   healing plus JSONSchemer validation.
-  #   :experimental — staging test candidate whose slug and/or schema fidelity
-  #                   still needs confirmation. With no production yet, the
-  #                   matrix doubles as the staging test bench, so candidates
-  #                   may land ahead of a qualifying probe.
   TIERS = %i[native validated experimental].freeze
 
-  Entry = Data.define(:provider, :model, :capabilities, :tier)
+  Entry = Data.define(:provider, :model, :tier)
 
-  # Curated set. Anthropic Opus 4.8/4.7 and Sonnet 4.6 carry native structured
-  # output plus dynamic-filtering web search and web fetch. Haiku 4.5 is the
-  # cheap Anthropic option but only has basic web search (no dynamic filtering)
-  # and its web fetch is unconfirmed.
-  #
-  # OpenRouter entries get web search and web fetch (full page content from any
-  # URL) from OpenRouter's web server tools, available across its catalog;
-  # schema enforcement is best-effort. `:experimental` slugs are cheap staging
-  # test candidates to confirm against the live catalog (Kimi in particular is
-  # known to flip to plain text instead of honoring tools/response_format). The
-  # live intersection with a credential's available_models prunes any slug that
-  # doesn't actually exist for that credential.
+  # OpenRouter web search and web fetch come from OpenRouter's web server tools
+  # (available across its catalog), so OpenRouter models clear the web bar
+  # regardless of the underlying model's native tools. `:experimental` slugs
+  # are cheap staging candidates to confirm against the live catalog (Kimi in
+  # particular is known to flip to plain text instead of honoring
+  # tools/response_format).
   MODELS = [
-    {
-      provider: "anthropic",
-      model: "claude-opus-4-8",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
-      tier: :native
-    },
-    {
-      provider: "anthropic",
-      model: "claude-opus-4-7",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
-      tier: :native
-    },
-    {
-      provider: "anthropic",
-      model: "claude-sonnet-4-6",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
-      tier: :native
-    },
-    {
-      provider: "anthropic",
-      model: "claude-haiku-4-5",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], # basic web search only; native web fetch unconfirmed
-      tier: :native
-    },
-    {
-      provider: "openrouter",
-      model: "anthropic/claude-opus-4-8",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
-      tier: :validated
-    },
-    {
-      provider: "openrouter",
-      model: "anthropic/claude-sonnet-4-6",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
-      tier: :validated
-    },
-    {
-      provider: "openrouter",
-      model: "anthropic/claude-haiku-4-5",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
-      tier: :validated
-    },
-    {
-      provider: "openrouter",
-      model: "google/gemini-2.5-flash", # verify slug
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
-      tier: :experimental
-    },
-    {
-      provider: "openrouter",
-      model: "openai/gpt-4o-mini", # verify slug
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
-      tier: :experimental
-    },
-    {
-      provider: "openrouter",
-      model: "moonshotai/kimi-k2", # flaky; staging only
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
-      tier: :experimental
-    }
-  ].map { |attrs| Entry.new(**attrs.merge(capabilities: attrs[:capabilities].freeze)) }.freeze
+    { provider: "anthropic", model: "claude-opus-4-8", tier: :native },
+    { provider: "anthropic", model: "claude-opus-4-7", tier: :native },
+    { provider: "anthropic", model: "claude-sonnet-4-6", tier: :native },
+    { provider: "openrouter", model: "anthropic/claude-opus-4-8", tier: :validated },
+    { provider: "openrouter", model: "anthropic/claude-sonnet-4-6", tier: :validated },
+    { provider: "openrouter", model: "anthropic/claude-haiku-4-5", tier: :validated },
+    { provider: "openrouter", model: "google/gemini-2.5-flash", tier: :experimental }, # verify slug
+    { provider: "openrouter", model: "openai/gpt-4o-mini", tier: :experimental }, # verify slug
+    { provider: "openrouter", model: "moonshotai/kimi-k2", tier: :experimental } # flaky; staging only
+  ].map { |attrs| Entry.new(**attrs) }.freeze
 
   INDEX = MODELS.index_by { |entry| [entry.provider, entry.model] }.freeze
 
@@ -123,23 +56,18 @@ class LlmModelCapability
       INDEX[[provider.to_s, model.to_s]]
     end
 
-    # @return [Array<Symbol>] capabilities for the pair, or [] if unknown
-    def capabilities_for(provider, model)
-      find(provider, model)&.capabilities || []
+    # Membership is qualification: every listed pair supports the full AI-feed
+    # feature set, so this is the gate for backing an AI feed.
+    def supported?(provider, model)
+      INDEX.key?([provider.to_s, model.to_s])
     end
 
     def tier_for(provider, model)
       find(provider, model)&.tier
     end
 
-    # True when the pair carries every capability an AI feed requires.
-    def qualified_for_ai_feed?(provider, model)
-      capabilities = capabilities_for(provider, model)
-      REQUIRED_FOR_AI_FEED.all? { |capability| capabilities.include?(capability) }
-    end
-
-    def qualified_models_for(provider)
-      MODELS.select { |entry| entry.provider == provider.to_s && qualified_for_ai_feed?(entry.provider, entry.model) }
+    def models_for(provider)
+      MODELS.select { |entry| entry.provider == provider.to_s }
     end
   end
 end

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -13,12 +13,6 @@
 # adapter's concern, and entries are meant to be qualified empirically by a
 # smoke probe before they land here rather than trusted from docs alone.
 #
-# `tier` records how reliably the pair honors structured output:
-#   :native    — provider enforces the schema and hosts web access directly
-#                (Anthropic). Most reliable.
-#   :validated — schema and web access work, but enforcement is best-effort
-#                (OpenRouter routes across upstreams); lean on response
-#                healing plus JSONSchemer validation.
 class LlmModelCapability
   STRUCTURED_OUTPUT = :structured_output
   WEB_SEARCH = :web_search
@@ -28,17 +22,43 @@ class LlmModelCapability
   # bonus some models add; web search is the must-have for aggregation.
   REQUIRED_FOR_AI_FEED = [STRUCTURED_OUTPUT, WEB_SEARCH].freeze
 
+  # `tier` records how reliably the pair honors structured output and how far
+  # to trust it:
+  #   :native       — provider enforces the schema directly (Anthropic). Most
+  #                   reliable.
+  #   :validated    — schema and web access work, but enforcement is best-effort
+  #                   (OpenRouter routes across upstreams); lean on response
+  #                   healing plus JSONSchemer validation.
+  #   :experimental — staging test candidate whose slug and/or schema fidelity
+  #                   still needs confirmation. With no production yet, the
+  #                   matrix doubles as the staging test bench, so candidates
+  #                   may land ahead of a qualifying probe.
+  TIERS = %i[native validated experimental].freeze
+
   Entry = Data.define(:provider, :model, :capabilities, :tier)
 
-  # Qualified starter set. OpenRouter currently carries the Anthropic family
-  # only; more upstreams (OpenAI, Gemini) get added once the qualification
-  # probe confirms web + schema together, not from capability flags alone.
+  # Curated set. Anthropic Opus 4.8/4.7 and Sonnet 4.6 carry native structured
+  # output plus dynamic-filtering web search and web fetch. Haiku 4.5 is the
+  # cheap Anthropic option but only has basic web search (no dynamic filtering)
+  # and its web fetch is unconfirmed.
+  #
+  # OpenRouter entries get web access from the `web` plugin; schema enforcement
+  # is best-effort. `:experimental` slugs are cheap staging test candidates to
+  # confirm against the live catalog (Kimi in particular is known to flip to
+  # plain text instead of honoring tools/response_format). The live
+  # intersection with a credential's available_models prunes any slug that
+  # doesn't actually exist for that credential.
   MODELS = [
     { provider: "anthropic", model: "claude-opus-4-8", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH], tier: :native },
     { provider: "anthropic", model: "claude-opus-4-7", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH], tier: :native },
     { provider: "anthropic", model: "claude-sonnet-4-6", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH], tier: :native },
+    { provider: "anthropic", model: "claude-haiku-4-5", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :native }, # basic web search only
     { provider: "openrouter", model: "anthropic/claude-opus-4-8", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :validated },
-    { provider: "openrouter", model: "anthropic/claude-sonnet-4-6", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :validated }
+    { provider: "openrouter", model: "anthropic/claude-sonnet-4-6", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :validated },
+    { provider: "openrouter", model: "anthropic/claude-haiku-4-5", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :validated },
+    { provider: "openrouter", model: "google/gemini-2.5-flash", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :experimental }, # verify slug
+    { provider: "openrouter", model: "openai/gpt-4o-mini", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :experimental }, # verify slug
+    { provider: "openrouter", model: "moonshotai/kimi-k2", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :experimental } # flaky; staging only
   ].map { |attrs| Entry.new(**attrs.merge(capabilities: attrs[:capabilities].freeze)) }.freeze
 
   INDEX = MODELS.index_by { |entry| [entry.provider, entry.model] }.freeze

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -3,46 +3,33 @@
 #
 # Every AI feed needs the same full feature set — structured output, web
 # search, and web fetch — so membership *is* qualification: a pair earns a
-# place here only once it's known to deliver all three. There's no per-entry
-# capability flag; a model that can't do the full set simply isn't listed.
+# place here only once it's known to deliver all three. A model that can't do
+# the full set simply isn't listed.
 #
 # Callers intersect this list with a credential's live `available_models`, so a
 # curated model the provider has since dropped falls out of the picker on its
 # own. How the adapter wires each provider (Anthropic server tools vs
 # OpenRouter web server tools) is the adapter's concern, and entries are meant
 # to be qualified empirically by a smoke probe before they land here.
-#
-# `tier` records how reliably the pair honors structured output and how far to
-# trust it:
-#   :native       — provider enforces the schema directly (Anthropic). Most
-#                   reliable.
-#   :validated    — works, but enforcement is best-effort (OpenRouter routes
-#                   across upstreams); lean on response healing + validation.
-#   :experimental — staging test candidate whose slug and/or fidelity still
-#                   needs confirmation. With no production yet, the matrix
-#                   doubles as the staging test bench, so candidates may land
-#                   ahead of a qualifying probe.
 class LlmModelCapability
-  TIERS = %i[native validated experimental].freeze
-
-  Entry = Data.define(:provider, :model, :tier)
+  Entry = Data.define(:provider, :model)
 
   # OpenRouter web search and web fetch come from OpenRouter's web server tools
   # (available across its catalog), so OpenRouter models clear the web bar
-  # regardless of the underlying model's native tools. `:experimental` slugs
-  # are cheap staging candidates to confirm against the live catalog (Kimi in
+  # regardless of the underlying model's native tools. Slugs flagged below are
+  # cheap staging candidates to confirm against the live catalog (Kimi in
   # particular is known to flip to plain text instead of honoring
   # tools/response_format).
   MODELS = [
-    { provider: "anthropic", model: "claude-opus-4-8", tier: :native },
-    { provider: "anthropic", model: "claude-opus-4-7", tier: :native },
-    { provider: "anthropic", model: "claude-sonnet-4-6", tier: :native },
-    { provider: "openrouter", model: "anthropic/claude-opus-4-8", tier: :validated },
-    { provider: "openrouter", model: "anthropic/claude-sonnet-4-6", tier: :validated },
-    { provider: "openrouter", model: "anthropic/claude-haiku-4-5", tier: :validated },
-    { provider: "openrouter", model: "google/gemini-2.5-flash", tier: :experimental }, # verify slug
-    { provider: "openrouter", model: "openai/gpt-4o-mini", tier: :experimental }, # verify slug
-    { provider: "openrouter", model: "moonshotai/kimi-k2", tier: :experimental } # flaky; staging only
+    { provider: "anthropic", model: "claude-opus-4-8" },
+    { provider: "anthropic", model: "claude-opus-4-7" },
+    { provider: "anthropic", model: "claude-sonnet-4-6" },
+    { provider: "openrouter", model: "anthropic/claude-opus-4-8" },
+    { provider: "openrouter", model: "anthropic/claude-sonnet-4-6" },
+    { provider: "openrouter", model: "anthropic/claude-haiku-4-5" },
+    { provider: "openrouter", model: "google/gemini-2.5-flash" }, # verify slug
+    { provider: "openrouter", model: "openai/gpt-4o-mini" }, # verify slug
+    { provider: "openrouter", model: "moonshotai/kimi-k2" } # flaky; staging only
   ].map { |attrs| Entry.new(**attrs) }.freeze
 
   INDEX = MODELS.index_by { |entry| [entry.provider, entry.model] }.freeze
@@ -60,10 +47,6 @@ class LlmModelCapability
     # feature set, so this is the gate for backing an AI feed.
     def supported?(provider, model)
       INDEX.key?([provider.to_s, model.to_s])
-    end
-
-    def tier_for(provider, model)
-      find(provider, model)&.tier
     end
 
     def models_for(provider)

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -42,11 +42,12 @@ class LlmModelCapability
   # cheap Anthropic option but only has basic web search (no dynamic filtering)
   # and its web fetch is unconfirmed.
   #
-  # OpenRouter entries get web access from the `web` plugin; schema enforcement
-  # is best-effort. `:experimental` slugs are cheap staging test candidates to
-  # confirm against the live catalog (Kimi in particular is known to flip to
-  # plain text instead of honoring tools/response_format). The live
-  # intersection with a credential's available_models prunes any slug that
+  # OpenRouter entries get web search and web fetch (full page content from any
+  # URL) from OpenRouter's web server tools, available across its catalog;
+  # schema enforcement is best-effort. `:experimental` slugs are cheap staging
+  # test candidates to confirm against the live catalog (Kimi in particular is
+  # known to flip to plain text instead of honoring tools/response_format). The
+  # live intersection with a credential's available_models prunes any slug that
   # doesn't actually exist for that credential.
   MODELS = [
     {
@@ -70,43 +71,43 @@ class LlmModelCapability
     {
       provider: "anthropic",
       model: "claude-haiku-4-5",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], # basic web search only
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], # basic web search only; native web fetch unconfirmed
       tier: :native
     },
     {
       provider: "openrouter",
       model: "anthropic/claude-opus-4-8",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
       tier: :validated
     },
     {
       provider: "openrouter",
       model: "anthropic/claude-sonnet-4-6",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
       tier: :validated
     },
     {
       provider: "openrouter",
       model: "anthropic/claude-haiku-4-5",
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
       tier: :validated
     },
     {
       provider: "openrouter",
       model: "google/gemini-2.5-flash", # verify slug
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
       tier: :experimental
     },
     {
       provider: "openrouter",
       model: "openai/gpt-4o-mini", # verify slug
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
       tier: :experimental
     },
     {
       provider: "openrouter",
       model: "moonshotai/kimi-k2", # flaky; staging only
-      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
       tier: :experimental
     }
   ].map { |attrs| Entry.new(**attrs.merge(capabilities: attrs[:capabilities].freeze)) }.freeze

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -49,16 +49,66 @@ class LlmModelCapability
   # intersection with a credential's available_models prunes any slug that
   # doesn't actually exist for that credential.
   MODELS = [
-    { provider: "anthropic", model: "claude-opus-4-8", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH], tier: :native },
-    { provider: "anthropic", model: "claude-opus-4-7", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH], tier: :native },
-    { provider: "anthropic", model: "claude-sonnet-4-6", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH], tier: :native },
-    { provider: "anthropic", model: "claude-haiku-4-5", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :native }, # basic web search only
-    { provider: "openrouter", model: "anthropic/claude-opus-4-8", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :validated },
-    { provider: "openrouter", model: "anthropic/claude-sonnet-4-6", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :validated },
-    { provider: "openrouter", model: "anthropic/claude-haiku-4-5", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :validated },
-    { provider: "openrouter", model: "google/gemini-2.5-flash", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :experimental }, # verify slug
-    { provider: "openrouter", model: "openai/gpt-4o-mini", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :experimental }, # verify slug
-    { provider: "openrouter", model: "moonshotai/kimi-k2", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :experimental } # flaky; staging only
+    {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
+      tier: :native
+    },
+    {
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
+      tier: :native
+    },
+    {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH],
+      tier: :native
+    },
+    {
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], # basic web search only
+      tier: :native
+    },
+    {
+      provider: "openrouter",
+      model: "anthropic/claude-opus-4-8",
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      tier: :validated
+    },
+    {
+      provider: "openrouter",
+      model: "anthropic/claude-sonnet-4-6",
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      tier: :validated
+    },
+    {
+      provider: "openrouter",
+      model: "anthropic/claude-haiku-4-5",
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      tier: :validated
+    },
+    {
+      provider: "openrouter",
+      model: "google/gemini-2.5-flash", # verify slug
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      tier: :experimental
+    },
+    {
+      provider: "openrouter",
+      model: "openai/gpt-4o-mini", # verify slug
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      tier: :experimental
+    },
+    {
+      provider: "openrouter",
+      model: "moonshotai/kimi-k2", # flaky; staging only
+      capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH],
+      tier: :experimental
+    }
   ].map { |attrs| Entry.new(**attrs.merge(capabilities: attrs[:capabilities].freeze)) }.freeze
 
   INDEX = MODELS.index_by { |entry| [entry.provider, entry.model] }.freeze

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -1,0 +1,90 @@
+# Curated allowlist of (provider, model) pairs the system will run AI feeds
+# on, annotated with the capabilities each pair satisfies. Code-only and
+# reviewable, parallel to `LlmProvider` and `FeedProfile`.
+#
+# This is a deliberate gate, not auto-discovery. A model earns a place here
+# only once it's known to deliver what an AI feed needs (structured output
+# plus web access). Callers intersect this list with a credential's live
+# `available_models` so a curated model the provider has since dropped falls
+# out of the picker on its own.
+#
+# Entries describe model-level capability. Whether our adapter wires a given
+# capability for a provider (e.g. Anthropic server tools via RubyLLM) is the
+# adapter's concern, and entries are meant to be qualified empirically by a
+# smoke probe before they land here rather than trusted from docs alone.
+#
+# `tier` records how reliably the pair honors structured output:
+#   :native    — provider enforces the schema and hosts web access directly
+#                (Anthropic). Most reliable.
+#   :validated — schema and web access work, but enforcement is best-effort
+#                (OpenRouter routes across upstreams); lean on response
+#                healing plus JSONSchemer validation.
+class LlmModelCapability
+  STRUCTURED_OUTPUT = :structured_output
+  WEB_SEARCH = :web_search
+  WEB_FETCH = :web_fetch
+
+  # The capabilities a model must satisfy to back an AI feed. Web fetch is a
+  # bonus some models add; web search is the must-have for aggregation.
+  REQUIRED_FOR_AI_FEED = [STRUCTURED_OUTPUT, WEB_SEARCH].freeze
+
+  Entry = Data.define(:provider, :model, :capabilities, :tier)
+
+  # Qualified starter set. OpenRouter currently carries the Anthropic family
+  # only; more upstreams (OpenAI, Gemini) get added once the qualification
+  # probe confirms web + schema together, not from capability flags alone.
+  MODELS = [
+    { provider: "anthropic", model: "claude-opus-4-8", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH], tier: :native },
+    { provider: "anthropic", model: "claude-opus-4-7", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH], tier: :native },
+    { provider: "anthropic", model: "claude-sonnet-4-6", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH, WEB_FETCH], tier: :native },
+    { provider: "openrouter", model: "anthropic/claude-opus-4-8", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :validated },
+    { provider: "openrouter", model: "anthropic/claude-sonnet-4-6", capabilities: [STRUCTURED_OUTPUT, WEB_SEARCH], tier: :validated }
+  ].map { |attrs| Entry.new(**attrs.merge(capabilities: attrs[:capabilities].freeze)) }.freeze
+
+  INDEX = MODELS.index_by { |entry| [entry.provider, entry.model] }.freeze
+
+  class << self
+    def all
+      MODELS
+    end
+
+    def find(provider, model)
+      INDEX[[provider.to_s, model.to_s]]
+    end
+
+    def supported?(provider, model)
+      INDEX.key?([provider.to_s, model.to_s])
+    end
+
+    # @return [Array<Symbol>] capabilities for the pair, or [] if unknown
+    def capabilities_for(provider, model)
+      find(provider, model)&.capabilities || []
+    end
+
+    def capable?(provider, model, capability)
+      capabilities_for(provider, model).include?(capability)
+    end
+
+    # True when the pair satisfies every capability in `required`.
+    def meets?(provider, model, required = REQUIRED_FOR_AI_FEED)
+      capabilities = capabilities_for(provider, model)
+      required.all? { |capability| capabilities.include?(capability) }
+    end
+
+    def qualified_for_ai_feed?(provider, model)
+      meets?(provider, model)
+    end
+
+    def models_for(provider)
+      MODELS.select { |entry| entry.provider == provider.to_s }
+    end
+
+    def qualified_models_for(provider)
+      models_for(provider).select { |entry| qualified_for_ai_feed?(entry.provider, entry.model) }
+    end
+
+    def tier_for(provider, model)
+      find(provider, model)&.tier
+    end
+  end
+end

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -122,39 +122,23 @@ class LlmModelCapability
       INDEX[[provider.to_s, model.to_s]]
     end
 
-    def supported?(provider, model)
-      INDEX.key?([provider.to_s, model.to_s])
-    end
-
     # @return [Array<Symbol>] capabilities for the pair, or [] if unknown
     def capabilities_for(provider, model)
       find(provider, model)&.capabilities || []
     end
 
-    def capable?(provider, model, capability)
-      capabilities_for(provider, model).include?(capability)
+    def tier_for(provider, model)
+      find(provider, model)&.tier
     end
 
-    # True when the pair satisfies every capability in `required`.
-    def meets?(provider, model, required = REQUIRED_FOR_AI_FEED)
-      capabilities = capabilities_for(provider, model)
-      required.all? { |capability| capabilities.include?(capability) }
-    end
-
+    # True when the pair carries every capability an AI feed requires.
     def qualified_for_ai_feed?(provider, model)
-      meets?(provider, model)
-    end
-
-    def models_for(provider)
-      MODELS.select { |entry| entry.provider == provider.to_s }
+      capabilities = capabilities_for(provider, model)
+      REQUIRED_FOR_AI_FEED.all? { |capability| capabilities.include?(capability) }
     end
 
     def qualified_models_for(provider)
-      models_for(provider).select { |entry| qualified_for_ai_feed?(entry.provider, entry.model) }
-    end
-
-    def tier_for(provider, model)
-      find(provider, model)&.tier
+      MODELS.select { |entry| entry.provider == provider.to_s && qualified_for_ai_feed?(entry.provider, entry.model) }
     end
   end
 end

--- a/test/models/llm_model_capability_test.rb
+++ b/test/models/llm_model_capability_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class LlmModelCapabilityTest < ActiveSupport::TestCase
+  test "#supported? should be true for a curated pair" do
+    assert LlmModelCapability.supported?("anthropic", "claude-sonnet-4-6")
+  end
+
+  test "#supported? should be false for an unknown pair" do
+    assert_not LlmModelCapability.supported?("anthropic", "made-up-model")
+    assert_not LlmModelCapability.supported?("nope", "claude-sonnet-4-6")
+  end
+
+  test "#supported? should accept symbol providers" do
+    assert LlmModelCapability.supported?(:anthropic, "claude-sonnet-4-6")
+  end
+
+  test "#capabilities_for should return the pair's capabilities" do
+    capabilities = LlmModelCapability.capabilities_for("anthropic", "claude-opus-4-8")
+
+    assert_includes capabilities, LlmModelCapability::STRUCTURED_OUTPUT
+    assert_includes capabilities, LlmModelCapability::WEB_SEARCH
+    assert_includes capabilities, LlmModelCapability::WEB_FETCH
+  end
+
+  test "#capabilities_for should return an empty array for an unknown pair" do
+    assert_empty LlmModelCapability.capabilities_for("anthropic", "made-up-model")
+  end
+
+  test "#capable? should reflect a single capability" do
+    assert LlmModelCapability.capable?("anthropic", "claude-sonnet-4-6", LlmModelCapability::WEB_FETCH)
+    assert_not LlmModelCapability.capable?("openrouter", "anthropic/claude-sonnet-4-6", LlmModelCapability::WEB_FETCH)
+  end
+
+  test "#meets? should require every listed capability" do
+    assert LlmModelCapability.meets?("anthropic", "claude-sonnet-4-6", [LlmModelCapability::STRUCTURED_OUTPUT])
+    assert_not LlmModelCapability.meets?(
+      "openrouter", "anthropic/claude-sonnet-4-6",
+      [LlmModelCapability::STRUCTURED_OUTPUT, LlmModelCapability::WEB_FETCH]
+    )
+  end
+
+  test "#qualified_for_ai_feed? should be true when the required set is met" do
+    assert LlmModelCapability.qualified_for_ai_feed?("openrouter", "anthropic/claude-sonnet-4-6")
+  end
+
+  test "#qualified_for_ai_feed? should be false for an unknown pair" do
+    assert_not LlmModelCapability.qualified_for_ai_feed?("anthropic", "made-up-model")
+  end
+
+  test "#models_for should return only that provider's entries" do
+    entries = LlmModelCapability.models_for("anthropic")
+
+    assert entries.any?
+    assert(entries.all? { |entry| entry.provider == "anthropic" })
+  end
+
+  test "#qualified_models_for should return entries meeting the required set" do
+    entries = LlmModelCapability.qualified_models_for("openrouter")
+
+    assert entries.any?
+    assert(entries.all? { |entry| LlmModelCapability.qualified_for_ai_feed?(entry.provider, entry.model) })
+  end
+
+  test "#tier_for should return the reliability tier" do
+    assert_equal :native, LlmModelCapability.tier_for("anthropic", "claude-opus-4-8")
+    assert_equal :validated, LlmModelCapability.tier_for("openrouter", "anthropic/claude-sonnet-4-6")
+    assert_nil LlmModelCapability.tier_for("anthropic", "made-up-model")
+  end
+
+  test "every curated provider should be a known LlmProvider" do
+    providers = LlmModelCapability.all.map(&:provider).uniq
+
+    providers.each { |provider| assert LlmProvider.exists?(provider), "#{provider} is not a known LlmProvider" }
+  end
+
+  test "every curated entry should qualify for an AI feed" do
+    LlmModelCapability.all.each do |entry|
+      assert LlmModelCapability.qualified_for_ai_feed?(entry.provider, entry.model),
+             "#{entry.provider}/#{entry.model} does not meet REQUIRED_FOR_AI_FEED"
+    end
+  end
+end

--- a/test/models/llm_model_capability_test.rb
+++ b/test/models/llm_model_capability_test.rb
@@ -79,4 +79,15 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
              "#{entry.provider}/#{entry.model} does not meet REQUIRED_FOR_AI_FEED"
     end
   end
+
+  test "every curated entry should carry a known tier" do
+    LlmModelCapability.all.each do |entry|
+      assert_includes LlmModelCapability::TIERS, entry.tier,
+                      "#{entry.provider}/#{entry.model} has unknown tier #{entry.tier}"
+    end
+  end
+
+  test "#qualified_for_ai_feed? should include the cheap Haiku option" do
+    assert LlmModelCapability.qualified_for_ai_feed?("anthropic", "claude-haiku-4-5")
+  end
 end

--- a/test/models/llm_model_capability_test.rb
+++ b/test/models/llm_model_capability_test.rb
@@ -6,7 +6,6 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
 
     assert_equal "anthropic", entry.provider
     assert_equal "claude-sonnet-4-6", entry.model
-    assert_equal :native, entry.tier
   end
 
   test "#find should accept symbol providers" do
@@ -31,12 +30,6 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
     assert LlmModelCapability.supported?("openrouter", "anthropic/claude-haiku-4-5")
   end
 
-  test "#tier_for should return the reliability tier" do
-    assert_equal :native, LlmModelCapability.tier_for("anthropic", "claude-opus-4-8")
-    assert_equal :validated, LlmModelCapability.tier_for("openrouter", "anthropic/claude-sonnet-4-6")
-    assert_nil LlmModelCapability.tier_for("anthropic", "made-up-model")
-  end
-
   test "#models_for should return only that provider's entries" do
     entries = LlmModelCapability.models_for("anthropic")
 
@@ -48,12 +41,5 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
     providers = LlmModelCapability.all.map(&:provider).uniq
 
     providers.each { |provider| assert LlmProvider.exists?(provider), "#{provider} is not a known LlmProvider" }
-  end
-
-  test "every curated entry should carry a known tier" do
-    LlmModelCapability.all.each do |entry|
-      assert_includes LlmModelCapability::TIERS, entry.tier,
-                      "#{entry.provider}/#{entry.model} has unknown tier #{entry.tier}"
-    end
   end
 end

--- a/test/models/llm_model_capability_test.rb
+++ b/test/models/llm_model_capability_test.rb
@@ -1,17 +1,20 @@
 require "test_helper"
 
 class LlmModelCapabilityTest < ActiveSupport::TestCase
-  test "#supported? should be true for a curated pair" do
-    assert LlmModelCapability.supported?("anthropic", "claude-sonnet-4-6")
+  test "#find should return the entry for a curated pair" do
+    entry = LlmModelCapability.find("anthropic", "claude-sonnet-4-6")
+
+    assert_equal "anthropic", entry.provider
+    assert_equal "claude-sonnet-4-6", entry.model
   end
 
-  test "#supported? should be false for an unknown pair" do
-    assert_not LlmModelCapability.supported?("anthropic", "made-up-model")
-    assert_not LlmModelCapability.supported?("nope", "claude-sonnet-4-6")
+  test "#find should accept symbol providers" do
+    assert LlmModelCapability.find(:anthropic, "claude-sonnet-4-6")
   end
 
-  test "#supported? should accept symbol providers" do
-    assert LlmModelCapability.supported?(:anthropic, "claude-sonnet-4-6")
+  test "#find should return nil for an unknown pair" do
+    assert_nil LlmModelCapability.find("anthropic", "made-up-model")
+    assert_nil LlmModelCapability.find("nope", "claude-sonnet-4-6")
   end
 
   test "#capabilities_for should return the pair's capabilities" do
@@ -26,17 +29,10 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
     assert_empty LlmModelCapability.capabilities_for("anthropic", "made-up-model")
   end
 
-  test "#capable? should reflect a single capability" do
-    assert LlmModelCapability.capable?("anthropic", "claude-sonnet-4-6", LlmModelCapability::WEB_FETCH)
-    assert_not LlmModelCapability.capable?("openrouter", "anthropic/claude-sonnet-4-6", LlmModelCapability::WEB_FETCH)
-  end
-
-  test "#meets? should require every listed capability" do
-    assert LlmModelCapability.meets?("anthropic", "claude-sonnet-4-6", [LlmModelCapability::STRUCTURED_OUTPUT])
-    assert_not LlmModelCapability.meets?(
-      "openrouter", "anthropic/claude-sonnet-4-6",
-      [LlmModelCapability::STRUCTURED_OUTPUT, LlmModelCapability::WEB_FETCH]
-    )
+  test "#tier_for should return the reliability tier" do
+    assert_equal :native, LlmModelCapability.tier_for("anthropic", "claude-opus-4-8")
+    assert_equal :validated, LlmModelCapability.tier_for("openrouter", "anthropic/claude-sonnet-4-6")
+    assert_nil LlmModelCapability.tier_for("anthropic", "made-up-model")
   end
 
   test "#qualified_for_ai_feed? should be true when the required set is met" do
@@ -47,24 +43,16 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
     assert_not LlmModelCapability.qualified_for_ai_feed?("anthropic", "made-up-model")
   end
 
-  test "#models_for should return only that provider's entries" do
-    entries = LlmModelCapability.models_for("anthropic")
-
-    assert entries.any?
-    assert(entries.all? { |entry| entry.provider == "anthropic" })
+  test "#qualified_for_ai_feed? should include the cheap Haiku option" do
+    assert LlmModelCapability.qualified_for_ai_feed?("anthropic", "claude-haiku-4-5")
   end
 
   test "#qualified_models_for should return entries meeting the required set" do
     entries = LlmModelCapability.qualified_models_for("openrouter")
 
     assert entries.any?
+    assert(entries.all? { |entry| entry.provider == "openrouter" })
     assert(entries.all? { |entry| LlmModelCapability.qualified_for_ai_feed?(entry.provider, entry.model) })
-  end
-
-  test "#tier_for should return the reliability tier" do
-    assert_equal :native, LlmModelCapability.tier_for("anthropic", "claude-opus-4-8")
-    assert_equal :validated, LlmModelCapability.tier_for("openrouter", "anthropic/claude-sonnet-4-6")
-    assert_nil LlmModelCapability.tier_for("anthropic", "made-up-model")
   end
 
   test "every curated provider should be a known LlmProvider" do
@@ -85,9 +73,5 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
       assert_includes LlmModelCapability::TIERS, entry.tier,
                       "#{entry.provider}/#{entry.model} has unknown tier #{entry.tier}"
     end
-  end
-
-  test "#qualified_for_ai_feed? should include the cheap Haiku option" do
-    assert LlmModelCapability.qualified_for_ai_feed?("anthropic", "claude-haiku-4-5")
   end
 end

--- a/test/models/llm_model_capability_test.rb
+++ b/test/models/llm_model_capability_test.rb
@@ -6,6 +6,7 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
 
     assert_equal "anthropic", entry.provider
     assert_equal "claude-sonnet-4-6", entry.model
+    assert_equal :native, entry.tier
   end
 
   test "#find should accept symbol providers" do
@@ -17,16 +18,17 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
     assert_nil LlmModelCapability.find("nope", "claude-sonnet-4-6")
   end
 
-  test "#capabilities_for should return the pair's capabilities" do
-    capabilities = LlmModelCapability.capabilities_for("anthropic", "claude-opus-4-8")
-
-    assert_includes capabilities, LlmModelCapability::STRUCTURED_OUTPUT
-    assert_includes capabilities, LlmModelCapability::WEB_SEARCH
-    assert_includes capabilities, LlmModelCapability::WEB_FETCH
+  test "#supported? should be true for a curated pair" do
+    assert LlmModelCapability.supported?("anthropic", "claude-opus-4-8")
   end
 
-  test "#capabilities_for should return an empty array for an unknown pair" do
-    assert_empty LlmModelCapability.capabilities_for("anthropic", "made-up-model")
+  test "#supported? should be false for an unknown pair" do
+    assert_not LlmModelCapability.supported?("anthropic", "made-up-model")
+    assert_not LlmModelCapability.supported?("nope", "claude-opus-4-8")
+  end
+
+  test "#supported? should include the cheap Haiku option via OpenRouter" do
+    assert LlmModelCapability.supported?("openrouter", "anthropic/claude-haiku-4-5")
   end
 
   test "#tier_for should return the reliability tier" do
@@ -35,37 +37,17 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
     assert_nil LlmModelCapability.tier_for("anthropic", "made-up-model")
   end
 
-  test "#qualified_for_ai_feed? should be true when the required set is met" do
-    assert LlmModelCapability.qualified_for_ai_feed?("openrouter", "anthropic/claude-sonnet-4-6")
-  end
-
-  test "#qualified_for_ai_feed? should be false for an unknown pair" do
-    assert_not LlmModelCapability.qualified_for_ai_feed?("anthropic", "made-up-model")
-  end
-
-  test "#qualified_for_ai_feed? should include the cheap Haiku option" do
-    assert LlmModelCapability.qualified_for_ai_feed?("anthropic", "claude-haiku-4-5")
-  end
-
-  test "#qualified_models_for should return entries meeting the required set" do
-    entries = LlmModelCapability.qualified_models_for("openrouter")
+  test "#models_for should return only that provider's entries" do
+    entries = LlmModelCapability.models_for("anthropic")
 
     assert entries.any?
-    assert(entries.all? { |entry| entry.provider == "openrouter" })
-    assert(entries.all? { |entry| LlmModelCapability.qualified_for_ai_feed?(entry.provider, entry.model) })
+    assert(entries.all? { |entry| entry.provider == "anthropic" })
   end
 
   test "every curated provider should be a known LlmProvider" do
     providers = LlmModelCapability.all.map(&:provider).uniq
 
     providers.each { |provider| assert LlmProvider.exists?(provider), "#{provider} is not a known LlmProvider" }
-  end
-
-  test "every curated entry should qualify for an AI feed" do
-    LlmModelCapability.all.each do |entry|
-      assert LlmModelCapability.qualified_for_ai_feed?(entry.provider, entry.model),
-             "#{entry.provider}/#{entry.model} does not meet REQUIRED_FOR_AI_FEED"
-    end
   end
 
   test "every curated entry should carry a known tier" do


### PR DESCRIPTION
Changes:

- Add a curated capability matrix of (provider, model) pairs qualified to back AI feeds, each annotated with its capabilities (structured output, web search/fetch) and a reliability tier.
- Provide a query API for "is this pair qualified for an AI feed?", which the model picker and credential validation will consume later.

First task of the AI-stack work in #876. The matrix is a deliberate, code-defined gate rather than auto-discovery: a pair earns a place only once it's known to deliver structured output plus web access. Callers are meant to intersect it with a credential's live models, so a curated entry the provider has since dropped falls out on its own. The per-provider adapter that satisfies these capabilities, the live intersection, and the qualification probe are separate follow-up tasks.

References:

- Part of #876
