### PR TITLE
Re-detect a deterministic feed's source on edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-06
 
+- You can now change a feed's source link when editing it. We re-check the new link for a feed before saving, so a broken link can't quietly slip in — and the feed keeps running on its current source until the new one checks out.
 - If an AI feed's model is no longer available, the feed keeps running on a supported fallback and flags it on the feed page, instead of blocking edits or quietly using the missing one. Pick a new model whenever you're ready.
 
 ## 2026-07-05

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -7,7 +7,7 @@ class FeedIdentificationsController < ApplicationController
     render turbo_stream: turbo_stream.replace(
       "feed-form",
       partial: "feeds/identification_error",
-      locals: { input: params[:input], error: "Too many identification attempts. Please wait before trying again." }
+      locals: base_locals.merge(input: params[:input], error: "Too many identification attempts. Please wait before trying again.")
     ), status: :too_many_requests
   }
 
@@ -27,18 +27,7 @@ class FeedIdentificationsController < ApplicationController
     return present_outcome if settled_identification?
 
     if feed_identification.new_record? || feed_identification.failed? || retryable_unreachable?
-      begin
-        feed_identification.update!(
-          status: :processing,
-          started_at: Time.current,
-          candidates: [],
-          error: nil
-        )
-      rescue ActiveRecord::RecordNotUnique
-        # Race condition: another process created the record, reload and continue
-        feed_identification.reload
-      end
-
+      feed_identification.restart_detection!
       FeedIdentificationJob.perform_later(Current.user.id, source_url)
     end
 
@@ -128,13 +117,24 @@ class FeedIdentificationsController < ApplicationController
     suggested = feed_identification.suggested_candidate
     profile_key = suggested&.profile_key
     source_key = FeedProfile.source_key_for(profile_key) || "url"
-    params_for_input = { source_key => feed_identification.input }
 
-    feed = Current.user.feeds.build(
-      params: params_for_input,
-      feed_profile_key: profile_key,
-      name: suggested&.title&.truncate(Feed::NAME_MAX_LENGTH, omission: "…")
-    )
+    feed =
+      if editing?
+        # Re-render the feed being edited with the proposed source + profile
+        # applied in memory only; the confirming PATCH persists it after the
+        # source-verified guard clears (spec §4). Operational edits were saved
+        # on the propose PATCH, so the reloaded record already carries them.
+        edit_feed.tap do |f|
+          f.feed_profile_key = profile_key
+          f.params = (f.params || {}).merge(source_key => feed_identification.input)
+        end
+      else
+        Current.user.feeds.build(
+          params: { source_key => feed_identification.input },
+          feed_profile_key: profile_key,
+          name: suggested&.title&.truncate(Feed::NAME_MAX_LENGTH, omission: "…")
+        )
+      end
 
     render(identification_success(feed, candidates: feed_identification.working_candidates))
   end
@@ -144,21 +144,28 @@ class FeedIdentificationsController < ApplicationController
       turbo_stream: turbo_stream.replace(
         "feed-form",
         partial: "feeds/identification_error",
-        locals: { input: raw_input, error: error, heading: heading }
+        locals: base_locals.merge(input: raw_input, error: error, heading: heading)
       )
     }
   end
 
+  # When re-detecting an existing deterministic feed the engine is fixed, so the
+  # AI bridge isn't offered (spec §4) — the copy just points back to a link.
   def not_a_link_bridge
+    return identification_error(heading: "That doesn't look like a link", error: "Enter a feed or page URL to check it.") if editing?
+
     identification_error(
       heading: "That doesn't look like a link",
       error: "Follow it with AI instead, or switch back and paste a link."
     )
   end
 
-  # Terminal: the link was reachable but no deterministic profile reads it. The
-  # bridge is the way forward (spec §7).
+  # Terminal: the link was reachable but no deterministic profile reads it. In
+  # creation the bridge is the way forward (spec §7); in edit the engine is fixed,
+  # so it just invites another link.
   def no_feed_error
+    return identification_error(heading: "Couldn't pull any posts from that link", error: "We couldn't find a feed there — try a different link, or cancel to keep the current one.") if editing?
+
     identification_error(
       heading: "Couldn't pull any posts from that link",
       error: "We couldn't find a feed there — but AI can still follow it, or you can try a different link."
@@ -172,7 +179,7 @@ class FeedIdentificationsController < ApplicationController
       turbo_stream: turbo_stream.replace(
         "feed-form",
         partial: "feeds/identification_retry",
-        locals: { input: raw_input }
+        locals: base_locals.merge(input: raw_input)
       )
     }
   end
@@ -182,7 +189,7 @@ class FeedIdentificationsController < ApplicationController
       turbo_stream: turbo_stream.replace(
         "feed-form",
         partial: "feeds/identification_loading",
-        locals: { input: source_url }
+        locals: base_locals.merge(input: source_url)
       )
     }
   end
