### PR TITLE
Fix timezone-fragile withdraw-posts date test

### DIFF
--- a/test/services/withdraw_all_posts_test.rb
+++ b/test/services/withdraw_all_posts_test.rb
@@ -149,8 +149,8 @@ class WithdrawAllPostsTest < ActiveSupport::TestCase
   test "#call should update the event with completion stats" do
     date1 = Date.new(2024, 1, 10)
     date2 = Date.new(2024, 1, 20)
-    create(:post, :published, feed: feed, freefeed_post_id: "post1", reposted_at: date1.to_time)
-    create(:post, :published, feed: feed, freefeed_post_id: "post2", reposted_at: date2.to_time)
+    create(:post, :published, feed: feed, freefeed_post_id: "post1", reposted_at: date1.in_time_zone)
+    create(:post, :published, feed: feed, freefeed_post_id: "post2", reposted_at: date2.in_time_zone)
 
     stub_request(:delete, "#{access_token.host}/v4/posts/post1").to_return(status: 200)
     stub_request(:delete, "#{access_token.host}/v4/posts/post2").to_return(status: 200)


### PR DESCRIPTION
Changes:

- Build `reposted_at` timestamps in `WithdrawAllPostsTest` with `Date#in_time_zone` instead of `Date#to_time`.

`Date#to_time` produces a system-local instant, but `WithdrawAllPosts` derives `dates_from`/`dates_to` via `#to_date` in the application zone (UTC). On a machine in a positive-offset zone (e.g. CEST), local midnight normalizes to the previous UTC day, so the assertion failed off-by-one (`2024-01-09` vs `2024-01-10`). The suite passed in CI (UTC) and only failed locally. Constructing the timestamps in the app zone makes the test stable in any system timezone.