### PR TITLE
Unify AI model availability on the capability matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-06
+
+- If an AI feed's model is no longer available, the feed keeps running on a supported fallback and flags it on the feed page, instead of blocking edits or quietly using the missing one. Pick a new model whenever you're ready.
+
 ## 2026-07-05
 
 - Added Moonshot (Kimi) as an AI provider — a lower-cost option you can connect with your own API key.

--- a/app/components/feed_ai_settings_component.rb
+++ b/app/components/feed_ai_settings_component.rb
@@ -40,9 +40,7 @@ class FeedAiSettingsComponent < ViewComponent::Base
   # are offered (spec §5); credentials left with no models are dropped entirely.
   def models_by_credential
     @models_by_credential ||= active_credentials.to_h do |credential|
-      verified = LlmModelCapability.models_for(credential.provider)
-      models = credential.available_models
-                         .select { |model| verified.include?(model["id"]) }
+      models = credential.supported_models
                          .map { |model| { "id" => model["id"], "name" => model["name"].presence || model["id"] } }
       [credential.id.to_s, models.sort_by { |model| model["name"].to_s.downcase }]
     end.select { |_id, models| models.any? }
@@ -68,16 +66,15 @@ class FeedAiSettingsComponent < ViewComponent::Base
     (models_by_credential[selected_credential_id] || []).map { |model| [model["name"], model["id"]] }
   end
 
-  # True when the feed's saved model can no longer be picked — either it dropped
-  # out of the credential's live snapshot, or it's no longer in the capability
-  # matrix — so the form should nudge the user to re-pick before re-enabling.
+  # True when the feed's saved model can no longer be picked — it dropped out of
+  # the matrix ∩ the credential's live snapshot — so the form should nudge the
+  # user to re-pick before re-enabling.
   def model_unavailable?
     return false unless section_visible?
     return false unless @feed.ai_credential&.active?
     return false if @feed.ai_model.blank?
 
-    !@feed.ai_model_available? ||
-      !LlmModelCapability.supported?(@feed.ai_credential.provider, @feed.ai_model)
+    !@feed.ai_model_supported?
   end
 
   private

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -40,11 +40,11 @@ class FeedPreviewsController < ApplicationController
   end
 
   # Server-side backstop for the Stimulus button: an AI preview needs an owned,
-  # active credential and a model that credential still offers.
+  # active credential and a verified model (matrix ∩ the credential's snapshot).
   def invalid_ai_selection?
     return false unless FeedProfile.depends_on_ai?(profile_key)
 
-    ai_credential.blank? || !ai_credential.offers_model?(ai_model)
+    ai_credential.blank? || !ai_credential.supports_model?(ai_model)
   end
 
   def previews

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -40,10 +40,30 @@ class AiCredential < ApplicationRecord
     user.update!(default_ai_credential: self)
   end
 
-  def offers_model?(model_id)
+  # Models this credential can actually back a feed with: the dev-verified
+  # capability matrix intersected with the provider's live snapshot (spec §5).
+  # Membership is qualification — a snapshot model absent from the matrix (or a
+  # provider with no matrix rows) yields nothing, so nothing unverified leaks
+  # into the picker or a run.
+  def supported_models
+    verified = LlmModelCapability.models_for(provider)
+    available_models.select { |model| verified.include?(model["id"]) }
+  end
+
+  def supports_model?(model_id)
     return false if model_id.blank?
 
-    available_models.any? { |model| model["id"] == model_id }
+    supported_models.any? { |model| model["id"] == model_id }
+  end
+
+  # The model to fall back to when a chosen model is no longer supported: the
+  # provider's configured default when it's still supported here, otherwise the
+  # first supported model, or nil when the provider has no verified models.
+  def default_supported_model
+    provider_default = LlmProvider.find(provider).default_model
+    return provider_default if supports_model?(provider_default)
+
+    supported_models.first&.fetch("id")
   end
 
   def ruby_llm_context

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -227,11 +227,45 @@ class Feed < ApplicationRecord
     return true unless FeedProfile.depends_on_ai?(feed_profile_key)
     return false unless ai_credential&.active?
 
-    ai_model_available?
+    # A dropped model no longer blocks preview — a run resolves to the
+    # credential's default supported model, so preview only needs some verified
+    # model to exist (spec §5).
+    ai_credential.supported_models.any?
   end
 
