### PR TITLE
Harden AI feed uid derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-07
 
+- AI feeds are steadier about not repeating or dropping posts: a link that only differs by `http`/`https`, `www`, or a port no longer counts as a new post, and posts with non-Latin links (like Cyrillic) come through instead of quietly disappearing.
 - AI-powered previews now get more time to finish — up to about four minutes, since they browse the web — so a slow one no longer gets cut off early, and the progress note says what's happening. A preview that does time out now stays timed out instead of quietly flipping to done after you've moved on.
 
 ## 2026-07-06

--- a/app/services/uid/resolver.rb
+++ b/app/services/uid/resolver.rb
@@ -1,3 +1,5 @@
+require "addressable/uri"
+
 module Uid
   # Derives a stable post uid from an AI-extracted item, anchored to source
   # identity rather than generated content: summaries change every run, so a
@@ -28,18 +30,35 @@ module Uid
       raw = (item["source_url"] || item[:source_url]).to_s.strip
       return if raw.empty?
 
-      uri = URI.parse(raw)
+      uri = parse_http(raw)
       return unless uri.is_a?(URI::HTTP) && uri.host.present?
       return if uri.path.delete_suffix("/").empty? && uri.query.nil? # bare homepage
 
       uri
+    end
+
+    # Non-ASCII/IDN permalinks make URI.parse raise, which used to silently drop
+    # the item. Percent-encode the path and punycode the host via Addressable,
+    # then retry — a Cyrillic URL should yield a stable uid, not vanish (spec §3).
+    def parse_http(raw)
+      URI.parse(raw)
     rescue URI::InvalidURIError
+      parse_encoded(raw)
+    end
+
+    def parse_encoded(raw)
+      URI.parse(Addressable::URI.parse(raw).normalize.to_s)
+    rescue Addressable::URI::InvalidURIError, URI::InvalidURIError
       nil
     end
 
     def normalize(uri)
-      uri.scheme = uri.scheme.downcase
-      uri.host = uri.host.downcase
+      # The uid is an identity key, not a fetch URL. Coerce the scheme to https
+      # and drop a leading www. and default ports, so a model flipping
+      # http/https/www between runs doesn't mint a duplicate repost (spec §3).
+      uri.scheme = "https"
+      uri.host = uri.host.downcase.sub(/\Awww\./, "")
+      uri.port = nil if [80, 443].include?(uri.port)
       uri.fragment = nil
       uri.query = clean_query(uri.query)
       uri.path = uri.path.delete_suffix("/") unless uri.path == "/"

--- a/test/services/uid/resolver_test.rb
+++ b/test/services/uid/resolver_test.rb
@@ -38,4 +38,32 @@ class Uid::ResolverTest < ActiveSupport::TestCase
     item = { "source_url" => "https://example.com/post/1" }
     assert_equal Uid::Resolver.call(item), Uid::Resolver.call(item)
   end
+
+  test "#call should coerce the scheme to https so http/https don't split a uid" do
+    assert_equal "https://example.com/a", Uid::Resolver.call({ "source_url" => "http://example.com/a" })
+    assert_equal Uid::Resolver.call({ "source_url" => "http://example.com/a" }),
+                 Uid::Resolver.call({ "source_url" => "https://example.com/a" })
+  end
+
+  test "#call should strip a leading www. so it doesn't split a uid" do
+    assert_equal "https://example.com/a", Uid::Resolver.call({ "source_url" => "https://www.example.com/a" })
+  end
+
+  test "#call should strip default ports" do
+    assert_equal "https://example.com/a", Uid::Resolver.call({ "source_url" => "https://example.com:443/a" })
+    assert_equal "https://example.com/a", Uid::Resolver.call({ "source_url" => "http://example.com:80/a" })
+  end
+
+  test "#call should percent-encode a non-ASCII path instead of dropping the item" do
+    uid = Uid::Resolver.call({ "source_url" => "https://example.com/статья" })
+
+    assert_equal "https://example.com/%D1%81%D1%82%D0%B0%D1%82%D1%8C%D1%8F", uid
+  end
+
+  test "#call should be idempotent under the hardening rules" do
+    item = { "source_url" => "http://www.Example.com:80/Post/?utm_source=x#frag" }
+    once = Uid::Resolver.call(item)
+
+    assert_equal once, Uid::Resolver.call({ "source_url" => once })
+  end
 end


### PR DESCRIPTION
Changes:

- In the uid string only (not the fetch URL), coerce the scheme to `https` and strip a leading `www.` and default ports — models flip `http`/`https`/`www` freely between runs, and keeping them in the uid means duplicate reposts.
- Percent-encode non-ASCII/IDN permalinks via `Addressable` instead of letting `URI.parse` raise, which used to make the item silently vanish.

First of the spec §3 (uid contract) rollout. Pure derivation change — no schema, no migration, no data backfill. Existing posts keep their stored uids; only newly-derived uids change, so at worst an item whose uid string shifts under the hardening is re-imported once.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §3
- Part of #904