### PR TITLE
Detection presentation: terminal vs transient states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 - Added Moonshot (Kimi) as an AI provider — a lower-cost option you can connect with your own API key.
 - Paste a bare address like `example.com` and we'll treat it as a link and check it for a feed. When a link has no standard feed, you can now choose to follow it with AI instead.
 - New feeds now start with a clear choice: follow a feed or channel by its link, or follow with AI by describing a source or topic in your own words.
+- When a link can't be followed, the next step is clearer: retry if it just couldn't be reached, or follow it with AI (or try a different link) when there's no feed to read.
 
 ## 2026-07-03
 

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -21,9 +21,12 @@ class FeedIdentificationsController < ApplicationController
     # rather than guessing (spec §1) — the user stays in the mode they chose.
     return render(not_a_link_bridge) if source_url.nil?
 
-    return present_outcome if feed_identification.success?
+    # A settled result — a working feed, or a reachable link with no feed — is
+    # shown as-is. Everything else kicks off a fresh detection, so the retry
+    # state's Retry actually re-checks a couldn't-reach result.
+    return present_outcome if settled_identification?
 
-    if feed_identification.new_record? || feed_identification.failed?
+    if feed_identification.new_record? || feed_identification.failed? || retryable_unreachable?
       begin
         feed_identification.update!(
           status: :processing,
@@ -94,6 +97,19 @@ class FeedIdentificationsController < ApplicationController
     end
 
     head :no_content
+  end
+
+  # A finished identification worth showing without re-detecting: a working feed
+  # or a reachable-but-featureless link. A couldn't-reach result is deliberately
+  # excluded so its Retry re-runs detection rather than re-rendering itself.
+  def settled_identification?
+    feed_identification.success? && feed_identification.outcome != :unreachable
+  end
+
+  # A prior success whose candidates were all unreachable — retrying should
+  # re-detect rather than re-render the same couldn't-reach state.
+  def retryable_unreachable?
+    feed_identification.success? && feed_identification.outcome == :unreachable
   end
 
   # Present the finished identification by how many candidates actually work

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -21,7 +21,7 @@ class FeedIdentificationsController < ApplicationController
     # rather than guessing (spec §1) — the user stays in the mode they chose.
     return render(not_a_link_bridge) if source_url.nil?
 
-    return handle_success_status if feed_identification.success?
+    return present_outcome if feed_identification.success?
 
     if feed_identification.new_record? || feed_identification.failed?
       begin
@@ -47,14 +47,9 @@ class FeedIdentificationsController < ApplicationController
       return render(identification_error(error: "Identification session expired. Please try again."))
     end
 
-    case feed_identification.status
-    when "processing"
-      handle_processing_status
-    when "success"
-      handle_success_status
-    when "failed"
-      handle_failed_status
-    end
+    return handle_processing_status if feed_identification.processing?
+
+    present_outcome
   end
 
   def destroy
@@ -101,6 +96,17 @@ class FeedIdentificationsController < ApplicationController
     head :no_content
   end
 
+  # Present the finished identification by how many candidates actually work
+  # (spec §7): the feed form when at least one does, otherwise the transient
+  # retry state (couldn't reach) or the terminal error that offers the AI bridge.
+  def present_outcome
+    case feed_identification.outcome
+    when :working then handle_success_status
+    when :unreachable then render(couldnt_reach_retry)
+    else render(no_feed_error)
+    end
+  end
+
   def handle_success_status
     suggested = feed_identification.suggested_candidate
     profile_key = suggested&.profile_key
@@ -114,12 +120,6 @@ class FeedIdentificationsController < ApplicationController
     )
 
     render(identification_success(feed, candidates: feed_identification.candidates))
-  end
-
-  def handle_failed_status
-    code = feed_identification.error.presence || "generic"
-    message = t("feed_identifications.failures.#{code}", default: :"feed_identifications.failures.generic")
-    render(identification_error(error: message))
   end
 
   def identification_error(error:, heading: "Feed identification failed")