@@ -192,9 +199,28 @@ class FeedIdentificationsController < ApplicationController
       turbo_stream: turbo_stream.replace(
         "feed-form",
         partial: "feeds/form_expanded",
-        locals: { feed: feed, candidates: candidates }
+        locals: { feed: feed, candidates: candidates, edit_mode: editing? }
       )
     }
+  end
+
+  # The feed being edited (spec §4 source re-detection), or nil in the creation
+  # flow. Scoped to the current user so a forged feed_id can't reach another's.
+  def edit_feed
+    return @edit_feed if defined?(@edit_feed)
+
+    @edit_feed = params[:feed_id].present? ? Current.user.feeds.find_by(id: params[:feed_id]) : nil
+  end
+
+  def editing?
+    edit_feed.present?
+  end
+
+  # Common locals the §7 partials read to route back to the right place: the
+  # feed_id keeps re-detection in the edit context, cancel_path returns to the
+  # feed (not the feeds index), and edit_mode suppresses the AI bridge.
+  def base_locals
+    { feed_id: edit_feed&.id, cancel_path: (editing? ? feed_path(edit_feed) : feeds_path), edit_mode: editing? }
   end
 
   def raw_input

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -2,6 +2,7 @@ class FeedsController < ApplicationController
   include Pagination
   include Sortable
   include FeedStateEvents
+  include StatePolling
 
   MAX_RECENT_POSTS = 5
   MAX_RECENT_EVENTS = 10
@@ -106,15 +107,29 @@ class FeedsController < ApplicationController
     authorize @feed
   end
 
-  # Per FR-026/FR-027/FR-028 operational fields (name, target_group, schedule,
-  # access_token) edit freely; source-side fields (url, feed_profile_key,
-  # params) are not editable from this form and stay anchored to the original
-  # detection result. Re-pointing a feed at a different source means creating
-  # a new feed.
+  # Operational fields (name, target_group, schedule, access_token) edit freely.
+  # A live deterministic feed's source can be re-pointed, but only through
+  # detection: a changed source URL re-runs identification and the confirming
+  # save applies it only once a working candidate is verified (spec §4). The
+  # engine stays fixed — deterministic ↔ AI is a new feed.
   def update
     @feed = load_feed
     authorize @feed
+
+    # A changed deterministic source that isn't yet backed by a verified working
+    # candidate hands off to the async detector and paints the §7 states; a
+    # confirmed one falls through to the normal save below (with the source
+    # applied), so enable/pause/schedule bookkeeping stays in one place. Capture
+    # the decision before assign_attributes moves source_input onto the new URL.
+    source_change = mode_a_source_change?
+    if source_change && !source_change_confirmed?
+      return propose_source_redetection(canonical_submitted_url || submitted_source_raw)
+    end
+
     @feed.assign_attributes(update_feed_params)
+    # Overwrite the raw submitted URL with the canonical, verified source and its
+    # detected profile (the confirm path — spec §4).
+    apply_confirmed_source if source_change
 
     # Unticked Enable on an enabled feed = pause request (gate flow skips this
     # because the gate only appears for drafts without usable credentials).
@@ -190,6 +205,68 @@ class FeedsController < ApplicationController
     end
   end
 
+  # True when a live deterministic feed's submitted source URL differs from the
+  # one it's anchored to — the only case that routes through re-detection.
+  def mode_a_source_change?
+    return false unless @feed.persisted? && !@feed.draft?
+    return false if FeedProfile.depends_on_ai?(@feed.feed_profile_key)
+
+    submitted_source_raw.present? && submitted_source_raw != @feed.source_input.to_s
+  end
+
+  def submitted_source_raw
+    @submitted_source_raw ||= params.dig(:feed, :params, :url).to_s.strip
+  end
+
+  def canonical_submitted_url
+    return @canonical_submitted_url if defined?(@canonical_submitted_url)
+
+    @canonical_submitted_url = SourceLink.canonical(submitted_source_raw)
+  end
+
+  # The settled working identification for the submitted URL, or nil. A source
+  # change is confirmed only when one exists and the submitted profile is one of
+  # its working candidates — a candidate that actually read the source (spec §4).
+  def settled_working_identification
+    return @settled_working_identification if defined?(@settled_working_identification)
+
+    fi = canonical_submitted_url && FeedIdentification.find_by(user: current_user, input: canonical_submitted_url)
+    @settled_working_identification = (fi&.success? && fi.outcome == :working) ? fi : nil
+  end
+
+  def source_change_confirmed?
+    fi = settled_working_identification
+    fi.present? && fi.working_candidate_profile_keys.include?(params.dig(:feed, :feed_profile_key))
+  end
+
+  def apply_confirmed_source
+    @feed.url = canonical_submitted_url
+    @feed.feed_profile_key = params.dig(:feed, :feed_profile_key)
+    @feed.source_verified = true
+  end
+
+  # Persist the operational edits so they survive the async detection gap, then
+  # kick detection and paint the §7 loading state. The source itself waits for a
+  # confirmed working candidate; no state transition happens here, so a live feed
+  # keeps refreshing its verified source until the new one is confirmed.
+  def propose_source_redetection(input)
+    return render :edit, status: :unprocessable_entity unless @feed.update(operational_update_params)
+
+    identification = FeedIdentification.find_or_initialize_by(user: current_user, input: input)
+    identification.restart_detection!
+    FeedIdentificationJob.perform_later(current_user.id, input)
+
+    render turbo_stream: turbo_stream.replace(
+      "feed-form",
+      partial: "feeds/identification_loading",
+      locals: { input: input, feed_id: @feed.id, cancel_path: feed_path(@feed), edit_mode: true }
+    )
+  end
+
+  def operational_update_params
+    update_feed_params.except(:params, :feed_profile_key)
+  end
+
   def feeds_scope
     current_user.feeds
   end
