### PR TITLE
Collapse duplicate uids within a refresh batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-03
+
+- Fixed a refresh failure when a feed served the same item twice in one batch, which could wrongly disable the feed.
+
 ## 2026-06-26
 
 - JSON feeds are now supported.

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -55,10 +55,25 @@ class FeedRefreshWorkflow
   def filter_new_entries(processed_entries)
     return [] if processed_entries.empty?
 
-    uids = processed_entries.map(&:uid)
+    deduped_entries = collapse_duplicate_uids(processed_entries)
+    uids = deduped_entries.map(&:uid)
     existing_uids = FeedEntryUid.where(feed_id: feed.id, uid: uids).pluck(:uid).to_set
-    new_entries = processed_entries.filter { |entry| existing_uids.exclude?(entry.uid) }
+    new_entries = deduped_entries.filter { |entry| existing_uids.exclude?(entry.uid) }
     reject_entries_before_threshold(new_entries)
+  end
+
+  # Two items in one batch can resolve to the same uid (e.g. a utm_ variant and
+  # the clean permalink, both normalized by Uid::Resolver). Keep the first and
+  # drop the rest, so insert_all doesn't hit the unique index and roll back the
+  # whole batch. Also enforces the digest regime's one-post-per-period invariant.
+  def collapse_duplicate_uids(entries)
+    seen = Set.new
+    unique_entries = entries.select { |entry| seen.add?(entry.uid) }
+
+    collapsed_count = entries.size - unique_entries.size
+    record_stats(collapsed_duplicate_uids: collapsed_count) if collapsed_count.positive?
+
+    unique_entries
   end
 
   # Entries at or before the feed's import threshold are dropped without

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -67,8 +67,7 @@ class FeedRefreshWorkflow
   # drop the rest, so insert_all doesn't hit the unique index and roll back the
   # whole batch. Also enforces the digest regime's one-post-per-period invariant.
   def collapse_duplicate_uids(entries)
-    seen = Set.new
-    unique_entries = entries.select { |entry| seen.add?(entry.uid) }
+    unique_entries = entries.uniq(&:uid)
 
     collapsed_count = entries.size - unique_entries.size
     record_stats(collapsed_duplicate_uids: collapsed_count) if collapsed_count.positive?

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -231,6 +231,35 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 1, workflow.stats[:entries_before_threshold]
   end
 
+  test "#filter_new_entries should collapse duplicate uids within the batch" do
+    test_feed = create(:feed)
+    workflow = FeedRefreshWorkflow.new(test_feed)
+
+    first = FeedEntry.new(feed: test_feed, uid: "dup", published_at: 1.hour.ago)
+    second = FeedEntry.new(feed: test_feed, uid: "dup", published_at: 2.hours.ago)
+    unique = FeedEntry.new(feed: test_feed, uid: "unique", published_at: 1.hour.ago)
+
+    result = workflow.send(:filter_new_entries, [first, second, unique])
+
+    assert_equal ["dup", "unique"], result.map(&:uid)
+    assert_same first, result.first
+    assert_equal 1, workflow.stats[:collapsed_duplicate_uids]
+  end
+
+  test "#filter_new_entries should not record collapsed count without duplicates" do
+    test_feed = create(:feed)
+    workflow = FeedRefreshWorkflow.new(test_feed)
+
+    entries = [
+      FeedEntry.new(feed: test_feed, uid: "a", published_at: 1.hour.ago),
+      FeedEntry.new(feed: test_feed, uid: "b", published_at: 1.hour.ago)
+    ]
+
+    workflow.send(:filter_new_entries, entries)
+
+    assert_nil workflow.stats[:collapsed_duplicate_uids]
+  end
+
   test "#filter_new_entries should keep entries without a published date despite the import threshold" do
     test_feed = create(:feed, import_after: 1.hour.ago)
     workflow = FeedRefreshWorkflow.new(test_feed)


### PR DESCRIPTION
Two items in one refresh batch can resolve to the same uid (e.g. a `utm_` variant and the clean permalink). `insert_all` then hit the unique index, rolled back the whole batch, and counted a refresh failure — ten of which auto-disable the feed.

`filter_new_entries` now collapses same-uid items within the batch, keeping the first. This is also the enforcement point for the digest regime's one-post-per-period invariant.

References:

- Closes #898