### PR TITLE
Support digest/standing-query AI feeds end-to-end

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,3 +66,8 @@ jobs:
 
       - name: Deploy to staging
         run: bin/kamal deploy -d staging
+
+      # TEMP (claude/digest-regime): live-verify the nullable source_url schema
+      # against the providers before merging #937. Remove before merge.
+      - name: Verify digest schema on staging
+        run: bin/kamal app exec --reuse "bin/rails ai:verify_digest_schema" -d staging

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,8 +66,3 @@ jobs:
 
       - name: Deploy to staging
         run: bin/kamal deploy -d staging
-
-      # TEMP (claude/digest-regime): live-verify the nullable source_url schema
-      # against the providers before merging #937. Remove before merge.
-      - name: Verify digest schema on staging
-        run: bin/kamal app exec --reuse "bin/rails ai:verify_digest_schema" -d staging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-07
 
+- AI feeds can now follow standing queries and roundups that don't have a single link — these come through as one digest post per day that cites its sources inline, instead of being dropped.
 - AI feeds are steadier about not repeating or dropping posts: a link that only differs by `http`/`https`, `www`, or a port no longer counts as a new post, and posts with non-Latin links (like Cyrillic) come through instead of quietly disappearing.
 - AI-powered previews now get more time to finish — up to about four minutes, since they browse the web — so a slow one no longer gets cut off early, and the progress note says what's happening. A preview that does time out now stays timed out instead of quietly flipping to done after you've moved on.
 

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -12,15 +12,22 @@ class FeedProfile
         "items" => {
           "type" => "object",
           "properties" => {
+            # The model never mints the uid — the processor derives it from
+            # source_url (spec §3). `uid` stays an accepted-but-optional property
+            # only so a stray field from a non-strict provider doesn't fail the
+            # schema; it's ignored downstream.
             "uid" => { "type" => "string" },
             "title" => { "type" => "string" },
             "body" => { "type" => "string" },
             "supplementary" => { "type" => "array", "items" => { "type" => "string" } },
             "images" => { "type" => "array", "items" => { "type" => "string" } },
-            "source_url" => { "type" => "string" },
+            # An explicit null signals the digest/standing-query regime; a real
+            # permalink signals feed-style (spec §3). The key is always required —
+            # a missing key is malformed, not a digest.
+            "source_url" => { "type" => ["string", "null"] },
             "published_at" => { "type" => "string" }
           },
-          "required" => ["uid", "body", "source_url"],
+          "required" => ["body", "source_url"],
           "additionalProperties" => false
         }
       }
@@ -398,10 +405,14 @@ class FeedProfile
 
             {{input}}
 
-            For each item, return a stable permalink as `uid`, a title, body text,
-            an optional list of supplementary comments, an optional list of image
-            URLs, the source URL, and the published date in ISO 8601. Return at
-            most 10 items.
+            For each item return: body text; an optional title; an optional list of
+            supplementary comments; an optional list of image URLs; and the
+            published date in ISO 8601 when the source shows one.
+
+            Set `source_url` to the item's own permalink. When an item summarizes or
+            digests content with no single permalink (a standing query or roundup),
+            set `source_url` to null and cite the sources inline in the body. Do not
+            return a uid. Return at most 10 items.
           PROMPT
           output_schema: UNIVERSAL_OUTPUT_SCHEMA
         }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -24,7 +24,9 @@ class Post < ApplicationRecord
   validates :uid, presence: true
   validates :uid, uniqueness: { scope: :feed_id }
   validates :published_at, presence: true
-  validates :source_url, presence: true
+  # A digest/standing-query post carries source_url = null (spec §3); allow_nil
+  # lets that through while still rejecting a blank string on a feed-style post.
+  validates :source_url, presence: true, allow_nil: true
   # Length limits gate enqueueing only. Once a post leaves the queue (published,
   # failed, withdrawn) these must not block the status transition, or a post that
   # slipped past with over-long content would wedge the publish chain: the rescue

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -38,8 +38,15 @@ class FeedRefreshWorkflow
 
   def load_feed_contents(*)
     raw_data = feed.loader_instance.load
