### PR TITLE
Track 2: two-step AI extraction (gather + structure)

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -21,11 +21,13 @@ class FeedProfile
             "source_url" => { "type" => "string" },
             "published_at" => { "type" => "string" }
           },
-          "required" => ["uid", "body", "source_url"]
+          "required" => ["uid", "body", "source_url"],
+          "additionalProperties" => false
         }
       }
     },
-    "required" => ["items"]
+    "required" => ["items"],
+    "additionalProperties" => false
   }.freeze
 
   PROFILES = {

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -58,13 +58,13 @@ class LlmClient
 
   attr_reader :credential
 
-  def call(ctx, prompt:, output_schema:, tools: [])
+  def call(ctx, prompt:, output_schema:)
     raise DetectionForbidden if Thread.current[:llm_detection_phase]
 
     started_at = Time.current
 
     begin
-      response = invoke_provider(model: ctx.model, prompt: prompt, output_schema: output_schema, tools: tools)
+      response = invoke_provider(model: ctx.model, prompt: prompt, output_schema: output_schema)
     rescue RubyLLM::RateLimitError => e
       write_usage(ctx, outcome: :rate_limited, started_at: started_at, error_message: e.message)
       raised = RateLimited.new(e.message)
@@ -144,10 +144,11 @@ class LlmClient
   end
 
   # Single seam tests stub. Returns a ProviderResponse.
-  def invoke_provider(model:, prompt:, output_schema:, tools:)
+  def invoke_provider(model:, prompt:, output_schema:)
     chat = credential.ruby_llm_context.chat(model: model, provider: LlmProvider.find(credential.provider).ruby_llm_provider)
     chat.with_schema(output_schema) if output_schema.present? && chat.respond_to?(:with_schema)
-    tools.each { |t| chat.with_tool(t) if chat.respond_to?(:with_tool) }
+    web_params = Adapter.for(credential.provider).web_params(model)
+    chat.with_params(**web_params) if web_params.present? && chat.respond_to?(:with_params)
 
     response = chat.ask(prompt)
     ProviderResponse.new(

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -58,13 +58,13 @@ class LlmClient
 
   attr_reader :credential
 
-  def call(ctx, prompt:, output_schema:)
+  def call(ctx, prompt:, output_schema:, web: false)
     raise DetectionForbidden if Thread.current[:llm_detection_phase]
 
     started_at = Time.current
 
     begin
-      response = invoke_provider(model: ctx.model, prompt: prompt, output_schema: output_schema)
+      response = invoke_provider(model: ctx.model, prompt: prompt, output_schema: output_schema, web: web)
     rescue RubyLLM::RateLimitError => e
       write_usage(ctx, outcome: :rate_limited, started_at: started_at, error_message: e.message)
       raised = RateLimited.new(e.message)
@@ -144,20 +144,26 @@ class LlmClient
   end
 
   # Single seam tests stub. Returns a ProviderResponse.
-  def invoke_provider(model:, prompt:, output_schema:)
+  def invoke_provider(model:, prompt:, output_schema:, web:)
     chat = credential.ruby_llm_context.chat(model: model, provider: LlmProvider.find(credential.provider).ruby_llm_provider)
     chat.with_schema(output_schema) if output_schema.present? && chat.respond_to?(:with_schema)
-    web_params = Adapter.for(credential.provider).web_params(model)
-    chat.with_params(**web_params) if web_params.present? && chat.respond_to?(:with_params)
+    if web
+      web_params = Adapter.for(credential.provider).web_params(model)
+      chat.with_params(**web_params) if web_params.present? && chat.respond_to?(:with_params)
+    end
 
     response = chat.ask(prompt)
     ProviderResponse.new(
-      payload: parse_payload(response),
+      payload: output_schema.present? ? parse_payload(response) : response_text(response),
       input_tokens: response.try(:input_tokens).to_i,
       output_tokens: response.try(:output_tokens).to_i,
       cache_write_tokens: response.try(:cached_tokens).to_i,
       cache_read_tokens: response.try(:cache_read_tokens).to_i
     )
+  end
+
+  def response_text(response)
+    response.respond_to?(:content) ? response.content.to_s : response.to_s
   end
 
   def parse_payload(response)

--- a/app/services/llm_client/adapter.rb
+++ b/app/services/llm_client/adapter.rb
@@ -1,0 +1,16 @@
+class LlmClient
+  # Per-provider web-access params for the LLM request. RubyLLM normalizes the
+  # rest of the request (messages, schema, tokens, errors) but has no web-access
+  # abstraction, so each provider's raw params are merged into the request via
+  # `with_params`. Selected by `credential.provider`.
+  module Adapter
+    REGISTRY = {
+      "anthropic" => "Anthropic",
+      "openrouter" => "OpenRouter"
+    }.freeze
+
+    def self.for(provider)
+      const_get(REGISTRY.fetch(provider.to_s)).new
+    end
+  end
+end

--- a/app/services/llm_client/adapter/anthropic.rb
+++ b/app/services/llm_client/adapter/anthropic.rb
@@ -2,7 +2,7 @@ class LlmClient
   module Adapter
     # Anthropic enables web access through provider-hosted server tools. Citations
     # are disabled because they conflict with structured output.
-    class Anthropic
+    class Anthropic < Base
       def web_params(_model)
         {
           tools: [

--- a/app/services/llm_client/adapter/anthropic.rb
+++ b/app/services/llm_client/adapter/anthropic.rb
@@ -1,0 +1,16 @@
+class LlmClient
+  module Adapter
+    # Anthropic enables web access through provider-hosted server tools. Citations
+    # are disabled because they conflict with structured output.
+    class Anthropic
+      def web_params(_model)
+        {
+          tools: [
+            { type: "web_search_20260209", name: "web_search" },
+            { type: "web_fetch_20260209", name: "web_fetch", citations: { enabled: false } }
+          ]
+        }
+      end
+    end
+  end
+end

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -1,6 +1,6 @@
 class LlmClient
   module Adapter
-    # Interface every provider adapter implements.
+    # Basic abstraction for an LLM provider adapter
     class Base
       # Provider-specific request params that enable web access, deep-merged
       # into the request via `with_params`.

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -1,0 +1,12 @@
+class LlmClient
+  module Adapter
+    # Interface every provider adapter implements.
+    class Base
+      # Provider-specific request params that enable web access, deep-merged
+      # into the request via `with_params`.
+      def web_params(_model)
+        raise NotImplementedError, "#{self.class} must implement #web_params"
+      end
+    end
+  end
+end

--- a/app/services/llm_client/adapter/open_router.rb
+++ b/app/services/llm_client/adapter/open_router.rb
@@ -1,0 +1,15 @@
+class LlmClient
+  module Adapter
+    # OpenRouter enables web access through its cross-model web plugin.
+    # `require_parameters` routes only to upstreams that honor the request's
+    # structured-output parameters.
+    class OpenRouter
+      def web_params(_model)
+        {
+          plugins: [{ id: "web" }],
+          provider: { require_parameters: true }
+        }
+      end
+    end
+  end
+end

--- a/app/services/llm_client/adapter/open_router.rb
+++ b/app/services/llm_client/adapter/open_router.rb
@@ -3,7 +3,7 @@ class LlmClient
     # OpenRouter enables web access through its cross-model web plugin.
     # `require_parameters` routes only to upstreams that honor the request's
     # structured-output parameters.
-    class OpenRouter
+    class OpenRouter < Base
       def web_params(_model)
         {
           plugins: [{ id: "web" }],

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -10,27 +10,44 @@ module Loader
   # not part of the profile config: it comes from the feed's override or
   # the provider default (see `#model_for`).
   class LlmLoader < Base
+    # Two calls, because structured output and web tools can't share one request:
+    # first gather content with web access (no schema), then convert that text
+    # into the structured items (schema, no web).
     def load
-      llm_client = options.fetch(:llm_client) { LlmClient.for(feed) }
-      ctx = LlmClient::CallContext.new(
-        feed: feed.persisted? ? feed : nil,
-        profile_key: feed.feed_profile_key,
-        stage: :loader,
-        model: model_for(llm_client.credential),
-        purpose: options.fetch(:purpose, :scheduled_run)
-      )
-      result = llm_client.call(ctx,
-                               prompt: rendered_prompt,
-                               output_schema: config.fetch(:output_schema))
+      client = options.fetch(:llm_client) { LlmClient.for(feed) }
+      ctx = call_context(client)
 
-      payload = result.payload
+      gathered = client.call(ctx, prompt: rendered_prompt, output_schema: nil, web: true).payload
+      payload = client.call(ctx, prompt: structuring_prompt(gathered), output_schema: config.fetch(:output_schema), web: false).payload
+
       raise StandardError, "LlmLoader payload missing 'items' array" unless payload.is_a?(Hash) && payload["items"].is_a?(Array)
 
+      items = payload["items"]
       limit = options[:limit]
-      limit ? payload["items"].first(limit) : payload["items"]
+      limit ? items.first(limit) : items
     end
 
     private
+
+    def call_context(client)
+      LlmClient::CallContext.new(
+        feed: feed.persisted? ? feed : nil,
+        profile_key: feed.feed_profile_key,
+        stage: :loader,
+        model: model_for(client.credential),
+        purpose: options.fetch(:purpose, :scheduled_run)
+      )
+    end
+
+    def structuring_prompt(gathered)
+      <<~PROMPT
+        Convert the gathered web content below into the required JSON object.
+        Use only what is present; do not invent items or fields.
+
+        GATHERED CONTENT:
+        #{gathered}
+      PROMPT
+    end
 
     # Feed override wins; otherwise the resolved credential's provider default,
     # so the model always matches the provider actually being called.

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -6,7 +6,7 @@ module Loader
   # into FeedEntry instances downstream.
   #
   # The profile entry must declare `loader: { class: "Loader::LlmLoader",
-  # config: { prompt_template:, output_schema:, tools? } }`. The model is
+  # config: { prompt_template:, output_schema: } }`. The model is
   # not part of the profile config: it comes from the feed's override or
   # the provider default (see `#model_for`).
   class LlmLoader < Base
@@ -21,8 +21,7 @@ module Loader
       )
       result = llm_client.call(ctx,
                                prompt: rendered_prompt,
-                               output_schema: config.fetch(:output_schema),
-                               tools: config.fetch(:tools, []))
+                               output_schema: config.fetch(:output_schema))
 
       payload = result.payload
       raise StandardError, "LlmLoader payload missing 'items' array" unless payload.is_a?(Hash) && payload["items"].is_a?(Array)

--- a/specs/005-feed-creation-ux-ai-overhaul/plan-02-llm-provider-seam.md
+++ b/specs/005-feed-creation-ux-ai-overhaul/plan-02-llm-provider-seam.md
@@ -1,0 +1,33 @@
+# LLM Provider Seam Implementation Plan (Track 2 of 6)
+
+**Goal:** Give `LlmClient` a thin per-provider seam that enables web access via `with_params`, and remove the `with_tool("web_search")` misuse.
+
+**Scope note:** An earlier draft of this plan added a `SchemaHealer` for loose JSON recovery. It was **dropped as speculative** — RubyLLM enforces structured output through both providers (`with_schema`), Anthropic does so natively, and the dev-verified matrix (§5) excludes OpenRouter models that don't return clean JSON. The required behaviour is parse-or-fail, which `LlmClient` already does. Revisit only if a verified model is observed wrapping its output. See spec §6.
+
+**Spec:** [`spec.md`](./spec.md) §6.
+
+## What shipped (one PR)
+
+- `LlmClient::Adapter.for(provider)` — factory keyed on `credential.provider`, raises `KeyError` for unknown providers.
+- `LlmClient::Adapter::Anthropic#web_params(model)` — provider-hosted `web_search`/`web_fetch` server tools, citations disabled.
+- `LlmClient::Adapter::OpenRouter#web_params(model)` — web plugin + `require_parameters`.
+- `LlmClient#invoke_provider` — injects `web_params` via `chat.with_params`; structured output still goes through `chat.with_schema`. The `with_tool` loop is gone; `tools:` removed from `#call`.
+- `Loader::LlmLoader` — stops passing `tools:`.
+
+`web_params` wire-format values are `[VERIFY-LIVE]`: the injection mechanism is verified against the RubyLLM source (`with_params` deep-merges into the request payload), but the exact provider strings (Anthropic tool versions, OpenRouter web mechanism) need a credentialed smoke run to confirm.
+
+## Verified mechanism
+
+- `Chat#with_params` sets `@params`, deep-merged into the rendered payload (`provider.rb` `Utils.deep_merge(render_payload(...), params)`). With no function tools, injecting `tools:`/`plugins:` lands cleanly alongside the schema's `output_config`.
+- RubyLLM 1.16 renders Anthropic structured output as the current `output_config.format` / `json_schema` (`providers/anthropic/chat.rb`). The adapter does not own schema injection.
+
+## Tests
+
+- `test/services/llm_client/adapter_test.rb` — factory selection (incl. symbol provider, unknown → `KeyError`) and each adapter's `web_params` shape.
+- Existing `llm_client_test` / `llm_loader_test` pass unchanged (they never used `tools:`).
+
+## Deferred / [VERIFY-LIVE]
+
+- Confirm Anthropic web tool-version strings and that citations-off is required with a schema.
+- Confirm OpenRouter's live web mechanism (web plugin vs `openrouter:web_search` server tool) and `require_parameters` routing.
+- Anthropic `pause_turn` / server-tool-loop handling.

--- a/specs/005-feed-creation-ux-ai-overhaul/plan-02-llm-provider-seam.md
+++ b/specs/005-feed-creation-ux-ai-overhaul/plan-02-llm-provider-seam.md
@@ -1,33 +1,33 @@
-# LLM Provider Seam Implementation Plan (Track 2 of 6)
+# LLM Provider Seam + Two-Step Extraction Plan (Track 2 of 6)
 
-**Goal:** Give `LlmClient` a thin per-provider seam that enables web access via `with_params`, and remove the `with_tool("web_search")` misuse.
-
-**Scope note:** An earlier draft of this plan added a `SchemaHealer` for loose JSON recovery. It was **dropped as speculative** — RubyLLM enforces structured output through both providers (`with_schema`), Anthropic does so natively, and the dev-verified matrix (§5) excludes OpenRouter models that don't return clean JSON. The required behaviour is parse-or-fail, which `LlmClient` already does. Revisit only if a verified model is observed wrapping its output. See spec §6.
+**Goal:** Make AI extraction work through RubyLLM by splitting it into two calls — gather (web, no schema) then structure (schema, no web) — and give `LlmClient` a per-provider web-params seam plus a `web:` flag.
 
 **Spec:** [`spec.md`](./spec.md) §6.
 
-## What shipped (one PR)
+## Why two steps (live findings)
 
-- `LlmClient::Adapter.for(provider)` — factory keyed on `credential.provider`, raises `KeyError` for unknown providers.
-- `LlmClient::Adapter::Anthropic#web_params(model)` — provider-hosted `web_search`/`web_fetch` server tools, citations disabled.
-- `LlmClient::Adapter::OpenRouter#web_params(model)` — web plugin + `require_parameters`.
-- `LlmClient#invoke_provider` — injects `web_params` via `chat.with_params`; structured output still goes through `chat.with_schema`. The `with_tool` loop is gone; `tools:` removed from `#call`.
-- `Loader::LlmLoader` — stops passing `tools:`.
+Verified against real Anthropic calls:
 
-`web_params` wire-format values are `[VERIFY-LIVE]`: the injection mechanism is verified against the RubyLLM source (`with_params` deep-merges into the request payload), but the exact provider strings (Anthropic tool versions, OpenRouter web mechanism) need a credentialed smoke run to confirm.
+- Schema + web tools in **one** call works at the raw API (HTTP 200, clean JSON) but **breaks through RubyLLM** — RubyLLM has no server-tool handling and mishandles the web tool once a schema is set.
+- Web alone and schema alone each work cleanly through RubyLLM.
+- We keep RubyLLM (no raw per-provider clients), so extraction is two calls that never combine the two.
 
-## Verified mechanism
+## What shipped
 
-- `Chat#with_params` sets `@params`, deep-merged into the rendered payload (`provider.rb` `Utils.deep_merge(render_payload(...), params)`). With no function tools, injecting `tools:`/`plugins:` lands cleanly alongside the schema's `output_config`.
-- RubyLLM 1.16 renders Anthropic structured output as the current `output_config.format` / `json_schema` (`providers/anthropic/chat.rb`). The adapter does not own schema injection.
+- **`LlmClient::Adapter`** — `for(provider)` factory; `Anthropic`/`OpenRouter` each expose `web_params(model) -> Hash`. Anthropic: `web_search_20260209`/`web_fetch_20260209` server tools, citations off. OpenRouter: web plugin + `require_parameters`.
+- **`LlmClient#call(ctx, prompt:, output_schema:, web:)`** — injects `web_params` via `with_params` only when `web: true`; returns raw text when `output_schema` is nil, parsed+validated JSON when a schema is given. Keeps usage bookkeeping (one row per call), error taxonomy, adapter selection. `with_tool` misuse removed.
+- **`Loader::LlmLoader`** — two calls: gather (`web: true`, no schema) → structure (schema, `web: false`, gathered text fed in). Returns `items`.
+- **`UNIVERSAL_OUTPUT_SCHEMA`** — `additionalProperties: false` on every object (Anthropic strict requirement, confirmed live).
 
 ## Tests
 
-- `test/services/llm_client/adapter_test.rb` — factory selection (incl. symbol provider, unknown → `KeyError`) and each adapter's `web_params` shape.
-- Existing `llm_client_test` / `llm_loader_test` pass unchanged (they never used `tools:`).
+- `test/services/llm_client/adapter_test.rb` — factory + `web_params` shape.
+- `test/services/loader/llm_loader_test.rb` — two-call order (gather web/no-schema, then structure schema/no-web), gathered text feeds the structuring prompt, limit, missing-items raise, model resolution.
+- `LlmClient`'s `web:`/no-schema-text internals are exercised at the loader seam and proven by live scripts; not separately unit-stubbed (tests deliberately stub at `invoke_provider`, away from RubyLLM).
 
 ## Deferred / [VERIFY-LIVE]
 
-- Confirm Anthropic web tool-version strings and that citations-off is required with a schema.
-- Confirm OpenRouter's live web mechanism (web plugin vs `openrouter:web_search` server tool) and `require_parameters` routing.
-- Anthropic `pause_turn` / server-tool-loop handling.
+- OpenRouter web mechanism + `require_parameters` — not yet run live.
+- Gather/structure prompts are functional placeholders — Track 4 owns the final prompts + system-prompt safeguards.
+- Structure step is a Haiku cost-optimization candidate (separate model per step).
+- Anthropic `pause_turn` handling is moot in the two-step path (gather returns `end_turn`); revisit only if a gather run pauses.

--- a/specs/005-feed-creation-ux-ai-overhaul/spec.md
+++ b/specs/005-feed-creation-ux-ai-overhaul/spec.md
@@ -147,33 +147,43 @@ The uid is the one place an AI feed can quietly corrupt itself (duplicate or dro
 - Follow-up tasks (named in #876): live intersection with `available_models`; display-name join for
   the picker; the dev-time compatibility probe (the gate that replaced the readiness tier).
 
-### 6. Provider seam
+### 6. Provider seam + two-step extraction
 
-RubyLLM 1.16 already normalizes structured output across providers — confirmed: `with_schema`
-renders the current Anthropic mechanism (`output_config.format` / `json_schema`,
-`providers/anthropic/chat.rb`) and OpenRouter's `response_format`. Both providers therefore return
-JSON shaped by the schema. RubyLLM has **no web-access abstraction**, so the seam exists *only* for
-that one gap.
+Verified against live Anthropic calls (Opus + Sonnet). Findings that shaped the design:
 
-- **Structured output goes straight through RubyLLM `with_schema`.** The adapter does not touch it.
-- **A thin per-provider seam** ("adapter"), selected by `credential.provider`, has a **single
-  responsibility: `web_params(model) -> Hash`**, merged into the request via `with_params`. It builds
-  the raw, provider-specific params RubyLLM won't:
-  - Anthropic: provider-hosted server tools (`web_search_20260209`/`web_fetch_20260209`), citations
-    disabled (they conflict with structured output).
-  - OpenRouter: the web plugin + `require_parameters`.
-  The exact wire-format values are confirmed by a credentialed smoke run, not from this repo.
-- **No response healing.** Because the schema already constrains both providers' output, the
-  required behaviour is just parse-or-fail: `LlmClient` parses the JSON and, on a non-JSON response,
-  records `schema_error` and the refresh retries next cycle. Fenced/prose recovery (`SchemaHealer`)
-  was considered and **dropped as speculative** — Anthropic enforces natively, and the dev-verified
-  matrix already excludes OpenRouter models that don't return clean JSON. Revisit only if a verified
-  model is *observed* wrapping its output in practice.
-- **`LlmClient` stays the orchestrator/bookkeeper**: adapter selection, `CallContext`, `chat.ask`
-  execution, JSON parsing + schema validation, the one-`LlmUsage`-per-call invariant, and the error
-  taxonomy (`schema_error`/`provider_error`/`rate_limited`/`timeout`). The `with_tool("web_search")`
-  misuse is removed — web is now `with_params`.
-- Verify Anthropic `pause_turn` / server-tool-loop handling against a live run.
+- RubyLLM 1.16 renders the current structured-output mechanism (`output_config.format`/`json_schema`
+  for Anthropic, `response_format` for OpenRouter) and `with_params` deep-merges into the request —
+  but RubyLLM has **no server-tool handling**: a web tool injected via `with_params` is mishandled by
+  RubyLLM's function-tool loop the moment a schema is also set (it tries to run the server tool
+  client-side and fails).
+- A **raw** Anthropic call with `output_config.format` **and** web tools in one request **works**
+  (HTTP 200, `end_turn`, clean schema JSON). So schema + web are *not* incompatible at the API — only
+  through RubyLLM. We keep RubyLLM rather than maintain raw per-provider clients.
+- Web alone (no schema) and schema alone (no web) each work cleanly *through* RubyLLM.
+
+So AI extraction is **two RubyLLM calls**, never combining schema + web in one:
+
+1. **Gather** — `web: true`, no schema. The model searches/fetches; `LlmClient` returns the raw text.
+2. **Structure** — schema, `web: false`. The gathered text is fed in; `with_schema` returns clean,
+   native JSON. No healing needed (so `SchemaHealer` stays dropped — §6 earlier rationale holds).
+
+Supporting pieces:
+
+- **Adapter** (`LlmClient::Adapter.for(provider)`), single responsibility `web_params(model) -> Hash`,
+  injected via `with_params` **only on the gather call** (`web: true`):
+  - Anthropic: server tools (`web_search_20260209`/`web_fetch_20260209`), citations off.
+  - OpenRouter: web plugin + `require_parameters`. *(OpenRouter not yet live-verified.)*
+- **`LlmClient#call(ctx, prompt:, output_schema:, web:)`** — injects web only when `web:`; returns the
+  raw text when `output_schema` is nil, parsed+validated JSON when a schema is given. Keeps adapter
+  selection, usage bookkeeping (one row per call → two per extraction), and the error taxonomy.
+- **`UNIVERSAL_OUTPUT_SCHEMA` carries `additionalProperties: false`** on every object — Anthropic
+  strict structured output rejects the schema without it (confirmed live).
+- The `with_tool("web_search")` misuse is removed.
+
+Latency note from live runs: gather dominates (web fetch), and varies widely by model/how much it
+fetches (Opus ~12s, Sonnet ~40–120s); structure is cheap (~12s) and is a good Haiku candidate later.
+The gather/structure prompts here are functional placeholders — Track 4 owns their final form and the
+system-prompt safeguards.
 
 ### 7. Mode A detection & presentation
 

--- a/specs/005-feed-creation-ux-ai-overhaul/spec.md
+++ b/specs/005-feed-creation-ux-ai-overhaul/spec.md
@@ -122,8 +122,8 @@ The uid is the one place an AI feed can quietly corrupt itself (duplicate or dro
   `(provider, model)` allowlist where *membership = qualification* (the pair is dev-verified to
   deliver structured output **and** web access together). **Drop tiers.** The two axes the old
   `tier` enum conflated both find better homes: *readiness* → dev-time compatibility testing (a pair
-  enters only once verified; no `:experimental` rows in production); *reliability* (native vs heal)
-  → the per-provider adapter (§6), since it's a provider property.
+  enters only once verified; no `:experimental` rows in production); enforcement reliability is a
+  provider property the adapter already embodies (§6), not a per-model flag.
 - **What the matrix does NOT store** — these are fetched live from the provider (source of truth):
   - **Display names** — Anthropic `display_name`, OpenRouter `name`.
   - **Availability** — intersect the matrix with the credential's live models so a dropped model
@@ -147,34 +147,33 @@ The uid is the one place an AI feed can quietly corrupt itself (duplicate or dro
 - Follow-up tasks (named in #876): live intersection with `available_models`; display-name join for
   the picker; the dev-time compatibility probe (the gate that replaced the readiness tier).
 
-### 6. Provider seam & response healing
+### 6. Provider seam
 
-RubyLLM 1.16 already normalizes structured output across providers (`with_schema` →
-`providers/anthropic/chat.rb` and `providers/openrouter/chat.rb` render their own shapes) but has
-**no server-tool / web support**. So the seam exists *only* for what RubyLLM doesn't cover — not as
-a layer that re-abstracts structured output.
+RubyLLM 1.16 already normalizes structured output across providers — confirmed: `with_schema`
+renders the current Anthropic mechanism (`output_config.format` / `json_schema`,
+`providers/anthropic/chat.rb`) and OpenRouter's `response_format`. Both providers therefore return
+JSON shaped by the schema. RubyLLM has **no web-access abstraction**, so the seam exists *only* for
+that one gap.
 
-- **Structured output goes straight through RubyLLM `with_schema`.** (Verify at implementation that
-  RubyLLM emits the *current* Anthropic mechanism, `output_config.format`; if it renders a stale
-  shape, the seam must also own schema injection via `with_params`.)
-- **`SchemaHealer`** — extracted, **provider-agnostic** mechanism: given loose text and a schema,
-  recover validated JSON (strip ```` ``` ```` fences, extract the outermost object/array,
-  lenient-parse, validate, trivial safe coercion) or fail as `schema_error`. No second LLM call.
-  Light by design: the dev-verified matrix is the real defense; healing only mops up cosmetic noise
-  from already-verified models.
-- **A thin per-provider seam** ("adapter"), selected by `credential.provider`, owns two things —
-  cut by *provider* (the axis of variation), not by concern:
-  - `web_params(model)` → merged via `with_params`. Anthropic: version-pinned server tools
-    (`web_search_20260209`/`web_fetch_20260209`, model-dependent), citations disabled when a schema
-    is set. OpenRouter: web server tool + `require_parameters`.
-  - `normalize(payload)` → passthrough for Anthropic (native enforcement, trusted); delegate to
-    `SchemaHealer` for OpenRouter (best-effort routing).
+- **Structured output goes straight through RubyLLM `with_schema`.** The adapter does not touch it.
+- **A thin per-provider seam** ("adapter"), selected by `credential.provider`, has a **single
+  responsibility: `web_params(model) -> Hash`**, merged into the request via `with_params`. It builds
+  the raw, provider-specific params RubyLLM won't:
+  - Anthropic: provider-hosted server tools (`web_search_20260209`/`web_fetch_20260209`), citations
+    disabled (they conflict with structured output).
+  - OpenRouter: the web plugin + `require_parameters`.
+  The exact wire-format values are confirmed by a credentialed smoke run, not from this repo.
+- **No response healing.** Because the schema already constrains both providers' output, the
+  required behaviour is just parse-or-fail: `LlmClient` parses the JSON and, on a non-JSON response,
+  records `schema_error` and the refresh retries next cycle. Fenced/prose recovery (`SchemaHealer`)
+  was considered and **dropped as speculative** — Anthropic enforces natively, and the dev-verified
+  matrix already excludes OpenRouter models that don't return clean JSON. Revisit only if a verified
+  model is *observed* wrapping its output in practice.
 - **`LlmClient` stays the orchestrator/bookkeeper**: adapter selection, `CallContext`, `chat.ask`
-  execution, the one-`LlmUsage`-per-call invariant, and the error taxonomy
-  (`schema_error`/`provider_error`/`rate_limited`/`timeout`). It orchestrates
-  `pick adapter → prepare → ask → normalize → record usage`. The `with_tool("web_search")` misuse is
-  removed (web is now `with_params` in `prepare`).
-- Verify Anthropic `pause_turn` / server-tool-loop handling at implementation.
+  execution, JSON parsing + schema validation, the one-`LlmUsage`-per-call invariant, and the error
+  taxonomy (`schema_error`/`provider_error`/`rate_limited`/`timeout`). The `with_tool("web_search")`
+  misuse is removed — web is now `with_params`.
+- Verify Anthropic `pause_turn` / server-tool-loop handling against a live run.
 
 ### 7. Mode A detection & presentation
 
@@ -210,8 +209,8 @@ processor), the same place the uid integrity checks live.
 
 ## Sequencing
 
-- **AI plumbing + integrity first**: `SchemaHealer` + per-provider seam (§6) and the `Uid::Resolver`
-  + ephemeral-uid rejection (§3) are foundational and largely independent.
+- **AI plumbing + integrity first**: the per-provider seam (§6) and the `Uid::Resolver` (§3) are
+  foundational and largely independent.
 - **Single AI profile** (§2) depends on web access via the seam.
 - **Explicit-mode creation** (§1, §7) depends on the single AI profile being what Mode B selects.
 - **Editing/lifecycle** (§4) is largely independent; the prompt-editing win lands once §2 exists.

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class LlmClient::AdapterTest < ActiveSupport::TestCase
+  test ".for should return the Anthropic adapter" do
+    assert_instance_of LlmClient::Adapter::Anthropic, LlmClient::Adapter.for("anthropic")
+  end
+
+  test ".for should return the OpenRouter adapter" do
+    assert_instance_of LlmClient::Adapter::OpenRouter, LlmClient::Adapter.for("openrouter")
+  end
+
+  test ".for should accept a symbol provider" do
+    assert_instance_of LlmClient::Adapter::Anthropic, LlmClient::Adapter.for(:anthropic)
+  end
+
+  test ".for should raise for an unknown provider" do
+    assert_raises(KeyError) { LlmClient::Adapter.for("nope") }
+  end
+
+  test "anthropic #web_params should declare web search and fetch server tools" do
+    types = LlmClient::Adapter::Anthropic.new.web_params("claude-opus-4-8").fetch(:tools).map { |t| t[:type] }
+
+    assert_includes types, "web_search_20260209"
+    assert_includes types, "web_fetch_20260209"
+  end
+
+  test "openrouter #web_params should enable the web plugin and require parameters" do
+    params = LlmClient::Adapter::OpenRouter.new.web_params("openai/gpt-4o")
+
+    assert_equal [{ id: "web" }], params.fetch(:plugins)
+    assert params.dig(:provider, :require_parameters)
+  end
+end

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -17,6 +17,16 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_raises(KeyError) { LlmClient::Adapter.for("nope") }
   end
 
+  test "every registered adapter should inherit from Base" do
+    LlmClient::Adapter::REGISTRY.each_key do |provider|
+      assert_kind_of LlmClient::Adapter::Base, LlmClient::Adapter.for(provider)
+    end
+  end
+
+  test "Base#web_params should raise NotImplementedError" do
+    assert_raises(NotImplementedError) { LlmClient::Adapter::Base.new.web_params("any-model") }
+  end
+
   test "anthropic #web_params should declare web search and fetch server tools" do
     types = LlmClient::Adapter::Anthropic.new.web_params("claude-opus-4-8").fetch(:tools).map { |t| t[:type] }
 

--- a/test/services/loader/llm_loader_test.rb
+++ b/test/services/loader/llm_loader_test.rb
@@ -17,44 +17,64 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
                      params: { "url" => "https://example.com" })
   end
 
-  # Captures the CallContext so tests can assert the resolved model, and
-  # exposes a #credential (real LlmClient does too) so the loader can read
-  # the provider for default-model resolution.
-  def fake_client(payload, credential: self.credential)
+  # Two-call fake: the web call (gather) returns text, the schema call
+  # (structure) returns the items payload. Records each call's opts + model.
+  def fake_client(structured:, gathered: "raw gathered text", credential: self.credential)
     Class.new do
-      attr_reader :credential, :last_ctx
+      attr_reader :credential, :calls
 
-      def initialize(payload, credential)
-        @payload = payload
+      def initialize(structured, gathered, credential)
+        @structured = structured
+        @gathered = gathered
         @credential = credential
+        @calls = []
       end
 
-      def call(ctx, **_opts)
-        @last_ctx = ctx
-        LlmClient::Result.new(payload: @payload, usage_id: 42)
+      def call(ctx, **opts)
+        @calls << opts.merge(model: ctx.model)
+        payload = opts[:web] ? @gathered : @structured
+        LlmClient::Result.new(payload: payload, usage_id: @calls.size)
       end
-    end.new(payload, credential)
+    end.new(structured, gathered, credential)
   end
 
-  test "#load should return the items array from the LLM response" do
+  test "#load should return the items array from the structured response" do
     items = [
-      { "title" => "Post A", "uid" => "https://example.com/a" },
-      { "title" => "Post B", "uid" => "https://example.com/b" }
+      { "title" => "Post A", "source_url" => "https://example.com/a" },
+      { "title" => "Post B", "source_url" => "https://example.com/b" }
     ]
-    loader = Loader::LlmLoader.new(feed, llm_client: fake_client({ "items" => items }))
+    loader = Loader::LlmLoader.new(feed, llm_client: fake_client(structured: { "items" => items }))
 
     assert_equal items, loader.load
   end
 
+  test "#load should gather with web first, then structure with the schema" do
+    client = fake_client(structured: { "items" => [] })
+    Loader::LlmLoader.new(feed, llm_client: client).load
+
+    assert_equal 2, client.calls.size
+    assert_equal true, client.calls[0][:web]
+    assert_nil client.calls[0][:output_schema]
+    assert_equal false, client.calls[1][:web]
+    assert client.calls[1][:output_schema].present?
+  end
+
+  test "#load should feed the gathered content into the structuring prompt" do
+    client = fake_client(structured: { "items" => [] }, gathered: "GATHERED-XYZ")
+    Loader::LlmLoader.new(feed, llm_client: client).load
+
+    assert_match "GATHERED-XYZ", client.calls[1][:prompt]
+  end
+
   test "#load should respect the limit option" do
-    items = (1..10).map { |i| { "title" => "Post #{i}", "uid" => "https://example.com/#{i}" } }
-    loader = Loader::LlmLoader.new(feed, llm_client: fake_client({ "items" => items }), limit: 3)
+    items = (1..10).map { |i| { "title" => "Post #{i}", "source_url" => "https://example.com/#{i}" } }
+    loader = Loader::LlmLoader.new(feed, llm_client: fake_client(structured: { "items" => items }), limit: 3)
 
     assert_equal 3, loader.load.size
   end
 
-  test "#load should raise when the payload is missing the items key" do
-    loader = Loader::LlmLoader.new(feed, llm_client: fake_client({ "wrong" => "shape" }))
+  test "#load should raise when the structured payload is missing the items key" do
+    loader = Loader::LlmLoader.new(feed, llm_client: fake_client(structured: { "wrong" => "shape" }))
 
     error = assert_raises(StandardError) { loader.load }
     assert_match(/items/, error.message)
@@ -62,18 +82,18 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
 
   test "#load should call the model from the feed override when set" do
     feed.update!(ai_model: "claude-opus-4-7")
-    client = fake_client({ "items" => [] })
+    client = fake_client(structured: { "items" => [] })
     Loader::LlmLoader.new(feed, llm_client: client).load
 
-    assert_equal "claude-opus-4-7", client.last_ctx.model
+    assert_equal ["claude-opus-4-7", "claude-opus-4-7"], client.calls.map { |c| c[:model] }
   end
 
   test "#load should fall back to the provider default model when no override" do
     assert_nil feed.ai_model
-    client = fake_client({ "items" => [] }, credential: credential)
+    client = fake_client(structured: { "items" => [] }, credential: credential)
     Loader::LlmLoader.new(feed, llm_client: client).load
 
-    assert_equal LlmProvider.find(credential.provider).default_model, client.last_ctx.model
+    assert_equal LlmProvider.find(credential.provider).default_model, client.calls.first[:model]
   end
 
   test "#rendered_prompt should substitute the source input" do


### PR DESCRIPTION
Changes:

- Add `LlmClient::Adapter` — per-provider seam (`web_params(model)`) for the web access RubyLLM doesn't abstract; injected via `with_params`.
- `LlmClient#call` gains a `web:` flag and a freeform path: it injects web only when `web: true`, and returns raw text when no `output_schema` is given (parsed+validated JSON when one is). Removes the `with_tool("web_search")` misuse.
- `Loader::LlmLoader` now extracts in **two calls**: gather (web on, no schema) → structure (schema on, web off, gathered text fed in). Each is a proven-working primitive; neither combines schema + web.
- `UNIVERSAL_OUTPUT_SCHEMA` requires `additionalProperties: false` (Anthropic strict structured output rejects it otherwise).

Why two steps: verified against live Anthropic calls. Schema + web tools in one request works at the raw API but **breaks through RubyLLM** (no server-tool handling). Web-alone and schema-alone each work cleanly through RubyLLM, so we split rather than maintain raw per-provider clients. Details and latency notes in spec §6.

Full suite green (2775). The gather/structure prompts are functional placeholders — Track 4 owns the final prompts and system-prompt safeguards. OpenRouter's web wire format is not yet live-verified.

References:

- Part of spec: #878