### PR TITLE
Keep an AI feed's prompt editable after it goes live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-06
 
+- You can now edit an AI feed's prompt after it's running, not just while it's a draft — with a heads-up that reworking it may pull in some older posts.
 - A greyed-out Preview button now tells you what's still missing — a source, an AI provider, or a model — instead of just sitting there.
 - Changing a feed's source or type while editing now flags whether it might repost items you've already seen — and a type change switches on "Skip older posts" by default so recent ones don't flood back in.
 - You can now change a feed's source link when editing it. We re-check the new link for a feed before saving, so a broken link can't quietly slip in — and the feed keeps running on its current source until the new one checks out.

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -342,7 +342,10 @@ class FeedsController < ApplicationController
       # profile switch can't leak in.
       ALWAYS_PERMITTED_PARAMS + [{ params: [:url] }]
     else
-      ALWAYS_PERMITTED_PARAMS
+      # A live AI feed's prompt stays editable (spec §4): the uid scheme is
+      # unchanged, so a prompt edit carries no duplicate risk (just possible
+      # backfill). The url isn't accepted here — an AI feed's source is its prompt.
+      ALWAYS_PERMITTED_PARAMS + [{ params: [:prompt] }]
     end
   end
 

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -40,11 +40,12 @@
           source and feed type are the feed's fixed identity, so they're grouped
           under one "Source" heading. %>
       <% source_label = feed.source_input_url? ? "Source URL" : "Source prompt" %>
-      <%# For an AI feed the prompt *is* the source and carries no duplicate risk,
-          so it stays an editable textarea while creating or editing a draft
-          (spec §1, §4). A deterministic feed's URL is editable when editing an
-          existing feed — a change re-runs detection before saving (spec §4). %>
-      <% ai_prompt_editable = FeedProfile.depends_on_ai?(feed.feed_profile_key) && (!edit_mode || feed.draft?) %>
+      <%# For an AI feed the prompt *is* the source: it stays an editable textarea
+          throughout, including edits to a live feed — the uid scheme is unchanged,
+          so there's no duplicate risk, at most some older posts backfilled (spec
+          §4). A deterministic feed's URL is editable when editing an existing feed
+          — a change re-runs detection before saving (spec §4). %>
+      <% ai_prompt_editable = FeedProfile.depends_on_ai?(feed.feed_profile_key) %>
       <% source_editable = edit_mode && !FeedProfile.depends_on_ai?(feed.feed_profile_key) %>
       <div>
         <h2 class="text-xl font-semibold text-heading mb-4">Source</h2>
@@ -60,7 +61,11 @@
                                 required: true,
                                 class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2",
                                 data: { preview_button_target: "source", action: "input->preview-button#refreshAvailability", key: "form.ai-prompt" } %>
-              <p class="text-sm text-muted">Describe a source or topic in your own words. You can tweak this before saving.</p>
+              <% if edit_mode && !feed.draft? %>
+                <p class="text-sm text-muted" data-key="form.prompt-backfill-note">Reworking the prompt may pull in some older posts you haven't seen yet. To hold those back, switch on “Skip older posts” below.</p>
+              <% else %>
+                <p class="text-sm text-muted">Describe a source or topic in your own words. You can tweak this before saving.</p>
+              <% end %>
             </div>
           <% elsif source_editable %>
             <div class="space-y-2">

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -571,14 +571,15 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='form.source-locked-note']", count: 0
   end
 
-  test "#edit should label the source as a prompt for a query-shaped feed" do
+  test "#edit should show the editable prompt for a query-shaped AI feed" do
     sign_in_as(user)
     prompt_feed = create(:feed, user: user, feed_profile_key: "llm", params: { "prompt" => "cat pictures" })
 
     get edit_feed_url(prompt_feed)
 
     assert_response :success
-    assert_select "label", text: "Source prompt"
+    assert_select "label", text: "What should AI follow?"
+    assert_select "textarea[name='feed[params][prompt]']", text: "cat pictures"
   end
 
   test "#edit should render Save feed button and unchecked always-interactable Enable checkbox for a draft" do

--- a/test/integration/feed_draft_flow_test.rb
+++ b/test/integration/feed_draft_flow_test.rb
@@ -120,21 +120,21 @@ class FeedDraftFlowTest < ActionDispatch::IntegrationTest
     assert_equal "enabled", draft.state
     assert_equal "No-RSS Blog", draft.name
 
