### PR TITLE
Point AI page reader loader at UNIVERSAL_OUTPUT_SCHEMA

### DIFF
--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -394,28 +394,7 @@ class FeedProfile
             an optional list of supplementary comments, an optional list of image URLs,
             the source URL, and the published date in ISO 8601.
           PROMPT
-          output_schema: {
-            "type" => "object",
-            "properties" => {
-              "items" => {
-                "type" => "array",
-                "items" => {
-                  "type" => "object",
-                  "properties" => {
-                    "uid" => { "type" => "string" },
-                    "title" => { "type" => "string" },
-                    "body" => { "type" => "string" },
-                    "supplementary" => { "type" => "array", "items" => { "type" => "string" } },
-                    "images" => { "type" => "array", "items" => { "type" => "string" } },
-                    "source_url" => { "type" => "string" },
-                    "published_at" => { "type" => "string" }
-                  },
-                  "required" => ["uid", "body", "source_url"]
-                }
-              }
-            },
-            "required" => ["items"]
-          },
+          output_schema: UNIVERSAL_OUTPUT_SCHEMA,
           tools: ["web_search", "web_fetch"]
         }
       },


### PR DESCRIPTION
Changes:

- Point the `llm_website_extractor` loader config at `UNIVERSAL_OUTPUT_SCHEMA` instead of its own inline copy of the schema

The inline duplicate lacked `additionalProperties: false`, which Anthropic's strict structured output rejects, so this profile's structure step failed on Anthropic. PR #885 fixed only `UNIVERSAL_OUTPUT_SCHEMA` itself; the structure call sends the loader's inline schema, which stayed divergent. Reusing the shared constant removes the duplicate and matches the `llm_web_search` profile.

References:

- Closes #899
- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §6
- Related PR: #885
- Related PR: #897