### PR TITLE
Skip a digest AI feed's redundant same-period runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-07
 
+- A daily AI digest feed no longer wastes AI calls re-checking within the same day — once its digest is in, extra scheduled runs are skipped until the next day. Hitting Refresh yourself still runs it right away.
 - AI feeds can now follow standing queries and roundups that don't have a single link — these come through as one digest post per day that cites its sources inline, instead of being dropped.
 - AI feeds are steadier about not repeating or dropping posts: a link that only differs by `http`/`https`, `www`, or a port no longer counts as a new post, and posts with non-Latin links (like Cyrillic) come through instead of quietly disappearing.
 - AI-powered previews now get more time to finish — up to about four minutes, since they browse the web — so a slow one no longer gets cut off early, and the progress note says what's happening. A preview that does time out now stays timed out instead of quietly flipping to done after you've moved on.

--- a/app/controllers/feeds/refreshes_controller.rb
+++ b/app/controllers/feeds/refreshes_controller.rb
@@ -10,7 +10,7 @@ class Feeds::RefreshesController < ApplicationController
     @feed = Current.user.feeds.find(params[:feed_id])
     authorize @feed, :refresh?
 
-    FeedRefreshJob.perform_later(@feed.id)
+    FeedRefreshJob.perform_later(@feed.id, manual: true)
 
     respond_to do |format|
       format.turbo_stream { render turbo_stream: "" }

--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -2,12 +2,15 @@ class FeedRefreshJob < ApplicationJob
   queue_as :default
 
   # @param feed_id [Integer] ID of the feed to refresh
-  def perform(feed_id)
+  # @param manual [Boolean] a user-initiated refresh forces through the digest
+  #   cadence skip; scheduled runs (the default) may skip a redundant same-period
+  #   digest before any LLM call.
+  def perform(feed_id, manual: false)
     feed = Feed.find_by(id: feed_id)
     return unless feed
 
     Feed.with_advisory_lock!("feed_refresh_#{feed.id}", timeout_seconds: 0) do
-      FeedRefreshWorkflow.new(feed).execute
+      FeedRefreshWorkflow.new(feed, manual: manual).execute
     end
   rescue Loader::Error => e
     # Loader errors reflect the remote feed's health (HTTP 404/500, timeouts,

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -78,8 +78,19 @@ class FeedRefreshWorkflow
     record_stats(unidentified_entries: unidentified_count) if unidentified_count.positive?
 
     identified_entries = processed_entries.reject { |entry| entry.uid.blank? }
-    @digest_only_run = identified_entries.any? && identified_entries.all? { |entry| Uid::Resolver.digest_uid?(entry.uid) }
+    @digest_period = digest_period_for(identified_entries)
     identified_entries
+  end
+
+  # The period this run committed to, read from the actual minted uids rather
+  # than re-derived from the clock at finalize — a run that mints digest:D just
+  # before UTC midnight must record D, not D+1, or its next-day digest gets
+  # skipped. nil unless every identified entry is a period-keyed digest, so a
+  # mixed or feed-style run never marks a period and thus never skips.
+  def digest_period_for(entries)
+    return nil unless entries.any? && entries.all? { |entry| Uid::Resolver.digest_uid?(entry.uid) }
+
+    Uid::Resolver.period_from_uid(entries.first.uid)
   end
 
   def filter_new_entries(processed_entries)
@@ -290,18 +301,16 @@ class FeedRefreshWorkflow
   end
 
   # Persist this run's regime so the next scheduled run can skip a redundant
-  # same-period digest. Only a digest-only run marks a period; anything else
-  # clears it, so a feed that stops producing digests (or produces nothing)
-  # resumes normal cadence. The equality guard avoids a needless write on every
-  # deterministic-feed refresh, where the period stays nil.
+  # same-period digest. Only a digest-only run marks a period (@digest_period);
+  # anything else leaves it nil, so a feed that stops producing digests (or
+  # produces nothing) resumes normal cadence. The equality guard avoids a
+  # needless write on every deterministic-feed refresh, where the period is nil.
   def record_digest_period
     schedule = feed.feed_schedule
     return unless schedule
