### PR TITLE
Chooser by working-candidate count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 - Paste a bare address like `example.com` and we'll treat it as a link and check it for a feed. When a link has no standard feed, you can now choose to follow it with AI instead.
 - New feeds now start with a clear choice: follow a feed or channel by its link, or follow with AI by describing a source or topic in your own words.
 - When a link can't be followed, the next step is clearer: retry if it just couldn't be reached, or follow it with AI (or try a different link) when there's no feed to read.
+- The "how should we fetch posts?" step is tidier: it only asks you to choose when more than one way actually works, and a single working option is just shown to you.
 
 ## 2026-07-03
 

--- a/app/components/candidate_option_component.html.erb
+++ b/app/components/candidate_option_component.html.erb
@@ -1,24 +1,19 @@
 <label class="flex items-start gap-3 rounded-lg border px-4 py-3 transition <%= row_classes %>"
        data-key="candidate.<%= profile_key %>">
-  <%= tag.input type: "radio", name: "feed[feed_profile_key]", value: profile_key, checked: selected?, disabled: disabled?, class: "mt-1" %>
+  <%= tag.input type: "radio", name: "feed[feed_profile_key]", value: profile_key, checked: selected?, class: "mt-1" %>
   <span class="flex flex-col gap-1">
     <span class="flex flex-wrap items-center gap-2">
       <span class="font-semibold text-heading"><%= display_name %></span>
       <% if badge_text %>
-        <%= render BadgeComponent.new(text: badge_text, color: badge_color, key: "candidate.#{profile_key}.status") %>
+        <%= render BadgeComponent.new(text: badge_text, color: :green, key: "candidate.#{profile_key}.status") %>
       <% end %>
-      <% if suggested? %>
+      <% if selected? %>
         <%= render BadgeComponent.new(text: "Suggested", color: :blue, key: "candidate.suggested-badge") %>
       <% end %>
     </span>
     <span class="text-body text-sm"><%= description %></span>
     <% if note %>
       <span class="text-body text-sm" data-key="candidate.<%= profile_key %>.note"><%= note %></span>
-    <% end %>
-    <% if candidate.ai? %>
-      <span class="text-body text-sm" data-key="candidate.ai-cost">
-        Fetching costs AI tokens. Previews and refreshes do too. You'll see your spend on the feed page.
-      </span>
     <% end %>
   </span>
 </label>

--- a/app/components/candidate_option_component.rb
+++ b/app/components/candidate_option_component.rb
@@ -1,11 +1,12 @@
 class CandidateOptionComponent < ViewComponent::Base
-  # Renders one detection candidate as a radio option in the "How should we fetch
-  # posts?" chooser: its name, description, self-test verdict badge, and note.
-  def initialize(candidate:, input:, selected:, single: false)
+  # Renders one working detection candidate as a radio option in the "How should
+  # we fetch posts?" chooser: its name, description, post-count verdict, and a
+  # "Suggested" flag on the preselected default. Only candidates that can fetch
+  # the source reach the chooser (spec §7), so every option is selectable.
+  def initialize(candidate:, input:, selected:)
     @candidate = candidate
     @input = input
     @selected = selected
-    @single = single
   end
 
   def before_render
@@ -14,7 +15,7 @@ class CandidateOptionComponent < ViewComponent::Base
 
   private
 
-  attr_reader :candidate, :input, :badge_text, :badge_color, :note
+  attr_reader :candidate, :input, :badge_text, :note
 
   def profile_key
     candidate.profile_key
@@ -32,45 +33,19 @@ class CandidateOptionComponent < ViewComponent::Base
     profile_key == @selected
   end
 
-  def disabled?
-    @single || candidate.failed?
-  end
-
-  # Only badge a usable default: a disabled (failed) candidate is never worth
-  # flagging even when it's the one preselected.
-  def suggested?
-    selected? && !disabled?
-  end
-
   def row_classes
-    if disabled? && !@single
-      "border-border bg-surface-muted opacity-70 cursor-not-allowed"
-    elsif @single
-      "border-brand-subtle bg-brand-subtle cursor-default"
+    if selected?
+      "border-ring bg-brand-subtle cursor-pointer"
     else
       "border-border bg-surface cursor-pointer hover:border-ring"
     end
   end
 
-  # Resolve the self-test verdict to its badge and note once. A candidate with
-  # no verdict leaves badge_text nil, so the template renders no badge.
+  # Every shown candidate passed its self-test; badge the post count and note an
+  # empty-but-valid source.
   def assign_verdict