-    record_stats(content_size: raw_data.bytesize)
+    record_stats(content_size: content_bytesize(raw_data))
     raw_data
+  end
+
+  # RSS/Atom loaders return a String body; AI loaders return an Array of items.
+  # Size both without assuming a String, so a scheduled AI refresh doesn't crash
+  # here before it can process anything.
+  def content_bytesize(raw_data)
+    raw_data.respond_to?(:bytesize) ? raw_data.bytesize : raw_data.to_json.bytesize
   end
 
   def process_feed_contents(raw_data)

--- a/app/services/normalizer/llm_normalizer.rb
+++ b/app/services/normalizer/llm_normalizer.rb
@@ -13,8 +13,17 @@ module Normalizer
   class LlmNormalizer < Base
     private
 
+    # A digest item carries source_url = null end-to-end (spec §3): keep it nil
+    # (not "") so the nullable column stores NULL and Post's conditional
+    # validation lets it publish. A feed-style item keeps its string permalink.
     def normalize_source_url
+      return nil if digest?
+
       raw_data["source_url"].to_s
+    end
+
+    def digest?
+      raw_data.key?("source_url") && raw_data["source_url"].nil?
     end
 
     def normalize_content
@@ -43,7 +52,7 @@ module Normalizer
 
     def validate_content
       errors = []
-      errors << "missing source_url" if normalize_source_url.blank?
+      errors << "missing source_url" if normalize_source_url.blank? && !digest?
       errors << "missing content" if normalize_content.blank?
       errors.concat(images_only_errors)
       errors

--- a/app/services/processor/passthrough_processor.rb
+++ b/app/services/processor/passthrough_processor.rb
@@ -8,12 +8,13 @@ module Processor
       entries = items.filter_map do |item|
         next unless item.is_a?(Hash)
 
-        uid = Uid::Resolver.call(item)
-        next if uid.blank?
-
         FeedEntry.new(
           feed: feed,
-          uid: uid,
+          # A digest item (source_url: null) gets a period uid; a feed-style
+          # permalink a normalized uid; an unusable permalink resolves to nil and
+          # is dropped-and-counted by the workflow (spec §3), so we no longer
+          # swallow it here.
+          uid: Uid::Resolver.call(item, clock: Time.current),
           # AI-extracted items rarely come with a reliable published_at;
           # fall back to the current time so downstream invariants hold.
           published_at: parse_time(item["published_at"] || item[:published_at]) || Time.current,

--- a/app/services/uid/resolver.rb
+++ b/app/services/uid/resolver.rb
@@ -9,15 +9,30 @@ module Uid
   class Resolver
     TRACKING_PARAM = /\A(utm_|fbclid\z|gclid\z|mc_)/
 
-    def self.call(item)
-      new(item).call
+    def self.call(item, clock:)
+      new(item, clock).call
     end
 
-    def initialize(item)
+    # The system-owned period for a digest run: the UTC date of the run. Shared
+    # with the cadence guard so both agree on "this period" (spec §3).
+    def self.digest_period(clock)
+      clock.utc.to_date
+    end
+
+    # Period-keyed uid for a digest/standing-query item. Non-URL by construction,
+    # so it never collides with a normalized permalink.
+    def self.digest_period_uid(clock)
+      "digest:#{digest_period(clock).iso8601}"
+    end
+
+    def initialize(item, clock)
       @item = item.is_a?(Hash) ? item : {}
+      @clock = clock
     end
 
     def call
+      return self.class.digest_period_uid(@clock) if digest?
+
       uri = deep_link
       uri && normalize(uri)
     end
@@ -25,6 +40,19 @@ module Uid
     private
 
     attr_reader :item
+
+    # The digest regime is signalled only by an explicit null source_url. A
+    # missing key is malformed and an empty/unusable string is dropped — neither
+    # is reinterpreted as a digest (spec §3's "unusable ≠ null").
+    def digest?
+      return false unless item.key?("source_url") || item.key?(:source_url)
+
+      source_url_value.nil?
+    end
+
+    def source_url_value
+      item.key?("source_url") ? item["source_url"] : item[:source_url]
+    end
 
     def deep_link
       raw = (item["source_url"] || item[:source_url]).to_s.strip

--- a/db/migrate/20260707115014_allow_null_posts_source_url.rb
+++ b/db/migrate/20260707115014_allow_null_posts_source_url.rb
@@ -1,0 +1,12 @@
+class AllowNullPostsSourceUrl < ActiveRecord::Migration[8.2]
+  # Digest/standing-query posts carry source_url = null end-to-end (spec 005 §3).
+  # The down side backfills any existing NULLs to "" before restoring NOT NULL,
+  # so a rollback after digest rows exist doesn't fail.
+  def up
+    change_column_null :posts, :source_url, true
+  end
+
+  def down
+    change_column_null :posts, :source_url, false, ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_03_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_07_115014) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -252,7 +252,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_03_120000) do
     t.bigint "feed_id", null: false
     t.string "freefeed_post_id"
     t.datetime "published_at", null: false
