### PR TITLE
Warn about duplicate risk on a source or profile edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-06
 
+- Changing a feed's source or type while editing now flags whether it might repost items you've already seen — and a type change switches on "Skip older posts" by default so recent ones don't flood back in.
 - You can now change a feed's source link when editing it. We re-check the new link for a feed before saving, so a broken link can't quietly slip in — and the feed keeps running on its current source until the new one checks out.
 - If an AI feed's model is no longer available, the feed keeps running on a supported fallback and flags it on the feed page, instead of blocking edits or quietly using the missing one. Pick a new model whenever you're ready.
 

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -118,25 +118,29 @@ class FeedIdentificationsController < ApplicationController
     profile_key = suggested&.profile_key
     source_key = FeedProfile.source_key_for(profile_key) || "url"
 
-    feed =
-      if editing?
-        # Re-render the feed being edited with the proposed source + profile
-        # applied in memory only; the confirming PATCH persists it after the
-        # source-verified guard clears (spec §4). Operational edits were saved
-        # on the propose PATCH, so the reloaded record already carries them.
-        edit_feed.tap do |f|
-          f.feed_profile_key = profile_key
-          f.params = (f.params || {}).merge(source_key => feed_identification.input)
-        end
-      else
-        Current.user.feeds.build(
-          params: { source_key => feed_identification.input },
-          feed_profile_key: profile_key,
-          name: suggested&.title&.truncate(Feed::NAME_MAX_LENGTH, omission: "…")
-        )
+    if editing?
+      # Re-render the feed being edited with the proposed source + profile
+      # applied in memory only; the confirming PATCH persists it after the
+      # source-verified guard clears (spec §4). Operational edits were saved
+      # on the propose PATCH, so the reloaded record already carries them.
+      profile_changed = edit_feed.feed_profile_key != profile_key
+      feed = edit_feed.tap do |f|
+        f.feed_profile_key = profile_key
+        f.params = (f.params || {}).merge(source_key => feed_identification.input)
       end
 
-    render(identification_success(feed, candidates: feed_identification.working_candidates))
+      # A source (and possibly profile) change is pending confirmation, so the
+      # form surfaces the matching duplicate-risk warning (spec §4).
+      render(identification_success(feed, candidates: feed_identification.working_candidates,
+                                          source_changed: true, profile_changed: profile_changed))
+    else
+      feed = Current.user.feeds.build(
+        params: { source_key => feed_identification.input },
+        feed_profile_key: profile_key,
+        name: suggested&.title&.truncate(Feed::NAME_MAX_LENGTH, omission: "…")
+      )
+      render(identification_success(feed, candidates: feed_identification.working_candidates))
+    end
   end
 
   def identification_error(error:, heading: "Feed identification failed")
@@ -194,12 +198,13 @@ class FeedIdentificationsController < ApplicationController
     }
   end
 
-  def identification_success(feed, candidates: [])
+  def identification_success(feed, candidates: [], source_changed: false, profile_changed: false)
     {
       turbo_stream: turbo_stream.replace(
         "feed-form",
         partial: "feeds/form_expanded",
-        locals: { feed: feed, candidates: candidates, edit_mode: editing? }
+        locals: { feed: feed, candidates: candidates, edit_mode: editing?,
+                  source_changed: source_changed, profile_changed: profile_changed }
       )
     }
   end

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (edit_mode: false, feed: @feed, candidates: []) %>
+<%# locals: (edit_mode: false, feed: @feed, candidates: [], source_changed: false, profile_changed: false) %>
 <% active_tokens = Current.user.access_tokens.active.order(:host) %>
 <%# The chooser is a real choice only with two or more working candidates; one
     working candidate is shown as a read-only annotation (spec §7). In edit mode
@@ -116,6 +116,23 @@
         <% if edit_mode && !ai_prompt_editable && !source_editable %>
           <p class="mt-3 text-sm text-muted" data-key="form.source-locked-note">This feed's source is fixed. To follow a different source, just start a new feed.</p>
         <% end %>