-  def ai_model_available?
-    ai_credential.present? && ai_credential.offers_model?(ai_model)
+  # True when the feed's chosen model is still in the matrix ∩ credential
+  # snapshot. This is the one availability rule every surface reads from.
+  def ai_model_supported?
+    ai_credential.present? && ai_credential.supports_model?(ai_model)
+  end
+
+  # The model an AI run/preview actually uses with `credential`: the chosen one
+  # when still supported, otherwise the credential's default supported model.
+  # Never hard-fails on a dropped model — the caller records the fallback so the
+  # feed page can prompt a re-pick (spec §5).
+  def effective_ai_model(credential = ai_credential)
+    return ai_model if credential.nil?
+    return ai_model if credential.supports_model?(ai_model)
+
+    credential.default_supported_model
+  end
+
+  # Records a one-time notice that the saved model dropped out and a fallback is
+  # in use, so the feed page can nudge a re-pick. Deduped by the dropped→fallback
+  # pair so repeated runs don't spam the activity log.
+  def note_ai_model_fallback!(from:, to:)
+    return if events.where(type: "feed_ai_model_unavailable").not_expired.exists?(
+      ["metadata->>'dropped_model' = ? AND metadata->>'fallback_model' = ?", from.to_s, to.to_s]
+    )
+
+    Event.create!(
+      type: "feed_ai_model_unavailable",
+      level: :warning,
+      subject: self,
+      user: user,
+      message: "",
+      metadata: { dropped_model: from, fallback_model: to }
+    )
   end
 
   # Creates and returns a loader instance for this feed
@@ -478,7 +512,9 @@ class Feed < ApplicationRecord
       errors.add(:ai_credential, "must be active (currently #{ai_credential.state})")
     elsif ai_model.blank?
       errors.add(:ai_model, "Choose a model for this feed.")
-    elsif !ai_model_available?
+    elsif ai_model_changed? && !ai_model_supported?
+      # Membership is enforced only on the change that sets it, so a later-dropped
+      # model never traps an unrelated edit — runs fall back gracefully instead.
       errors.add(:ai_model, "This model isn't available anymore. Pick another one.")
     end
   end

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -60,18 +60,19 @@ module Loader
 
     # The chosen model when the credential still supports it, otherwise its
     # default supported model — a dropped model degrades gracefully instead of
-    # failing the run (spec §5). A persisted feed records the fallback once so
-    # the feed page can prompt a re-pick. Falls back to the provider default only
-    # when the credential exposes no verified models at all.
+    # failing the run (spec §5). The provider default is the last resort when the
+    # credential exposes no verified models at all. A persisted feed records the
+    # fallback once, keyed on the model actually used, so the page prompts a
+    # re-pick even when the whole snapshot dropped out.
     def model_for(credential)
       chosen = feed.ai_model
-      resolved = feed.effective_ai_model(credential)
+      resolved = feed.effective_ai_model(credential).presence || LlmProvider.find(credential.provider).default_model
 
-      if feed.persisted? && chosen.present? && resolved.present? && resolved != chosen
+      if feed.persisted? && chosen.present? && resolved != chosen
         feed.note_ai_model_fallback!(from: chosen, to: resolved)
       end
 
-      resolved.presence || LlmProvider.find(credential.provider).default_model
+      resolved
     end
 
     def config

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -58,10 +58,20 @@ module Loader
       PROMPT
     end
 
-    # Feed override wins; otherwise the resolved credential's provider default,
-    # so the model always matches the provider actually being called.
+    # The chosen model when the credential still supports it, otherwise its
+    # default supported model — a dropped model degrades gracefully instead of
+    # failing the run (spec §5). A persisted feed records the fallback once so
+    # the feed page can prompt a re-pick. Falls back to the provider default only
+    # when the credential exposes no verified models at all.
     def model_for(credential)
