### PR TITLE
Editable prompt on draft AI feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 - When a link can't be followed, the next step is clearer: retry if it just couldn't be reached, or follow it with AI (or try a different link) when there's no feed to read.
 - The "how should we fetch posts?" step is tidier: it only asks you to choose when more than one way actually works, and a single working option is just shown to you.
 - Creating an AI feed now lets you tweak the prompt before saving, and it checks for new posts once a day by default.
+- You can keep editing an AI feed's prompt while it's still a draft, not just when you first create it.
 
 ## 2026-07-03
 

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -39,9 +39,10 @@
           source and feed type are the feed's fixed identity, so they're grouped
           under one "Source" heading. %>
       <% source_label = feed.source_input_url? ? "Source URL" : "Source prompt" %>
-      <%# For an AI feed the prompt *is* the source, so while creating it stays an
-          editable textarea (spec §1) — unlike a detected URL, which is read-only. %>
-      <% ai_prompt_editable = !edit_mode && FeedProfile.depends_on_ai?(feed.feed_profile_key) %>
+      <%# For an AI feed the prompt *is* the source and carries no duplicate risk,
+          so it stays an editable textarea while creating or editing a draft
+          (spec §1, §4) — unlike a detected URL, which is read-only. %>
+      <% ai_prompt_editable = FeedProfile.depends_on_ai?(feed.feed_profile_key) && (!edit_mode || feed.draft?) %>
       <div>
         <h2 class="text-xl font-semibold text-heading mb-4">Source</h2>
 
@@ -98,7 +99,7 @@
           <%= f.hidden_field :feed_profile_key %>
         <% end %>
 
-        <% if edit_mode %>
+        <% if edit_mode && !ai_prompt_editable %>
           <p class="mt-3 text-sm text-muted" data-key="form.source-locked-note">The source and feed type are locked in when a feed is created. To follow a different source, just start a new feed.</p>
         <% end %>
       </div>

--- a/test/integration/smart_feed_creation_edit_test.rb
+++ b/test/integration/smart_feed_creation_edit_test.rb
@@ -1,10 +1,8 @@
 require "test_helper"
 
-# FR-026 / FR-027 / FR-028 edit semantics: operational fields can be
-# edited freely; source-side fields stay anchored after creation.
-# Updates never re-run detection or preview because the create-time
-# detection is authoritative (the form keeps the URL and profile key
-# read-only on edit).
+# Edit semantics: operational fields edit freely; a deterministic feed's source
+# and profile stay anchored after creation. An AI feed's prompt carries no
+# duplicate risk, so it stays editable while the feed is a draft (spec §4).
 class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
@@ -26,6 +24,14 @@ class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
                      target_group: "testgroup",
                      feed_profile_key: "rss",
                      params: { "url" => "http://example.com/feed.xml" })
+  end
+
+  def draft_ai_feed
+    @draft_ai_feed ||= create(:feed,
+                              user: user,
+                              state: :draft,
+                              feed_profile_key: "llm",
+                              params: { "prompt" => "follow the A24 blog" })
   end
 
   test "#patch should accept an operational-only edit on an enabled feed without re-running detection" do
@@ -88,5 +94,41 @@ class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
 
     feed.reload
     assert_equal original_profile, feed.feed_profile_key
+  end
+
+  test "#edit should let a draft AI feed's prompt be edited" do
+    sign_in_as(user)
+
+    get edit_feed_url(draft_ai_feed)
+
+    assert_response :success
+    assert_select "textarea[name='feed[params][prompt]']", text: "follow the A24 blog"
+    assert_select "[data-key='form.source-locked-note']", count: 0
+  end
+
+  test "#patch should update a draft AI feed's prompt" do
+    sign_in_as(user)
+
+    patch feed_url(draft_ai_feed), params: { feed: { params: { prompt: "follow Pitchfork reviews" } } }
+
+    assert_redirected_to feed_path(draft_ai_feed)
+    draft_ai_feed.reload
+    assert_equal "follow Pitchfork reviews", draft_ai_feed.params["prompt"]
+  end
+
+  test "#edit should keep an enabled AI feed's prompt read-only" do
+    sign_in_as(user)
+    credential = create(:ai_credential, :active, user: user,
+                                                 available_models: [{ "id" => "claude-sonnet-4-6", "name" => "Claude Sonnet 4.6" }])
+    enabled_ai = create(:feed, user: user, access_token: access_token, state: :enabled,
+                               target_group: "testgroup", feed_profile_key: "llm",
+                               params: { "prompt" => "follow the A24 blog" },
+                               ai_credential: credential, ai_model: "claude-sonnet-4-6")
+
+    get edit_feed_url(enabled_ai)
+
+    assert_response :success
+    assert_select "textarea[name='feed[params][prompt]']", count: 0
+    assert_select "[data-key='form.source-display']"
   end
 end


### PR DESCRIPTION
Changes:

- Keep an AI feed's prompt editable while the feed is a draft, not only at creation (spec §4): the prompt is the source and carries no duplicate risk, so its textarea stays editable on the draft edit form. A deterministic feed's source and an enabled AI feed's prompt remain read-only, and the "source is locked" note now shows only when the source actually is locked. Drafts already permit the prompt param, so no controller change is needed.

This is the first, lowest-risk slice of #912's editing unlock — AI prompt edits are bounds-only (no re-detection). Deterministic source-URL editing (which re-runs detection) and the duplicate-risk warnings are follow-ups.

References:

- Part of #912
- Related spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §4

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhJda14Fa15W8XbvSTrF4D)_