+
+        <%# Duplicate-risk warning for a pending source/profile change (spec §4).
+            A profile change reworks how posts are identified, so it's the louder
+            warning and turns the "skip older posts" threshold on by default. %>
+        <% if source_changed %>
+          <% if profile_changed %>
+            <%= render AlertComponent.new(variant: :warning, class: "mt-4", data: { key: "form.dup-risk-warning" }) do %>
+              <p class="font-semibold">This changes how posts are identified</p>
+              <p class="text-sm">Reading this source a different way can bring some recent posts back through. We've switched on “Skip older posts” below to hold them back — pick a start date that suits you. It can't promise zero repeats.</p>
+            <% end %>
+          <% else %>
+            <%= render AlertComponent.new(variant: :info, class: "mt-4", data: { key: "form.dup-risk-warning" }) do %>
+              <p class="font-semibold">Heads up: you're pointing this feed somewhere new</p>
+              <p class="text-sm">If the same posts live at new addresses there, they might arrive again. To skip ones you've already seen, switch on “Skip older posts” below.</p>
+            <% end %>
+          <% end %>
+        <% end %>
       </div>
 
       <div class="space-y-2">
@@ -219,6 +236,7 @@
           <div class="flex items-start">
             <div class="flex h-6 items-center">
               <%= f.check_box :import_after_enabled,
+                              checked: feed.import_after_enabled || profile_changed,
                               data: {
                                 field_toggle_target: "checkbox",
                                 action: "change->field-toggle#toggle",
@@ -234,7 +252,7 @@
           <%# mt-6 lives on the toggled panel (not a wrapper space-y) so the gap
               only appears when the fields are shown — a hidden element renders
               no margin. %>
-          <div class="mt-6 space-y-2 <%= "hidden" unless feed.import_after_enabled %>"
+          <div class="mt-6 space-y-2 <%= "hidden" unless feed.import_after_enabled || profile_changed %>"
                data-field-toggle-target="panel"
                data-key="form.import-after-fields">
             <div class="grid gap-4 sm:grid-cols-2">
@@ -242,7 +260,10 @@
                 <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
                   <%= icon("calendar", css_class: "size-5 text-muted") %>
                 </div>
+                <%# A profile change defaults the threshold on (spec §4); seed
+                    today so "on" reads as a complete cutoff, not a blank field. %>
                 <%= f.text_field :import_after_date,
+                                 value: feed.import_after_date || (Date.current.iso8601 if profile_changed),
                                  placeholder: "Pick a date",
                                  autocomplete: "off",
                                  class: "w-full rounded-md border border-border-strong bg-surface py-2 ps-10 pe-3 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2",

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -705,6 +705,36 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type=hidden][name='_method'][value='patch']"
   end
 
+  test "#show should warn about repeats and offer the threshold for a same-profile source change" do
+    sign_in_as(user)
+    feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
+    new_url = "http://example.com/new.xml"
+    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+           candidates: [{ "profile_key" => "rss", "test_status" => "passed", "rank" => 0, "depends_on_ai" => false, "title" => "New" }])
+
+    get feed_identifications_path, params: { input: new_url, feed_id: feed.id },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "[data-key='form.dup-risk-warning']"
+    assert_select "input[data-key='form.import-after-enabled'][checked]", count: 0
+  end
+
+  test "#show should default the threshold on when re-detection changes the profile" do
+    sign_in_as(user)
+    feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
+    new_url = "https://xkcd.com/rss.xml"
+    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+           candidates: [{ "profile_key" => "xkcd", "test_status" => "passed", "rank" => 0, "depends_on_ai" => false, "title" => "xkcd" }])
+
+    get feed_identifications_path, params: { input: new_url, feed_id: feed.id },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "[data-key='form.dup-risk-warning']"
+    assert_select "input[data-key='form.import-after-enabled'][checked]"
+  end
+
   test "#show should drop the AI bridge and cancel to the feed when edit re-detection finds no feed" do
     sign_in_as(user)
     feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })


### PR DESCRIPTION
Changes:

- When a deterministic feed's source re-detection is pending confirmation, the edit form now shows an edit-specific duplicate-risk warning (spec §4).
- A same-profile source change is the lighter note: the same posts may arrive again if they moved addresses, with "Skip older posts" offered.
- A profile change is the louder warning (the uid scheme shifts, so recent items can repost) and **defaults the "Skip older posts" threshold on**, seeded to today, with honest copy that it can't promise zero repeats.
- `import_after` stays the single backlog lever — no silent baseline reseed.

Builds on the re-detection flow from #930. The warning is driven by the re-render the detector produces, so it appears exactly when the user is about to confirm a change.

Known limitation (follow-up): the tier is chosen from the pre-selected (suggested) candidate; if a multi-candidate chooser is present and the user switches back to the original profile, the warning stays on the louder tier rather than updating live. It errs toward more protection (threshold on), so it's safe, just not reactive.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §4
- Part of #912
- Builds on #930