+    return if schedule.last_digest_period == @digest_period
 
-    period = @digest_only_run ? Uid::Resolver.digest_period(Time.current) : nil
-    return if schedule.last_digest_period == period
-
-    schedule.update!(last_digest_period: period)
+    schedule.update!(last_digest_period: @digest_period)
   end
 
   def record_feed_refresh_skipped

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -2,6 +2,7 @@ class FeedRefreshWorkflow
   include Workflow
   include StatsRecorder
 
+  step :skip_current_digest_period
   step :initialize_workflow
   step :load_feed_contents
   step :process_feed_contents
@@ -14,8 +15,9 @@ class FeedRefreshWorkflow
 
   attr_reader :feed
 
-  def initialize(feed)
+  def initialize(feed, manual: false)
     @feed = feed
+    @manual = manual
   end
 
   private
@@ -30,6 +32,25 @@ class FeedRefreshWorkflow
     disable_credential_on_auth_error(error)
     create_feed_refresh_error_event(error)
     feed.record_refresh_failure!
+  end
+
+  # A digest feed's period slot is consumed the moment it produces a period-keyed
+  # post; refreshing again in the same period just re-runs the costly gather +
+  # structure only to dedup the result away. Skip such a scheduled run before any
+  # LLM call (spec §3). A manual refresh always forces through — the user asked
+  # for it — and mixed/feed-style runs never mark a period, so they never skip.
+  def skip_current_digest_period(input)
+    return input unless skip_scheduled_digest_run?
+
+    record_feed_refresh_skipped
+    halt!
+  end
+
+  def skip_scheduled_digest_run?
+    return false if @manual
+
+    period = feed.feed_schedule&.last_digest_period
+    period.present? && period == Uid::Resolver.digest_period(Time.current)
   end
 
   def initialize_workflow(*)
@@ -56,7 +77,9 @@ class FeedRefreshWorkflow
     unidentified_count = processed_entries.count { |entry| entry.uid.blank? }
     record_stats(unidentified_entries: unidentified_count) if unidentified_count.positive?
 
-    processed_entries.reject { |entry| entry.uid.blank? }
+    identified_entries = processed_entries.reject { |entry| entry.uid.blank? }
+    @digest_only_run = identified_entries.any? && identified_entries.all? { |entry| Uid::Resolver.digest_uid?(entry.uid) }
+    identified_entries
   end
 
   def filter_new_entries(processed_entries)
@@ -184,6 +207,7 @@ class FeedRefreshWorkflow
 
     record_completed_at
     feed.reset_refresh_failures!
+    record_digest_period
     Metrics.increment("feed_refresh_total", status: "ok", profile: feed.feed_profile_key)
     create_feed_refresh_stats_event(posts)
 
@@ -263,5 +287,38 @@ class FeedRefreshWorkflow
         }
       }
     )
+  end
+
+  # Persist this run's regime so the next scheduled run can skip a redundant
+  # same-period digest. Only a digest-only run marks a period; anything else
+  # clears it, so a feed that stops producing digests (or produces nothing)
+  # resumes normal cadence. The equality guard avoids a needless write on every
+  # deterministic-feed refresh, where the period stays nil.
+  def record_digest_period
+    schedule = feed.feed_schedule
+    return unless schedule
+
+    period = @digest_only_run ? Uid::Resolver.digest_period(Time.current) : nil
+    return if schedule.last_digest_period == period
+
+    schedule.update!(last_digest_period: period)
+  end
+
+  def record_feed_refresh_skipped
+    period = feed.feed_schedule.last_digest_period
+    Metrics.increment("feed_refresh_total", status: "skipped", profile: feed.feed_profile_key)
+
+    # Debug level keeps this routine, expected skip out of the user event feed
+    # while leaving it visible to operators.
+    Event.create!(
+      type: "feed_refresh_skipped",
+      level: :debug,
+      subject: feed,
+      user: feed.user,
+      message: "",
+      metadata: { period: period.iso8601 }
+    )
+
+    Rails.logger.info "Feed refresh skipped for feed #{feed.id}: digest period #{period} still current"
   end
 end

