### PR TITLE
Give AI feed previews a longer, terminal budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-07
+
+- AI-powered previews now get more time to finish — up to about four minutes, since they browse the web — so a slow one no longer gets cut off early, and the progress note says what's happening. A preview that does time out now stays timed out instead of quietly flipping to done after you've moved on.
+
 ## 2026-07-06
 
 - You can now edit an AI feed's prompt after it's running, not just while it's a draft — with a heads-up that reworking it may pull in some older posts.

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -13,6 +13,11 @@ class FeedPreviewsController < ApplicationController
     "failed" => "failed"
   }.freeze
 
+  # AI previews browse the web (Sonnet gather runs 40–120s, plus structuring), so
+  # they need a far longer budget than a deterministic fetch or they'd time out
+  # mid-run (spec §6). ~4 minutes at the shared 2.5s poll interval.
+  AI_PREVIEW_MAX_POLLS = 98
+
   # GET /feed_preview?profile_key=…&params[…]=…
   # Workhorse for the lazy turbo-frame and polling: find or create the row for
   # (user, profile_key, params_digest), start a run when it has no fresh result,
@@ -20,7 +25,7 @@ class FeedPreviewsController < ApplicationController
   def show
     preview = locate_preview
     preview = start_run(preview) if needs_run?(preview)
-    preview.timeout! if (preview.pending? || preview.processing?) && preview.updated_at < polling_timeout.ago
+    preview.timeout! if (preview.pending? || preview.processing?) && preview.updated_at < preview_polling_timeout.ago
     render_state(preview, inert_while_running: true)
   end
 
@@ -30,7 +35,20 @@ class FeedPreviewsController < ApplicationController
     render_state(start_run(locate_preview))
   end
 
+  helper_method :preview_max_polls
+
   private
+
+  # Poll cap for the current preview's profile: the longer AI budget for a
+  # web-browsing run, the shared default otherwise. Drives both the client
+  # poller (view) and the server-side timeout.
+  def preview_max_polls
+    FeedProfile.depends_on_ai?(profile_key) ? AI_PREVIEW_MAX_POLLS : polling_max_polls
+  end
+
+  def preview_polling_timeout
+    ((preview_max_polls - 2) * polling_interval_ms).fdiv(1000).seconds
+  end
 
   def guard_preview
     return render_cleared if source_blank? || !FeedProfile.exists?(profile_key)

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -37,13 +37,15 @@ class FeedPreview < ApplicationRecord
     (params || {})[key]
   end
 
-  # Transitions to :failed only if still non-terminal. The status guard in the
-  # UPDATE means a concurrently completing job won't be clobbered.
+  # Transitions to :failed only if still non-terminal. Rotating run_id makes the
+  # timeout terminal (spec §6): the still-running job holds the old run_id, so its
+  # run_id-gated transitions now update 0 rows and can't flip the row back to
+  # :ready after the user has already seen the timeout and left.
   def timeout!
     updated = self.class
                   .where(id: self.id)
                   .where(status: [:pending, :processing])
-                  .update_all(status: :failed, updated_at: Time.current)
+                  .update_all(status: :failed, run_id: SecureRandom.uuid, updated_at: Time.current)
     reload if updated.positive?
   end
 

--- a/app/views/feed_previews/_processing.html.erb
+++ b/app/views/feed_previews/_processing.html.erb
@@ -1,4 +1,5 @@
 <%# locals: (preview: nil) %>
+<% ai = preview && FeedProfile.depends_on_ai?(preview.feed_profile_key) %>
 <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-xs"
      role="status"
      aria-busy="true"
@@ -7,7 +8,12 @@
     <%= render SpinnerComponent.new %>
   </div>
   <div class="space-y-1">
-    <p class="font-semibold text-heading">Building a preview…</p>
-    <p class="text-body">This usually takes a few seconds while we fetch and format this feed.</p>
+    <% if ai %>
+      <p class="font-semibold text-heading">AI is browsing the web…</p>
+      <p class="text-body">This can take a couple of minutes while it reads sources and pulls posts together.</p>
+    <% else %>
+      <p class="font-semibold text-heading">Building a preview…</p>
+      <p class="text-body">This usually takes a few seconds while we fetch and format this feed.</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/feed_previews/show.html.erb
+++ b/app/views/feed_previews/show.html.erb
@@ -18,7 +18,7 @@
         polling_endpoint_value: feed_preview_path(preview_path_options.merge(format: :turbo_stream)),
         polling_stop_condition_value: "[data-preview-done]",
         polling_interval_value: polling_interval_ms,
