### PR TITLE
Add feed UX + AI overhaul design spec and first track plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ When writing instructions or explanations:
 
 ## Specs
 
-Specs in `specs/` are historical records committed **together with their implementation**. A spec directory appears in the repo only when the described work has shipped. They are ordered chronologically (`001-`, `002-`, …). If the codebase diverges from a spec's text, a later spec or PR evolved the design — the code is the source of truth, the spec is the rationale record.
+Specs in `specs/` are design and rationale records, ordered chronologically (`001-`, `002-`, …). A spec may be written before implementation and delivered across **multiple PRs**, so a spec directory can exist ahead of (or alongside) the shipped work. If the codebase diverges from a spec's text, a later spec or PR evolved the design — the code is the source of truth, the spec is the rationale record.
 
 ## Error Reporting
 

--- a/specs/005-feed-creation-ux-ai-overhaul/plan-01-uid-integrity.md
+++ b/specs/005-feed-creation-ux-ai-overhaul/plan-01-uid-integrity.md
@@ -1,0 +1,285 @@
+# uid Integrity Implementation Plan (Track 1 of 6)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make AI-feed post uids stable across runs by deriving them from the item's source permalink (system-normalized) instead of trusting a model-supplied `uid`.
+
+**Architecture:** Introduce a pure, unit-tested `Uid::Resolver` that turns an AI-extracted item into a stable uid by normalizing its `source_url` permalink (lowercase scheme/host, drop fragment, strip tracking query params, canonicalize trailing slash). `PassthroughProcessor` calls it instead of reading `item["uid"]`. Items without a usable deep-link permalink are dropped, exactly as today — so this is a strict improvement with no behaviour change for digests yet.
+
+**Tech Stack:** Ruby (mise-managed), Rails edge, Minitest + FactoryBot, RuboCop.
+
+**Spec:** [`spec.md`](./spec.md) §3 (uid contract). This plan delivers the permalink-normalization core of §3. The **digest/period-keyed fallback** and the **explicit model regime signal** are deferred to Track 4 (Single AI profile), where the output schema and system prompt change.
+
+## Global Constraints
+
+- Ruby/Node via mise; run binstubs directly in local dev: `bin/rails test`, `bin/rubocop -f github`. (Remote Claude Code env: prefix with `docker compose exec app`.)
+- Minitest with FactoryBot; create test data with factories, lazy (memoized helper methods, not eager `setup`).
+- Unit-test naming: `test "#method should ..."`.
+- Always end source files with a trailing newline.
+- Fix RuboCop violations after each change: `bin/rubocop -f github`.
+- Report handled exceptions via `Rails.error.report(e, context: {...})`.
+- Atomic commits, short imperative subjects ≤ 50 chars. No CHANGELOG entry — this change is internal (no user-facing behaviour change).
+
+## File Structure
+
+- `app/services/uid/resolver.rb` — new. Pure service: `Uid::Resolver.call(item, clock:) -> String | nil`. One responsibility: derive a stable uid string from an item, or `nil` when no usable permalink exists.
+- `app/services/processor/passthrough_processor.rb` — modify. Replace the `item["uid"]` read with a `Uid::Resolver.call` call; keep the existing blank-uid drop.
+- `test/services/uid/resolver_test.rb` — new. Unit tests for the resolver (no DB).
+- `test/services/processor/passthrough_processor_test.rb` — new or modify. Pipeline-level tests, including run-twice uid stability.
+
+---
+
+### Task 1: `Uid::Resolver`
+
+**Files:**
+- Create: `app/services/uid/resolver.rb`
+- Test: `test/services/uid/resolver_test.rb`
+
+**Interfaces:**
+- Consumes: nothing (pure; `item` is a `Hash` with string or symbol keys, `clock` responds to `#to_date`).
+- Produces: `Uid::Resolver.call(item, clock:) -> String | nil`. Returns a normalized URL string for a usable deep-link `source_url`; returns `nil` when `source_url` is missing, unparseable, non-HTTP, or a bare homepage.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/services/uid/resolver_test.rb`:
+
+```ruby
+require "test_helper"
+
+class Uid::ResolverTest < ActiveSupport::TestCase
+  def clock = Time.utc(2026, 6, 29, 10, 0, 0)
+
+  test "#call should normalize a deep-link permalink into a uid" do
+    item = { "source_url" => "https://Example.COM/Blog/Post-1/" }
+    assert_equal "https://example.com/Blog/Post-1", Uid::Resolver.call(item, clock: clock)
+  end
+
+  test "#call should strip tracking params and fragments" do
+    item = { "source_url" => "https://example.com/p/9?utm_source=rss&id=7&fbclid=abc#top" }
+    assert_equal "https://example.com/p/9?id=7", Uid::Resolver.call(item, clock: clock)
+  end
+
+  test "#call should drop a query that is only tracking params" do
+    item = { "source_url" => "https://example.com/p/9?utm_source=rss" }
+    assert_equal "https://example.com/p/9", Uid::Resolver.call(item, clock: clock)
+  end
+
+  test "#call should accept symbol keys" do
+    item = { source_url: "https://example.com/a" }
+    assert_equal "https://example.com/a", Uid::Resolver.call(item, clock: clock)
+  end
+
+  test "#call should return nil for a bare homepage" do
+    assert_nil Uid::Resolver.call({ "source_url" => "https://example.com/" }, clock: clock)
+  end
+
+  test "#call should return nil when source_url is missing" do
+    assert_nil Uid::Resolver.call({ "body" => "hi" }, clock: clock)
+  end
+
+  test "#call should return nil for a non-http or malformed url" do
+    assert_nil Uid::Resolver.call({ "source_url" => "ftp://example.com/x" }, clock: clock)
+    assert_nil Uid::Resolver.call({ "source_url" => "not a url" }, clock: clock)
+  end
+
+  test "#call should be identical across runs for the same permalink" do
+    item = { "source_url" => "https://example.com/post/1" }
+    first = Uid::Resolver.call(item, clock: clock)
+    second = Uid::Resolver.call(item, clock: Time.utc(2026, 7, 1))
+    assert_equal first, second
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/services/uid/resolver_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Uid` (resolver doesn't exist yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `app/services/uid/resolver.rb`:
+
+```ruby
+module Uid
+  # Derives a stable post uid from an AI-extracted item, anchored to source
+  # identity rather than generated content (summaries change every run, so a
+  # content hash would break dedup). A usable deep-link permalink becomes a
+  # normalized-URL uid that matches across runs; an item without one returns
+  # nil and is dropped upstream.
+  #
+  # The digest/period-keyed fallback and the model's explicit regime signal
+  # arrive with the single-AI-profile work (Track 4); `clock` is threaded now
+  # so that addition needs no signature change.
+  class Resolver
+    TRACKING_PARAM = /\A(utm_|fbclid\z|gclid\z|mc_)/
+
+    def self.call(item, clock:)
+      new(item, clock).call
+    end
+
+    def initialize(item, clock)
+      @item = item.is_a?(Hash) ? item : {}
+      @clock = clock
+    end
+
+    def call
+      uri = deep_link
+      uri && normalize(uri)
+    end
+
+    private
+
+    attr_reader :item, :clock
+
+    def deep_link
+      raw = (item["source_url"] || item[:source_url]).to_s.strip
+      return if raw.empty?
+
+      uri = URI.parse(raw)
+      return unless uri.is_a?(URI::HTTP) && uri.host.present?
+      return if uri.path.delete_suffix("/").empty? && uri.query.nil? # bare homepage
+
+      uri
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def normalize(uri)
+      uri.scheme = uri.scheme.downcase
+      uri.host = uri.host.downcase
+      uri.fragment = nil
+      uri.query = clean_query(uri.query)
+      uri.path = uri.path.delete_suffix("/") unless uri.path == "/"
+      uri.to_s
+    end
+
+    def clean_query(query)
+      return if query.nil?
+
+      kept = URI.decode_www_form(query).reject { |key, _| key.match?(TRACKING_PARAM) }
+      kept.empty? ? nil : URI.encode_www_form(kept)
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bin/rails test test/services/uid/resolver_test.rb`
+Expected: PASS (8 runs, 0 failures).
+
+- [ ] **Step 5: Lint**
+
+Run: `bin/rubocop -f github app/services/uid/resolver.rb test/services/uid/resolver_test.rb`
+Expected: no offenses (fix any reported before committing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/uid/resolver.rb test/services/uid/resolver_test.rb
+git commit -m "Add Uid::Resolver for permalink-normalized uids"
+```
+
+---
+
+### Task 2: Wire `Uid::Resolver` into `PassthroughProcessor`
+
+**Files:**
+- Modify: `app/services/processor/passthrough_processor.rb`
+- Test: `test/services/processor/passthrough_processor_test.rb`
+
+**Interfaces:**
+- Consumes: `Uid::Resolver.call(item, clock:)` from Task 1.
+- Produces: no signature change — `Processor::PassthroughProcessor.new(feed, raw_data).process` still returns a `Processor::Result`; entries now carry resolver-derived uids and items without a usable permalink are dropped.
+
+- [ ] **Step 1: Write the failing test**
+
+Create (or extend) `test/services/processor/passthrough_processor_test.rb`:
+
+```ruby
+require "test_helper"
+
+class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
+  def feed = @feed ||= create(:feed)
+
+  def process(items) = Processor::PassthroughProcessor.new(feed, items).process
+
+  test "#process should derive a normalized permalink uid and ignore model-supplied uid" do
+    items = [{ "uid" => "ephemeral-123", "source_url" => "https://Example.com/post/1/?utm_source=x", "body" => "hi" }]
+
+    entries = process(items).entries
+
+    assert_equal 1, entries.size
+    assert_equal "https://example.com/post/1", entries.first.uid
+  end
+
+  test "#process should produce identical uids across separate runs" do
+    items = [{ "source_url" => "https://example.com/a", "body" => "x" }]
+
+    first = process(items).entries.first.uid
+    second = process(items).entries.first.uid
+
+    assert_equal first, second
+  end
+
+  test "#process should drop items without a usable permalink" do
+    items = [{ "source_url" => "https://example.com/", "body" => "homepage only" }]
+
+    assert_empty process(items).entries
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/services/processor/passthrough_processor_test.rb`
+Expected: FAIL on the first test — uid is still `"ephemeral-123"` (the old `item["uid"]` read), not the normalized permalink.
+
+- [ ] **Step 3: Update the processor**
+
+In `app/services/processor/passthrough_processor.rb`, replace the uid line inside the `filter_map` block. Change:
+
+```ruby
+        uid = item["uid"].presence || item[:uid].presence
+        next if uid.blank?
+```
+
+to:
+
+```ruby
+        uid = Uid::Resolver.call(item, clock: Time.current)
+        next if uid.blank?
+```
+
+(The `next if uid.blank?` guard stays — it now drops items the resolver couldn't anchor to a permalink, preserving today's "drop unidentifiable item" behaviour.)
+
+- [ ] **Step 4: Run the processor tests to verify they pass**
+
+Run: `bin/rails test test/services/processor/passthrough_processor_test.rb`
+Expected: PASS (3 runs, 0 failures).
+
+- [ ] **Step 5: Run the broader suite to catch regressions**
+
+Run: `bin/rails test test/services/`
+Expected: PASS. If a pre-existing AI-pipeline test asserted on a model-supplied `uid`, update it to assert the resolver-derived permalink uid (the model-supplied `uid` is intentionally ignored now).
+
+- [ ] **Step 6: Lint**
+
+Run: `bin/rubocop -f github app/services/processor/passthrough_processor.rb test/services/processor/passthrough_processor_test.rb`
+Expected: no offenses.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/processor/passthrough_processor.rb test/services/processor/passthrough_processor_test.rb
+git commit -m "Derive passthrough uids via Uid::Resolver"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage (§3):** permalink-normalized, system-derived uid ✓ (Task 1); model-supplied uid no longer trusted ✓ (Task 2); run-twice-identical assertion ✓ (Task 1 Step 1 + Task 2 Step 1). Deferred-by-design and called out at the top: digest/period-keyed fallback and the explicit model regime signal → Track 4. "Ephemeral-uid rejection" from §3 is satisfied **by construction** here — the model no longer mints the uid, so an unstable uid can't occur; an item without a stable permalink is dropped rather than admitted.
+- **Placeholders:** none — every step has full code or an exact command.
+- **Type consistency:** `Uid::Resolver.call(item, clock:)` returns `String | nil`; the processor drops on `nil` via the retained `next if uid.blank?`. `clock` is consumed in Task 1 (threaded for Track 4) though unused by the current permalink path — intentional, documented in the class comment.

