### PR TITLE
Validate redirect hops when fetching untrusted URLs (SSRF)

### DIFF
--- a/app/services/file_buffer.rb
+++ b/app/services/file_buffer.rb
@@ -53,7 +53,13 @@ class FileBuffer
 
   def url_to_io(url)
     normalized_url = normalize_url(url)
-    response = http_client.get(normalized_url, headers: { "User-Agent" => USER_AGENT })
+    # Attachment URLs are model- or source-supplied: fetch public-only, so a
+    # redirect can't reach a private/internal address at publish time (SSRF).
+    response = http_client.get(
+      normalized_url,
+      headers: { "User-Agent" => USER_AGENT },
+      options: { validate_url: PublicUrl.method(:safe?) }
+    )
 
     unless response.success?
       raise Error, "Failed to download attachment from #{url}: HTTP #{response.status}"

--- a/app/services/llm_client/tools/web_fetch.rb
+++ b/app/services/llm_client/tools/web_fetch.rb
@@ -14,7 +14,10 @@ class LlmClient
       def execute(url:)
         return { error: "Refused: pass one absolute public http(s) URL." } unless PublicUrl.safe?(url)
 
-        response = HttpClient.build(max_redirects: MAX_REDIRECTS).get(url.to_s.strip)
+        # public-only so a redirect can't slip past the check above to an
+        # internal address (SSRF; spec 005 §8).
+        response = HttpClient.build(max_redirects: MAX_REDIRECTS)
+                             .get(url.to_s.strip, options: { validate_url: PublicUrl.method(:safe?) })
         return { error: "HTTP #{response.status}" } unless response.success?
 
         { content: readable_text(response.body) }

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -28,6 +28,9 @@ module HttpClient
   class ConnectionError < Error; end
   class TimeoutError < Error; end
   class TooManyRedirectsError < Error; end
+  # Raised in public-only mode when the initial URL or any redirect hop is not a
+  # public host (SSRF guard; see FaradayAdapter#ensure_public_url!).
+  class BlockedUrlError < Error; end
 
   def self.build(options = {})
     adapter_class = options.delete(:adapter) || default_adapter_class

--- a/lib/http_client/faraday_adapter.rb
+++ b/lib/http_client/faraday_adapter.rb
@@ -35,6 +35,9 @@ module HttpClient
     private
 
     def perform_request(method, url, body: nil, headers: {}, options: {})
+      validate_url = options.fetch(:validate_url, self.options[:validate_url])
+      ensure_public_url!(url, validate_url) if validate_url
+
       connection = build_connection(options)
 
       response = connection.send(method) do |request|
@@ -62,6 +65,7 @@ module HttpClient
       timeout = request_options.fetch(:timeout, options[:timeout])
       follow_redirects = request_options.fetch(:follow_redirects, options[:follow_redirects])
       max_redirects = request_options.fetch(:max_redirects, options[:max_redirects])
+      validate_url = request_options.fetch(:validate_url, options[:validate_url])
 
       Faraday.new do |config|
         config.request :multipart
@@ -69,10 +73,28 @@ module HttpClient
         config.options.open_timeout = timeout
 
         if follow_redirects
-          config.response :follow_redirects, limit: max_redirects
+          redirect_options = { limit: max_redirects }
+          redirect_options[:callback] = redirect_guard(validate_url) if validate_url
+          config.response :follow_redirects, **redirect_options
         end
 
         config.adapter Faraday.default_adapter
+      end
+    end
+
+    # In public-only mode a caller passes a `validate_url` callable (typically
+    # PublicUrl.method(:safe?)). We check the initial URL and, via the redirect
+    # callback below, every hop — because follow_redirects otherwise chases a
+    # public URL's 302 straight to a private/loopback/metadata address, past the
+    # caller's one-time check (SSRF; spec 005 §8).
+    def ensure_public_url!(url, validate_url)
+      raise BlockedUrlError, "Blocked non-public URL: #{url}" unless validate_url.call(url.to_s)
+    end
+
+    def redirect_guard(validate_url)
+      lambda do |_response_env, new_request_env|
+        target = new_request_env.url.to_s
+        raise BlockedUrlError, "Blocked non-public redirect to #{target}" unless validate_url.call(target)
       end
     end
   end

--- a/test/lib/http_client/faraday_adapter_test.rb
+++ b/test/lib/http_client/faraday_adapter_test.rb
@@ -334,4 +334,40 @@ class HttpClient::FaradayAdapterTest < ActiveSupport::TestCase
 
     assert_equal 200, response.status
   end
+
+  test "public-only mode blocks a private hop at the end of a public chain" do
+    stub_request(:get, "https://a.example/1")
+      .to_return(status: 302, headers: { "Location" => "https://b.example/2" })
+    stub_request(:get, "https://b.example/2")
+      .to_return(status: 302, headers: { "Location" => "http://127.0.0.1/secret" })
+
+    assert_raises(HttpClient::BlockedUrlError) do
+      client.get("https://a.example/1", options: public_only)
+    end
+
+    assert_not_requested :get, "http://127.0.0.1/secret"
+  end
+
+  test "public-only mode blocks a redirect to the cloud metadata address" do
+    stub_request(:get, "https://example.com/go")
+      .to_return(status: 302, headers: { "Location" => "http://169.254.169.254/latest/meta-data/" })
+
+    assert_raises(HttpClient::BlockedUrlError) do
+      client.get("https://example.com/go", options: public_only)
+    end
+
+    assert_not_requested :get, "http://169.254.169.254/latest/meta-data/"
+  end
+
+  test "public-only mode blocks a redirect to a private address in encoded (decimal) form" do
+    # 2130706433 == 127.0.0.1; the guard canonicalizes it the way the socket would.
+    stub_request(:get, "https://example.com/go")
+      .to_return(status: 302, headers: { "Location" => "http://2130706433/" })
+
+    assert_raises(HttpClient::BlockedUrlError) do
+      client.get("https://example.com/go", options: public_only)
+    end
+
+    assert_not_requested :get, "http://2130706433/"
+  end
 end