-    t.string "source_url", null: false
+    t.string "source_url"
     t.integer "status", default: 0, null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false

--- a/lib/tasks/ai_schema_verify.rake
+++ b/lib/tasks/ai_schema_verify.rake
@@ -1,0 +1,44 @@
+namespace :ai do
+  # One-off live check that each configured provider accepts the digest output
+  # schema — specifically the nullable `source_url` union (spec 005 §3) that
+  # Anthropic's structured output must accept and the model must be able to emit
+  # as JSON null. Run on staging via `kamal app exec` where the API keys live.
+  # Read-only apart from the one LlmUsage row each call records.
+  desc "Verify the AI output schema (nullable source_url) against live providers"
+  task verify_digest_schema: :environment do
+    schema = FeedProfile::UNIVERSAL_OUTPUT_SCHEMA
+    prompt = <<~PROMPT
+      Return a JSON object with an "items" array of exactly two items.
+      Item 1 (feed-style): body "First real post", source_url "https://example.com/1".
+      Item 2 (digest/roundup with no single link): body "A summary of several sources",
+      and source_url set to JSON null. Do not include a uid field.
+    PROMPT
+
+    checks = [%w[anthropic claude-sonnet-4-6], %w[moonshot kimi-k2.5]]
+
+    checks.each do |provider, model|
+      credential = AiCredential.active.find_by(provider: provider)
+      unless credential
+        puts "[#{provider}/#{model}] SKIP: no active credential on this environment"
+        next
+      end
+
+      begin
+        client = LlmClient.new(credential)
+        ctx = LlmClient::CallContext.new(feed: nil, profile_key: "llm", stage: :loader, model: model, purpose: :preview)
+        # web:false keeps the check cheap and focused: schema acceptance is
+        # independent of the web tools the real loader adds.
+        payload = client.call(ctx, prompt: prompt, output_schema: schema, web: false).payload
+        items = Array(payload["items"])
+        null_sources = items.count { |item| item["source_url"].nil? }
+
+        puts "[#{provider}/#{model}] PASS: schema accepted; #{items.size} items, #{null_sources} with null source_url"
+        items.each_with_index do |item, i|
+          puts "    item #{i}: source_url=#{item['source_url'].inspect} body=#{item['body'].to_s[0, 48].inspect}"
+        end
+      rescue StandardError => e
+        puts "[#{provider}/#{model}] FAIL: #{e.class}: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/tasks/ai_schema_verify.rake
+++ b/lib/tasks/ai_schema_verify.rake
@@ -2,42 +2,40 @@ namespace :ai do
   # One-off live check that each configured provider accepts the digest output
   # schema — specifically the nullable `source_url` union (spec 005 §3) that
   # Anthropic's structured output must accept and the model must be able to emit
-  # as JSON null. Run on staging via `kamal app exec` where the API keys live.
-  # Read-only apart from the one LlmUsage row each call records.
+  # as JSON null. Uses the capability-probe provider so it reads the same ENV
+  # keys the probe jobs use on staging. If a provider rejects the schema, the
+  # `.ask` call raises and is reported as FAIL.
   desc "Verify the AI output schema (nullable source_url) against live providers"
   task verify_digest_schema: :environment do
     schema = FeedProfile::UNIVERSAL_OUTPUT_SCHEMA
     prompt = <<~PROMPT
       Return a JSON object with an "items" array of exactly two items.
       Item 1 (feed-style): body "First real post", source_url "https://example.com/1".