--- a/specs/005-feed-creation-ux-ai-overhaul/spec.md
+++ b/specs/005-feed-creation-ux-ai-overhaul/spec.md
@@ -1,0 +1,226 @@
+# Feed Creation UX + AI Architecture Overhaul
+
+**Date**: 2026-06-29 | **Status**: Design (pre-implementation)
+
+**Related**: [`001-smart-feed-creation`](../001-smart-feed-creation/spec.md) (the flow this revises),
+[`002-feed-drafts`](../002-feed-drafts/spec.md), [`003-unify-feed-preview-stack`](../003-unify-feed-preview-stack/spec.md),
+[`004-manual-feed-preview`](../004-manual-feed-preview/spec.md) · PRs: #873 (per-feed provider/model), #877 (capability matrix, WIP)
+
+This is the design/rationale record for a set of related changes to feed creation UX and the
+AI (LLM) stack. It may ship across multiple PRs. Where the code later diverges, the code is the
+source of truth; this document records *why* the decisions were made.
+
+## Why
+
+Several gaps surfaced while revisiting the `001-smart-feed-creation` decisions:
+
+- The single smart-input field + shape auto-detection conflates two genuinely different things
+  (a URL vs a prompt) and hides the AI capability behind an ambiguous box.
+- "Feed type" is surfaced as a concept the user shouldn't have to reason about; for prompt feeds
+  it's meaningless.
+- The two AI profiles (`llm_website_extractor`, `llm_web_search`) are the same machinery with
+  different prompts/tools — redundant.
+- Source/profile editing is locked after a feed leaves draft; this is over-restrictive, and
+  especially painful for AI feeds where the prompt *is* the source.
+- The LLM stack leaks "how we talk to a provider" (structured output, web access) into the feed
+  profile instead of behind a thin per-provider seam, and the current `with_tool("web_search")`
+  call is a no-op misuse (RubyLLM `with_tool` is for function tools, not server tools).
+- Preview is *believed* to gate enabling, but the code already does not gate on it.
+
+## Core mental model
+
+The user picks an **engine** (mechanism), not an input syntax. Two modes:
+
+| | Mode A — "Follow a feed or channel" | Mode B — "Follow with AI" |
+|---|---|---|
+| Engine | Deterministic profiles (RSS, YouTube, Reddit, …) | Single AI profile (LLM + web access) |
+| Input | A URL (single-line **"Source link"** field) | Free-form **"What should AI follow?"** textarea |
+| Accepts | A link (scheme auto-fixed) | A link, several links, or a description |
+
+The **mode toggle** carries the mechanism; the **field label** carries the expected input type.
+There is no auto-detection of input *shape* — the user stays in the engine they chose — but each
+field *validates* form within its mode. A URL pasted into Mode B is fine (AI reads it); a non-URL
+in Mode A is routed to Mode B via an inline bridge.
+
+## Decisions
+
+### 1. Entry & modes
+
+- **Two explicit modes by mechanism**, labelled "Follow a feed or channel" / "Follow with AI".
+  Drop shape auto-detection.
+- **Two label slots, each with one job**: mode toggle = mechanism; field label = input type
+  ("Source link" / "What should AI follow?"). Never overload one with both — that was the
+  category error in the old single box.
+- Mode A field: single-line URL input. **Silent scheme-fix** (`example.com` → `https://example.com`);
+  **respect an explicit `http://`** (never force https — some feeds are http-only);
+  **no shorthand expansion** (`r/x`, `@handle` are *not* expanded — ambiguous handles can't be
+  resolved deterministically and the AI bridge handles them better).
+- **Mode A has exactly two failure exits, and they are the same exit**: input isn't a URL
+  (client-side, before any fetch) or is a URL but yields no feed (after detection). Both route to
+  the same **"Follow with AI instead"** bridge, carrying the input into Mode B.
+
+### 2. AI feed model
+
+- **Collapse the two AI profiles into one** (`input_shape: :any`). Web access is intrinsic to the
+  AI engine, not a per-profile toggle, so it leaves the profile config.
+- **One free-form prompt** captures *both* what to follow and how to transform it
+  (e.g. "Follow A24's blog and turn each new post into a one-line announcement"). The
+  source/transformation boundary is genuinely fuzzy for AI feeds; forcing a structured
+  source+instructions split adds friction without clarity.
+- A **system prompt wraps** the user prompt and owns: the goal (aggregate web content per the user
+  prompt), the structured-output schema, the uid contract (§3), the standing-query-vs-feed-style
+  regime distinction (§3), and the safeguards (§8). The user prompt is data inside this frame.
+
+### 3. uid contract (integrity)
+
+The uid is the one place an AI feed can quietly corrupt itself (duplicate or dropped reposts).
+
+- **uid is anchored to source identity, not generated content.** Content-hash uids are fatal here
+  because AI feeds may *summarize/reshape* content — the body changes every run. The default is
+  **`normalize(permalink)`**: lowercase host, strip `utm_*`/fragments, canonicalize trailing slash.
+- **The model never mints the uid string.** It only *signals the regime* per item: a real permalink
+  (feed-style → dedup) or a null permalink + period hint (standing-query/digest). The **processor**
+  mints the actual uid string using a trustworthy server clock — the model has no reliable clock and
+  must not stamp dates.
+- **Standing query / digest is first-class** (e.g. "is AGI achieved yet?", asked daily). It emerges
+  from the permalink rule: no permalink → processor mints a **period-keyed** uid (default = run date)
+  → one fresh post per period. A standing query yields exactly one synthesized item per run.
+- **Placement is load-bearing.** `filter_new_entries` (dedup) and the blank-uid drop both run *after*
+  `process_feed_contents`, so the uid must be final by the end of that step. uid minting therefore
+  lives in `PassthroughProcessor` (mirroring `RssProcessor#extract_uid`), delegating policy to a
+  new, unit-tested, clock-injected `Uid::Resolver`. Minting it any later would let the existing
+  guards drop digest items.
+
+### 4. Editing & lifecycle
+
+- **Unlock** source/profile/prompt editing after draft (controller strong-params + the disabled
+  form fields in `_form_expanded.html.erb`).
+- **`import_after` is the single user-owned backlog lever**, not a dedup mechanism. No silent
+  baseline reseed — a reseed can't match revision-2 items against revision-1 items, so it would
+  silently swallow transition-window posts (a worse, invisible failure than the duplicates it
+  prevents).
+- **Three-tier, edit-specific warnings** (honest about real risk):
+  - **Prompt edit (AI, same profile)** → *no duplicate risk* (uid scheme unchanged). Light
+    "this might bring in older posts" backfill note; threshold optional.
+  - **Source URL edit (same profile)** → possible repeats if the same content moved; warn, offer
+    threshold.
+  - **Profile change (uid scheme changes)** → recent items likely repeat; warn, **default the
+    threshold on**. Caveat in copy: the threshold filters by *publication date*, so it's a
+    strong-but-not-airtight guard for AI items that lack real dates — don't *promise* zero repeats.
+- **Preview is not an enable-gate** — already true in code (`Feed#can_be_enabled?` checks name,
+  active token, target group, profile, cron; not preview). Only leftover nicety: a disabled Preview
+  button could explain what's missing instead of going inert.
+
+### 5. Model selection & capability matrix
+
+- **Model picker is gated to a curated, dev-verified allowlist** with a sensible default
+  pre-selected and ignorable. Showing a model that can't do web+schema is a silent, async footgun;
+  hiding the picker entirely throws away the per-feed flexibility shipped in #873.
+- **Graceful degradation**: if a feed's selected model later drops out of the matrix, fall back to
+  the provider's default supported model with a notice — don't start failing.
+- **The matrix (`LlmModelCapability`) shrinks to its irreducible core**: a pure
+  `(provider, model)` allowlist where *membership = qualification* (the pair is dev-verified to
+  deliver structured output **and** web access together). **Drop tiers.** The two axes the old
+  `tier` enum conflated both find better homes: *readiness* → dev-time compatibility testing (a pair
+  enters only once verified; no `:experimental` rows in production); *reliability* (native vs heal)
+  → the per-provider adapter (§6), since it's a provider property.
+- **What the matrix does NOT store** — these are fetched live from the provider (source of truth):
+  - **Display names** — Anthropic `display_name`, OpenRouter `name`.
+  - **Availability** — intersect the matrix with the credential's live models so a dropped model
+    falls out on its own.
+  - **Advertised structured-output support** — Anthropic `capabilities.structured_outputs`,
+    OpenRouter `supported_parameters`.
+- **Why a matrix is still required** (can't go fully dynamic): the two facts that actually gate an
+  AI feed are *not* in either API — Anthropic per-model web-tool support (documented only by model
+  family), and the *reliability of web+schema together* (the "Kimi flips to plain text" failure).
+  Only dev testing reveals these; the matrix encodes exactly that verified set.
+
+#### `LlmModelCapability` — implementation notes (trims #877 before merge)
+
+- Remove `tier`, `TIERS`, `tier_for`, and the tier assertions; remove the `:experimental` rows
+  (gemini, gpt-4o-mini, kimi). Keep `all`/`find`/`supported?`/`models_for` and the
+  "membership = qualification" framing.
+- Do **not** add a `label` field — display names are joined live from the provider models list.
+- Add an invariant test: every `LlmProvider.default_model` is `supported?` by the matrix.
+- Optional CI assertion: every matrix entry still advertises `structured_outputs` in the live API
+  (early warning on silent provider changes).
+- Follow-up tasks (named in #876): live intersection with `available_models`; display-name join for
+  the picker; the dev-time compatibility probe (the gate that replaced the readiness tier).
+
+### 6. Provider seam & response healing
+
+RubyLLM 1.16 already normalizes structured output across providers (`with_schema` →
+`providers/anthropic/chat.rb` and `providers/openrouter/chat.rb` render their own shapes) but has
+**no server-tool / web support**. So the seam exists *only* for what RubyLLM doesn't cover — not as
+a layer that re-abstracts structured output.
+
+- **Structured output goes straight through RubyLLM `with_schema`.** (Verify at implementation that
+  RubyLLM emits the *current* Anthropic mechanism, `output_config.format`; if it renders a stale
+  shape, the seam must also own schema injection via `with_params`.)
+- **`SchemaHealer`** — extracted, **provider-agnostic** mechanism: given loose text and a schema,
+  recover validated JSON (strip ```` ``` ```` fences, extract the outermost object/array,
+  lenient-parse, validate, trivial safe coercion) or fail as `schema_error`. No second LLM call.
+  Light by design: the dev-verified matrix is the real defense; healing only mops up cosmetic noise
+  from already-verified models.
+- **A thin per-provider seam** ("adapter"), selected by `credential.provider`, owns two things —
+  cut by *provider* (the axis of variation), not by concern:
+  - `web_params(model)` → merged via `with_params`. Anthropic: version-pinned server tools
+    (`web_search_20260209`/`web_fetch_20260209`, model-dependent), citations disabled when a schema
+    is set. OpenRouter: web server tool + `require_parameters`.
+  - `normalize(payload)` → passthrough for Anthropic (native enforcement, trusted); delegate to
+    `SchemaHealer` for OpenRouter (best-effort routing).
+- **`LlmClient` stays the orchestrator/bookkeeper**: adapter selection, `CallContext`, `chat.ask`
+  execution, the one-`LlmUsage`-per-call invariant, and the error taxonomy
+  (`schema_error`/`provider_error`/`rate_limited`/`timeout`). It orchestrates
+  `pick adapter → prepare → ask → normalize → record usage`. The `with_tool("web_search")` misuse is
+  removed (web is now `with_params` in `prepare`).
+- Verify Anthropic `pause_turn` / server-tool-loop handling at implementation.
+
+### 7. Mode A detection & presentation
+
+- Detection in Mode A is deterministic and **LLM-free**, so it can cheaply *test* each candidate
+  (passed / couldn't-reach / won't-work). Presentation keys off the count of **working** candidates:
+  - **0 working** (none matched, or the only match failed extraction) → error state (not the
+    expanded form): *"Couldn't pull any posts from that link… AI can still follow it."* with
+    **"Follow with AI instead"** (link, carries the URL into Mode B), *"Try a different link"*, and
+    *Cancel* (→ feeds index).
+  - **1 working** → no chooser; auto-select and show the **detected type as a plain annotation**
+    (the profile's `display_name`, consistent with index/detail pages — not generated prose).
+  - **≥2 working** → show the chooser ("How should we fetch posts?"), highest-specificity
+    pre-selected. The *only* place "feed type" is a real choice; expected to be rare.
+- **"Couldn't reach" ≠ "no feed"**: a transient network failure is a retry state, not the AI bridge.
+- The AI bridge is **one-directional discovery**, never a silent fallback engine — Mode A never runs
+  AI on its own; it only *offers* the door to Mode B.
+
+### 8. System-prompt safeguards
+
+Two safeguards earn a place in the prompt because they're aggregator-specific and the model won't do
+them unprompted:
+
+1. **Prompt-injection defense** — fetched/searched content is untrusted *data*, never instructions;
+   the only instructions are the system prompt and the user's feed prompt.
+2. **No fabrication / grounding** — only include items actually found via web tools; every item
+   carries a real source URL; never invent posts, sources, or content (reinforces uid-as-permalink).
+
+General harmful-content moderation is kept **minimal** — lean on the model's safety training and the
+fact that the user authored the prompt and owns their feed; aggressive category-filtering would break
+legitimate feeds (e.g. world news). **Prompt safeguards are defense-in-depth, not a security
+boundary** — any *hard* guarantee belongs in the deterministic validation layer (normalizer/
+processor), the same place the uid integrity checks live.
+
+## Sequencing
+
+- **AI plumbing + integrity first**: `SchemaHealer` + per-provider seam (§6) and the `Uid::Resolver`
+  + ephemeral-uid rejection (§3) are foundational and largely independent.
+- **Single AI profile** (§2) depends on web access via the seam.
+- **Explicit-mode creation** (§1, §7) depends on the single AI profile being what Mode B selects.
+- **Editing/lifecycle** (§4) is largely independent; the prompt-editing win lands once §2 exists.
+- The capability-matrix trim (§5) can land anytime; its follow-ups gate the picker work.
+
+## Open / deferred
+
+- Hourly digests (sub-day period granularity for standing queries) — emergent fallback only for now;
+  a finer period is a later explicit feature.
+- Disabled-Preview-button "what's missing" affordance — optional nicety.
+- Confirm RubyLLM's Anthropic structured-output rendering is current (`output_config.format`) at
+  implementation; if stale, the seam also owns schema injection.


### PR DESCRIPTION
Changes:

- Add `specs/005-feed-creation-ux-ai-overhaul/spec.md` — the design/rationale record for revisiting the `001-smart-feed-creation` flow.
- Add `specs/005-feed-creation-ux-ai-overhaul/plan-01-uid-integrity.md` — the bite-sized TDD plan for the first implementation track (system-normalized permalink uids).
- Relax the CLAUDE.md Specs note: a spec may precede implementation and ship across multiple PRs.

The spec captures decisions from a design pass over feed creation UX and the AI stack: explicit URL-vs-prompt entry modes (engine chosen by the user, no shape auto-detection), a single AI profile driven by one free-form prompt, system-minted permalink uids with a first-class standing-query/digest fallback, unlocked source/profile/prompt editing with edit-specific warnings, a dev-verified `(provider, model)` capability matrix (with live-fetched names/availability), and a thin per-provider seam over RubyLLM plus an extracted provider-agnostic `SchemaHealer`. It also documents why the matrix can't go fully dynamic and the trims #877 needs before merge.

The work is sliced into six dependency-ordered tracks (see the spec's Sequencing). This PR includes the plan for Track 1 only; later tracks get their own plans.

This is documentation only — no behaviour change. Implementation follows in later PRs.

References:

- Related PR: #873
- Related PR: #877