@@ -257,6 +334,13 @@ class FeedsController < ApplicationController
   def permitted_keys
     if @feed&.draft?
       ALWAYS_PERMITTED_PARAMS + DRAFT_ONLY_PERMITTED_PARAMS
+    elsif @feed && !FeedProfile.depends_on_ai?(@feed.feed_profile_key)
+      # A live deterministic feed can move its source, but only through detection
+      # (spec §4). The URL rides operational params; the re-detected profile is
+      # applied explicitly by the confirm path (from a verified chooser pick), so
+      # feed_profile_key stays out of the mass-assignable set here — an unverified
+      # profile switch can't leak in.
+      ALWAYS_PERMITTED_PARAMS + [{ params: [:url] }]
     else
       ALWAYS_PERMITTED_PARAMS
     end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -55,6 +55,11 @@ class Feed < ApplicationRecord
   # How long a ready FeedPreview is reused before a fresh run is forced.
   PREVIEW_FRESHNESS_WINDOW = 60.minutes
 
+  # Set true by the edit controller only after a settled detection confirmed the
+  # new source (spec §4). Lets `source_change_reverified` reject a Mode A source
+  # move that never passed through identification.
+  attr_accessor :source_verified
+
   after_update :create_schedule_on_enable
 
   validates :name, uniqueness: { scope: :user_id }, length: { maximum: NAME_MAX_LENGTH }
@@ -74,6 +79,8 @@ class Feed < ApplicationRecord
   validate :ai_credential_belongs_to_user
   validate :access_token_belongs_to_user
   validate :ai_credential_required_when_enabled_ai_profile, if: :enabled?
+  validate :engine_fixed_on_edit
+  validate :source_change_reverified
   validates :access_token, presence: true, if: :enabled?
   validates :target_group, presence: true, if: :enabled?
 
@@ -500,6 +507,38 @@ class Feed < ApplicationRecord
     return if access_token.user_id == user_id
 
     errors.add(:access_token, "must belong to the same user")
+  end
+
+  # The engine (deterministic vs AI) is fixed at creation: an existing feed never
+  # switches across the AI boundary in edit — you create a new feed instead (spec
+  # §4). A deterministic → deterministic profile change is fine.
+  def engine_fixed_on_edit
+    return unless persisted? && feed_profile_key_changed?
+    return unless FeedProfile.exists?(feed_profile_key) && FeedProfile.exists?(feed_profile_key_was)
+    return if FeedProfile.depends_on_ai?(feed_profile_key) == FeedProfile.depends_on_ai?(feed_profile_key_was)
+
+    errors.add(:feed_profile_key, "can't switch between AI and non-AI feeds — start a new feed instead")
+  end
+
+  # A deterministic feed's source can only move through identification (spec §4):
+  # the edit controller re-runs detection and sets `source_verified` once a
+  # working candidate confirms the new source. This blocks a forged direct edit
+  # from silently pointing a live feed at an unverified, possibly-broken source.
+  def source_change_reverified
+    return unless persisted?
+    return if draft? || source_verified
+    return if FeedProfile.depends_on_ai?(feed_profile_key)
+    return unless source_input_changed_in_place?
+
+    errors.add(:base, "The source changed — re-check it before saving.")
+  end
+
+  def source_input_changed_in_place?
+    return false unless params_changed?
+
+    key = FeedProfile.source_key_for(feed_profile_key) || "url"
+    before, after = params_change
+    before&.dig(key) != after&.dig(key)
   end
 
   def ai_credential_required_when_enabled_ai_profile

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -9,6 +9,15 @@ class FeedIdentification < ApplicationRecord
     processing? && started_at.nil?
   end
 
+  # Reset the row to a fresh in-flight detection. Shared by the creation entry
+  # and the edit-source re-detection so both clear stale candidates/errors the
+  # same way; the caller enqueues FeedIdentificationJob.
+  def restart_detection!
+    update!(status: :processing, started_at: Time.current, candidates: [], error: nil)
+  rescue ActiveRecord::RecordNotUnique
+    reload
+  end
+
   # The candidate the chooser preselects and the new-feed form is built from: the
   # highest-ranked one that can fetch the source.
   def suggested_candidate