--- a/app/services/uid/resolver.rb
+++ b/app/services/uid/resolver.rb
@@ -25,6 +25,13 @@ module Uid
       "digest:#{digest_period(clock).iso8601}"
     end
 
+    # True for a uid minted by .digest_period_uid. Lets the refresh workflow
+    # classify a run's regime (digest-only vs feed-style) from its uids alone,
+    # without re-deriving policy.
+    def self.digest_uid?(uid)
+      uid.to_s.start_with?("digest:")
+    end
+
     def initialize(item, clock)
       @item = item.is_a?(Hash) ? item : {}
       @clock = clock

--- a/app/services/uid/resolver.rb
+++ b/app/services/uid/resolver.rb
@@ -9,6 +9,12 @@ module Uid
   class Resolver
     TRACKING_PARAM = /\A(utm_|fbclid\z|gclid\z|mc_)/
 
+    # The full shape of a period-keyed digest uid: the literal prefix plus an
+    # ISO-8601 date. Kept strict (anchored, exact date shape) so a
+    # source-controlled guid that merely starts with "digest:" can't be
+    # misread as a digest by the refresh workflow's regime check.
+    DIGEST_UID = /\Adigest:(\d{4}-\d{2}-\d{2})\z/
+
     def self.call(item, clock:)
       new(item, clock).call
     end
@@ -29,7 +35,21 @@ module Uid
     # classify a run's regime (digest-only vs feed-style) from its uids alone,
     # without re-deriving policy.
     def self.digest_uid?(uid)
-      uid.to_s.start_with?("digest:")
+      DIGEST_UID.match?(uid.to_s)
+    end
+
+    # The Date carried by a period-keyed digest uid, or nil if the uid isn't a
+    # well-formed one. The refresh workflow records this — rather than
+    # re-deriving the period from the clock at finalize time — so a run that
+    # mints its uid just before UTC midnight records the period it actually
+    # served, not the next day's (which would skip that day's digest).
+    def self.period_from_uid(uid)
+      match = DIGEST_UID.match(uid.to_s)
+      return unless match
+
+      Date.iso8601(match[1])
+    rescue Date::Error
+      nil
     end
 
     def initialize(item, clock)

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -545,6 +545,9 @@
         <%= render AlertComponent.new(variant: :error) do %>
           <%= render EventDescriptionComponent.for(Event.new(type: "feed_refresh_error", level: :error, subject: sample_feed, message: "Connection timeout", metadata: { error: { stage: "load_feed_contents" } })) %>
         <% end %>
+        <%= render AlertComponent.new(variant: :info) do %>
+          <%= render EventDescriptionComponent.for(Event.new(type: "feed_refresh_skipped", level: :debug, subject: sample_feed, metadata: { period: Date.current.iso8601 })) %>
+        <% end %>
         <%= render AlertComponent.new(variant: :warning) do %>
           <%= render EventDescriptionComponent.for(Event.new(type: "access_token_validation_failed", level: :warning, subject: sample_token, metadata: { disabled_feed_ids: Feed.limit(3).pluck(:id) })) %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,9 @@ en:
     feed_refresh_error:
       name: "Feed refresh failed"
       description_html: "%{subject_link} couldn't refresh; %{message}"
+    feed_refresh_skipped:
+      name: "Feed refresh skipped"
+      description_html: "%{subject_link} already produced this period's digest, so the scheduled refresh was skipped"
     ai_credential_deactivated:
       name: "AI credential deactivated"
       description_html: "AI credential %{subject_link} stopped working; update the key to resume its feeds."

--- a/db/migrate/20260707130000_add_last_digest_period_to_feed_schedules.rb
+++ b/db/migrate/20260707130000_add_last_digest_period_to_feed_schedules.rb
@@ -1,0 +1,5 @@
+class AddLastDigestPeriodToFeedSchedules < ActiveRecord::Migration[8.2]
+  def change
+    add_column :feed_schedules, :last_digest_period, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_07_115014) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_07_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -156,6 +156,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_07_115014) do
     t.datetime "last_run_at"
     t.datetime "next_run_at"
     t.datetime "updated_at", null: false
