### PR TITLE
Add ViewComponent compatibility shim for Rails edge

### DIFF
--- a/config/initializers/view_component_compat.rb
+++ b/config/initializers/view_component_compat.rb
@@ -1,0 +1,11 @@
+# Rails edge moved template handler registration to
+# ActionView::Template::Handlers and removed the old
+# ActionView::Template.template_handler_extensions, which ViewComponent's
+# compiler still calls. Restore it until ViewComponent catches up.
+ActiveSupport.on_load(:action_view) do
+  unless ActionView::Template.respond_to?(:template_handler_extensions)
+    ActionView::Template.singleton_class.define_method(:template_handler_extensions) do
+      ActionView::Template::Handlers.extensions
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Add an initializer restoring `ActionView::Template.template_handler_extensions`, delegating to the new `ActionView::Template::Handlers.extensions` API

Rails edge (`bf13f50`) moved template handler registration to `ActionView::Template::Handlers` and removed the old method, which ViewComponent 4.12.0 still calls when compiling components — crashing the test suite at boot during eager loading. The shim is guarded with `respond_to?`, so it becomes a no-op and can be removed once ViewComponent supports the new API.

References:

- Fixes CI for #893