-      feed.ai_model.presence || LlmProvider.find(credential.provider).default_model
+      chosen = feed.ai_model
+      resolved = feed.effective_ai_model(credential)
+
+      if feed.persisted? && chosen.present? && resolved.present? && resolved != chosen
+        feed.note_ai_model_fallback!(from: chosen, to: resolved)
+      end
+
+      resolved.presence || LlmProvider.find(credential.provider).default_model
     end
 
     def config

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -551,6 +551,9 @@
         <%= render AlertComponent.new(variant: :warning) do %>
           <%= render EventDescriptionComponent.for(Event.new(type: "feed_target_group_unavailable", level: :warning, subject: sample_feed, metadata: { reason: "posting_denied", target_group: "cats" })) %>
         <% end %>
+        <%= render AlertComponent.new(variant: :warning) do %>
+          <%= render EventDescriptionComponent.for(Event.new(type: "feed_ai_model_unavailable", level: :warning, subject: sample_feed, metadata: { dropped_model: "claude-opus-4-7", fallback_model: "claude-sonnet-4-6" })) %>
+        <% end %>
       </div>
     </section>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,9 @@ en:
         posting_denied: "it lost permission to post to its FreeFeed group"
         group_not_found: "its FreeFeed group no longer exists or was renamed"
         default: "its FreeFeed group is no longer available"
+    feed_ai_model_unavailable:
+      name: "AI model unavailable"
+      description_html: "%{subject_link}'s AI model is no longer available, so it's running on a fallback for now — pick a new model to keep it accurate."
     feed_refresh:
       name: "Feed refreshed"
       description_html: "%{subject_link} refreshed"

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -148,23 +148,25 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     credential = create(:ai_credential, :active, user: user, available_models: models)
 
     get feed_preview_url(profile_key: "llm", "params" => { prompt: "anything here" },
-                         ai_credential_id: credential.id, ai_model: "claude-opus-4-7")
+                         ai_credential_id: credential.id, ai_model: "claude-sonnet-4-6")
 
     preview = user.feed_previews.last
     assert_equal credential.id, preview.ai_credential_id
-    assert_equal "claude-opus-4-7", preview.ai_model
+    assert_equal "claude-sonnet-4-6", preview.ai_model
   end
 
-  test "#show should keep separate previews for different models on the same source" do
+  test "#show should keep separate previews for different verified models on the same source" do
     sign_in_as(user)
-    credential = create(:ai_credential, :active, user: user, available_models: models)
+    anthropic = create(:ai_credential, :active, user: user, available_models: models)
+    moonshot = create(:ai_credential, :active, user: user, provider: "moonshot",
+                                                available_models: [{ "id" => "kimi-k2.5", "name" => "Kimi K2.5" }])
     source = { prompt: "anything here" }
 
     assert_difference("FeedPreview.count", 2) do
       get feed_preview_url(profile_key: "llm", "params" => source,
-                           ai_credential_id: credential.id, ai_model: "claude-sonnet-4-6")
+                           ai_credential_id: anthropic.id, ai_model: "claude-sonnet-4-6")
       get feed_preview_url(profile_key: "llm", "params" => source,
-                           ai_credential_id: credential.id, ai_model: "claude-opus-4-7")
+                           ai_credential_id: moonshot.id, ai_model: "kimi-k2.5")
     end
   end
 
@@ -188,6 +190,19 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
       assert_no_enqueued_jobs do
         get feed_preview_url(profile_key: "llm", "params" => { prompt: "anything here" },
                              ai_credential_id: credential.id, ai_model: "made-up-model"),
+            headers: TURBO_STREAM
+      end
+    end
+  end
+
+  test "#show should not preview a model that is offered but not dev-verified" do
+    sign_in_as(user)
+    credential = create(:ai_credential, :active, user: user, available_models: models)
+
+    assert_no_difference("FeedPreview.count") do
+      assert_no_enqueued_jobs do
+        get feed_preview_url(profile_key: "llm", "params" => { prompt: "anything here" },
+                             ai_credential_id: credential.id, ai_model: "claude-opus-4-7"),
             headers: TURBO_STREAM
       end
     end

--- a/test/models/ai_credential_test.rb
+++ b/test/models/ai_credential_test.rb
@@ -114,17 +114,61 @@ class AiCredentialTest < ActiveSupport::TestCase
     assert_equal "disabled", enabled_feed.reload.state
   end
 