@@ -137,6 +137,27 @@ class FeedIdentificationsController < ApplicationController
       heading: "That doesn't look like a link",
       error: "Follow it with AI instead, or switch back and paste a link."
     )
+  end
+
+  # Terminal: the link was reachable but no deterministic profile reads it. The
+  # bridge is the way forward (spec §7).
+  def no_feed_error
+    identification_error(
+      heading: "Couldn't pull any posts from that link",
+      error: "We couldn't find a feed there — but AI can still follow it, or you can try a different link."
+    )
+  end
+
+  # Transient: nothing connected. Retrying is the primary path; the bridge is a
+  # secondary escape so the state can't dead-end (spec §7).
+  def couldnt_reach_retry
+    {
+      turbo_stream: turbo_stream.replace(
+        "feed-form",
+        partial: "feeds/identification_retry",
+        locals: { input: raw_input }
+      )
+    }
   end
 
   def identification_loading

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -16,7 +16,37 @@ class FeedIdentification < ApplicationRecord
       detected_candidates.first
   end
 
+  # Candidates that can fetch the source (spec §7): the count of these drives how
+  # the result is presented. A candidate counts unless it's known-broken —
+  # tested and failed, or unreachable — so a passed candidate works.
+  def working_candidates
+    candidates.reject do |attributes|
+      candidate = Candidate.new(attributes)
+      candidate.failed? || candidate.unreachable?
+    end
+  end
+
+  # How the detection result should present (spec §7):
+  #   :working     — at least one candidate read the source → the feed form
+  #   :unreachable — nothing connected (couldn't-reach) → the transient retry state
+  #   :no_feed     — reachable, but no candidate yields a feed → the terminal
+  #                  error that offers the AI bridge
+  def outcome
+    return :working if working_candidates.any?
+    return :unreachable if unreachable_only?
+
+    :no_feed
+  end
+
   private
+
+  # Nothing was reachable to judge: the initial fetch never connected, or every
+  # detected candidate failed on the network.
+  def unreachable_only?
+    return true if error == "fetch_failed"
+
+    candidates.present? && candidates.all? { |attributes| Candidate.new(attributes).unreachable? }
+  end
 
   # Lazy so the suggestion chain stops wrapping at the first match; memoized
   # so the repeated lookups share one enumerator.

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -43,7 +43,7 @@ class FeedIdentification < ApplicationRecord
   # Nothing was reachable to judge: the initial fetch never connected, or every
   # detected candidate failed on the network.
   def unreachable_only?
-    return true if error == "fetch_failed"
+    return true if error == "unreachable"
 
     candidates.present? && candidates.all? { |attributes| Candidate.new(attributes).unreachable? }
   end

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -1,9 +1,9 @@
 class FeedIdentificationFetcher
-  # A hard fetch failure: the source returned no usable response, as opposed to a
-  # page that loads but fits no structured profile (which falls back to the AI
-  # option). Every subclass persists the "fetch_failed" error code (the UI
-  # resolves it to text via I18n); the class and its message exist only for the
-  # logs.
+  # A fetch that yielded no usable response. UnreachableError (couldn't connect)
+  # persists as "unreachable" and reads as a transient retry; every other
+  # FetchError (bad status, redirect loop, a blocked non-public host) persists as
+  # "unreadable" and reads as a terminal "no feed here" (spec §7). The class and
+  # its message exist only for the logs.
   class FetchError < StandardError; end
   class UnreachableError < FetchError; end    # no answer: DNS, refused, or timeout
   class RedirectLimitError < FetchError; end  # followed too many redirects
@@ -38,11 +38,16 @@ class FeedIdentificationFetcher
     else
       feed_identification.update!(status: :failed, candidates: [], error: "unidentifiable")
     end
+  rescue UnreachableError => e
+    # Couldn't connect (DNS, refused, timeout): genuinely transient, so the UI
+    # offers a retry. Expected, so log without reporting it as a bug.
+    @logger.info("Feed identification couldn't reach #{sanitize_input_for_logging(@input)}: #{e.class} (#{e.message})")
+    feed_identification.update!(status: :failed, candidates: [], error: "unreachable")
   rescue FetchError => e