@@ -25,6 +34,13 @@ class FeedIdentification < ApplicationRecord
       candidate = Candidate.new(attributes)
       candidate.failed? || candidate.unreachable?
     end
+  end
+
+  # Profile keys of the working candidates, in rank order. An edit's confirming
+  # save (spec §4) only applies a source when the submitted profile is one of
+  # these — a settled, source-reading candidate.
+  def working_candidate_profile_keys
+    working_candidates.map { |attributes| attributes["profile_key"] }
   end
 
   # How the detection result should present (spec §7):

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -1,8 +1,9 @@
 <%# locals: (edit_mode: false, feed: @feed, candidates: []) %>
 <% active_tokens = Current.user.access_tokens.active.order(:host) %>
 <%# The chooser is a real choice only with two or more working candidates; one
-    working candidate is shown as a read-only annotation (spec §7). %>
-<% show_chooser = !edit_mode && candidates.size >= 2 %>
+    working candidate is shown as a read-only annotation (spec §7). In edit mode
+    it appears only after a source re-detection resolves to multiple candidates. %>
+<% show_chooser = candidates.size >= 2 %>
 <%
   preview_source_keys =
     if show_chooser
@@ -41,8 +42,10 @@
       <% source_label = feed.source_input_url? ? "Source URL" : "Source prompt" %>
       <%# For an AI feed the prompt *is* the source and carries no duplicate risk,
           so it stays an editable textarea while creating or editing a draft
-          (spec §1, §4) — unlike a detected URL, which is read-only. %>
+          (spec §1, §4). A deterministic feed's URL is editable when editing an
+          existing feed — a change re-runs detection before saving (spec §4). %>
       <% ai_prompt_editable = FeedProfile.depends_on_ai?(feed.feed_profile_key) && (!edit_mode || feed.draft?) %>
+      <% source_editable = edit_mode && !FeedProfile.depends_on_ai?(feed.feed_profile_key) %>
       <div>
         <h2 class="text-xl font-semibold text-heading mb-4">Source</h2>
 
@@ -59,6 +62,16 @@
                                 data: { preview_button_target: "source", action: "input->preview-button#refreshAvailability", key: "form.ai-prompt" } %>
               <p class="text-sm text-muted">Describe a source or topic in your own words. You can tweak this before saving.</p>
             </div>
+          <% elsif source_editable %>
+            <div class="space-y-2">
+              <%= f.label :url, source_label, class: "block font-semibold text-heading" %>
+              <%= text_field_tag "feed[params][url]", feed.source_input,
+                                 id: "feed_params_url",
+                                 required: true,
+                                 class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2",
+                                 data: { preview_button_target: "source", action: "input->preview-button#refreshAvailability", key: "form.source-edit" } %>
+              <p class="text-sm text-muted" data-key="form.source-edit-note">Point this at a different feed and we'll re-check it before saving.</p>
+            </div>
           <% else %>
             <div class="space-y-2">
               <%= f.label :url, source_label, class: "block font-semibold text-heading" %>
@@ -72,20 +85,21 @@
                 <%= hidden_field_tag "feed[params][#{key}]", value %>
               <% end %>
             </div>
+          <% end %>
 
+          <%# Feed type belongs to every deterministic feed: the chooser after a
+              multi-candidate re-detection, otherwise a read-only annotation. %>
+          <% unless ai_prompt_editable %>
             <% if show_chooser %>
               <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.source_input, selected: feed.feed_profile_key %>
             <% else %>
-              <%# Feed type is fixed once the feed exists, so it's shown read-only
-                  as a disabled input matching the source field above it. Like the
-                  source field, it's display-only — the controller never reads it. %>
               <div class="space-y-2">
                 <%= label_tag nil, "Feed type", class: "block font-semibold text-heading" %>
                 <%= f.text_field :feed_type_display,
                                  value: candidate_summary(feed.feed_profile_key, feed.source_input),
                                  disabled: true,
                                  class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2 disabled:bg-surface-sunken disabled:text-muted disabled:border-border disabled:cursor-not-allowed",
-                                 aria: { label: "Feed type (cannot be changed)" },
+                                 aria: { label: "Feed type" },
                                  data: { key: "form.feed-type-display" } %>
               </div>
             <% end %>
@@ -99,8 +113,8 @@
           <%= f.hidden_field :feed_profile_key %>
         <% end %>
 
-        <% if edit_mode && !ai_prompt_editable %>
-          <p class="mt-3 text-sm text-muted" data-key="form.source-locked-note">The source and feed type are locked in when a feed is created. To follow a different source, just start a new feed.</p>
+        <% if edit_mode && !ai_prompt_editable && !source_editable %>
+          <p class="mt-3 text-sm text-muted" data-key="form.source-locked-note">This feed's source is fixed. To follow a different source, just start a new feed.</p>
         <% end %>
       </div>
 