-    if candidate.passed?
-      count = candidate.posts_found
-      @badge_text = count.zero? ? "Tested" : "Tested · #{count} #{'post'.pluralize(count)}"
-      @badge_color = :green
-      @note = "No posts yet. We'll pick up new ones as they're published." if count.zero?
-    elsif candidate.unreachable?
-      @badge_text = "Couldn't reach"
-      @badge_color = :yellow
-      @note = "We couldn't reach the source just now. Pick this only if you think it's temporary."
-    elsif candidate.failed?
-      @badge_text = "Won't work"
-      @badge_color = :red
-      @note = "We tried, but couldn't read any posts from this source."
-    elsif candidate.not_tested?
-      @badge_text = "Not tested"
-      @badge_color = :gray
-    end
+    count = candidate.posts_found
+    @badge_text = count.zero? ? "Tested" : "Tested · #{count} #{'post'.pluralize(count)}"
+    @note = "No posts yet. We'll pick up new ones as they're published." if count.zero?
   end
 end

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -135,7 +135,7 @@ class FeedIdentificationsController < ApplicationController
       name: suggested&.title&.truncate(Feed::NAME_MAX_LENGTH, omission: "…")
     )
 
-    render(identification_success(feed, candidates: feed_identification.candidates))
+    render(identification_success(feed, candidates: feed_identification.working_candidates))
   end
 
   def identification_error(error:, heading: "Feed identification failed")

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -17,10 +17,11 @@ class FeedIdentification < ApplicationRecord
   end
 
   # Candidates that can fetch the source (spec §7): the count of these drives how
-  # the result is presented. A candidate counts unless it's known-broken —
-  # tested and failed, or unreachable — so a passed candidate works.
+  # the result is presented. A candidate counts unless it's known-broken — tested
+  # and failed, or unreachable — so in practice this is the passed set (detection
+  # always records a verdict). Memoized: read a few times per request.
   def working_candidates
-    candidates.reject do |attributes|
+    @working_candidates ||= candidates.reject do |attributes|
       candidate = Candidate.new(attributes)
       candidate.failed? || candidate.unreachable?
     end

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -9,11 +9,11 @@ class FeedIdentification < ApplicationRecord
     processing? && started_at.nil?
   end
 
-  # The candidate the chooser preselects and the new-feed form is built from.
+  # The candidate the chooser preselects and the new-feed form is built from: the
+  # highest-ranked one that can fetch the source.
   def suggested_candidate
-    detected_candidates.find(&:passed?) || detected_candidates.find(&:not_tested?) ||
-      detected_candidates.find(&:unreachable?) || detected_candidates.reject(&:failed?).first ||
-      detected_candidates.first
+    attributes = working_candidates.first
+    Candidate.new(attributes) if attributes
   end
 
   # Candidates that can fetch the source (spec §7): the count of these drives how
@@ -46,11 +46,5 @@ class FeedIdentification < ApplicationRecord
     return true if error == "unreachable"
 
     candidates.present? && candidates.all? { |attributes| Candidate.new(attributes).unreachable? }
-  end
-
-  # Lazy so the suggestion chain stops wrapping at the first match; memoized
-  # so the repeated lookups share one enumerator.
-  def detected_candidates
-    @detected_candidates ||= candidates.lazy.map { |attributes| Candidate.new(attributes) }
   end
 end

--- a/app/models/feed_identification/candidate.rb
+++ b/app/models/feed_identification/candidate.rb
@@ -18,10 +18,6 @@ class FeedIdentification
       @attributes["posts_found"].to_i
     end
 
-    def ai?
-      @attributes["depends_on_ai"] == true
-    end
-
     def passed?
       test_status == "passed"
     end
@@ -32,10 +28,6 @@ class FeedIdentification
 
     def unreachable?
       test_status == "unreachable"
-    end
-
-    def not_tested?
-      test_status == "not_tested"
     end
 
     private

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -557,75 +557,39 @@
     <%# Feed profile chooser %>
     <section id="feed-profile-chooser" class="scroll-mt-6 space-y-4" data-key="section.feed-profile-chooser">
       <h2 class="border-b border-border pb-2 text-xl font-semibold text-heading">Feed profile chooser</h2>
-      <p class="text-body">The "How should we fetch posts?" radio group shown once a source is identified. Every option carries its self-test verdict, the suggested default is preselected, and a source that can't be read is disabled.</p>
+      <p class="text-body">The "How should we fetch posts?" radio group shown when two or more ways to fetch a source both work. Each option carries its post-count verdict, and the suggested default is preselected. One working option is shown as a read-only annotation instead of a chooser.</p>
 
       <%
         # selected mirrors the option the add-feed flow preselects in production.