-    # Expected (a bad or unreachable source): log with detail for debugging, but
-    # don't report it as a bug. e.message carries the status or underlying cause.
+    # Reached the source but it's unusable (bad status, redirect loop): retrying
+    # won't help, so this reads as a terminal "no feed here".
     @logger.info("Feed identification fetch failed for #{sanitize_input_for_logging(@input)}: #{e.class} (#{e.message})")
-    feed_identification.update!(status: :failed, candidates: [], error: "fetch_failed")
+    feed_identification.update!(status: :failed, candidates: [], error: "unreadable")
   rescue StandardError => e
     # Unexpected: report it as a bug, then surface a neutral code.
     sanitized = sanitize_input_for_logging(@input)
@@ -63,7 +68,7 @@ class FeedIdentificationFetcher
   # loopback, or metadata address must not be dialed. Redirects that hop into a
   # private range are a separate fetch-layer gap tracked in #920.
   def fetch_body_for_input
-    raise UnreachableError, "blocked non-public URL" unless PublicUrl.safe?(@input)
+    raise FetchError, "blocked non-public URL" unless PublicUrl.safe?(@input)
 
     response = http_client.get(@input)
     raise ResponseStatusError.new(response.status) unless response.success?

--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -30,4 +30,6 @@
                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
     <p class="text-sm text-muted">AI can follow it even when there's no standard feed to read.</p>
   </div>
+
+  <%= link_to "Cancel", feeds_path, class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
 </div>

--- a/app/views/feeds/_identification_retry.html.erb
+++ b/app/views/feeds/_identification_retry.html.erb
@@ -1,0 +1,35 @@
+<%# locals: (input: nil) %>
+<%# The transient "couldn't reach" state (spec §7): retrying is the primary
+    path, with the AI bridge as a secondary escape so it can't dead-end. Marked
+    as an identification state so polling stops here. %>
+<div id="feed-form"
+     data-identification-state="error"
+     class="rounded-lg border border-border bg-surface px-6 py-8 shadow-sm space-y-6">
+  <div class="rounded-md bg-surface-muted p-4">
+    <div class="flex">
+      <div class="flex-shrink-0">
+        <%= icon("refresh-ccw", css_class: "size-5 text-muted") %>
+      </div>
+      <div class="ml-3">
+        <h3 class="text-sm font-medium text-heading">Couldn't reach that link</h3>
+        <div class="mt-2 text-sm text-body">
+          <p>It might be a temporary hiccup — give it another go, or follow it with AI instead.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex flex-wrap items-center gap-4">
+    <%= button_to "Retry", feed_identifications_path,
+                  params: { input: input },
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto",
+                  data: { key: "identification.retry", turbo_submits_with: "Checking…" } %>
+
+    <%= button_to "Follow with AI instead", feed_identifications_path,
+                  params: { input: input, mode: "ai" },
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto",
+                  data: { key: "identification.ai-bridge" } %>
+  </div>
+
+  <%= link_to "Cancel", feeds_path, class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,13 +30,6 @@
 en:
   hello: "Hello world"
 
-  feed_identifications:
-    failures:
-      fetch_failed: "We couldn't load this source."
-      unidentifiable: "We couldn't find a way to follow this source."
-      internal_error: "An error occurred while identifying the feed."
-      generic: "We couldn't identify a feed profile for this URL."
-
   events:
     feed_enabled:
       name: "Feed enabled"

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -83,6 +83,8 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
             <title>Test Post</title>
             <description>Test content</description>
             <link>http://example.com/post1</link>
+            <guid>http://example.com/post1</guid>
+            <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
           </item>
         </channel>
       </rss>
@@ -291,7 +293,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "identification.ai-bridge"
   end
 
-  test "#show should render the localized failure message for a fetch failure" do
+  test "#show should show the transient retry state when the source can't be reached" do
     sign_in_as(user)
     url = "http://example.com/down.xml"
 