-  test "#offers_model? should be true only for a model in available_models" do
-    credential = build(:ai_credential, available_models: [{ "id" => "claude-sonnet-4-6" }])
+  test "#supported_models should keep only models the capability matrix verifies" do
+    credential = build(:ai_credential, provider: "anthropic",
+                                       available_models: [{ "id" => "claude-sonnet-4-6" }, { "id" => "unverified-model" }])
 
-    assert credential.offers_model?("claude-sonnet-4-6")
-    assert_not credential.offers_model?("some-other-model")
+    assert_equal ["claude-sonnet-4-6"], credential.supported_models.map { |model| model["id"] }
   end
 
-  test "#offers_model? should be false for a blank model id" do
+  test "#supported_models should be empty for a provider with no matrix rows" do
+    credential = build(:ai_credential, provider: "anthropic",
+                                       available_models: [{ "id" => "some-model" }])
+    credential.provider = "openrouter"
+
+    assert_empty credential.supported_models
+  end
+
+  test "#supports_model? should be true only for a verified model in the snapshot" do
+    credential = build(:ai_credential, provider: "anthropic",
+                                       available_models: [{ "id" => "claude-sonnet-4-6" }])
+
+    assert credential.supports_model?("claude-sonnet-4-6")
+    assert_not credential.supports_model?("some-other-model")
+  end
+
+  test "#supports_model? should be false for a snapshot model missing from the matrix" do
+    credential = build(:ai_credential, provider: "anthropic",
+                                       available_models: [{ "id" => "unverified-model" }])
+
+    assert_not credential.supports_model?("unverified-model")
+  end
+
+  test "#supports_model? should be false for a blank model id" do
     credential = build(:ai_credential, available_models: [{ "id" => "claude-sonnet-4-6" }])
 
-    assert_not credential.offers_model?(nil)
-    assert_not credential.offers_model?("")
+    assert_not credential.supports_model?(nil)
+    assert_not credential.supports_model?("")
+  end
+
+  test "#default_supported_model should prefer the provider default when supported" do
+    credential = build(:ai_credential, provider: "anthropic",
+                                       available_models: [{ "id" => "claude-sonnet-4-6" }])
+
+    assert_equal "claude-sonnet-4-6", credential.default_supported_model
+  end
+
+  test "#default_supported_model should resolve a moonshot credential to its verified model" do
+    credential = build(:ai_credential, provider: "moonshot",
+                                       available_models: [{ "id" => "kimi-k2.5" }])
+
+    assert_equal "kimi-k2.5", credential.default_supported_model
+  end
+
+  test "#default_supported_model should be nil when nothing is supported" do
+    credential = build(:ai_credential, provider: "anthropic",
+                                       available_models: [{ "id" => "unverified-model" }])
+
+    assert_nil credential.default_supported_model
   end
 end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -397,10 +397,18 @@ class FeedTest < ActiveSupport::TestCase
     assert_not feed.can_be_previewed?
   end
 
-  test "#can_be_previewed? should be false for an AI profile whose model is no longer available" do
+  test "#can_be_previewed? should stay true when the saved model dropped but the credential has a fallback" do
     credential = create(:ai_credential, :active, available_models: [{ "id" => "claude-sonnet-4-6" }])
     feed = build(:feed, user: credential.user, feed_profile_key: "llm",
                         params: { "prompt" => "ruby news" }, ai_credential: credential, ai_model: "removed-model")
+
+    assert feed.can_be_previewed?
+  end
+
+  test "#can_be_previewed? should be false when the credential has no verified models" do
+    credential = create(:ai_credential, :active, available_models: [{ "id" => "unverified-model" }])
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "ruby news" }, ai_credential: credential, ai_model: "unverified-model")
 
     assert_not feed.can_be_previewed?
   end
@@ -788,6 +796,70 @@ class FeedTest < ActiveSupport::TestCase
 
     assert_not feed.valid?
     assert_includes feed.errors[:ai_model], "This model isn't available anymore. Pick another one."