--- a/test/lib/http_client/faraday_adapter_test.rb
+++ b/test/lib/http_client/faraday_adapter_test.rb
@@ -288,4 +288,50 @@ class HttpClient::FaradayAdapterTest < ActiveSupport::TestCase
     assert_equal "Success", response.body
     assert response.success?
   end
+
+  # --- public-only mode (SSRF redirect guard) ---
+
+  def public_only
+    { validate_url: PublicUrl.method(:safe?) }
+  end
+
+  test "public-only mode blocks a non-public initial URL before any request" do
+    error = assert_raises(HttpClient::BlockedUrlError) do
+      client.get("http://127.0.0.1/secret", options: public_only)
+    end
+
+    assert_match(/non-public/i, error.message)
+    assert_not_requested :get, "http://127.0.0.1/secret"
+  end
+
+  test "public-only mode blocks a redirect to a private address and never fetches it" do
+    stub_request(:get, "https://example.com/redirect")
+      .to_return(status: 302, headers: { "Location" => "http://127.0.0.1/metadata" })
+
+    assert_raises(HttpClient::BlockedUrlError) do
+      client.get("https://example.com/redirect", options: public_only)
+    end
+
+    assert_not_requested :get, "http://127.0.0.1/metadata"
+  end
+
+  test "public-only mode allows a redirect between public hosts" do
+    stub_request(:get, "https://example.com/redirect")
+      .to_return(status: 302, headers: { "Location" => "https://example.org/final" })
+    stub_request(:get, "https://example.org/final")
+      .to_return(status: 200, body: "ok")
+
+    response = client.get("https://example.com/redirect", options: public_only)
+
+    assert_equal 200, response.status
+    assert_equal "ok", response.body
+  end
+
+  test "without public-only mode the initial URL is not validated" do
+    stub_request(:get, "http://127.0.0.1/allowed").to_return(status: 200, body: "ok")
+
+    response = client.get("http://127.0.0.1/allowed")
+
+    assert_equal 200, response.status
+  end
 end

--- a/test/services/file_buffer_test.rb
+++ b/test/services/file_buffer_test.rb
@@ -102,4 +102,12 @@ class FileBufferTest < ActiveSupport::TestCase
       FileBuffer.new.load(url)
     end
   end
+
+  test "#load should refuse an attachment URL that redirects to a private address" do
+    url = "https://example.com/image.jpg"
+    stub_request(:get, url).to_return(status: 302, headers: { "Location" => "http://127.0.0.1/metadata" })
+
+    assert_raises(FileBuffer::Error) { FileBuffer.new.load(url) }
+    assert_not_requested :get, "http://127.0.0.1/metadata"
+  end
 end

--- a/test/services/llm_client/tools/web_fetch_test.rb
+++ b/test/services/llm_client/tools/web_fetch_test.rb
@@ -13,7 +13,7 @@ class LlmClient::Tools::WebFetchTest < ActiveSupport::TestCase
       @requested = []
     end
 
-    def get(url)
+    def get(url, **)
       @requested << url
       @response
     end
@@ -70,10 +70,20 @@ class LlmClient::Tools::WebFetchTest < ActiveSupport::TestCase
 
   test "#execute should surface transport errors as an error result" do
     raising = Object.new
-    def raising.get(_url) = raise(HttpClient::TimeoutError, "timed out")
+    def raising.get(_url, **) = raise(HttpClient::TimeoutError, "timed out")
 
     HttpClient.stub(:build, ->(**) { raising }) do
       assert_equal "timed out", tool.execute(url: "https://example.com/")[:error]
     end
+  end
+
+  test "#execute should refuse a public URL that redirects to a private address" do
+    url = "https://example.com/page"
+    stub_request(:get, url).to_return(status: 302, headers: { "Location" => "http://127.0.0.1/metadata" })
+
+    result = tool.execute(url: url)
+
+    assert result[:error].present?
+    assert_not_requested :get, "http://127.0.0.1/metadata"
   end
 end


### PR DESCRIPTION
Changes:

- Add an opt-in **public-only** mode to `HttpClient`: when a caller passes `options: { validate_url: <callable> }`, the adapter validates the initial URL and **every redirect hop** against the validator, raising `BlockedUrlError` on a non-public host.
- Route the two untrusted-URL fetches through it with `PublicUrl.method(:safe?)`: attachment upload at publish (`FileBuffer`) and the Kimi client-side web tool (`LlmClient::Tools::WebFetch`).

`PublicUrl.safe?` only ever validated the *initial* URL, but the Faraday adapter transparently follows up to 5 redirects — so a public URL that 302-redirects to `http://127.0.0.1/` or the cloud-metadata address (`169.254.169.254`) was still fetched, bypassing the guard. Validating each hop closes that.

Scope: this closes redirects to private/loopback/metadata **address literals**. A redirect to a DNS *name* that resolves to a private address, and DNS rebinding (TOCTOU), remain — both need resolve-and-pin at the socket layer, the deeper fix noted in the issue. The validator is injected by the caller, so `lib/http_client` stays decoupled from the app's `PublicUrl`.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §8
- Closes #920
- Related PR: #919