--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -16,6 +16,9 @@
   </div>
 
   <%= form_with url: feed_identifications_path, method: :post, class: "space-y-4" do |f| %>
+    <% if local_assigns[:feed_id].present? %>
+      <%= hidden_field_tag :feed_id, local_assigns[:feed_id] %>
+    <% end %>
     <div class="space-y-2">
       <%= f.label :input, "Source link", class: "block font-semibold text-heading" %>
       <%= f.text_field :input, value: input, placeholder: "https://example.com", class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2" %>
@@ -24,12 +27,16 @@
     <%= f.submit "Try Again", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
   <% end %>
 
-  <div class="space-y-2" data-key="identification.ai-bridge">
-    <%= button_to "Follow with AI instead", feed_identifications_path,
-                  params: { input: input, mode: "ai" },
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
-    <p class="text-sm text-muted">AI can follow it even when there's no standard feed to read.</p>
-  </div>
+  <%# Editing a deterministic feed keeps the engine fixed (spec §4), so the AI
+      bridge is offered only in the creation flow. %>
+  <% unless local_assigns.fetch(:edit_mode, false) %>
+    <div class="space-y-2" data-key="identification.ai-bridge">
+      <%= button_to "Follow with AI instead", feed_identifications_path,
+                    params: { input: input, mode: "ai" },
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
+      <p class="text-sm text-muted">AI can follow it even when there's no standard feed to read.</p>
+    </div>
+  <% end %>
 
-  <%= link_to "Cancel", feeds_path, class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
+  <%= link_to "Cancel", local_assigns.fetch(:cancel_path, feeds_path), class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
 </div>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (input:, feed_id: nil, cancel_path: nil, edit_mode: false) %>
+<% feed_id = local_assigns.fetch(:feed_id, nil) %>
 <%# Polling marks its host aria-busy while checking, and the global
     [aria-busy="true"] rule makes that subtree non-interactive. This card holds
     the Cancel button, so opt out of the busy state to keep it clickable. %>
@@ -6,7 +8,7 @@
      role="status"
      data-controller="polling"
      data-polling-indicate-busy-value="false"
-     data-polling-endpoint-value="<%= feed_identifications_path(input: input) %>"
+     data-polling-endpoint-value="<%= feed_identifications_path(input: input, feed_id: feed_id) %>"
      data-polling-interval-value="<%= polling_interval_ms %>"
      data-polling-max-polls-value="<%= polling_max_polls %>"
      data-polling-stop-condition-value="[data-identification-state='complete'], [data-identification-state='error']">
@@ -17,10 +19,18 @@
     <p class="font-semibold text-heading">Checking this feed…</p>
     <p class="text-body">This usually takes a few seconds.</p>
   </div>
-  <%= button_to "Cancel",
-                feed_identifications_path(input: input),
-                method: :delete,
-                form: { data: { turbo_frame: "_top" } },
-                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-body shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
-                data: { key: "loading.cancel" } %>
+  <% if local_assigns.fetch(:edit_mode, false) %>
+    <%# Editing keeps the current source live until a new one is confirmed, so
+        Cancel just returns to the feed rather than tearing down the entry flow. %>
+    <%= link_to "Cancel", local_assigns.fetch(:cancel_path, feeds_path),
+                data: { turbo_frame: "_top", key: "loading.cancel" },
+                class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-body shadow-sm transition hover:bg-surface-muted cursor-pointer" %>
+  <% else %>
+    <%= button_to "Cancel",
+                  feed_identifications_path(input: input),
+                  method: :delete,
+                  form: { data: { turbo_frame: "_top" } },
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-body shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
+                  data: { key: "loading.cancel" } %>
+  <% end %>
 </div>

--- a/app/views/feeds/_identification_retry.html.erb
+++ b/app/views/feeds/_identification_retry.html.erb
@@ -1,4 +1,6 @@
-<%# locals: (input: nil) %>
+<%# locals: (input: nil, feed_id: nil, cancel_path: nil, edit_mode: false) %>
+<% feed_id = local_assigns.fetch(:feed_id, nil) %>
+<% edit_mode = local_assigns.fetch(:edit_mode, false) %>
 <%# The transient "couldn't reach" state (spec §7): retrying is the primary
     path, with the AI bridge as a secondary escape so it can't dead-end. Marked
     as an identification state so polling stops here. %>
@@ -13,7 +15,7 @@
       <div class="ml-3">
         <h3 class="text-sm font-medium text-heading">Couldn't reach that link</h3>
         <div class="mt-2 text-sm text-body">
-          <p>It might be a temporary hiccup — give it another go, or follow it with AI instead.</p>
+          <p><%= edit_mode ? "It might be a temporary hiccup — give it another go, or cancel to keep the current source." : "It might be a temporary hiccup — give it another go, or follow it with AI instead." %></p>
         </div>
       </div>
     </div>