-        polling_max_polls_value: polling_max_polls
+        polling_max_polls_value: preview_max_polls
       }) do %>
     <div id="feed-preview-body" data-polling-target="content">
       <% case preview.status %>

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -399,6 +399,52 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     assert user.feed_previews.last.failed?
   end
 
+  test "#show should not time out an AI preview within its longer budget" do
+    sign_in_as(user)
+    credential = create(:ai_credential, :active, user: user, available_models: models)
+    create(:feed_preview, :processing, user: user, feed_profile_key: "llm",
+                                       params: { "prompt" => "ruby news" },
+                                       ai_credential_id: credential.id, ai_model: "claude-sonnet-4-6",
+                                       updated_at: 90.seconds.ago)
+
+    assert_no_enqueued_jobs do
+      get feed_preview_url(profile_key: "llm", "params" => { prompt: "ruby news" },
+                           ai_credential_id: credential.id, ai_model: "claude-sonnet-4-6"),
+          headers: TURBO_STREAM
+    end
+
+    assert_response :success
+    assert_not user.feed_previews.last.failed?, "an AI preview should survive past the deterministic budget"
+  end
+
+  test "#show should time out an AI preview past its longer budget" do
+    sign_in_as(user)
+    credential = create(:ai_credential, :active, user: user, available_models: models)
+    create(:feed_preview, :processing, user: user, feed_profile_key: "llm",
+                                       params: { "prompt" => "ruby news" },
+                                       ai_credential_id: credential.id, ai_model: "claude-sonnet-4-6",
+                                       updated_at: 5.minutes.ago)
+
+    get feed_preview_url(profile_key: "llm", "params" => { prompt: "ruby news" },
+                         ai_credential_id: credential.id, ai_model: "claude-sonnet-4-6"),
+        headers: TURBO_STREAM
+
+    assert_response :success
+    assert user.feed_previews.last.failed?
+  end
+
+  test "#create should show the AI-browsing copy for an AI preview" do
+    sign_in_as(user)
+    credential = create(:ai_credential, :active, user: user, available_models: models)
+
+    post feed_preview_url(profile_key: "llm", "params" => { prompt: "ruby news" },
+                          ai_credential_id: credential.id, ai_model: "claude-sonnet-4-6"),
+         headers: TURBO_STREAM
+
+    assert_response :success
+    assert_match(/AI is browsing the web/, response.body)
+  end
+
   test "#show should scope previews to the current user" do
     other = create(:user)
     create(:feed_preview, :completed, user: other, feed_profile_key: "rss",

--- a/test/models/feed_preview_test.rb
+++ b/test/models/feed_preview_test.rb
@@ -124,6 +124,20 @@ class FeedPreviewTest < ActiveSupport::TestCase
     assert preview.ready?
   end
 
+  test "#timeout! should rotate run_id so a stale run can't revive the preview" do
+    preview = create(:feed_preview, :processing, user: user, run_id: "run-1")
+
+    preview.timeout!
+
+    assert preview.failed?
+    assert_not_equal "run-1", preview.run_id
+    # A late completion from the timed-out run holds the old run_id, so its
+    # run_id-gated transition now matches nothing and can't flip it back.
+    revived = FeedPreview.where(id: preview.id, run_id: "run-1").update_all(status: FeedPreview.statuses[:ready])
+    assert_equal 0, revived
+    assert preview.reload.failed?
+  end
+
   test ".digest_for should depend only on the profile's source input" do
     same_source = FeedPreview.digest_for("rss", { "url" => "https://x.test" })
     with_extra = FeedPreview.digest_for("rss", { "url" => "https://x.test", "derived" => "anything" })


### PR DESCRIPTION
Changes:

- AI-profile previews now poll for ~4 minutes (client and server) instead of the ~90s deterministic budget, so a web-browsing run (Sonnet gather 40–120s plus structuring) no longer times out mid-flight.
- The progress note reads "AI is browsing the web" for AI previews.
- A preview timeout now rotates the row's `run_id`, making it terminal: a late-completing job holds the old `run_id`, so its run_id-gated transition matches nothing and can't flip the preview `failed → ready` after the user has left.

Independent of the other spec-005 tracks — applies to already-shipped AI profiles.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §6
- Closes #906