+    t.date "last_digest_period"
     t.index ["feed_id"], name: "index_feed_schedules_on_feed_id"
   end
 

--- a/test/controllers/feeds/refreshes_controller_test.rb
+++ b/test/controllers/feeds/refreshes_controller_test.rb
@@ -47,7 +47,7 @@ class Feeds::RefreshesControllerTest < ActionDispatch::IntegrationTest
   test "create schedules refresh job" do
     sign_in_as(user)
 
-    assert_enqueued_with(job: FeedRefreshJob, args: [feed.id]) do
+    assert_enqueued_with(job: FeedRefreshJob, args: [feed.id, { manual: true }]) do
       post feed_refresh_path(feed)
     end
 
@@ -58,7 +58,7 @@ class Feeds::RefreshesControllerTest < ActionDispatch::IntegrationTest
   test "create responds with turbo stream" do
     sign_in_as(user)
 
-    assert_enqueued_with(job: FeedRefreshJob, args: [feed.id]) do
+    assert_enqueued_with(job: FeedRefreshJob, args: [feed.id, { manual: true }]) do
       post feed_refresh_path(feed), as: :turbo_stream
     end
 

--- a/test/jobs/feed_refresh_job_test.rb
+++ b/test/jobs/feed_refresh_job_test.rb
@@ -103,4 +103,29 @@ class FeedRefreshJobTest < ActiveJob::TestCase
       end
     end
   end
+
+  test ".perform_now should forward manual: true to the workflow" do
+    assert_equal true, captured_manual_flag { FeedRefreshJob.perform_now(feed.id, manual: true) }
+  end
+
+  test ".perform_now should default the workflow to a scheduled (non-manual) run" do
+    assert_equal false, captured_manual_flag { FeedRefreshJob.perform_now(feed.id) }
+  end
+
+  private
+
+  # Stubs the workflow so it doesn't run, capturing the manual: flag the job
+  # hands it. A digest feed's cadence skip hinges on this flag being scheduled
+  # by default and forced through only on a user-initiated refresh.
+  def captured_manual_flag
+    captured = nil
+    fake_workflow = Object.new
+    fake_workflow.define_singleton_method(:execute) { nil }
+
+    FeedRefreshWorkflow.stub(:new, ->(_feed, **kwargs) { captured = kwargs[:manual]; fake_workflow }) do
+      yield
+    end
+
+    captured
+  end
 end

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -786,7 +786,11 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
       feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(feed).execute }
 
-      assert_equal Time.current.utc.to_date, feed.feed_schedule.reload.last_digest_period
+      recorded = feed.feed_schedule.reload.last_digest_period
+      assert_equal Time.current.utc.to_date, recorded
+      # The recorded period is read from the minted uid, not re-derived from the
+      # clock, so it always matches the digest the run actually produced.
+      assert_equal Uid::Resolver.period_from_uid(feed.posts.last.uid), recorded
     end
   end
 
@@ -839,9 +843,11 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     end
   end
 
-  test "#execute should not mark a period for a mixed digest/feed-style run" do
+  test "#execute should clear the period for a mixed digest/feed-style run" do
     freeze_time do
