### PR TITLE
Explain what a disabled Preview button is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-06
 
+- A greyed-out Preview button now tells you what's still missing — a source, an AI provider, or a model — instead of just sitting there.
 - Changing a feed's source or type while editing now flags whether it might repost items you've already seen — and a type change switches on "Skip older posts" by default so recent ones don't flood back in.
 - You can now change a feed's source link when editing it. We re-check the new link for a feed before saving, so a broken link can't quietly slip in — and the feed keeps running on its current source until the new one checks out.
 - If an AI feed's model is no longer available, the feed keeps running on a supported fallback and flags it on the feed page, instead of blocking edits or quietly using the missing one. Pick a new model whenever you're ready.

--- a/app/javascript/controllers/preview_button_controller.js
+++ b/app/javascript/controllers/preview_button_controller.js
@@ -8,7 +8,7 @@ import { Controller } from "@hotwired/stimulus"
 //   provider + model for AI profiles), then opens the modal
 // - on modal close, clears the frame so the polling host unmounts (stops polling)
 export default class extends Controller {
-  static targets = ["button", "frame", "source"]
+  static targets = ["button", "frame", "source", "hint"]
   static values = {
     endpoint: String,
     source: String,
@@ -64,13 +64,31 @@ export default class extends Controller {
 
   refreshAvailability() {
     if (!this.hasButtonTarget) return
+    const reason = this._unavailableReason()
+    this.buttonTarget.disabled = reason != null
+    this._showHint(reason)
+  }
+
+  // What's still missing before a preview can run, phrased for the user, or null
+  // when it's ready. Mirrors the enable checks so the hint never disagrees with
+  // the button (spec §4 nicety).
+  _unavailableReason() {
     const profileKey = this._selectedProfileKey()
-    let ready = !!profileKey && !!this._currentSource().trim()
-    // AI profiles can't preview until a provider and model are picked.
-    if (ready && this._isAiProfile(profileKey)) {
-      ready = !!this._aiCredentialValue() && !!this._aiModelValue()
+    if (!profileKey) return "Pick a feed type to preview."
+    if (!this._currentSource().trim()) {
+      return this._isAiProfile(profileKey) ? "Add a prompt to preview." : "Add a source URL to preview."
     }
-    this.buttonTarget.disabled = !ready
+    if (this._isAiProfile(profileKey)) {
+      if (!this._aiCredentialValue()) return "Choose an AI provider to preview."
+      if (!this._aiModelValue()) return "Choose a model to preview."
+    }
+    return null
+  }
+
+  _showHint(reason) {
+    if (!this.hasHintTarget) return
+    this.hintTarget.textContent = reason || ""
+    this.hintTarget.hidden = reason == null
   }
 
   // The source is the static value from detection, unless an editable field (an

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -160,6 +160,12 @@
               class: "inline-flex items-center gap-1 rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
               data: { preview_button_target: "button", action: "click->preview-button#open", key: "preview.open" } %>
 
+        <%# Explains why Preview is disabled instead of leaving it inert (spec §4);
+            the preview-button controller fills and reveals it to match the button. %>
+        <p class="mt-2 text-sm text-muted" hidden
+           data-preview-button-target="hint"
+           data-key="preview.hint"></p>
+
         <%= render ModalComponent.new(title: "Feed preview", modal_id: "feed-preview-modal") do %>
           <%= turbo_frame_tag "feed-preview", data: { preview_button_target: "frame" } do %>
             <%# Shown right away when the modal opens so the spinner is visible

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -1081,6 +1081,8 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     # button, or it can't read the selected feed_profile_key at click time.
     assert_select "#feed-form[data-controller~='preview-button'] [data-key='preview.open']", count: 1
     assert_select "#feed-form[data-controller~='preview-button'] input[name='feed[feed_profile_key]']", count: 1
+    # The controller fills this hint to say what's missing when Preview is disabled.
+    assert_select "[data-preview-button-target='hint'][data-key='preview.hint']", count: 1
   end
 
   test "#destroy should remove own feed" do


### PR DESCRIPTION
Changes:

- A disabled Preview button now shows a short hint saying what's still missing — a source, an AI provider, or a model — instead of sitting inert (spec §4).
- The `preview-button` Stimulus controller derives the hint from the same checks that enable the button, so the two can never disagree; the hint updates live as the user fills the form and hides once Preview is ready.

Small nicety closing out spec §4's editing work. No server behavior changes — the button's server-rendered disabled state is unchanged; the hint is a progressive enhancement.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §4
- Part of #912