### PR TITLE
Drop non-public attachment URLs before persistence (LFI)

### DIFF
--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -70,8 +70,13 @@ module Normalizer
       @content ||= normalize_content
     end
 
+    # §8: every attachment URL must be an absolute public http(s) URL or be
+    # dropped (the attachment, not the post). Filtering here — the choke point
+    # every normalizer flows through — keeps a relative or local-path value (e.g.
+    # a feed's `<img src="/etc/passwd">`) from reaching FileBuffer at publish,
+    # where File.exist? would read it off the server (LFI).
     def attachment_urls
-      @attachment_urls ||= normalize_attachment_urls
+      @attachment_urls ||= normalize_attachment_urls.select { |url| PublicUrl.safe?(url) }
     end
 
     def comments

--- a/test/services/normalizer/rss_normalizer_test.rb
+++ b/test/services/normalizer/rss_normalizer_test.rb
@@ -34,6 +34,23 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
     assert_equal "enqueued", post.status
   end
 
+  test "#normalize should drop a non-public attachment URL and keep the public one" do
+    # A feed-supplied local path or relative URL must not reach FileBuffer, where
+    # File.exist? would read it off the server at publish (§8, LFI).
+    entry = create(:feed_entry, raw_data: {
+      "summary" => "Photo of the day.",
+      "link" => "https://example.com/photo",
+      "enclosures" => [
+        { "url" => "/etc/passwd", "type" => "image/jpeg" },
+        { "url" => "https://example.com/ok.jpg", "type" => "image/jpeg" }
+      ]
+    })
+
+    post = Normalizer::RssNormalizer.new(entry).normalize
+
+    assert_equal ["https://example.com/ok.jpg"], post.attachment_urls
+  end
+
   test "#normalize should include media:thumbnail with nil type in attachment_urls" do
     entry = create(:feed_entry, raw_data: {
       "summary" => "Photo of the day.",


### PR DESCRIPTION
Changes:

- Filter attachment URLs through `PublicUrl.safe?` in `Normalizer::Base#attachment_urls` — the choke point every normalizer flows through — so a feed-supplied relative or local-path image is dropped before it reaches the `Post`.

Deterministic normalizers (RSS, etc.) stored raw `<img src>` / `<enclosure url>` values verbatim, and `Post` had no attachment-URL validation. A feed the attacker controls could supply ``'&lt;img src="/etc/passwd"&gt;'``; at publish `FileBuffer#load` runs `File.exist?` first and reads the local file off the server, uploading it as an attachment (local file disclosure). `LlmNormalizer` already filtered its image URLs this way; this extends the same guard to every feed type at a single point. Per spec §8, a bad attachment is dropped, not the post — so a post with one unusable image link still goes out with its remaining valid ones.

Surfaced by the review of #940.

References:

- Spec: `specs/005-feed-creation-ux-ai-overhaul/spec.md` §8
- Follow-up to: #940