@@ -303,7 +305,22 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, 'data-identification-state="error"'
-    assert_select "p", text: I18n.t("feed_identifications.failures.fetch_failed")
+    assert_select "[data-key='identification.retry']"
+    assert_select "[data-key='identification.ai-bridge']"
+  end
+
+  test "#show should show the terminal no-feed error when a reachable link has no working feed" do
+    sign_in_as(user)
+    url = "http://example.com/page.html"
+    create(:feed_identification, user: user, input: url, started_at: Time.current, status: :success,
+                                 candidates: [{ "profile_key" => "rss", "test_status" => "failed" }])
+
+    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_includes response.body, 'data-identification-state="error"'
+    assert_includes response.body, "identification.ai-bridge"
+    assert_includes response.body, "pull any posts"
   end
 
   test "#show should return error when feed detail is missing" do

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -269,8 +269,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_includes response.body, 'action="replace"'
-    assert_includes response.body, 'target="feed-form"'
+    assert_includes response.body, 'data-identification-state="complete"'
   end
 
   test "#show should return error when status is failed" do
@@ -297,7 +296,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     url = "http://example.com/down.xml"
 
-    stub_request(:get, url).to_return(status: 500)
+    stub_request(:get, url).to_timeout
 
     post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
     perform_enqueued_jobs
@@ -307,6 +306,21 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, 'data-identification-state="error"'
     assert_select "[data-key='identification.retry']"
     assert_select "[data-key='identification.ai-bridge']"
+  end
+
+  test "#create should re-run detection when retrying a couldn't-reach success" do
+    sign_in_as(user)
+    url = "http://example.com/feed.xml"
+    # A success whose only candidate was unreachable: Retry must re-detect rather
+    # than re-render the same couldn't-reach state.
+    create(:feed_identification, user: user, input: url, started_at: Time.current, status: :success,
+                                 candidates: [{ "profile_key" => "youtube", "test_status" => "unreachable" }])
+
+    assert_enqueued_with(job: FeedIdentificationJob) do
+      post feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_includes response.body, 'data-controller="polling"'
   end
 
   test "#show should show the terminal no-feed error when a reachable link has no working feed" do

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -137,10 +137,16 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_equal :unreachable, id.outcome
   end
 
-  test "#outcome should be :unreachable when the initial fetch failed" do
-    id = FeedIdentification.new(user: user, input: "https://example.com", status: :failed, error: "fetch_failed", candidates: [])
+  test "#outcome should be :unreachable when the initial fetch couldn't connect" do
+    id = FeedIdentification.new(user: user, input: "https://example.com", status: :failed, error: "unreachable", candidates: [])
 
     assert_equal :unreachable, id.outcome
+  end
+
+  test "#outcome should be :no_feed when the source was reachable but unreadable" do
+    id = FeedIdentification.new(user: user, input: "https://example.com", status: :failed, error: "unreadable", candidates: [])
+
+    assert_equal :no_feed, id.outcome
   end
 
   test "#outcome should be :no_feed when nothing was identified" do

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -103,6 +103,52 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_equal "rss", id.suggested_candidate.profile_key
   end
 