-      feed = digest_feed_with_schedule
+      # Seed a stale period so this proves the mixed run *clears* it, not just a
+      # trivial nil == nil no-write.
+      feed = digest_feed_with_schedule(last_digest_period: Time.current.utc.to_date - 1)
       loader = counting_loader([
         { "source_url" => nil, "body" => "roundup" },
         { "source_url" => "https://example.com/post-1", "body" => "a real post" }
@@ -849,7 +855,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
       feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(feed).execute }
 
-      assert_nil feed.feed_schedule.reload.last_digest_period, "mixed runs never skip"
+      assert_nil feed.feed_schedule.reload.last_digest_period, "mixed runs never mark a period"
     end
   end
 end

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -37,6 +37,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
   test ".workflow_steps should list expected sequence" do
     expected_steps = [
+      :skip_current_digest_period,
       :initialize_workflow,
       :load_feed_contents,
       :process_feed_contents,
@@ -752,6 +753,103 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
       metric.reload
       assert_equal 1, metric.posts_count, "Metric should reflect only new posts from second refresh"
+    end
+  end
+
+  # --- Digest cadence skip (spec §3) ---
+
+  def digest_feed_with_schedule(last_digest_period: nil)
+    user = create(:user)
+    credential = create(:ai_credential, :active, user: user,
+                                                 available_models: [{ "id" => "claude-sonnet-4-6" }])
+    feed = create(:feed, :enabled, feed_profile_key: "llm", user: user,
+                                   ai_credential: credential, ai_model: "claude-sonnet-4-6",
+                                   params: { "prompt" => "daily roundup" })
+    create(:feed_schedule, feed: feed, last_digest_period: last_digest_period)
+    feed
+  end
+
+  # A loader stub that counts its invocations, so a skipped run can assert the
+  # LLM loader never ran.
+  def counting_loader(items)
+    loader = Object.new
+    loads = []
+    loader.define_singleton_method(:load) { loads << true; items }
+    loader.define_singleton_method(:load_count) { loads.size }
+    loader
+  end
+
+  test "#execute should record the period after a digest-only run" do
+    freeze_time do
+      feed = digest_feed_with_schedule
+      loader = counting_loader([{ "source_url" => nil, "body" => "roundup" }])
+
+      feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(feed).execute }
+
+      assert_equal Time.current.utc.to_date, feed.feed_schedule.reload.last_digest_period
+    end
+  end
+
+  test "#execute should skip a scheduled run while the digest period is still current" do
+    freeze_time do
+      feed = digest_feed_with_schedule(last_digest_period: Time.current.utc.to_date)
+      loader = counting_loader([{ "source_url" => nil, "body" => "roundup" }])
+
+      feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(feed).execute }
+
+      assert_equal 0, loader.load_count, "the LLM loader must not run when skipping"
+      assert_equal 0, feed.posts.count
+      assert_equal 1, Event.where(subject: feed, type: "feed_refresh_skipped", level: "debug").count
+    end
+  end
+
+  test "#execute should force a manual run through the cadence skip" do
+    freeze_time do
+      feed = digest_feed_with_schedule(last_digest_period: Time.current.utc.to_date)
+      loader = counting_loader([{ "source_url" => nil, "body" => "roundup" }])
+
+      feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(feed, manual: true).execute }
+
+      assert_equal 1, loader.load_count, "a manual refresh runs even in the current period"
+      assert_equal 1, feed.posts.count
+      assert_equal 0, Event.where(subject: feed, type: "feed_refresh_skipped").count
+    end
+  end
+
+  test "#execute should not skip when the recorded digest period is stale" do
+    freeze_time do
+      feed = digest_feed_with_schedule(last_digest_period: Time.current.utc.to_date - 1)
+      loader = counting_loader([{ "source_url" => nil, "body" => "today's roundup" }])
+
+      feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(feed).execute }
+
+      assert_equal 1, loader.load_count
+      assert_equal Time.current.utc.to_date, feed.feed_schedule.reload.last_digest_period
+    end
+  end
+
+  test "#execute should clear the recorded period when a run produces feed-style items" do
+    freeze_time do
+      feed = digest_feed_with_schedule(last_digest_period: Time.current.utc.to_date - 1)
+      loader = counting_loader([{ "source_url" => "https://example.com/post-1", "body" => "a real post" }])
+
+      feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(feed).execute }
+
+      assert_nil feed.feed_schedule.reload.last_digest_period
+    end
+  end
+
+  test "#execute should not mark a period for a mixed digest/feed-style run" do
+    freeze_time do
+      feed = digest_feed_with_schedule
+      loader = counting_loader([
+        { "source_url" => nil, "body" => "roundup" },
+        { "source_url" => "https://example.com/post-1", "body" => "a real post" }
+      ])
+
+      feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(feed).execute }
+
+      assert_nil feed.feed_schedule.reload.last_digest_period, "mixed runs never skip"
     end
   end
 end

