### PR TITLE
Editable prompt and daily default for AI feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 - New feeds now start with a clear choice: follow a feed or channel by its link, or follow with AI by describing a source or topic in your own words.
 - When a link can't be followed, the next step is clearer: retry if it just couldn't be reached, or follow it with AI (or try a different link) when there's no feed to read.
 - The "how should we fetch posts?" step is tidier: it only asks you to choose when more than one way actually works, and a single working option is just shown to you.
-- Creating an AI feed now lets you tweak the prompt right in the form before saving, and it checks for new posts once a day by default.
+- Creating an AI feed now lets you tweak the prompt before saving, and it checks for new posts once a day by default.
 
 ## 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 - New feeds now start with a clear choice: follow a feed or channel by its link, or follow with AI by describing a source or topic in your own words.
 - When a link can't be followed, the next step is clearer: retry if it just couldn't be reached, or follow it with AI (or try a different link) when there's no feed to read.
 - The "how should we fetch posts?" step is tidier: it only asks you to choose when more than one way actually works, and a single working option is just shown to you.
+- Creating an AI feed now lets you tweak the prompt right in the form before saving, and it checks for new posts once a day by default.
 
 ## 2026-07-03
 

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -74,8 +74,9 @@ class FeedIdentificationsController < ApplicationController
 
   # Build a draft AI feed straight from the carried input — no detection, the AI
   # profile is the destination and the prompt is the source (Mode A→B bridge).
+  # AI feeds default to a daily cadence (spec §1).
   def handle_ai_bridge
-    feed = Current.user.feeds.build(feed_profile_key: "llm", params: { "prompt" => raw_input })
+    feed = Current.user.feeds.build(feed_profile_key: "llm", params: { "prompt" => raw_input }, schedule_interval: "1d")
     render(identification_success(feed, candidates: []))
   end
 