-        chooser_candidate = ->(profile_key, depends_on_ai: false, test_status: nil, posts_found: 0) {
+        chooser_candidate = ->(profile_key, posts_found: 0) {
           {
             "profile_key" => profile_key,
             "title" => FeedProfile.display_name_for(profile_key),
-            "depends_on_ai" => depends_on_ai,
-            "test_status" => test_status,
+            "depends_on_ai" => false,
+            "test_status" => "passed",
             "posts_found" => posts_found,
             "rank" => 0,
-            "rank_reason" => depends_on_ai ? "ai_fallback" : "specific_match"
+            "rank_reason" => "specific_match"
           }
         }
 
         chooser_examples = [
           {
-            title: "Single source, locked in",
-            note: "Only one way to fetch this source, so it's preselected and can't be changed.",
-            single: true,
-            selected: "rss",
-            candidates: [chooser_candidate.call("rss", test_status: "passed", posts_found: 5)]
-          },
-          {
-            title: "Working source with an AI fallback",
-            note: "A source that passed its test is suggested; the AI reader is offered as a backup.",
-            selected: "rss",
+            title: "Two working sources",
+            note: "Both fetch the source; the more specific one is suggested.",
+            selected: "xkcd",
             candidates: [
-              chooser_candidate.call("rss", test_status: "passed", posts_found: 5),
-              chooser_candidate.call("llm", depends_on_ai: true, test_status: "not_tested")
+              chooser_candidate.call("xkcd", posts_found: 5),
+              chooser_candidate.call("rss", posts_found: 3)
             ]
           },
           {
             title: "Works, but nothing to show yet",
-            note: "The test passed but the source has no posts at the moment.",
+            note: "Both passed their test; one has no posts at the moment.",
             selected: "rss",
             candidates: [
-              chooser_candidate.call("rss", test_status: "passed", posts_found: 0),
-              chooser_candidate.call("llm", depends_on_ai: true, test_status: "not_tested")
-            ]
-          },
-          {
-            title: "Source failed, AI takes over",
-            note: "The structured source couldn't be read, so it's disabled and the AI reader is suggested.",
-            selected: "llm",
-            candidates: [
-              chooser_candidate.call("rss", test_status: "failed", posts_found: 0),
-              chooser_candidate.call("llm", depends_on_ai: true, test_status: "not_tested")
-            ]
-          },
-          {
-            title: "Source couldn't be reached",
-            note: "A working source is suggested; the unreachable one stays pickable in case it was a temporary blip.",
-            selected: "rss",
-            candidates: [
-              chooser_candidate.call("rss", test_status: "passed", posts_found: 3),
-              chooser_candidate.call("xkcd", test_status: "unreachable")
-            ]
-          },
-          {
-            title: "Every verdict together",
-            note: "Passed, failed, unreachable, and an untested AI option side by side.",
-            selected: "rss",
-            candidates: [
-              chooser_candidate.call("rss", test_status: "passed", posts_found: 4),
-              chooser_candidate.call("youtube", test_status: "failed"),
-              chooser_candidate.call("xkcd", test_status: "unreachable"),
-              chooser_candidate.call("llm", depends_on_ai: true, test_status: "not_tested")
+              chooser_candidate.call("rss", posts_found: 4),
+              chooser_candidate.call("json_feed", posts_found: 0)
             ]
           }
         ]
@@ -641,7 +605,6 @@
             <%= render "feeds/candidate_chooser",
                        candidates: example[:candidates],
                        input: "https://example.com/feed.xml",
-                       single: example.fetch(:single, false),
                        selected: example[:selected] %>
           </div>
         <% end %>

--- a/app/views/feeds/_candidate_chooser.html.erb
+++ b/app/views/feeds/_candidate_chooser.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (candidates: [], input: nil, single: false, selected: nil) %>
+<%# locals: (candidates: [], input: nil, selected: nil) %>
 
 <div class="space-y-2"
      data-key="candidates">
@@ -9,13 +9,8 @@
       <%= render CandidateOptionComponent.new(
             candidate: FeedIdentification::Candidate.new(attributes),
             input: input,
-            selected: selected,
-            single: single
+            selected: selected
           ) %>
     <% end %>
   </div>
-
-  <% if single %>
-    <p class="text-sm text-muted" data-key="candidate.single-note">This is the only way we can fetch this source, so it's locked in.</p>
-  <% end %>
 </div>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -1,7 +1,8 @@
 <%# locals: (edit_mode: false, feed: @feed, candidates: []) %>
 <% active_tokens = Current.user.access_tokens.active.order(:host) %>
-<% show_chooser = !edit_mode && candidates.any? %>
-<% single_candidate = show_chooser && candidates.size == 1 %>
+<%# The chooser is a real choice only with two or more working candidates; one
+    working candidate is shown as a read-only annotation (spec §7). %>
+<% show_chooser = !edit_mode && candidates.size >= 2 %>
 <%
   preview_source_keys =
     if show_chooser
@@ -56,7 +57,7 @@
           </div>
 
           <% if show_chooser %>
-            <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.source_input, single: single_candidate, selected: feed.feed_profile_key %>
+            <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.source_input, selected: feed.feed_profile_key %>
           <% else %>
             <%# Feed type is fixed once the feed exists, so it's shown read-only
                 as a disabled input matching the source field above it. Like the
@@ -73,10 +74,9 @@
           <% end %>
         </div>
 
-        <%# A read-only display or a disabled single-option radio won't submit
-            the profile key, so a hidden field carries it whenever the chooser
-            isn't offering a live selection. %>
-        <% if !show_chooser || single_candidate %>
+        <%# A read-only annotation won't submit the profile key, so a hidden field
+            carries it whenever the chooser isn't offering a live selection. %>
+        <% unless show_chooser %>
           <%= f.hidden_field :feed_profile_key %>
         <% end %>
 

--- a/test/components/candidate_option_component_test.rb
+++ b/test/components/candidate_option_component_test.rb
@@ -6,9 +6,9 @@ class CandidateOptionComponentTest < ViewComponent::TestCase
     FeedIdentification::Candidate.new(attributes)
   end
 
-  def render_option(attributes, input: "https://example.com/feed.xml", selected: nil, single: false)
+  def render_option(attributes, input: "https://example.com/feed.xml", selected: nil)
     render_inline CandidateOptionComponent.new(
-      candidate: candidate(attributes), input: input, selected: selected, single: single
+      candidate: candidate(attributes), input: input, selected: selected
     )
   end
 
@@ -33,32 +33,10 @@ class CandidateOptionComponentTest < ViewComponent::TestCase
     assert_match(/no posts yet/i, result.at_css("[data-key='candidate.rss.note']").text)
   end
 
-  test "#render should give a failed source a red badge, an advisory, and a disabled radio" do
-    result = render_option({ "profile_key" => "rss", "test_status" => "failed" })
+  test "#render should render a selectable radio for every option" do
+    result = render_option({ "profile_key" => "rss", "test_status" => "passed", "posts_found" => 2 })
 
-    assert_includes result.at_css("[data-key='candidate.rss.status']")["class"], "red"
-    assert result.at_css("[data-key='candidate.rss.note']").present?
-    assert_not_nil result.at_css("input[type=radio][disabled]")
-  end
-
-  test "#render should give an unreachable source a yellow badge and advisory" do
-    result = render_option({ "profile_key" => "rss", "test_status" => "unreachable" })
-
-    assert_includes result.at_css("[data-key='candidate.rss.status']")["class"], "yellow"
-    assert_match(/couldn't reach/i, result.at_css("[data-key='candidate.rss.note']").text)
-  end
-
-  test "#render should label an untested AI candidate as not tested with no note" do
-    result = render_option({ "profile_key" => "llm", "test_status" => "not_tested" })
-
-    assert_equal "Not tested", result.at_css("[data-key='candidate.llm.status']").text.strip
-    assert_nil result.at_css("[data-key='candidate.llm.note']")
-  end
-
-  test "#render should omit the badge when the candidate carries no verdict" do
-    result = render_option({ "profile_key" => "rss" })
-
-    assert_nil result.at_css("[data-key='candidate.rss.status']")
+    assert_nil result.at_css("input[type=radio][disabled]")
   end
 
   test "#render should flag the selected candidate as suggested and check its radio" do
@@ -68,23 +46,9 @@ class CandidateOptionComponentTest < ViewComponent::TestCase
     assert_not_nil result.at_css("[data-key='candidate.suggested-badge']")
   end
 
-  test "#render should not flag a disabled candidate even when it is the selected one" do
-    result = render_option({ "profile_key" => "rss", "test_status" => "failed" }, selected: "rss")
+  test "#render should not flag an unselected candidate as suggested" do
+    result = render_option({ "profile_key" => "rss", "test_status" => "passed", "posts_found" => 2 }, selected: "xkcd")
 
     assert_nil result.at_css("[data-key='candidate.suggested-badge']")
-    assert_not_nil result.at_css("input[type=radio][disabled]")
-  end
-
-  test "#render should lock a single candidate with no suggested badge and a disabled radio" do
-    result = render_option({ "profile_key" => "rss", "test_status" => "passed", "posts_found" => 2 }, selected: "rss", single: true)
-
-    assert_nil result.at_css("[data-key='candidate.suggested-badge']")
-    assert_not_nil result.at_css("input[type=radio][disabled]")
-  end
-
-  test "#render should surface the AI token-cost note for AI candidates" do
-    result = render_option({ "profile_key" => "llm", "test_status" => "not_tested", "depends_on_ai" => true })
-
-    assert_match(/costs AI tokens/i, result.at_css("[data-key='candidate.ai-cost']").text)
   end
 end

--- a/test/controllers/development/components_controller_test.rb
+++ b/test/controllers/development/components_controller_test.rb
@@ -67,9 +67,8 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select '[data-key="section.feed-profile-chooser"]'
     assert_select '[data-key="feed-profile-chooser-example.0"] [data-key="candidates"]'
-    # The states are exercised across the examples: a disabled (failed/locked)
-    # option, a checked default, and the Suggested badge all render.
-    assert_select '[data-key="section.feed-profile-chooser"] input[type=radio][disabled]'
+    # Every option is selectable; the suggested default is checked and badged.
+    assert_select '[data-key="section.feed-profile-chooser"] input[type=radio][disabled]', count: 0
     assert_select '[data-key="section.feed-profile-chooser"] input[type=radio][checked]'
     assert_select '[data-key="section.feed-profile-chooser"] [data-key="candidate.suggested-badge"]'
   end

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -550,7 +550,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, url
   end
 
-  test "#show should render the candidate chooser when multiple candidates exist" do
+  test "#show should render the candidate chooser when multiple candidates work" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
     create(
@@ -560,8 +560,8 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       started_at: Time.current,
       status: :success,
       candidates: [
-        { "profile_key" => "rss", "title" => "Example", "depends_on_ai" => false, "rank" => 0, "rank_reason" => "specific_match" },
-        { "profile_key" => "llm", "title" => "Example", "depends_on_ai" => true, "rank" => 1, "rank_reason" => "ai_fallback" }
+        { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 2, "rank" => 0, "rank_reason" => "specific_match" },
+        { "profile_key" => "json_feed", "title" => "Example", "test_status" => "passed", "posts_found" => 3, "rank" => 1, "rank_reason" => "generic_match" }
       ]
     )
 
@@ -570,13 +570,10 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "data-key=\"candidates\""
     assert_includes response.body, "data-key=\"candidate.rss\""
-    assert_includes response.body, "data-key=\"candidate.llm\""
-    # While the user can still pick, the field asks how to fetch; it only
-    # switches to the static "Feed type" label once the choice is frozen.
+    assert_includes response.body, "data-key=\"candidate.json_feed\""
+    # The chooser asks how to fetch; it only switches to the static "Feed type"
+    # label once the choice is frozen (edit mode).
     assert_select "label", text: "How should we fetch posts?"
-    # The AI option already names its dependency ("AI"), so there's
-    # no redundant AI badge — the cost note carries that signal instead.
-    assert_not_includes response.body, "data-key=\"candidate.ai-badge\""
   end
 
   def success_identification(url, candidates)

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -380,49 +380,6 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "specific_match", payload.first["rank_reason"]
   end
 
-  test "#show should render an AI candidate payload if one is persisted" do
-    sign_in_as(user)
-    url = "http://example.com/feed.xml"
-
-    # Detection can't produce an AI candidate anymore (structural exclusion,
-    # spec §7), so this hand-writes one to guard the view's handling of it —
-    # the AI-candidate presentation is retired with the two-mode UX in #909.
-    FeedIdentification.create!(
-      user: user,
-      input: url,
-      status: :success,
-      candidates: [
-        { "profile_key" => "llm", "title" => "Example", "depends_on_ai" => true, "rank" => 0, "rank_reason" => "ai_fallback" }
-      ]
-    )
-
-    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
-
-    payload = extract_candidates_payload(response.body)
-    assert_equal 1, payload.size
-    assert_equal "llm", payload.first["profile_key"]
-    assert_equal true, payload.first["depends_on_ai"]
-    assert_equal "ai_fallback", payload.first["rank_reason"]
-  end
-
-  test "#show should note AI token cost only on the AI fetch option" do
-    sign_in_as(user)
-    url = "http://example.com/feed.xml"
-    FeedIdentification.create!(
-      user: user,
-      input: url,
-      status: :success,
-      candidates: [
-        { "profile_key" => "rss", "title" => "Example", "depends_on_ai" => false, "rank" => 0, "rank_reason" => "" },
-        { "profile_key" => "llm", "title" => "Example", "depends_on_ai" => true, "rank" => 1, "rank_reason" => "ai_fallback" }
-      ]
-    )
-
-    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
-
-    assert_response :success
-    assert_select "[data-key='candidate.ai-cost']", count: 1
-  end
 
   test "#show should preselect the default schedule interval with no blank option" do
     sign_in_as(user)
@@ -622,57 +579,6 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, "data-key=\"candidate.ai-badge\""
   end
 
-  test "#show should label a query source as a prompt and pass it to the chooser" do
-    sign_in_as(user)
-    query = "climate change"
-    create(
-      :feed_identification,
-      user: user,
-      input: query,
-      started_at: Time.current,
-      status: :success,
-      candidates: [
-        { "profile_key" => "llm", "title" => "Climate", "depends_on_ai" => true, "rank" => 0, "rank_reason" => "ai_fallback" }
-      ]
-    )
-
-    get feed_identifications_path, params: { input: query }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
-
-    assert_response :success
-    assert_select "label", text: "Source prompt"
-    assert_select "[data-key='candidate.llm']",
-                  text: /Follow with AI: "#{query}"/
-  end
-
-  test "#show should render a locked single-option chooser when one candidate exists" do
-    sign_in_as(user)
-    url = "http://example.com/feed.xml"
-    create(
-      :feed_identification,
-      user: user,
-      input: url,
-      started_at: Time.current,
-      status: :success,
-      candidates: [
-        { "profile_key" => "llm", "title" => "Example", "depends_on_ai" => true, "rank" => 0, "rank_reason" => "ai_fallback" }
-      ]
-    )
-
-    get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
-
-    assert_response :success
-    # The chooser shows even with a single option, so the user sees what was picked.
-    assert_select "[data-key='candidates']", count: 1
-    assert_select "[data-key='candidate.llm']", count: 1
-    assert_select "[data-key='candidate.single-note']", count: 1
-    # The only option is preselected and locked.
-    assert_select "input[type=radio][name='feed[feed_profile_key]'][checked][disabled]", count: 1
-    # A disabled radio doesn't submit, so a hidden field carries the value.
-    assert_select "input[type=hidden][name='feed[feed_profile_key]'][value='llm']", count: 1
-    # No "Suggested" badge when there's nothing to compare against.
-    assert_select "[data-key='candidate.suggested-badge']", count: 0
-  end
-
   def success_identification(url, candidates)
     create(:feed_identification, user: user, input: url, started_at: Time.current, status: :success, candidates: candidates)
   end
@@ -681,27 +587,44 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     get feed_identifications_path, params: { input: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
   end
 
-  test "#show should mark a passed candidate as tested and preselect it" do
+  test "#show should show a single working candidate as an annotation, not a chooser" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
     success_identification(url, [
-      { "profile_key" => "rss", "title" => "Example", "depends_on_ai" => false, "rank" => 0, "rank_reason" => "specific_match", "test_status" => "passed", "posts_found" => 5 },
-      { "profile_key" => "llm", "title" => "Example", "depends_on_ai" => true, "rank" => 1, "rank_reason" => "ai_fallback", "test_status" => "not_tested" }
+      { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 3 }
     ])
 
     show_chooser(url)
 
     assert_response :success
-    assert_select "[data-key='candidate.rss.status']", text: "Tested · 5 posts"
-    assert_select "input[type=radio][value='rss'][checked]"
-    assert_select "input[type=radio][value='rss'][disabled]", count: 0
+    assert_select "[data-key='candidates']", count: 0
+    assert_select "[data-key='form.feed-type-display']", count: 1
+    assert_select "input[type=hidden][name='feed[feed_profile_key]'][value='rss']", count: 1
   end
 
-  test "#show should note when the preselected candidate has no posts yet" do
+  test "#show should render the chooser and preselect the suggested candidate for two working candidates" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
     success_identification(url, [
-      { "profile_key" => "rss", "title" => "Example", "depends_on_ai" => false, "rank" => 0, "rank_reason" => "specific_match", "test_status" => "passed", "posts_found" => 0 }
+      { "profile_key" => "xkcd", "title" => "Example", "test_status" => "passed", "posts_found" => 5 },
+      { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 3 }
+    ])
+
+    show_chooser(url)
+
+    assert_response :success
+    assert_select "[data-key='candidates']", count: 1
+    assert_select "[data-key='candidate.xkcd.status']", text: "Tested · 5 posts"
+    assert_select "input[type=radio][value='xkcd'][checked]"
+    assert_select "input[type=radio][disabled]", count: 0
+  end
+
+  test "#show should note when a working candidate has no posts yet" do
+    sign_in_as(user)
+    url = "http://example.com/feed.xml"
+    success_identification(url, [
+      { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 0 },
+      { "profile_key" => "json_feed", "title" => "Example", "test_status" => "passed", "posts_found" => 2 }
     ])
 
     show_chooser(url)
@@ -710,53 +633,21 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='candidate.rss.note']", text: /no posts yet/i
   end
 
-  test "#show should disable a failed candidate and fall back to the AI option" do
+  test "#show should drop non-working candidates from the presentation" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
     success_identification(url, [
-      { "profile_key" => "rss", "title" => "Example", "depends_on_ai" => false, "rank" => 0, "rank_reason" => "specific_match", "test_status" => "failed", "posts_found" => 0 },
-      { "profile_key" => "llm", "title" => "Example", "depends_on_ai" => true, "rank" => 1, "rank_reason" => "ai_fallback", "test_status" => "not_tested" }
+      { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 2 },
+      { "profile_key" => "xkcd", "title" => "Example", "test_status" => "unreachable" }
     ])
 
     show_chooser(url)
 
     assert_response :success
-    assert_select "input[type=radio][value='rss'][disabled]"
-    assert_select "input[type=radio][value='rss'][checked]", count: 0
-    assert_select "[data-key='candidate.rss.note']"
-    assert_select "input[type=radio][value='llm'][checked]"
-  end
-
-  test "#show should keep an unreachable candidate selectable with a transient advisory" do
-    sign_in_as(user)
-    url = "http://example.com/feed.xml"
-    success_identification(url, [
-      { "profile_key" => "rss", "title" => "Example", "depends_on_ai" => false, "rank" => 0, "rank_reason" => "specific_match", "test_status" => "passed", "posts_found" => 2 },
-      { "profile_key" => "xkcd", "title" => "Example", "depends_on_ai" => false, "rank" => 1, "rank_reason" => "generic_match", "test_status" => "unreachable" }
-    ])
-
-    show_chooser(url)
-
-    assert_response :success
-    assert_select "input[type=radio][value='xkcd'][disabled]", count: 0
-    assert_select "[data-key='candidate.xkcd.note']", text: /couldn't reach/i
-    assert_select "input[type=radio][value='rss'][checked]"
-  end
-
-  test "#show should preselect a passed candidate ranked behind a failed one" do
-    sign_in_as(user)
-    url = "http://example.com/feed.xml"
-    success_identification(url, [
-      { "profile_key" => "xkcd", "title" => "Example", "depends_on_ai" => false, "rank" => 0, "rank_reason" => "specific_match", "test_status" => "failed", "posts_found" => 0 },
-      { "profile_key" => "rss", "title" => "Example", "depends_on_ai" => false, "rank" => 1, "rank_reason" => "generic_match", "test_status" => "passed", "posts_found" => 4 }
-    ])
-
-    show_chooser(url)
-
-    assert_response :success
-    assert_select "input[type=radio][value='rss'][checked]"
-    assert_select "input[type=radio][value='xkcd'][checked]", count: 0
-    assert_select "input[type=radio][value='xkcd'][disabled]"
+    # One candidate works → annotation; the unreachable one isn't offered.
+    assert_select "[data-key='candidates']", count: 0
+    assert_select "[data-key='candidate.xkcd']", count: 0
+    assert_select "input[type=hidden][name='feed[feed_profile_key]'][value='rss']", count: 1
   end
 
   test "#show should truncate detected title to Feed::NAME_MAX_LENGTH" do

--- a/test/models/feed_identification/candidate_test.rb
+++ b/test/models/feed_identification/candidate_test.rb
@@ -17,17 +17,10 @@ class FeedIdentification::CandidateTest < ActiveSupport::TestCase
     assert_equal 3, candidate("posts_found" => 3).posts_found
   end
 
-  test "#ai? should be true only when depends_on_ai is true" do
-    assert candidate("depends_on_ai" => true).ai?
-    assert_not candidate("depends_on_ai" => false).ai?
-    assert_not candidate({}).ai?
-  end
-
   test "status predicates should reflect test_status" do
     assert candidate("test_status" => "passed").passed?
     assert candidate("test_status" => "failed").failed?
     assert candidate("test_status" => "unreachable").unreachable?
-    assert candidate("test_status" => "not_tested").not_tested?
   end
 
   test "status predicates should be false for a different verdict" do
@@ -35,7 +28,6 @@ class FeedIdentification::CandidateTest < ActiveSupport::TestCase
 
     assert_not subject.failed?
     assert_not subject.unreachable?
-    assert_not subject.not_tested?
   end
 
   test "status predicates should be false when no verdict is present" do
@@ -44,6 +36,5 @@ class FeedIdentification::CandidateTest < ActiveSupport::TestCase
     assert_not subject.passed?
     assert_not subject.failed?
     assert_not subject.unreachable?
-    assert_not subject.not_tested?
   end
 end

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -48,7 +48,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     FeedIdentification.new(user: user, input: "https://example.com/feed.xml", candidates: candidates)
   end
 
-  test "#suggested_candidate should prefer a passed candidate over a failed one ranked ahead of it" do
+  test "#suggested_candidate should be the highest-ranked working candidate" do
     id = identification([
       { "profile_key" => "rss", "test_status" => "failed" },
       { "profile_key" => "atom", "test_status" => "passed" }
@@ -57,47 +57,29 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_equal "atom", id.suggested_candidate.profile_key
   end
 
-  test "#suggested_candidate should prefer passed over not_tested and unreachable" do
+  test "#suggested_candidate should skip failed and unreachable candidates" do
     id = identification([
       { "profile_key" => "youtube", "test_status" => "unreachable" },
-      { "profile_key" => "llm", "test_status" => "not_tested" },
-      { "profile_key" => "rss", "test_status" => "passed" }
-    ])
-
-    assert_equal "rss", id.suggested_candidate.profile_key
-  end
-
-  test "#suggested_candidate should fall back to the AI option when every structured candidate failed" do
-    id = identification([
       { "profile_key" => "rss", "test_status" => "failed" },
-      { "profile_key" => "llm", "test_status" => "not_tested" }
+      { "profile_key" => "atom", "test_status" => "passed" }
     ])
 
-    assert_equal "llm", id.suggested_candidate.profile_key
+    assert_equal "atom", id.suggested_candidate.profile_key
   end
 
-  test "#suggested_candidate should prefer the AI option over an unreachable source" do
-    id = identification([
-      { "profile_key" => "youtube", "test_status" => "unreachable" },
-      { "profile_key" => "llm", "test_status" => "not_tested" }
-    ])
-
-    assert_equal "llm", id.suggested_candidate.profile_key
-  end
-
-  test "#suggested_candidate should never preselect a failed candidate" do
+  test "#suggested_candidate should be nil when no candidate works" do
     id = identification([
       { "profile_key" => "rss", "test_status" => "failed" },
       { "profile_key" => "youtube", "test_status" => "unreachable" }
     ])
 
-    assert_equal "youtube", id.suggested_candidate.profile_key
+    assert_nil id.suggested_candidate
   end
 
   test "#suggested_candidate should fall back to the first candidate when none carry a verdict" do
     id = identification([
       { "profile_key" => "rss" },
-      { "profile_key" => "llm" }
+      { "profile_key" => "atom" }
     ])
 
     assert_equal "rss", id.suggested_candidate.profile_key


### PR DESCRIPTION
Changes:

- Present the "how should we fetch posts?" chooser by working-candidate count (spec §7): it appears only when two or more candidates actually work; a single working candidate is shown as a read-only annotation; non-working candidates aren't offered at all. The feed form is built from the working candidates, and `suggested_candidate` is simply the highest-ranked working one.
- Retire the now-unreachable AI-candidate rendering. Detection can't produce an AI candidate (structural exclusion, §7), so `CandidateOptionComponent` drops its failed / unreachable / not-tested / AI-cost branches — every shown option is a selectable, passed source — and `FeedIdentification::Candidate` sheds its unused `ai?` / `not_tested?` predicates.

This finishes the §7 detection presentation for #909, building on #922 / #923 / #924. The dev component showcase and its tests are updated to the new (passed-only) chooser.

References:

- Closes #909
- Related PR: #922
- Related PR: #924

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhJda14Fa15W8XbvSTrF4D)_