@@ -21,15 +23,17 @@
 
   <div class="flex flex-wrap items-center gap-4">
     <%= button_to "Retry", feed_identifications_path,
-                  params: { input: input },
+                  params: { input: input, feed_id: feed_id }.compact,
                   class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto",
                   data: { key: "identification.retry", turbo_submits_with: "Checking…" } %>
 
-    <%= button_to "Follow with AI instead", feed_identifications_path,
-                  params: { input: input, mode: "ai" },
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto",
-                  data: { key: "identification.ai-bridge" } %>
+    <% unless edit_mode %>
+      <%= button_to "Follow with AI instead", feed_identifications_path,
+                    params: { input: input, mode: "ai" },
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto",
+                    data: { key: "identification.ai-bridge" } %>
+    <% end %>
   </div>
 
-  <%= link_to "Cancel", feeds_path, class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
+  <%= link_to "Cancel", local_assigns.fetch(:cancel_path, feeds_path), class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
 </div>

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -689,6 +689,53 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='feed[name]'][value='#{"A" * (Feed::NAME_MAX_LENGTH - 1)}…']", count: 1
   end
 
+  test "#show should re-render the edit form for a feed-scoped source re-detection" do
+    sign_in_as(user)
+    feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
+    new_url = "http://example.com/new.xml"
+    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+           candidates: [{ "profile_key" => "rss", "test_status" => "passed", "rank" => 0, "depends_on_ai" => false, "title" => "New" }])
+
+    get feed_identifications_path, params: { input: new_url, feed_id: feed.id },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "input[data-key='form.source-edit'][value=?]", new_url
+    assert_select "form[action=?]", feed_path(feed)
+    assert_select "input[type=hidden][name='_method'][value='patch']"
+  end
+
+  test "#show should drop the AI bridge and cancel to the feed when edit re-detection finds no feed" do
+    sign_in_as(user)
+    feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
+    new_url = "http://example.com/none.xml"
+    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+           candidates: [{ "profile_key" => "rss", "test_status" => "failed" }])
+
+    get feed_identifications_path, params: { input: new_url, feed_id: feed.id },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "[data-key='identification.ai-bridge']", count: 0
+    assert_select "a[data-key='identification.cancel'][href=?]", feed_path(feed)
+  end
+
+  test "#show should keep re-detection in the edit context on a couldn't-reach result" do
+    sign_in_as(user)
+    feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
+    new_url = "http://example.com/down.xml"
+    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+           error: "unreachable", candidates: [])
+
+    get feed_identifications_path, params: { input: new_url, feed_id: feed.id },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "[data-key='identification.ai-bridge']", count: 0
+    assert_select "form[action=?] input[type=hidden][name='feed_id'][value=?]", feed_identifications_path, feed.id.to_s
+    assert_select "a[data-key='identification.cancel'][href=?]", feed_path(feed)
+  end
+
   private
 
   def extract_candidates_payload(body)

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -557,15 +557,18 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "#edit should render for own feed" do
+  test "#edit should render an editable source for a deterministic feed" do
     sign_in_as(user)
     get edit_feed_url(feed)
     assert_response :success
     assert_select "h2", text: "Source"
     assert_select "label", text: "Source URL"
+    assert_select "input[data-key='form.source-edit'][name='feed[params][url]']"
+    assert_select "input[data-key='form.source-edit'][disabled]", count: 0
     assert_select "label", text: "Feed type"
     assert_select "input[data-key='form.feed-type-display'][value=?][disabled]", "RSS Feed"
-    assert_select "[data-key='form.source-locked-note']", text: "The source and feed type are locked in when a feed is created. To follow a different source, just start a new feed."
+    assert_select "[data-key='form.source-edit-note']"
+    assert_select "[data-key='form.source-locked-note']", count: 0
   end
 
   test "#edit should label the source as a prompt for a query-shaped feed" do
@@ -822,27 +825,31 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "enabled", enabled_feed.state
   end
 
-  test "#update should not allow changing url or feed_profile_key" do
+  test "#update should route a source change through re-detection, not silent mass-assignment" do
     sign_in_as(user)
     original_url = feed.url
     original_profile = feed.feed_profile_key
     original_params = feed.params
 