-      Item 2 (digest/roundup with no single link): body "A summary of several sources",
+      Item 2 (a digest/roundup with no single link): body "A summary of several sources",
       and source_url set to JSON null. Do not include a uid field.
     PROMPT
 
-    checks = [%w[anthropic claude-sonnet-4-6], %w[moonshot kimi-k2.5]]
-
-    checks.each do |provider, model|
-      credential = AiCredential.active.find_by(provider: provider)
-      unless credential
-        puts "[#{provider}/#{model}] SKIP: no active credential on this environment"
+    [%w[anthropic claude-sonnet-4-6], %w[moonshot kimi-k2.5]].each do |provider_key, model|
+      unless LlmCapabilityProbe::Provider.configured?(provider_key)
+        puts "[#{provider_key}/#{model}] SKIP: no API key in environment"
         next
       end
 
       begin
-        client = LlmClient.new(credential)
-        ctx = LlmClient::CallContext.new(feed: nil, profile_key: "llm", stage: :loader, model: model, purpose: :preview)
-        # web:false keeps the check cheap and focused: schema acceptance is
-        # independent of the web tools the real loader adds.
-        payload = client.call(ctx, prompt: prompt, output_schema: schema, web: false).payload
-        items = Array(payload["items"])
+        provider = LlmCapabilityProbe::Provider.build(provider_key)
+        raw = provider.chat(model).with_schema(schema).ask(prompt).content
+        payload = raw.is_a?(Hash) ? raw : JSON.parse(raw.to_s)
+        errors = JSONSchemer.schema(schema).validate(payload).to_a
+        items = payload.is_a?(Hash) ? Array(payload["items"]) : []
         null_sources = items.count { |item| item["source_url"].nil? }
 
-        puts "[#{provider}/#{model}] PASS: schema accepted; #{items.size} items, #{null_sources} with null source_url"
+        verdict = errors.empty? ? "PASS (schema accepted)" : "FAIL (schema violation: #{errors.first['error']})"
+        puts "[#{provider_key}/#{model}] #{verdict}: #{items.size} items, #{null_sources} with null source_url"
         items.each_with_index do |item, i|
           puts "    item #{i}: source_url=#{item['source_url'].inspect} body=#{item['body'].to_s[0, 48].inspect}"
         end
       rescue StandardError => e
-        puts "[#{provider}/#{model}] FAIL: #{e.class}: #{e.message}"
+        puts "[#{provider_key}/#{model}] FAIL: #{e.class}: #{e.message.to_s[0, 300]}"
       end
     end
   end

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -209,4 +209,13 @@ class FeedProfileTest < ActiveSupport::TestCase
   test "#display_name_for should titleize unknown profile keys" do
     assert_equal "Custom Profile", FeedProfile.display_name_for("custom_profile")
   end
+
+  test "UNIVERSAL_OUTPUT_SCHEMA should accept a null source_url and no uid, but require the key" do
+    schemer = JSONSchemer.schema(FeedProfile::UNIVERSAL_OUTPUT_SCHEMA)
+
+    assert schemer.valid?({ "items" => [{ "body" => "roundup", "source_url" => nil }] }), "digest item (null source_url, no uid)"
+    assert schemer.valid?({ "items" => [{ "body" => "x", "source_url" => "https://e.com/a" }] }), "feed-style item"
+    assert schemer.valid?({ "items" => [{ "uid" => "z", "body" => "x", "source_url" => nil }] }), "a stray uid is tolerated"
+    assert_not schemer.valid?({ "items" => [{ "body" => "x" }] }), "a missing source_url key is malformed, not a digest"
+  end
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -46,10 +46,12 @@ class PostTest < ActiveSupport::TestCase
     assert post.errors.of_kind?(:published_at, :blank)
   end
 
