### PR TITLE
Fix Moonshot credential validation crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-08
+
+- Fixed Moonshot (Kimi) API key checks: they used to fail with an error and leave the key stuck in "validating" — now they go through like the other providers.
+
 ## 2026-07-07
 
 - AI feeds are steadier and safer: they now treat the pages they read as data rather than instructions to follow, and won't invent posts when a source turns up nothing — an empty check just brings in nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-08
 
 - Fixed Moonshot (Kimi) API key checks: they used to fail with an error and leave the key stuck in "validating" — now they go through like the other providers.
+- An API key check that can't reach the provider no longer leaves the key stuck in "validating" — it's marked as failed with the error, so you can try again.
 
 ## 2026-07-07
 

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -122,8 +122,12 @@ class LlmClient
   private
 
   # Single seam tests stub. Calls the provider's models listing endpoint.
+  # Resolves through LlmProvider because registry names don't always match
+  # RubyLLM's provider keys (Moonshot rides on :openai); resolving the raw
+  # name returns nil for those providers.
   def fetch_provider_models
-    RubyLLM::Provider.resolve(credential.provider.to_sym)
+    provider = LlmProvider.find(credential.provider)
+    RubyLLM::Provider.resolve(provider.ruby_llm_provider)
                      .new(credential.ruby_llm_context.config)
                      .list_models
   end

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -114,7 +114,9 @@ class LlmClient
     fetch_provider_models.map { |model| serialize_model(model) }
   rescue RubyLLM::UnauthorizedError, RubyLLM::ForbiddenError, RubyLLM::PaymentRequiredError => e
     raise AuthError, e.message
-  rescue RubyLLM::Error, RubyLLM::ConfigurationError => e
+  rescue Net::ReadTimeout, Net::OpenTimeout, Faraday::TimeoutError => e
+    raise Timeout, e.message
+  rescue RubyLLM::Error, RubyLLM::ConfigurationError, Faraday::ConnectionFailed => e
     Rails.error.report(e, context: { credential_id: credential.id, provider: credential.provider })
     raise ProviderError, e.message
   end

--- a/test/jobs/ai_credential_validation_job_test.rb
+++ b/test/jobs/ai_credential_validation_job_test.rb
@@ -63,4 +63,19 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
 
     assert_equal "inactive", credential.reload.state
   end
+
+  # No LlmClient stubbing: goes through the real client so a transport error
+  # the client fails to map to LlmClient::Error would escape the job's rescue
+  # and strand the credential in "validating".
+  test "#perform should not strand credential in validating when the provider is unreachable" do
+    moonshot = create(:ai_credential, user: user, state: :pending, provider: "moonshot",
+                      credential_data: { "api_key" => "sk-moon-test" })
+    stub_request(:get, "https://api.moonshot.ai/v1/models").to_timeout
+
+    AiCredentialValidationJob.perform_now(moonshot)
+
+    moonshot.reload
+    assert_equal "inactive", moonshot.state
+    assert_not_nil moonshot.last_error
+  end
 end

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -77,6 +77,13 @@ class LlmProviderTest < ActiveSupport::TestCase
     end
   end
 
+  test "every provider's ruby_llm_provider should resolve to a registered RubyLLM provider" do
+    LlmProvider.all.each do |provider|
+      assert_not_nil RubyLLM::Provider.resolve(provider.ruby_llm_provider),
+                     "#{provider.name} maps to unknown RubyLLM provider #{provider.ruby_llm_provider}"
+    end
+  end
+
   test "#find should accept symbol keys" do
     assert_equal "anthropic", LlmProvider.find(:anthropic).name
     assert_equal "openrouter", LlmProvider.find(:openrouter).name

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -303,6 +303,47 @@ class LlmClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "#available_models should resolve providers by their RubyLLM key, not the registry name" do
+    moonshot = create(:ai_credential, :active, user: user, provider: "moonshot",
+                      credential_data: { "api_key" => "sk-#{SecureRandom.hex(16)}" })
+    client = LlmClient.new(moonshot)
+
+    fake_provider_class = Class.new do
+      def initialize(_config); end
+      def list_models; []; end
+    end
+
+    resolved_keys = []
+    resolver = lambda do |key|
+      resolved_keys << key
+      fake_provider_class
+    end
+
+    RubyLLM::Provider.stub(:resolve, resolver) do
+      assert_equal [], client.available_models
+    end
+
+    assert_equal [:openai], resolved_keys
+  end
+
+  test "#available_models should list moonshot models through its OpenAI-compatible endpoint" do
+    moonshot = create(:ai_credential, :active, user: user, provider: "moonshot",
+                      credential_data: { "api_key" => "sk-moon-test" })
+    client = LlmClient.new(moonshot)
+
+    stub_request(:get, "https://api.moonshot.ai/v1/models")
+      .with(headers: { "Authorization" => "Bearer sk-moon-test" })
+      .to_return(
+        status: 200,
+        body: { data: [{ id: "kimi-k2.5", object: "model", owned_by: "moonshot" }] }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    models = client.available_models
+
+    assert_equal ["kimi-k2.5"], models.map { |m| m["id"] }
+  end
+
   test "#call should raise AuthError for RubyLLM::UnauthorizedError" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, RubyLLM::UnauthorizedError.new("401"))

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -289,6 +289,20 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_raises(LlmClient::ProviderError) { client.available_models }
   end
 
+  test "#available_models should raise Timeout on a network timeout" do
+    client = LlmClient.new(credential)
+    stub_provider_models(client) { raise Faraday::TimeoutError, "execution expired" }
+
+    assert_raises(LlmClient::Timeout) { client.available_models }
+  end
+
+  test "#available_models should raise ProviderError when the provider is unreachable" do
+    client = LlmClient.new(credential)
+    stub_provider_models(client) { raise Faraday::ConnectionFailed, "connection refused" }
+
+    assert_raises(LlmClient::ProviderError) { client.available_models }
+  end
+
   test "#available_models should call the provider models endpoint with the credential api_key" do
     client = LlmClient.new(credential)
 


### PR DESCRIPTION
Changes:

- Resolve the RubyLLM provider class by the provider's RubyLLM key instead of the F2 registry name, so Moonshot (which rides on RubyLLM's `:openai` provider) validates instead of crashing
- Map network timeouts and connection failures in `LlmClient#available_models` to known `LlmClient` errors, so a validation run against an unreachable provider marks the credential as failed instead of stranding it in "validating"
- Add regression tests for both paths and a registry guard ensuring every `LlmProvider` entry maps to a registered RubyLLM provider

Fixes a production `NoMethodError` reported by Honeybadger: `RubyLLM::Provider.resolve` silently returns nil for unknown keys, and the F2 registry name only coincides with RubyLLM's key for Anthropic and OpenRouter. The crash bypassed the validation job's error handling and left the credential stuck in "validating" with no recovery.