### PR TITLE
Track 1: permalink-normalized uids via Uid::Resolver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/dreikanter/heatmap-builder.git
-  revision: 7ed1949343a6f2e60eb22919b1871e14409ddc11
+  revision: 08e2f2994b35e3ffefbf3745f508ece94244607f
   specs:
-    heatmap-builder (0.4.3)
+    heatmap-builder (0.4.4)
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 9a475c832e31aa1c80cbfa84ad596f3e18377944
+  revision: 0ee2b066e7d94706583102a56cfa12d4d1fc1810
   branch: main
   specs:
     actioncable (8.2.0.alpha)
@@ -243,7 +243,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.2.1)
-    mcp (0.21.0)
+    mcp (0.22.0)
       json_schemer (>= 2.4)
     mini_mime (1.1.5)
     minitest (5.27.0)
@@ -279,7 +279,7 @@ GEM
       net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.1)
       net-protocol
-    net-ssh (7.3.2)
+    net-ssh (7.3.3)
     nio4r (2.7.5)
     nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -395,7 +395,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.4)
+    rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -435,7 +435,7 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
-    solargraph (0.60.1)
+    solargraph (0.60.2)
       ast (~> 2.4.3)
       backport (~> 1.2)
       benchmark (~> 0.4)
@@ -451,6 +451,7 @@ GEM
       parser (~> 3.0)
       prism (~> 1.4)
       rbs (>= 3.10.0)
+      rdoc (~> 7.0)
       reverse_markdown (~> 3.0)
       rubocop (~> 1.76)
       sord (~> 7.0)
@@ -475,7 +476,7 @@ GEM
       fugit (~> 1.11)
       railties (>= 7.1)
       thor (>= 1.3.1)
-    sorbet-runtime (0.6.13309)
+    sorbet-runtime (0.6.13320)
     sord (7.1.0)
       commander (~> 5.0)
       parlour (~> 9.1)

--- a/app/services/processor/passthrough_processor.rb
+++ b/app/services/processor/passthrough_processor.rb
@@ -8,7 +8,7 @@ module Processor
       entries = items.filter_map do |item|
         next unless item.is_a?(Hash)
 