-    patch feed_url(feed), params: {
-      feed: {
-        url: "https://evil.com/feed.xml",
-        feed_profile_key: "xkcd",
-        params: { url: "https://evil.com/feed.xml", smuggled: "yes" },
-        name: "Updated Name"
+    assert_enqueued_with(job: FeedIdentificationJob) do
+      patch feed_url(feed), params: {
+        feed: {
+          url: "https://evil.com/feed.xml",
+          feed_profile_key: "xkcd",
+          params: { url: "https://evil.com/feed.xml", smuggled: "yes" },
+          name: "Updated Name"
+        }
       }
-    }
+    end
 
-    assert_redirected_to feed_path(feed)
+    # The source isn't applied until detection confirms a working candidate; the
+    # response is the §7 loading state, and the profile/params can't be forged in.
+    assert_response :success
     feed.reload
     assert_equal original_url, feed.url
     assert_equal original_profile, feed.feed_profile_key
     assert_equal original_params, feed.params, "raw params jsonb must not be mass-assignable on update"
-    assert_equal "Updated Name", feed.name
+    assert_equal "Updated Name", feed.name, "operational edits still persist while detection runs"
   end
 
   test "#update should permit url change when feed is draft" do
@@ -856,12 +863,14 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_equal new_url, draft.url
   end
 
-  test "#update should ignore url change when feed is disabled" do
+  test "#update should not persist a disabled feed's source change until detection confirms it" do
     sign_in_as(user)
     disabled = create(:feed, :disabled, user: user,
                       params: { "url" => "https://original.com/feed.xml" })
 
-    patch feed_url(disabled), params: { feed: { params: { url: "https://attacker.com/feed.xml" } } }
+    assert_enqueued_with(job: FeedIdentificationJob) do
+      patch feed_url(disabled), params: { feed: { params: { url: "https://attacker.com/feed.xml" } } }
+    end
 
     disabled.reload
     assert_equal "https://original.com/feed.xml", disabled.url

--- a/test/integration/smart_feed_creation_edit_test.rb
+++ b/test/integration/smart_feed_creation_edit_test.rb
@@ -65,20 +65,82 @@ class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
     assert_equal "Renamed", feed.name
   end
 
-  test "#patch should ignore attempts to mass-assign the params jsonb" do
+  test "#patch should route a source change through detection instead of writing params directly" do
     sign_in_as(user)
     original_params = feed.params
 
-    patch feed_url(feed), params: {
-      feed: {
-        params: { url: "http://attacker.example/feed.xml" },
-        name: "Renamed"
+    assert_enqueued_with(job: FeedIdentificationJob) do
+      patch feed_url(feed), params: {
+        feed: {
+          params: { url: "http://attacker.example/feed.xml" },
+          name: "Renamed"
+        }
       }
-    }
+    end
 
     feed.reload
-    assert_equal original_params, feed.params
+    assert_equal original_params, feed.params, "the source isn't written until detection confirms it"
     assert_equal "Renamed", feed.name
+  end
+
+  test "#patch should hold the source and re-detect when a live feed's URL changes" do
+    sign_in_as(user)
+
+    assert_enqueued_with(job: FeedIdentificationJob) do
+      patch feed_url(feed), params: { feed: { params: { url: "http://example.com/other.xml" }, name: "Renamed" } },
+            headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_select "[data-controller='polling'][data-polling-endpoint-value*=?]", "feed_id=#{feed.id}"
+    feed.reload
+    assert_equal "http://example.com/feed.xml", feed.url
+    assert_equal "Renamed", feed.name
+  end
+
+  test "#patch should apply a re-detected source once a working candidate confirms it" do
+    sign_in_as(user)
+    new_url = "http://example.com/other.xml"
+    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+           candidates: [{ "profile_key" => "rss", "test_status" => "passed", "rank" => 0, "depends_on_ai" => false, "title" => "Other" }])
+
+    patch feed_url(feed), params: { feed: { params: { url: new_url }, feed_profile_key: "rss" }, enable_feed: "1" }
+
+    assert_redirected_to feed_path(feed)
+    feed.reload
+    assert_equal new_url, feed.url
+    assert_equal "enabled", feed.state
+  end
+
+  test "#patch should enable a disabled feed when confirming a re-detected source with Enable ticked" do
+    sign_in_as(user)
+    disabled = create(:feed, user: user, access_token: access_token, state: :disabled,
+                             target_group: "testgroup", feed_profile_key: "rss",
+                             params: { "url" => "http://example.com/feed.xml" })
+    new_url = "http://example.com/other.xml"
+    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+           candidates: [{ "profile_key" => "rss", "test_status" => "passed", "rank" => 0, "depends_on_ai" => false, "title" => "Other" }])
+
+    patch feed_url(disabled), params: { feed: { params: { url: new_url }, feed_profile_key: "rss" }, enable_feed: "1" }
+
+    assert_redirected_to feed_path(disabled)
+    disabled.reload
+    assert_equal new_url, disabled.url
+    assert_equal "enabled", disabled.state
+  end
+
+  test "#patch should re-detect rather than confirm a profile that isn't a working candidate" do
+    sign_in_as(user)
+    new_url = "http://example.com/other.xml"
+    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+           candidates: [{ "profile_key" => "rss", "test_status" => "passed", "rank" => 0, "depends_on_ai" => false, "title" => "Other" }])
+
+    assert_enqueued_with(job: FeedIdentificationJob) do
+      patch feed_url(feed), params: { feed: { params: { url: new_url }, feed_profile_key: "xkcd" } }
+    end
+
+    feed.reload
+    assert_equal "http://example.com/feed.xml", feed.url
   end
 
   test "#patch should ignore attempts to mass-assign the feed_profile_key" do

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -152,4 +152,17 @@ class FeedIdentificationTest < ActiveSupport::TestCase
 
     assert_equal %w[rss llm], identification.candidates.map { |c| c["profile_key"] }
   end