-  test "should require source_url" do
-    post = build(:post, source_url: nil)
-    assert_not post.valid?
-    assert post.errors.of_kind?(:source_url, :blank)
+  test "should allow a null source_url for a digest post but reject a blank string" do
+    assert build(:post, source_url: nil).valid?, "a digest post carries source_url = null (spec §3)"
+
+    blank = build(:post, source_url: "")
+    assert_not blank.valid?
+    assert blank.errors.of_kind?(:source_url, :blank)
   end
 
   test "should allow empty content" do

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -374,6 +374,48 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal "Feedjira::NoParserAvailable", error_event.metadata["error"]["class"]
   end
 
+  test "#execute should persist a digest item as a publishable null-source post" do
+    digest_user = create(:user)
+    credential = create(:ai_credential, :active, user: digest_user,
+                                                 available_models: [{ "id" => "claude-sonnet-4-6" }])
+    digest_feed = create(:feed, :enabled, feed_profile_key: "llm", user: digest_user,
+                                          ai_credential: credential, ai_model: "claude-sonnet-4-6",
+                                          params: { "prompt" => "daily roundup" })
+
+    loader = Object.new
+    loader.define_singleton_method(:load) { [{ "source_url" => nil, "body" => "Today: A, B, C" }] }
+
+    digest_feed.stub(:loader_instance, loader) do
+      FeedRefreshWorkflow.new(digest_feed).execute
+    end
+
+    post = digest_feed.posts.last
+    assert_not_nil post, "a digest item should persist a post"
+    assert_nil post.source_url
+    assert_match(/\Adigest:\d{4}-\d{2}-\d{2}\z/, post.uid)
+    assert_equal "Today: A, B, C", post.content
+  end
+
+  test "#execute should collapse two digest items in one run into a single period post" do
+    digest_user = create(:user)
+    credential = create(:ai_credential, :active, user: digest_user,
+                                                 available_models: [{ "id" => "claude-sonnet-4-6" }])
+    digest_feed = create(:feed, :enabled, feed_profile_key: "llm", user: digest_user,
+                                          ai_credential: credential, ai_model: "claude-sonnet-4-6",
+                                          params: { "prompt" => "daily roundup" })
+
+    loader = Object.new
+    loader.define_singleton_method(:load) do
+      [{ "source_url" => nil, "body" => "part one" }, { "source_url" => nil, "body" => "part two" }]
+    end
+
+    digest_feed.stub(:loader_instance, loader) do
+      FeedRefreshWorkflow.new(digest_feed).execute
+    end
+
+    assert_equal 1, digest_feed.posts.count, "same-period digests collapse to one post"
+  end
+
   test "#execute should disable the AI credential and related feeds on auth failure" do
     llm_user = create(:user)
     credential = create(:ai_credential, :active, user: llm_user)

--- a/test/services/normalizer/llm_normalizer_test.rb
+++ b/test/services/normalizer/llm_normalizer_test.rb
@@ -49,6 +49,15 @@ class Normalizer::LlmNormalizerTest < ActiveSupport::TestCase
     assert_includes post.validation_errors, "missing source_url"
   end
 
+  test "#normalize should publish a digest post carrying a null source_url" do
+    entry = feed_entry("source_url" => nil, "uid" => "digest:2026-07-07")
+    post = Normalizer::LlmNormalizer.new(entry).normalize
+
+    assert_equal "enqueued", post.status
+    assert_nil post.source_url
+    assert_not_includes post.validation_errors, "missing source_url"
+  end
+
   test "#normalize should reject when content is missing" do
     post = Normalizer::LlmNormalizer.new(feed_entry("body" => "")).normalize
 

--- a/test/services/processor/passthrough_processor_test.rb
+++ b/test/services/processor/passthrough_processor_test.rb
@@ -45,7 +45,7 @@ class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
     assert_equal first, second
   end
 