--- a/test/services/uid/resolver_test.rb
+++ b/test/services/uid/resolver_test.rb
@@ -98,4 +98,23 @@ class Uid::ResolverTest < ActiveSupport::TestCase
     assert_not Uid::Resolver.digest_uid?(nil)
     assert_not Uid::Resolver.digest_uid?("")
   end
+
+  test ".digest_uid? should reject a loose or malformed digest-prefixed uid" do
+    # A source-controlled guid that merely starts with "digest:" is not a digest.
+    assert_not Uid::Resolver.digest_uid?("digest:foo")
+    assert_not Uid::Resolver.digest_uid?("digest:2026-07-07/extra")
+    assert_not Uid::Resolver.digest_uid?("prefix-digest:2026-07-07")
+  end
+
+  test ".period_from_uid should extract the date carried by a digest uid" do
+    assert_equal Date.new(2026, 7, 7), Uid::Resolver.period_from_uid("digest:2026-07-07")
+    assert_equal Uid::Resolver.digest_period(clock),
+                 Uid::Resolver.period_from_uid(Uid::Resolver.digest_period_uid(clock))
+  end
+
+  test ".period_from_uid should return nil for a non-digest or invalid-date uid" do
+    assert_nil Uid::Resolver.period_from_uid("https://example.com/a")
+    assert_nil Uid::Resolver.period_from_uid("digest:2026-13-01")
+    assert_nil Uid::Resolver.period_from_uid(nil)
+  end
 end

--- a/test/services/uid/resolver_test.rb
+++ b/test/services/uid/resolver_test.rb
@@ -87,4 +87,15 @@ class Uid::ResolverTest < ActiveSupport::TestCase
   test ".digest_period should be the clock's UTC date" do
     assert_equal Date.new(2026, 7, 7), Uid::Resolver.digest_period(clock)
   end
+
+  test ".digest_uid? should recognize a period-keyed uid" do
+    assert Uid::Resolver.digest_uid?(Uid::Resolver.digest_period_uid(clock))
+    assert Uid::Resolver.digest_uid?("digest:2026-07-07")
+  end
+
+  test ".digest_uid? should be false for a permalink uid or blank" do
+    assert_not Uid::Resolver.digest_uid?("https://example.com/a")
+    assert_not Uid::Resolver.digest_uid?(nil)
+    assert_not Uid::Resolver.digest_uid?("")
+  end
 end


### PR DESCRIPTION
Changes:

- A digest AI feed consumes its period slot the moment it produces a period-keyed post. The refresh workflow now skips a **scheduled** run before any LLM call when the previous run was digest-only and that period (UTC date) is still current, recording it as a `feed_refresh_skipped` event.
- A **manual** refresh (the Refresh button) always forces through — the flag is threaded from the refreshes controller through `FeedRefreshJob` to the workflow. Scheduled runs default to skippable.
- The workflow classifies each run's regime from its minted uids: a digest-only run records the period on the feed schedule (new `feed_schedules.last_digest_period` column); a mixed or feed-style run clears it, so those never skip.
- The recorded period is read from the actual minted `digest:<date>` uid rather than re-derived from the clock at finalize time, so a run that finishes just after UTC midnight can't record the wrong day and skip the next day's digest. The digest-uid predicate is anchored to the full shape so a source-controlled guid can't be misread as a digest.

A digest feed on a sub-daily cron would otherwise pay the full gather + structure cost every couple of hours and discard all but the first result as same-period duplicates. Mode B feeds already default to a daily schedule; this makes the "one digest per period" guarantee cheap rather than dedup-after-the-fact. Skip events are recorded at debug level, so they stay out of the user event feed while remaining visible to operators.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §3
- Part of #904
- Builds on #937