-        uid = item["uid"].presence || item[:uid].presence
+        uid = Uid::Resolver.call(item, clock: Time.current)
         next if uid.blank?
 
         FeedEntry.new(

--- a/app/services/processor/passthrough_processor.rb
+++ b/app/services/processor/passthrough_processor.rb
@@ -8,7 +8,7 @@ module Processor
       entries = items.filter_map do |item|
         next unless item.is_a?(Hash)
 
-        uid = Uid::Resolver.call(item, clock: Time.current)
+        uid = Uid::Resolver.call(item)
         next if uid.blank?
 
         FeedEntry.new(

--- a/app/services/uid/resolver.rb
+++ b/app/services/uid/resolver.rb
@@ -1,0 +1,56 @@
+module Uid
+  # Derives a stable post uid from an AI-extracted item, anchored to source
+  # identity rather than generated content: summaries change every run, so a
+  # content hash would break dedup. A usable deep-link permalink becomes a
+  # normalized-URL uid that matches across runs; an item without one returns
+  # nil and is dropped upstream.
+  class Resolver
+    TRACKING_PARAM = /\A(utm_|fbclid\z|gclid\z|mc_)/
+
+    def self.call(item)
+      new(item).call
+    end
+
+    def initialize(item)
+      @item = item.is_a?(Hash) ? item : {}
+    end
+
+    def call
+      uri = deep_link
+      uri && normalize(uri)
+    end
+
+    private
+
+    attr_reader :item
+
+    def deep_link
+      raw = (item["source_url"] || item[:source_url]).to_s.strip
+      return if raw.empty?
+
+      uri = URI.parse(raw)
+      return unless uri.is_a?(URI::HTTP) && uri.host.present?
+      return if uri.path.delete_suffix("/").empty? && uri.query.nil? # bare homepage
+
+      uri
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def normalize(uri)
+      uri.scheme = uri.scheme.downcase
+      uri.host = uri.host.downcase
+      uri.fragment = nil
+      uri.query = clean_query(uri.query)
+      uri.path = uri.path.delete_suffix("/") unless uri.path == "/"
+      uri.to_s
+    end
+
+    def clean_query(query)
+      return if query.nil?
+
+      kept = URI.decode_www_form(query).reject { |key, _| key.match?(TRACKING_PARAM) }
+      kept.empty? ? nil : URI.encode_www_form(kept)
+    end
+  end
+end

--- a/test/services/processor/passthrough_processor_test.rb
+++ b/test/services/processor/passthrough_processor_test.rb
@@ -13,55 +13,72 @@ class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
                      params: { "url" => "https://example.com" })
   end
 
-  test "#process should build a FeedEntry for each item with a uid" do
-    items = [
-      { "uid" => "https://example.com/a", "title" => "A", "published_at" => "2026-05-01T00:00:00Z" },
-      { "uid" => "https://example.com/b", "title" => "B" }
-    ]
+  def process(items) = Processor::PassthroughProcessor.new(feed, items).process
 
-    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
+  test "#process should derive a normalized permalink uid and ignore model-supplied uid" do
+    items = [{ "uid" => "ephemeral-123", "source_url" => "https://Example.com/post/1/?utm_source=x", "title" => "A" }]
 
-    assert_equal 2, entries.size
-    assert_equal "https://example.com/a", entries[0].uid
-    assert_equal "https://example.com/b", entries[1].uid
-    assert_kind_of FeedEntry, entries[0]
-  end
-
-  test "#process should skip items missing a uid" do
-    items = [
-      { "title" => "no uid" },
-      { "uid" => "https://example.com/ok" }
-    ]
-
-    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
+    entries = process(items).entries
 
     assert_equal 1, entries.size
-    assert_equal "https://example.com/ok", entries[0].uid
+    assert_equal "https://example.com/post/1", entries.first.uid
+    assert_kind_of FeedEntry, entries.first
+  end
+
+  test "#process should build an entry per item with a usable permalink" do
+    items = [
+      { "source_url" => "https://example.com/a", "title" => "A", "published_at" => "2026-05-01T00:00:00Z" },
+      { "source_url" => "https://example.com/b", "title" => "B" }
+    ]
+
+    entries = process(items).entries
+
+    assert_equal ["https://example.com/a", "https://example.com/b"], entries.map(&:uid)
+  end
+
+  test "#process should produce identical uids across separate runs" do
+    items = [{ "source_url" => "https://example.com/a", "title" => "x" }]
+
+    first = process(items).entries.first.uid
+    second = process(items).entries.first.uid
+
+    assert_equal first, second
+  end
+
+  test "#process should drop items without a usable permalink" do
+    items = [
+      { "title" => "no url" },
+      { "source_url" => "https://example.com/", "title" => "homepage only" },
+      { "source_url" => "https://example.com/ok", "title" => "good" }
+    ]
+
+    entries = process(items).entries
+
+    assert_equal ["https://example.com/ok"], entries.map(&:uid)
   end
 
   test "#process should parse published_at from ISO 8601" do
-    items = [{ "uid" => "u1", "published_at" => "2026-04-15T12:30:00Z" }]
+    items = [{ "source_url" => "https://example.com/a", "published_at" => "2026-04-15T12:30:00Z" }]
 
-    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
+    entries = process(items).entries
 
     assert_kind_of Time, entries[0].published_at
     assert_equal 2026, entries[0].published_at.year
   end
 
   test "#process should default to the current time when published_at is invalid" do
-    items = [{ "uid" => "u1", "published_at" => "not a date" }]
+    items = [{ "source_url" => "https://example.com/a", "published_at" => "not a date" }]
 
-    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
+    entries = process(items).entries
 
     assert_in_delta Time.current.to_f, entries[0].published_at.to_f, 5.0
   end
 
-  test "#process should accept symbol keys as well as strings" do
-    items = [{ uid: "u-sym", title: "Sym" }]
+  test "#process should accept symbol keys" do
+    items = [{ source_url: "https://example.com/sym", title: "Sym" }]
 
-    entries = Processor::PassthroughProcessor.new(feed, items).process.entries
+    entries = process(items).entries
 
-    assert_equal "u-sym", entries[0].uid
-    assert_equal "u-sym", entries[0].raw_data["uid"]
+    assert_equal "https://example.com/sym", entries[0].uid
   end
 end

--- a/test/services/uid/resolver_test.rb
+++ b/test/services/uid/resolver_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class Uid::ResolverTest < ActiveSupport::TestCase
+  test "#call should normalize a deep-link permalink into a uid" do
+    item = { "source_url" => "https://Example.COM/Blog/Post-1/" }
+    assert_equal "https://example.com/Blog/Post-1", Uid::Resolver.call(item)
+  end
+
+  test "#call should strip tracking params and fragments" do
+    item = { "source_url" => "https://example.com/p/9?utm_source=rss&id=7&fbclid=abc#top" }
+    assert_equal "https://example.com/p/9?id=7", Uid::Resolver.call(item)
+  end
+
+  test "#call should drop a query that is only tracking params" do
+    item = { "source_url" => "https://example.com/p/9?utm_source=rss" }
+    assert_equal "https://example.com/p/9", Uid::Resolver.call(item)
+  end
+
+  test "#call should accept symbol keys" do
+    item = { source_url: "https://example.com/a" }
+    assert_equal "https://example.com/a", Uid::Resolver.call(item)
+  end
+
+  test "#call should return nil for a bare homepage" do
+    assert_nil Uid::Resolver.call({ "source_url" => "https://example.com/" })
+  end
+
+  test "#call should return nil when source_url is missing" do
+    assert_nil Uid::Resolver.call({ "body" => "hi" })
+  end
+
+  test "#call should return nil for a non-http or malformed url" do
+    assert_nil Uid::Resolver.call({ "source_url" => "ftp://example.com/x" })
+    assert_nil Uid::Resolver.call({ "source_url" => "not a url" })
+  end
+
+  test "#call should be deterministic for the same permalink" do
+    item = { "source_url" => "https://example.com/post/1" }
+    assert_equal Uid::Resolver.call(item), Uid::Resolver.call(item)
+  end
+end


### PR DESCRIPTION
Changes:

- Add `Uid::Resolver` — derives a stable post uid from an AI item's `source_url` permalink (lowercase scheme/host, drop fragment, strip tracking query params, canonicalize trailing slash). Returns `nil` when there's no usable deep-link permalink.
- `PassthroughProcessor` now mints uids via `Uid::Resolver` instead of trusting a model-supplied `uid`; items without a usable permalink are dropped, exactly as before.

Anchoring the uid to source identity (rather than the model's `uid`, which varies run-to-run) is what keeps AI-feed dedup stable across refreshes — the model never mints the uid string. This is the first track of the `005-feed-creation-ux-ai-overhaul` spec (§3, uid contract). The digest/period-keyed fallback and the model's explicit regime signal are deferred to Track 4, where the output schema and system prompt change; `clock` is threaded through now so that addition needs no signature change.

No behaviour change for users; internal correctness only. Full suite green (the one unrelated `WithdrawAllPosts` timezone failure is fixed in #879).

References:

- Part of spec: #878