+  end
+
+  test "#saving an unrelated edit should not re-validate a saved model that later dropped" do
+    user = create(:user)
+    credential = create(:ai_credential, :active, user: user, available_models: [{ "id" => "claude-sonnet-4-6" }])
+    feed = create(:feed, user: user, access_token: access_token_for(user), state: :enabled,
+                         target_group: "testgroup", feed_profile_key: "llm",
+                         params: { "prompt" => "ruby news" }, ai_credential: credential, ai_model: "claude-sonnet-4-6")
+
+    credential.update!(available_models: [])
+    feed.name = "Renamed"
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "#changing to an unsupported model on an enabled feed should be rejected" do
+    user = create(:user)
+    credential = create(:ai_credential, :active, user: user, available_models: [{ "id" => "claude-sonnet-4-6" }])
+    feed = create(:feed, user: user, access_token: access_token_for(user), state: :enabled,
+                         target_group: "testgroup", feed_profile_key: "llm",
+                         params: { "prompt" => "ruby news" }, ai_credential: credential, ai_model: "claude-sonnet-4-6")
+
+    feed.ai_model = "removed-model"
+
+    assert_not feed.valid?
+    assert_includes feed.errors[:ai_model], "This model isn't available anymore. Pick another one."
+  end
+
+  test "#effective_ai_model should return the chosen model when it is still supported" do
+    credential = create(:ai_credential, :active, available_models: [{ "id" => "claude-sonnet-4-6" }])
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "x" }, ai_credential: credential, ai_model: "claude-sonnet-4-6")
+
+    assert_equal "claude-sonnet-4-6", feed.effective_ai_model
+  end
+
+  test "#effective_ai_model should fall back to the default supported model when the chosen one dropped" do
+    credential = create(:ai_credential, :active, available_models: [{ "id" => "claude-sonnet-4-6" }])
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "x" }, ai_credential: credential, ai_model: "removed-model")
+
+    assert_equal "claude-sonnet-4-6", feed.effective_ai_model
+  end
+
+  test "#ai_model_supported? should follow the credential's matrix-intersected snapshot" do
+    credential = create(:ai_credential, :active, available_models: [{ "id" => "claude-sonnet-4-6" }])
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "x" }, ai_credential: credential, ai_model: "claude-sonnet-4-6")
+
+    assert feed.ai_model_supported?
+    feed.ai_model = "removed-model"
+    assert_not feed.ai_model_supported?
+  end
+
+  test "#note_ai_model_fallback! should record one event and dedupe the same drop" do
+    feed = create(:feed, feed_profile_key: "llm", params: { "prompt" => "x" })
+
+    assert_difference -> { feed.events.where(type: "feed_ai_model_unavailable").count }, 1 do
+      feed.note_ai_model_fallback!(from: "removed-model", to: "claude-sonnet-4-6")
+    end
+
+    assert_no_difference -> { feed.events.where(type: "feed_ai_model_unavailable").count } do
+      feed.note_ai_model_fallback!(from: "removed-model", to: "claude-sonnet-4-6")
+    end
   end
 
   test "#enabling a non-AI feed should not require an ai_credential" do

--- a/test/services/feed_preview_workflow_test.rb
+++ b/test/services/feed_preview_workflow_test.rb
@@ -132,10 +132,10 @@ class FeedPreviewWorkflowTest < ActiveSupport::TestCase
   end
 
   test "#execute should run the AI loader with the preview's selected provider and model" do
-    credential = create(:ai_credential, :active, user: user)
+    credential = create(:ai_credential, :active, user: user, available_models: [{ "id" => "claude-sonnet-4-6" }])
     preview = create(:feed_preview, user: user, feed_profile_key: "llm",
                      params: { "prompt" => "rust async" }, ai_credential: credential,
-                     ai_model: "claude-opus-4-7", status: :pending, run_id: "run-ai")
+                     ai_model: "claude-sonnet-4-6", status: :pending, run_id: "run-ai")
 
     captured_feed = nil
     captured_model = nil
@@ -153,7 +153,7 @@ class FeedPreviewWorkflowTest < ActiveSupport::TestCase
     end
 
     assert_equal credential.id, captured_feed.ai_credential_id
-    assert_equal "claude-opus-4-7", captured_feed.ai_model
-    assert_equal "claude-opus-4-7", captured_model
+    assert_equal "claude-sonnet-4-6", captured_feed.ai_model
+    assert_equal "claude-sonnet-4-6", captured_model
   end
 end

--- a/test/services/loader/llm_loader_test.rb
+++ b/test/services/loader/llm_loader_test.rb
@@ -103,12 +103,27 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
     assert_match(/items/, error.message)
   end
 
