### PR TITLE
Add AiCredential#llm_provider

### DIFF
--- a/app/components/ai_credential_details_component.rb
+++ b/app/components/ai_credential_details_component.rb
@@ -15,7 +15,7 @@ class AiCredentialDetailsComponent < ViewComponent::Base
     result = [
       {
         label: "Provider",
-        value: LlmProvider.find(@ai_credential.provider).display_name,
+        value: @ai_credential.llm_provider.display_name,
         key: "ai_credential.provider"
       },
       {

--- a/app/components/ai_credential_list_item_component.rb
+++ b/app/components/ai_credential_list_item_component.rb
@@ -55,7 +55,7 @@ class AiCredentialListItemComponent < ListItemComponent
   end
 
   def provider_name
-    LlmProvider.find(credential.provider).display_name
+    credential.llm_provider.display_name
   end
 
   def menu

--- a/app/components/feed_ai_settings_component.rb
+++ b/app/components/feed_ai_settings_component.rb
@@ -58,7 +58,7 @@ class FeedAiSettingsComponent < ViewComponent::Base
 
   def credential_options
     selectable_credentials.map do |credential|
-      ["#{credential.display_name} · #{LlmProvider.find(credential.provider).display_name}", credential.id]
+      ["#{credential.display_name} · #{credential.llm_provider.display_name}", credential.id]
     end
   end
 

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -40,6 +40,10 @@ class AiCredential < ApplicationRecord
     user.update!(default_ai_credential: self)
   end
 
+  def llm_provider
+    LlmProvider.find(provider)
+  end
+
   # Models this credential can actually back a feed with: the dev-verified
   # capability matrix intersected with the provider's live snapshot (spec §5).
   # Membership is qualification — a snapshot model absent from the matrix (or a
@@ -60,7 +64,7 @@ class AiCredential < ApplicationRecord
   # provider's configured default when it's still supported here, otherwise the
   # first supported model, or nil when the provider has no verified models.
   def default_supported_model
-    provider_default = LlmProvider.find(provider).default_model
+    provider_default = llm_provider.default_model
     return provider_default if supports_model?(provider_default)
 
     supported_models.first&.fetch("id")
@@ -68,7 +72,7 @@ class AiCredential < ApplicationRecord
 
   def ruby_llm_context
     RubyLLM.context do |config|
-      LlmProvider.find(provider).configure(config, credential_data["api_key"])
+      llm_provider.configure(config, credential_data["api_key"])
     end
   end
 

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -128,8 +128,7 @@ class LlmClient
   # RubyLLM's provider keys (Moonshot rides on :openai); resolving the raw
   # name returns nil for those providers.
   def fetch_provider_models
-    provider = LlmProvider.find(credential.provider)
-    RubyLLM::Provider.resolve(provider.ruby_llm_provider)
+    RubyLLM::Provider.resolve(credential.llm_provider.ruby_llm_provider)
                      .new(credential.ruby_llm_context.config)
                      .list_models
   end
@@ -151,7 +150,7 @@ class LlmClient
 
   # Single seam tests stub. Returns a ProviderResponse.
   def invoke_provider(model:, prompt:, output_schema:, web:, system: nil)
-    provider = LlmProvider.find(credential.provider)
+    provider = credential.llm_provider
     chat = credential.ruby_llm_context.chat(
       model: model, provider: provider.ruby_llm_provider, assume_model_exists: provider.assume_model_exists?
     )

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -77,7 +77,7 @@ module Loader
     # re-pick even when the whole snapshot dropped out.
     def model_for(credential)
       chosen = feed.ai_model
-      resolved = feed.effective_ai_model(credential).presence || LlmProvider.find(credential.provider).default_model
+      resolved = feed.effective_ai_model(credential).presence || credential.llm_provider.default_model
 
       if feed.persisted? && chosen.present? && resolved != chosen
         feed.note_ai_model_fallback!(from: chosen, to: resolved)

--- a/app/views/ai_credentials/edit.html.erb
+++ b/app/views/ai_credentials/edit.html.erb
@@ -21,7 +21,7 @@
         <div class="space-y-2">
           <%= label_tag "ai_credential_provider", "AI Provider", class: "block font-semibold text-heading" %>
           <%= text_field_tag "ai_credential_provider",
-                             LlmProvider.find(@ai_credential.provider).display_name,
+                             @ai_credential.llm_provider.display_name,
                              disabled: true,
                              class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2 disabled:bg-surface-sunken disabled:text-muted disabled:border-border disabled:cursor-not-allowed" %>
         </div>

--- a/test/models/ai_credential_test.rb
+++ b/test/models/ai_credential_test.rb
@@ -83,6 +83,11 @@ class AiCredentialTest < ActiveSupport::TestCase
     assert_equal credential.id, user.reload.default_ai_credential_id
   end
 
+  test "#llm_provider should return the registry entry for the provider attribute" do
+    credential = create(:ai_credential, user: user, provider: "anthropic")
+    assert_equal LlmProvider.find("anthropic"), credential.llm_provider
+  end
+
   test "destroy should be a no-op when no feeds reference the credential" do
     credential = create(:ai_credential, user: user)
 


### PR DESCRIPTION
Changes:

- Add `AiCredential#llm_provider` returning the credential's `LlmProvider` registry entry
- Replace every `LlmProvider.find(credential.provider)` call site (services, components, views, and inside the model itself) with the new method

The credential already knows its provider, so callers shouldn't have to reach through the attribute into the registry — the lookup now lives in one place on the model.

References:

- Related PR: #946