-    # Source-side fields stay anchored once the feed leaves the draft envelope:
-    # strong params silently drops url, feed_profile_key, and params on
-    # non-drafts (FR-026/027/028). Keep enable_feed=1 so the operational save
-    # leaves the feed in the enabled state.
+    # The engine stays anchored once the feed leaves the draft envelope — a
+    # forged feed_profile_key is dropped — but an AI feed's prompt is its source
+    # and stays editable on a live feed (spec §4). Keep enable_feed=1 so the save
+    # leaves the feed enabled.
     patch feed_path(draft), params: {
       feed: {
-        params: { prompt: "https://attacker.example/feed.xml" },
+        params: { prompt: "follow a different blog" },
         feed_profile_key: "rss"
       },
       enable_feed: "1"
     }
     draft.reload
-    assert_equal "enabled", draft.state, "Feed should stay enabled across the operational-only edit"
-    assert_equal ai_url, draft.source_input, "Source should be locked after promotion"
-    assert_equal "llm", draft.feed_profile_key, "Profile key should be locked after promotion"
+    assert_equal "enabled", draft.state, "Feed should stay enabled across the edit"
+    assert_equal "follow a different blog", draft.source_input, "AI prompt stays editable on a live feed"
+    assert_equal "llm", draft.feed_profile_key, "Engine stays locked — feed_profile_key can't be mass-assigned"
 
     # Step 6: feeds index should show the feed in the enabled bucket of the
     # 3-bucket summary line, and the row itself should carry the enabled

--- a/test/integration/smart_feed_creation_edit_test.rb
+++ b/test/integration/smart_feed_creation_edit_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 # Edit semantics: operational fields edit freely; a deterministic feed's source
-# and profile stay anchored after creation. An AI feed's prompt carries no
-# duplicate risk, so it stays editable while the feed is a draft (spec §4).
+# re-runs detection before saving. An AI feed's prompt is its source and the uid
+# scheme never changes, so it stays editable throughout — draft or live (spec §4).
 class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
@@ -178,19 +178,36 @@ class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
     assert_equal "follow Pitchfork reviews", draft_ai_feed.params["prompt"]
   end
 
-  test "#edit should keep an enabled AI feed's prompt read-only" do
-    sign_in_as(user)
-    credential = create(:ai_credential, :active, user: user,
-                                                 available_models: [{ "id" => "claude-sonnet-4-6", "name" => "Claude Sonnet 4.6" }])
-    enabled_ai = create(:feed, user: user, access_token: access_token, state: :enabled,
-                               target_group: "testgroup", feed_profile_key: "llm",
-                               params: { "prompt" => "follow the A24 blog" },
-                               ai_credential: credential, ai_model: "claude-sonnet-4-6")
+  def enabled_ai_feed
+    @enabled_ai_feed ||= begin
+      credential = create(:ai_credential, :active, user: user,
+                                                   available_models: [{ "id" => "claude-sonnet-4-6", "name" => "Claude Sonnet 4.6" }])
+      create(:feed, user: user, access_token: access_token, state: :enabled,
+                    target_group: "testgroup", feed_profile_key: "llm",
+                    params: { "prompt" => "follow the A24 blog" },
+                    ai_credential: credential, ai_model: "claude-sonnet-4-6")
+    end
+  end
 
-    get edit_feed_url(enabled_ai)
+  test "#edit should keep a live AI feed's prompt editable with a backfill note" do
+    sign_in_as(user)
+
+    get edit_feed_url(enabled_ai_feed)
 
     assert_response :success
-    assert_select "textarea[name='feed[params][prompt]']", count: 0
-    assert_select "[data-key='form.source-display']"
+    assert_select "textarea[name='feed[params][prompt]']", text: "follow the A24 blog"
+    assert_select "[data-key='form.prompt-backfill-note']"
+    assert_select "[data-key='form.source-locked-note']", count: 0
+  end
+
+  test "#patch should update a live AI feed's prompt" do
+    sign_in_as(user)
+
+    patch feed_url(enabled_ai_feed), params: { feed: { params: { prompt: "follow Pitchfork reviews" }, name: enabled_ai_feed.name }, enable_feed: "1" }
+
+    assert_redirected_to feed_path(enabled_ai_feed)
+    enabled_ai_feed.reload
+    assert_equal "follow Pitchfork reviews", enabled_ai_feed.params["prompt"]
+    assert_equal "enabled", enabled_ai_feed.state
   end
 end


### PR DESCRIPTION
Changes:

- An AI feed's prompt stays an editable textarea when editing a live (enabled or disabled) feed, not just a draft — completing spec §4's prompt unlock.
- Permit the `prompt` param on non-draft AI feeds (the URL is still not accepted — an AI feed's source is its prompt; the engine stays fixed).
- Show a light backfill note on a live-feed prompt edit — no duplicate risk since the uid scheme is unchanged, at most some older posts pulled in — pointing at the optional "Skip older posts" threshold.

This reverses the interim draft-only restriction from #876/#928 (which had a test asserting enabled prompts were read-only). §4's tier-1 warning only makes sense with the prompt editable on a live feed, so this closes out the editing spec.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §4
- Part of #912
- Revisits #876