-  test "#load should call the model from the feed override when set" do
-    feed.update!(ai_model: "claude-opus-4-7")
-    client = fake_client(structured: { "items" => [] })
-    Loader::LlmLoader.new(feed, llm_client: client).load
+  test "#load should use the feed's chosen model when the credential still supports it" do
+    supported = create(:ai_credential, :active, user: user, available_models: [{ "id" => "claude-sonnet-4-6" }])
+    supported_feed = create(:feed, user: user, ai_credential: supported, feed_profile_key: "llm",
+                                   params: { "prompt" => "x" }, ai_model: "claude-sonnet-4-6")
+    client = fake_client(structured: { "items" => [] }, credential: supported)
+    Loader::LlmLoader.new(supported_feed, llm_client: client).load
 
-    assert_equal ["claude-opus-4-7"], client.calls.map { |c| c[:model] }
+    assert_equal ["claude-sonnet-4-6"], client.calls.map { |c| c[:model] }
+  end
+
+  test "#load should fall back to a supported model and record a notice when the chosen model dropped" do
+    supported = create(:ai_credential, :active, user: user, available_models: [{ "id" => "claude-sonnet-4-6" }])
+    dropped_feed = create(:feed, user: user, ai_credential: supported, feed_profile_key: "llm",
+                                 params: { "prompt" => "x" }, ai_model: "removed-model")
+    client = fake_client(structured: { "items" => [] }, credential: supported)
+
+    assert_difference -> { dropped_feed.events.where(type: "feed_ai_model_unavailable").count }, 1 do
+      Loader::LlmLoader.new(dropped_feed, llm_client: client).load
+    end
+
+    assert_equal ["claude-sonnet-4-6"], client.calls.map { |c| c[:model] }
   end
 
   test "#load should fall back to the provider default model when no override" do

--- a/test/services/loader/llm_loader_test.rb
+++ b/test/services/loader/llm_loader_test.rb
@@ -126,6 +126,19 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
     assert_equal ["claude-sonnet-4-6"], client.calls.map { |c| c[:model] }
   end
 
+  test "#load should record a notice and use the provider default when the whole snapshot dropped" do
+    empty = create(:ai_credential, :active, user: user, available_models: [])
+    orphaned = create(:feed, user: user, ai_credential: empty, feed_profile_key: "llm",
+                             params: { "prompt" => "x" }, ai_model: "claude-opus-4-7")
+    client = fake_client(structured: { "items" => [] }, credential: empty)
+
+    assert_difference -> { orphaned.events.where(type: "feed_ai_model_unavailable").count }, 1 do
+      Loader::LlmLoader.new(orphaned, llm_client: client).load
+    end
+
+    assert_equal [LlmProvider.find("anthropic").default_model], client.calls.map { |c| c[:model] }
+  end
+
   test "#load should fall back to the provider default model when no override" do
     assert_nil feed.ai_model
     client = fake_client(structured: { "items" => [] }, credential: credential)


### PR DESCRIPTION
Changes:

- Add `AiCredential#supported_models` / `#supports_model?` / `#default_supported_model` — the dev-verified matrix intersected with the credential's live snapshot — as the single source of truth for AI model availability (replaces the snapshot-only `offers_model?`).
- Validate `ai_model` membership only on the change that sets it (`ai_model_changed?`), so a model that drops out later never blocks an unrelated edit or the enable transition.
- Preview and scheduled runs resolve to the credential's default supported model via `Feed#effective_ai_model` instead of hard-failing; a scheduled run records a one-time `feed_ai_model_unavailable` notice on the feed page prompting a re-pick.
- Point the model picker, the "model unavailable" nudge, and the preview backstop at the same rule.

Previously a dropped model behaved three different ways — it blocked saving, blocked preview, and let a scheduled run silently keep using the missing model. §4's edit unlock would have turned the save-block into a trap. This collapses all of that into one rule: membership is checked once, when it changes; everywhere else a missing model degrades gracefully to a supported one and tells the user about it.

The notice degrades gracefully even in the corner case where a credential's whole snapshot drops out of the matrix — the run falls back to the provider default and still records the event.

References:

- Closes #910
- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §5
- Supersedes #874 (graceful degradation replaces auto-disable-on-missing-model)