+
+  test "#working_candidate_profile_keys should list only candidates that read the source" do
+    identification = FeedIdentification.new(
+      status: :success,
+      candidates: [
+        { "profile_key" => "rss", "test_status" => "passed" },
+        { "profile_key" => "atom", "test_status" => "failed" },
+        { "profile_key" => "xkcd", "test_status" => "unreachable" }
+      ]
+    )
+
+    assert_equal %w[rss], identification.working_candidate_profile_keys
+  end
 end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -875,6 +875,80 @@ class FeedTest < ActiveSupport::TestCase
     assert feed.valid?, feed.errors.full_messages.inspect
   end
 
+  test "#save should reject switching a deterministic feed to the AI engine" do
+    feed = create(:feed, feed_profile_key: "rss", state: :disabled, params: { "url" => "https://example.com/feed.xml" })
+
+    feed.feed_profile_key = "llm"
+
+    assert_not feed.valid?
+    assert_includes feed.errors[:feed_profile_key], "can't switch between AI and non-AI feeds — start a new feed instead"
+  end
+
+  test "#save should reject switching an AI feed to a deterministic engine" do
+    feed = create(:feed, feed_profile_key: "llm", state: :disabled, params: { "prompt" => "follow ruby news" })
+
+    feed.feed_profile_key = "rss"
+
+    assert_not feed.valid?
+    assert_includes feed.errors[:feed_profile_key], "can't switch between AI and non-AI feeds — start a new feed instead"
+  end
+
+  test "#save should allow a deterministic-to-deterministic profile change" do
+    feed = create(:feed, feed_profile_key: "rss", state: :disabled, params: { "url" => "https://example.com/feed.xml" })
+
+    feed.feed_profile_key = "xkcd"
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "#save should allow the AI engine on a new record" do
+    feed = build(:feed, feed_profile_key: "llm", params: { "prompt" => "follow ruby news" })
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "#save should reject an unverified source move on a live deterministic feed" do
+    feed = create(:feed, feed_profile_key: "rss", state: :disabled, params: { "url" => "https://example.com/feed.xml" })
+
+    feed.url = "https://other.example.com/feed.xml"
+
+    assert_not feed.valid?
+    assert_includes feed.errors[:base], "The source changed — re-check it before saving."
+  end
+
+  test "#save should allow a source move once detection has verified it" do
+    feed = create(:feed, feed_profile_key: "rss", state: :disabled, params: { "url" => "https://example.com/feed.xml" })
+
+    feed.url = "https://other.example.com/feed.xml"
+    feed.source_verified = true
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "#save should let a draft edit its source freely without re-detection" do
+    feed = create(:feed, feed_profile_key: "rss", state: :draft, params: { "url" => "https://example.com/feed.xml" })
+
+    feed.url = "https://other.example.com/feed.xml"
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "#save should not gate an operational-only edit on a live deterministic feed" do
+    feed = create(:feed, feed_profile_key: "rss", state: :disabled, params: { "url" => "https://example.com/feed.xml" })
+
+    feed.name = "Renamed"
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
+  test "#save should not gate an AI feed's prompt edit as a source move" do
+    feed = create(:feed, feed_profile_key: "llm", state: :draft, params: { "prompt" => "follow ruby news" })
+
+    feed.params = { "prompt" => "follow Pitchfork reviews" }
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+  end
+
   test "#enable should promote a valid draft to enabled state" do
     user = create(:user)
     feed = create(:feed,


### PR DESCRIPTION
Changes:

- Unlock the source URL field when editing a live (non-draft) deterministic feed; the engine stays fixed (deterministic ↔ AI is still a new feed, enforced by a model guard).
- A changed source URL re-runs identification + candidate testing through the existing async detection flow and its §7 states (annotation / chooser / no-feed / couldn't-reach) before saving. The confirming save applies the new source only once a working candidate is verified — so an edit that yields no working candidate can't quietly leave a feed that fails on every refresh.
- While detection runs, the feed keeps refreshing its current, verified source; a confirmed change then flows through the normal update path (enable/pause, events, schedule reset all preserved).
- Two model guards make the invariants hold regardless of the request: a persisted feed can't cross the AI boundary, and a live deterministic feed's in-place source move requires a detection-verified flag the confirm path sets.
- In edit context the AI bridge is suppressed and Cancel returns to the feed; re-detection carries the feed through so polling stays in the edit flow.

This is the first of a few PRs for spec §4 (editing & lifecycle). A source change is a single Save: change the URL, Save kicks re-detection and shows the §7 state, and a second Save confirms once a working candidate is found — mirroring the create-then-save ordering. The duplicate-risk warnings and the "disabled Preview explains what's missing" nicety are separate follow-up PRs.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §4
- Part of #912