--- a/app/javascript/controllers/preview_button_controller.js
+++ b/app/javascript/controllers/preview_button_controller.js
@@ -8,7 +8,7 @@ import { Controller } from "@hotwired/stimulus"
 //   provider + model for AI profiles), then opens the modal
 // - on modal close, clears the frame so the polling host unmounts (stops polling)
 export default class extends Controller {
-  static targets = ["button", "frame"]
+  static targets = ["button", "frame", "source"]
   static values = {
     endpoint: String,
     source: String,
@@ -39,14 +39,14 @@ export default class extends Controller {
   open(event) {
     event?.preventDefault()
     const profileKey = this._selectedProfileKey()
-    if (!profileKey || !this.sourceValue.trim() || !this.hasFrameTarget) return
+    if (!profileKey || !this._currentSource().trim() || !this.hasFrameTarget) return
 
     const sourceKey = this.sourceKeysValue[profileKey]
     if (!sourceKey) return
 
     const url = new URL(this.endpointValue, window.location.origin)
     url.searchParams.set("profile_key", profileKey)
-    url.searchParams.set(`params[${sourceKey}]`, this.sourceValue)
+    url.searchParams.set(`params[${sourceKey}]`, this._currentSource())
     if (this._isAiProfile(profileKey)) {
       const credential = this._aiCredentialValue()
       const model = this._aiModelValue()
@@ -65,12 +65,18 @@ export default class extends Controller {
   refreshAvailability() {
     if (!this.hasButtonTarget) return
     const profileKey = this._selectedProfileKey()
-    let ready = !!profileKey && !!this.sourceValue.trim()
+    let ready = !!profileKey && !!this._currentSource().trim()
     // AI profiles can't preview until a provider and model are picked.
     if (ready && this._isAiProfile(profileKey)) {
       ready = !!this._aiCredentialValue() && !!this._aiModelValue()
     }
     this.buttonTarget.disabled = !ready
+  }
+
+  // The source is the static value from detection, unless an editable field (an
+  // AI feed's prompt) is present — then it's whatever the user has typed.
+  _currentSource() {
+    return this.hasSourceTarget ? this.sourceTarget.value : this.sourceValue
   }
 
   _selectedProfileKey() {

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -39,43 +39,61 @@
           source and feed type are the feed's fixed identity, so they're grouped
           under one "Source" heading. %>
       <% source_label = feed.source_input_url? ? "Source URL" : "Source prompt" %>
+      <%# For an AI feed the prompt *is* the source, so while creating it stays an
+          editable textarea (spec §1) — unlike a detected URL, which is read-only. %>
+      <% ai_prompt_editable = !edit_mode && FeedProfile.depends_on_ai?(feed.feed_profile_key) %>
       <div>
         <h2 class="text-xl font-semibold text-heading mb-4">Source</h2>
 
         <div class="space-y-6">
-          <div class="space-y-2">
-            <%= f.label :url, source_label, class: "block font-semibold text-heading" %>
-            <%= f.text_field :url_display,
-                             value: feed.source_input,
-                             disabled: true,
-                             class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2 disabled:bg-surface-sunken disabled:text-muted disabled:border-border disabled:cursor-not-allowed",
-                             aria: { label: "#{source_label} (cannot be changed)" },
-                             data: { key: "form.source-display" } %>
-            <% feed.params&.each do |key, value| %>
-              <%= hidden_field_tag "feed[params][#{key}]", value %>
-            <% end %>
-          </div>
-
-          <% if show_chooser %>
-            <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.source_input, selected: feed.feed_profile_key %>
-          <% else %>
-            <%# Feed type is fixed once the feed exists, so it's shown read-only
-                as a disabled input matching the source field above it. Like the
-                source field, it's display-only — the controller never reads it. %>
+          <% if ai_prompt_editable %>
             <div class="space-y-2">
-              <%= label_tag nil, "Feed type", class: "block font-semibold text-heading" %>
-              <%= f.text_field :feed_type_display,
-                               value: candidate_summary(feed.feed_profile_key, feed.source_input),
+              <%= label_tag "feed_params_prompt", "What should AI follow?", class: "block font-semibold text-heading" %>
+              <%= text_area_tag "feed[params][prompt]", feed.source_input,
+                                id: "feed_params_prompt",
+                                rows: 3,
+                                maxlength: 2000,
+                                required: true,
+                                class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2",
+                                data: { preview_button_target: "source", action: "input->preview-button#refreshAvailability", key: "form.ai-prompt" } %>
+              <p class="text-sm text-muted">Describe a source or topic in your own words. You can tweak this before saving.</p>
+            </div>
+          <% else %>
+            <div class="space-y-2">
+              <%= f.label :url, source_label, class: "block font-semibold text-heading" %>
+              <%= f.text_field :url_display,
+                               value: feed.source_input,
                                disabled: true,
                                class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2 disabled:bg-surface-sunken disabled:text-muted disabled:border-border disabled:cursor-not-allowed",
-                               aria: { label: "Feed type (cannot be changed)" },
-                               data: { key: "form.feed-type-display" } %>
+                               aria: { label: "#{source_label} (cannot be changed)" },
+                               data: { key: "form.source-display" } %>
+              <% feed.params&.each do |key, value| %>
+                <%= hidden_field_tag "feed[params][#{key}]", value %>
+              <% end %>
             </div>
+
+            <% if show_chooser %>
+              <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.source_input, selected: feed.feed_profile_key %>
+            <% else %>
+              <%# Feed type is fixed once the feed exists, so it's shown read-only
+                  as a disabled input matching the source field above it. Like the
+                  source field, it's display-only — the controller never reads it. %>
+              <div class="space-y-2">
+                <%= label_tag nil, "Feed type", class: "block font-semibold text-heading" %>
+                <%= f.text_field :feed_type_display,
+                                 value: candidate_summary(feed.feed_profile_key, feed.source_input),
+                                 disabled: true,
+                                 class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2 disabled:bg-surface-sunken disabled:text-muted disabled:border-border disabled:cursor-not-allowed",
+                                 aria: { label: "Feed type (cannot be changed)" },
+                                 data: { key: "form.feed-type-display" } %>
+              </div>
+            <% end %>
           <% end %>
         </div>
 
-        <%# A read-only annotation won't submit the profile key, so a hidden field
-            carries it whenever the chooser isn't offering a live selection. %>
+        <%# A read-only annotation or the editable AI prompt won't submit the
+            profile key, so a hidden field carries it whenever the chooser isn't
+            offering a live selection. %>
         <% unless show_chooser %>
           <%= f.hidden_field :feed_profile_key %>
         <% end %>

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -189,6 +189,28 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "https://example.com/page"
   end
 
+  test "#create should give a bridged AI feed an editable prompt" do
+    sign_in_as(user)
+
+    post feed_identifications_path, params: { input: "follow the A24 blog", mode: "ai" },
+                                    headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    # The prompt is the source, so it stays editable while creating (spec §1).
+    assert_select "textarea[name='feed[params][prompt]']", text: "follow the A24 blog"
+    assert_select "input[type=text][name='feed[params][url]']", count: 0
+  end
+
+  test "#create should default a bridged AI feed to a daily schedule" do
+    sign_in_as(user)
+
+    post feed_identifications_path, params: { input: "follow the A24 blog", mode: "ai" },
+                                    headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "select[name='feed[schedule_interval]'] option[value='1d'][selected='selected']"
+  end
+
   test "#show should require authentication" do
     get feed_identifications_path, params: { input: "http://example.com/feed.xml" }
     assert_redirected_to new_session_path

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -196,9 +196,11 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
                                     headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    # The prompt is the source, so it stays editable while creating (spec §1).
-    assert_select "textarea[name='feed[params][prompt]']", text: "follow the A24 blog"
+    # The prompt is the source, so it stays editable while creating (spec §1);
+    # exactly one prompt field, and the profile key still submits.
+    assert_select "textarea[name='feed[params][prompt]']", { count: 1, text: "follow the A24 blog" }
     assert_select "input[type=text][name='feed[params][url]']", count: 0
+    assert_select "input[type=hidden][name='feed[feed_profile_key]'][value='llm']", count: 1
   end
 
   test "#create should default a bridged AI feed to a daily schedule" do
@@ -510,8 +512,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     get feed_identifications_path, params: { input: handle }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_includes response.body, 'name="feed[params][prompt]"'
-    assert_includes response.body, "value=\"#{handle}\""
+    assert_select "textarea[name='feed[params][prompt]']", text: handle
     refute_includes response.body, 'name="feed[params][url]"'
   end
 
@@ -532,7 +533,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     get feed_identifications_path, params: { input: query }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_includes response.body, 'name="feed[params][prompt]"'
+    assert_select "textarea[name='feed[params][prompt]']", text: query
     refute_includes response.body, 'name="feed[params][url]"'
   end
 


### PR DESCRIPTION
Changes:

- Keep an AI feed's prompt editable while creating it (spec §1): because the prompt *is* the source, the create form renders it as an editable "What should AI follow?" textarea rather than the read-only display a detected URL gets. The manual preview now reads the live prompt — the preview button takes its source from the field when one is present, falling back to the detected value otherwise.
- Default a bridged (Mode B) AI feed to a daily cadence.

This is the Mode B create-form half of #911, building on the two-mode entry (#923). The reverse hint — when a Mode B prompt is exactly one URL, quietly offering the cheaper deterministic engine — is a follow-up PR.

References:

- Part of #911
- Related PR: #923
- Related spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §1

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhJda14Fa15W8XbvSTrF4D)_