-  test "#process should drop items without a usable permalink" do
+  test "#process should leave unusable-permalink uids nil for the workflow to drop and count" do
     items = [
       { "title" => "no url" },
       { "source_url" => "https://example.com/", "title" => "homepage only" },
@@ -54,7 +54,16 @@ class Processor::PassthroughProcessorTest < ActiveSupport::TestCase
 
     entries = process(items).entries
 
-    assert_equal ["https://example.com/ok"], entries.map(&:uid)
+    assert_equal [nil, nil, "https://example.com/ok"], entries.map(&:uid)
+  end
+
+  test "#process should mint a period uid for a digest item (null source_url)" do
+    items = [{ "source_url" => nil, "body" => "today's roundup" }]
+
+    entries = process(items).entries
+
+    assert_equal 1, entries.size
+    assert_match(/\Adigest:\d{4}-\d{2}-\d{2}\z/, entries.first.uid)
   end
 
   test "#process should parse published_at from ISO 8601" do

--- a/test/services/uid/resolver_test.rb
+++ b/test/services/uid/resolver_test.rb
@@ -1,69 +1,90 @@
 require "test_helper"
 
 class Uid::ResolverTest < ActiveSupport::TestCase
+  # Fixed clock so digest period uids are deterministic.
+  def clock
+    @clock ||= Time.utc(2026, 7, 7, 9, 30, 0)
+  end
+
+  def uid_for(item)
+    Uid::Resolver.call(item, clock: clock)
+  end
+
   test "#call should normalize a deep-link permalink into a uid" do
-    item = { "source_url" => "https://Example.COM/Blog/Post-1/" }
-    assert_equal "https://example.com/Blog/Post-1", Uid::Resolver.call(item)
+    assert_equal "https://example.com/Blog/Post-1", uid_for({ "source_url" => "https://Example.COM/Blog/Post-1/" })
   end
 
   test "#call should strip tracking params and fragments" do
-    item = { "source_url" => "https://example.com/p/9?utm_source=rss&id=7&fbclid=abc#top" }
-    assert_equal "https://example.com/p/9?id=7", Uid::Resolver.call(item)
+    assert_equal "https://example.com/p/9?id=7", uid_for({ "source_url" => "https://example.com/p/9?utm_source=rss&id=7&fbclid=abc#top" })
   end
 
   test "#call should drop a query that is only tracking params" do
-    item = { "source_url" => "https://example.com/p/9?utm_source=rss" }
-    assert_equal "https://example.com/p/9", Uid::Resolver.call(item)
+    assert_equal "https://example.com/p/9", uid_for({ "source_url" => "https://example.com/p/9?utm_source=rss" })
   end
 
   test "#call should accept symbol keys" do
-    item = { source_url: "https://example.com/a" }
-    assert_equal "https://example.com/a", Uid::Resolver.call(item)
+    assert_equal "https://example.com/a", uid_for({ source_url: "https://example.com/a" })
   end
 
   test "#call should return nil for a bare homepage" do
-    assert_nil Uid::Resolver.call({ "source_url" => "https://example.com/" })
+    assert_nil uid_for({ "source_url" => "https://example.com/" })
   end
 
   test "#call should return nil when source_url is missing" do
-    assert_nil Uid::Resolver.call({ "body" => "hi" })
+    assert_nil uid_for({ "body" => "hi" })
   end
 
   test "#call should return nil for a non-http or malformed url" do
-    assert_nil Uid::Resolver.call({ "source_url" => "ftp://example.com/x" })
-    assert_nil Uid::Resolver.call({ "source_url" => "not a url" })
+    assert_nil uid_for({ "source_url" => "ftp://example.com/x" })
+    assert_nil uid_for({ "source_url" => "not a url" })
   end
 
   test "#call should be deterministic for the same permalink" do
     item = { "source_url" => "https://example.com/post/1" }
-    assert_equal Uid::Resolver.call(item), Uid::Resolver.call(item)
+    assert_equal uid_for(item), uid_for(item)
   end
 
   test "#call should coerce the scheme to https so http/https don't split a uid" do
-    assert_equal "https://example.com/a", Uid::Resolver.call({ "source_url" => "http://example.com/a" })
-    assert_equal Uid::Resolver.call({ "source_url" => "http://example.com/a" }),
-                 Uid::Resolver.call({ "source_url" => "https://example.com/a" })
+    assert_equal "https://example.com/a", uid_for({ "source_url" => "http://example.com/a" })
+    assert_equal uid_for({ "source_url" => "http://example.com/a" }), uid_for({ "source_url" => "https://example.com/a" })
   end
 
   test "#call should strip a leading www. so it doesn't split a uid" do
-    assert_equal "https://example.com/a", Uid::Resolver.call({ "source_url" => "https://www.example.com/a" })
+    assert_equal "https://example.com/a", uid_for({ "source_url" => "https://www.example.com/a" })
   end
 
   test "#call should strip default ports" do
-    assert_equal "https://example.com/a", Uid::Resolver.call({ "source_url" => "https://example.com:443/a" })
-    assert_equal "https://example.com/a", Uid::Resolver.call({ "source_url" => "http://example.com:80/a" })
+    assert_equal "https://example.com/a", uid_for({ "source_url" => "https://example.com:443/a" })
+    assert_equal "https://example.com/a", uid_for({ "source_url" => "http://example.com:80/a" })
   end
 
   test "#call should percent-encode a non-ASCII path instead of dropping the item" do
-    uid = Uid::Resolver.call({ "source_url" => "https://example.com/статья" })
-
-    assert_equal "https://example.com/%D1%81%D1%82%D0%B0%D1%82%D1%8C%D1%8F", uid
+    assert_equal "https://example.com/%D1%81%D1%82%D0%B0%D1%82%D1%8C%D1%8F",
+                 uid_for({ "source_url" => "https://example.com/статья" })
   end
 
   test "#call should be idempotent under the hardening rules" do
-    item = { "source_url" => "http://www.Example.com:80/Post/?utm_source=x#frag" }
-    once = Uid::Resolver.call(item)
+    once = uid_for({ "source_url" => "http://www.Example.com:80/Post/?utm_source=x#frag" })
+    assert_equal once, uid_for({ "source_url" => once })
+  end
 
-    assert_equal once, Uid::Resolver.call({ "source_url" => once })
+  test "#call should mint a period uid for an explicit null source_url (digest regime)" do
+    assert_equal "digest:2026-07-07", uid_for({ "source_url" => nil, "body" => "roundup" })
+    assert_equal "digest:2026-07-07", uid_for({ source_url: nil })
+  end
+
+  test "#call should key the digest uid to the UTC date of the run" do
+    later = Time.utc(2026, 7, 8, 1, 0, 0)
+    assert_equal "digest:2026-07-08", Uid::Resolver.call({ "source_url" => nil }, clock: later)
+  end
+
+  test "#call should treat a missing key or empty string as unusable, not digest" do
+    assert_nil uid_for({ "body" => "no source_url key" })
+    assert_nil uid_for({ "source_url" => "" })
+    assert_nil uid_for({ "source_url" => "   " })
+  end
+
+  test ".digest_period should be the clock's UTC date" do
+    assert_equal Date.new(2026, 7, 7), Uid::Resolver.digest_period(clock)
   end
 end


### PR DESCRIPTION
Changes:

- The AI output schema's `source_url` becomes `string | null`: a real permalink is a feed-style item, an explicit `null` signals a standing-query/digest item. The key stays required (a missing key is malformed, not a digest).
- The model no longer mints the uid — dropped from the prompt, and kept only as an optional schema property so a stray field from a non-strict provider doesn't fail validation. The processor derives every uid: a normalized permalink for feed-style items, a period-keyed `digest:<UTC-date>` uid (from an injected clock) for digests.
- Null-source digest posts now flow end-to-end: normalizer carve-out, conditional `Post` validation (`allow_nil`), and a nullable `posts.source_url` column. A digest cites its sources inline in the body.
- An unusable-but-present permalink resolves to nil and is dropped-and-counted by the workflow, never reinterpreted as a digest.
- Fixes a latent crash that blocked every scheduled AI refresh: the refresh workflow sized its payload with `String#bytesize`, which an AI loader's `Array` payload doesn't answer to (AI feeds had only ever run via preview, which sizes differently).
- Adds an `ai:verify_digest_schema` maintenance task to re-check the schema against live providers.

**Live-verified on staging ✅** (the branch was deployed to staging and `ai:verify_digest_schema` run against real keys): Anthropic's strict structured output accepts the `["string","null"]` union and emits a genuine JSON `null` for the digest item; Kimi produces the same structure (its schema is client-side-validated and de-fenced by `LlmClient`, so the union is never provider-rejected).

Second of the spec §3 rollout (after uid hardening #936). PR C (cadence skip) follows.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §3
- Part of #904
- Builds on #936