+  test "#working_candidates should exclude failed and unreachable candidates" do
+    id = identification([
+      { "profile_key" => "rss", "test_status" => "passed" },
+      { "profile_key" => "atom", "test_status" => "failed" },
+      { "profile_key" => "youtube", "test_status" => "unreachable" }
+    ])
+
+    assert_equal ["rss"], id.working_candidates.map { |c| c["profile_key"] }
+  end
+
+  test "#outcome should be :working when at least one candidate reads the source" do
+    id = identification([
+      { "profile_key" => "rss", "test_status" => "passed" },
+      { "profile_key" => "atom", "test_status" => "failed" }
+    ])
+
+    assert_equal :working, id.outcome
+  end
+
+  test "#outcome should be :no_feed when the source is reachable but no candidate works" do
+    id = identification([{ "profile_key" => "rss", "test_status" => "failed" }])
+
+    assert_equal :no_feed, id.outcome
+  end
+
+  test "#outcome should be :unreachable when every candidate failed on the network" do
+    id = identification([
+      { "profile_key" => "rss", "test_status" => "unreachable" },
+      { "profile_key" => "atom", "test_status" => "unreachable" }
+    ])
+
+    assert_equal :unreachable, id.outcome
+  end
+
+  test "#outcome should be :unreachable when the initial fetch failed" do
+    id = FeedIdentification.new(user: user, input: "https://example.com", status: :failed, error: "fetch_failed", candidates: [])
+
+    assert_equal :unreachable, id.outcome
+  end
+
+  test "#outcome should be :no_feed when nothing was identified" do
+    id = FeedIdentification.new(user: user, input: "https://example.com", status: :failed, error: "unidentifiable", candidates: [])
+
+    assert_equal :no_feed, id.outcome
+  end
+
   test "should accept multiple ranked candidates" do
     identification = FeedIdentification.create!(
       user: user,

--- a/test/services/feed_identification_fetcher_test.rb
+++ b/test/services/feed_identification_fetcher_test.rb
@@ -101,7 +101,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_equal "failed", feed_identification.status
-    assert_equal "fetch_failed", feed_identification.error
+    assert_equal "unreadable", feed_identification.error
     assert_not_requested :get, url
   end
 
@@ -122,7 +122,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     assert_equal "unidentifiable", feed_identification.error
   end
 
-  test "#identify should fail with a generic message when the source returns an error status" do
+  test "#identify should mark a bad response status as unreadable (reachable, no feed)" do
     url = "http://example.com/error.xml"
 
     stub_request(:get, url)
@@ -134,10 +134,10 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_not_nil feed_identification
     assert_equal "failed", feed_identification.status
-    assert_equal "fetch_failed", feed_identification.error
+    assert_equal "unreadable", feed_identification.error
   end
 
-  test "#identify should fail with a generic message on a redirect loop" do
+  test "#identify should mark a redirect loop as unreadable" do
     url = "http://example.com/loop.xml"
 
     stub_request(:get, url)
@@ -148,10 +148,10 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_equal "failed", feed_identification.status
-    assert_equal "fetch_failed", feed_identification.error
+    assert_equal "unreadable", feed_identification.error
   end
 
-  test "#identify should fail with a generic message when the source is unreachable" do
+  test "#identify should mark a connection failure as unreachable (transient)" do
     url = "http://example.com/timeout.xml"
 
     stub_request(:get, url)
@@ -163,7 +163,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_not_nil feed_identification
     assert_equal "failed", feed_identification.status
-    assert_equal "fetch_failed", feed_identification.error
+    assert_equal "unreachable", feed_identification.error
   end
 
   test "#identify should log the failure class and status for diagnosis" do


### PR DESCRIPTION
Changes:

- Route a finished identification by *outcome* rather than raw status (spec §7): `FeedIdentification#outcome` classifies the result as `:working` / `:unreachable` / `:no_feed` from the count of candidates that can actually fetch the source.
- At least one working candidate → the feed form, as before.
- Reachable but no working feed → the terminal error, which offers the "Follow with AI instead" bridge and a Cancel back to the feeds index.
- Couldn't reach anything (the initial fetch failed, or every candidate failed on the network) → a new transient retry state: Retry is primary, the AI bridge a secondary escape so the state can't dead-end.

This completes the Mode A detection & presentation for #909. A `success` identification whose only candidate failed its self-test used to render a chooser of dead options; it now lands in the terminal error. The per-error-code failure copy is gone with the status-based dispatch.

Deferred to a follow-up (both localized to the chooser view): presenting the chooser itself by working-candidate count (annotation for one, chooser for two-plus) and retiring the now-unused AI-candidate rendering.

References:

- Part of #909
- Related PR: #922
- Related PR: #923

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhJda14Fa15W8XbvSTrF4D)_