### PR TITLE
Fix page header whitespace, stat overflow, and content size formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-08
 
+- Long source URLs and UIDs on post pages no longer spill outside the page — they're neatly cropped with an ellipsis, and hovering a cropped UID shows the full value.
 - Content size in event stats now uses thousands separators, so big numbers are easier to read at a glance.
 - Choosing between following a link or following with AI on the new-feed page now uses tabs, so each option gets its own address you can bookmark or share.
 - Fixed Moonshot (Kimi) API key checks: they used to fail with an error and leave the key stuck in "validating" — now they go through like the other providers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-08
 
 - Long source URLs and UIDs on post pages no longer spill outside the page — they're neatly cropped with an ellipsis, and hovering a cropped UID shows the full value.
-- Content size in event stats now uses thousands separators, so big numbers are easier to read at a glance.
+- Event stats are easier to read: big numbers now use thousands separators, and step timings show as seconds and minutes instead of raw values.
 - Choosing between following a link or following with AI on the new-feed page now uses tabs, so each option gets its own address you can bookmark or share.
 - Fixed Moonshot (Kimi) API key checks: they used to fail with an error and leave the key stuck in "validating" — now they go through like the other providers.
 - An API key check that can't reach the provider no longer leaves the key stuck in "validating" — it's marked as failed with the error, so you can try again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-08
 
+- Content size in event stats now uses thousands separators, so big numbers are easier to read at a glance.
 - Choosing between following a link or following with AI on the new-feed page now uses tabs, so each option gets its own address you can bookmark or share.
 - Fixed Moonshot (Kimi) API key checks: they used to fail with an error and leave the key stuck in "validating" — now they go through like the other providers.
 - An API key check that can't reach the provider no longer leaves the key stuck in "validating" — it's marked as failed with the error, so you can try again.

--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -12,9 +12,7 @@
     <div class="relative bg-surface rounded-lg shadow">
       <!-- Modal header -->
       <div class="flex items-center justify-between p-4 md:p-6">
-        <h3 id="<%= @modal_id %>-title" class="text-3xl font-semibold text-heading">
-          <%= @title %>
-        </h3>
+        <h3 id="<%= @modal_id %>-title" class="text-3xl font-semibold text-heading"><%= @title %></h3>
         <%= tag.button type: "button",
                        class: "text-muted bg-transparent hover:bg-surface-sunken hover:text-heading rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center",
                        data: { action: "modal#close" } do %>

--- a/app/components/page_header_component.html.erb
+++ b/app/components/page_header_component.html.erb
@@ -4,10 +4,7 @@
   <% end %>
   <div class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
     <div class="flex flex-col gap-5">
-      <%= tag.h1(class: class_names("text-4xl font-semibold mb-0 text-heading", "flex items-center gap-3" => title_icon?), data: @title_data) do %>
-        <%= title_icon if title_icon? %>
-        <%= @title %>
-      <% end %>
+      <%= tag.h1(title_content, class: class_names("text-4xl font-semibold mb-0 text-heading", "flex items-center gap-3" => title_icon?), data: @title_data) %>
       <% if context_paragraphs? %>
         <% context_paragraphs.each do |paragraph| %>
           <p class="text-body"><%= paragraph %></p>

--- a/app/components/page_header_component.rb
+++ b/app/components/page_header_component.rb
@@ -20,9 +20,10 @@ class PageHeaderComponent < ViewComponent::Base
 
   private
 
-  # Joined without whitespace so the h1 text has no stray leading/trailing
-  # spaces; the flex gap handles icon spacing.
+  # Compacting before joining keeps the h1 text free of stray leading
+  # whitespace when there is no icon; the single-space separator keeps a
+  # text-node icon readable while flex layout ignores it for element icons.
   def title_content
-    safe_join([title_icon, @title].compact)
+    safe_join([title_icon, @title].compact, " ")
   end
 end

--- a/app/components/page_header_component.rb
+++ b/app/components/page_header_component.rb
@@ -17,4 +17,12 @@ class PageHeaderComponent < ViewComponent::Base
     @title = title
     @title_data = title_data
   end
+
+  private
+
+  # Joined without whitespace so the h1 text has no stray leading/trailing
+  # spaces; the flex gap handles icon spacing.
+  def title_content
+    safe_join([title_icon, @title].compact)
+  end
 end

--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -44,7 +44,7 @@ class PostDetailsComponent < ViewComponent::Base
 
   def add_source_url_item(component)
     value = if @post.source_url.present?
-      helpers.link_to(@post.source_url, @post.source_url, target: "_blank", rel: "noopener", class: "text-brand underline underline-offset-4 transition hover:text-brand-hover truncate block")
+      helpers.link_to(@post.source_url, @post.source_url, target: "_blank", rel: "noopener", title: @post.source_url, class: "text-brand underline underline-offset-4 transition hover:text-brand-hover")
     else
       content_tag(:span, "None", class: "text-muted")
     end
@@ -52,7 +52,8 @@ class PostDetailsComponent < ViewComponent::Base
     component.with_item(StatListItemComponent.new(
       label: "Source URL",
       value: value,
-      key: "post.source_url"
+      key: "post.source_url",
+      truncate: @post.source_url.present?
     ))
   end
 
@@ -75,8 +76,9 @@ class PostDetailsComponent < ViewComponent::Base
   def add_uid_item(component)
     component.with_item(StatListItemComponent.new(
       label: "UID",
-      value: content_tag(:code, @post.uid, class: "text-sm truncate block", title: @post.uid),
-      key: "post.uid"
+      value: content_tag(:code, @post.uid, class: "text-sm", title: @post.uid),
+      key: "post.uid",
+      truncate: true
     ))
   end
 
@@ -96,7 +98,8 @@ class PostDetailsComponent < ViewComponent::Base
     component.with_item(StatListItemComponent.new(
       label: "FreeFeed Post ID",
       value: value,
-      key: "post.freefeed_post_id"
+      key: "post.freefeed_post_id",
+      truncate: true
     ))
   end
 end

--- a/app/components/post_details_component.rb
+++ b/app/components/post_details_component.rb
@@ -75,7 +75,7 @@ class PostDetailsComponent < ViewComponent::Base
   def add_uid_item(component)
     component.with_item(StatListItemComponent.new(
       label: "UID",
-      value: content_tag(:code, @post.uid, class: "text-sm"),
+      value: content_tag(:code, @post.uid, class: "text-sm truncate block", title: @post.uid),
       key: "post.uid"
     ))
   end

--- a/app/components/stat_item_component.rb
+++ b/app/components/stat_item_component.rb
@@ -1,10 +1,11 @@
 # Abstract base class — subclasses must define DEFAULT_ITEM_CLASS, LABEL_CLASSES, and VALUE_CLASSES.
 class StatItemComponent < ViewComponent::Base
-  def initialize(label:, value:, key: nil, muted: false)
+  def initialize(label:, value:, key: nil, muted: false, truncate: false)
     @label = label
     @value = value
     @key = key
     @muted = muted
+    @truncate = truncate
   end
 
   def call
@@ -20,7 +21,17 @@ class StatItemComponent < ViewComponent::Base
   end
 
   def value_element
-    content_tag(:dd, @value, class: class_names(self.class::VALUE_CLASSES, @muted ? "text-muted" : "text-heading"), data: value_data)
+    content_tag(:dd, value_content, class: class_names(self.class::VALUE_CLASSES, @muted ? "text-muted" : "text-heading", "min-w-0" => @truncate), data: value_data)
+  end
+
+  # Cropping a long value needs two cooperating pieces: min-w-0 so the flex
+  # cell can shrink below its content width, and a block wrapper that crops
+  # the overflow with an ellipsis. Bundling them behind one option keeps the
+  # contract in one place instead of split across callers.
+  def value_content
+    return @value unless @truncate
+
+    content_tag(:div, @value, class: "truncate")
   end
 
   def label_data

--- a/app/components/stat_list_item_component.rb
+++ b/app/components/stat_list_item_component.rb
@@ -1,7 +1,5 @@
 class StatListItemComponent < StatItemComponent
   DEFAULT_ITEM_CLASS = "flex items-baseline justify-between gap-4 p-4"
   LABEL_CLASSES      = "text-base text-heading whitespace-nowrap"
-  # min-w-0 lets the value cell shrink inside the flex row so long values
-  # (URLs, UIDs) can be ellipsized by a truncate child instead of overflowing.
-  VALUE_CLASSES      = "text-base min-w-0"
+  VALUE_CLASSES      = "text-base"
 end

--- a/app/components/stat_list_item_component.rb
+++ b/app/components/stat_list_item_component.rb
@@ -1,5 +1,7 @@
 class StatListItemComponent < StatItemComponent
   DEFAULT_ITEM_CLASS = "flex items-baseline justify-between gap-4 p-4"
   LABEL_CLASSES      = "text-base text-heading whitespace-nowrap"
-  VALUE_CLASSES      = "text-base"
+  # min-w-0 lets the value cell shrink inside the flex row so long values
+  # (URLs, UIDs) can be ellipsized by a truncate child instead of overflowing.
+  VALUE_CLASSES      = "text-base min-w-0"
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -32,6 +32,8 @@ module EventsHelper
       time ? long_time_tag(time) : value
     elsif key.to_s == "total_duration"
       format_event_duration(value.to_f)
+    elsif key.to_s == "content_size"
+      number_with_delimiter(value)
     else
       value
     end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -27,12 +27,14 @@ module EventsHelper
   end
 
   def format_stat_value(key, value)
-    if key.to_s.end_with?("_at")
+    key = key.to_s
+
+    if key.end_with?("_at")
       time = Time.zone.parse(value.to_s) rescue nil
       time ? long_time_tag(time) : value
-    elsif key.to_s == "total_duration"
+    elsif key.end_with?("_duration")
       format_event_duration(value.to_f)
-    elsif key.to_s == "content_size"
+    elsif value.is_a?(Integer)
       number_with_delimiter(value)
     else
       value

--- a/test/components/page_header_component_test.rb
+++ b/test/components/page_header_component_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+require "view_component/test_case"
+
+class PageHeaderComponentTest < ViewComponent::TestCase
+  test "#render should render title without surrounding whitespace" do
+    result = render_inline(PageHeaderComponent.new(title: "New Feed"))
+
+    assert_equal "New Feed", result.at_css("h1").text
+  end
+
+  test "#render should render title icon inside the heading" do
+    result = render_inline(PageHeaderComponent.new(title: "New Feed")) do |component|
+      component.with_title_icon { "*" }
+    end
+
+    assert_equal "*New Feed", result.at_css("h1").text
+    assert_includes result.at_css("h1")["class"], "flex"
+  end
+end

--- a/test/components/page_header_component_test.rb
+++ b/test/components/page_header_component_test.rb
@@ -13,7 +13,7 @@ class PageHeaderComponentTest < ViewComponent::TestCase
       component.with_title_icon { "*" }
     end
 
-    assert_equal "*New Feed", result.at_css("h1").text
+    assert_equal "* New Feed", result.at_css("h1").text
     assert_includes result.at_css("h1")["class"], "flex"
   end
 end

--- a/test/components/post_details_component_test.rb
+++ b/test/components/post_details_component_test.rb
@@ -28,8 +28,9 @@ class PostDetailsComponentTest < ViewComponent::TestCase
 
     result = render_inline(PostDetailsComponent.new(post: post))
 
-    link = result.css('[data-key="post.source_url.value"] a').first
-    assert_includes link["class"], "truncate"
+    link = result.css('[data-key="post.source_url.value"] div.truncate a').first
+    assert_not_nil link
+    assert_equal post.source_url, link["title"]
   end
 
   test "#render should truncate the UID and expose the full value in a title" do
@@ -37,8 +38,16 @@ class PostDetailsComponentTest < ViewComponent::TestCase
 
     result = render_inline(PostDetailsComponent.new(post: post))
 
-    code = result.css('[data-key="post.uid.value"] code').first
-    assert_includes code["class"], "truncate"
+    code = result.css('[data-key="post.uid.value"] div.truncate code').first
+    assert_not_nil code
     assert_equal post.uid, code["title"]
+  end
+
+  test "#render should truncate the FreeFeed post ID" do
+    post = create(:post, :published, feed: feed)
+
+    result = render_inline(PostDetailsComponent.new(post: post))
+
+    assert_not_nil result.css('[data-key="post.freefeed_post_id.value"] div.truncate').first
   end
 end

--- a/test/components/post_details_component_test.rb
+++ b/test/components/post_details_component_test.rb
@@ -22,4 +22,23 @@ class PostDetailsComponentTest < ViewComponent::TestCase
 
     assert_nil result.css('[data-key="post.reposted"]').first
   end
+
+  test "#render should truncate the source URL instead of overflowing" do
+    post = create(:post, feed: feed, source_url: "https://example.com/#{'a' * 200}")
+
+    result = render_inline(PostDetailsComponent.new(post: post))
+
+    link = result.css('[data-key="post.source_url.value"] a').first
+    assert_includes link["class"], "truncate"
+  end
+
+  test "#render should truncate the UID and expose the full value in a title" do
+    post = create(:post, feed: feed, uid: "uid-#{'b' * 200}")
+
+    result = render_inline(PostDetailsComponent.new(post: post))
+
+    code = result.css('[data-key="post.uid.value"] code').first
+    assert_includes code["class"], "truncate"
+    assert_equal post.uid, code["title"]
+  end
 end

--- a/test/components/stat_list_item_component_test.rb
+++ b/test/components/stat_list_item_component_test.rb
@@ -46,4 +46,10 @@ class StatListItemComponentTest < ViewComponent::TestCase
     assert_includes result.at_css("div")["class"], "items-baseline"
     assert_includes result.at_css("div")["class"], "justify-between"
   end
+
+  test "#render should let the value shrink so truncated children can ellipsize" do
+    result = render_inline(StatListItemComponent.new(label: "Posts", value: "42"))
+
+    assert_includes result.at_css("dd")["class"], "min-w-0"
+  end
 end

--- a/test/components/stat_list_item_component_test.rb
+++ b/test/components/stat_list_item_component_test.rb
@@ -47,9 +47,17 @@ class StatListItemComponentTest < ViewComponent::TestCase
     assert_includes result.at_css("div")["class"], "justify-between"
   end
 
-  test "#render should let the value shrink so truncated children can ellipsize" do
+  test "#render should not crop the value by default" do
     result = render_inline(StatListItemComponent.new(label: "Posts", value: "42"))
 
+    assert_not_includes result.at_css("dd")["class"], "min-w-0"
+    assert_nil result.at_css("dd div.truncate")
+  end
+
+  test "#render should crop the value when truncate is enabled" do
+    result = render_inline(StatListItemComponent.new(label: "UID", value: "x" * 200, truncate: true))
+
     assert_includes result.at_css("dd")["class"], "min-w-0"
+    assert_equal "x" * 200, result.at_css("dd div.truncate").text
   end
 end

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -97,6 +97,11 @@ class EventsHelperTest < ActionView::TestCase
     assert_equal "1m 35s", format_stat_value("total_duration", 95.0)
   end
 
+  test "#format_stat_value should format content_size with delimiters" do
+    assert_equal "1,234,567", format_stat_value("content_size", 1234567)
+    assert_equal "512", format_stat_value("content_size", 512)
+  end
+
   test "#format_stat_value should return value as-is for other keys" do
     assert_equal 5, format_stat_value("new_posts", 5)
     assert_equal "foo", format_stat_value("some_key", "foo")

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -97,13 +97,18 @@ class EventsHelperTest < ActionView::TestCase
     assert_equal "1m 35s", format_stat_value("total_duration", 95.0)
   end
 
-  test "#format_stat_value should format content_size with delimiters" do
+  test "#format_stat_value should format integer values with delimiters" do
     assert_equal "1,234,567", format_stat_value("content_size", 1234567)
-    assert_equal "512", format_stat_value("content_size", 512)
+    assert_equal "12,500", format_stat_value("total_entries", 12500)
+    assert_equal "5", format_stat_value("new_posts", 5)
+  end
+
+  test "#format_stat_value should format step duration keys" do
+    assert_equal "12.8s", format_stat_value("load_feed_contents_duration", 12.845)
+    assert_equal "1m 35s", format_stat_value("persist_posts_duration", 95.0)
   end
 
   test "#format_stat_value should return value as-is for other keys" do
-    assert_equal 5, format_stat_value("new_posts", 5)
     assert_equal "foo", format_stat_value("some_key", "foo")
   end
 end


### PR DESCRIPTION
Changes:

- Trim stray whitespace inside the page header `h1` (visible on the New Feed page) and the modal title, caused by ERB indentation rendering as text nodes inside the heading.
- Format event stat numbers (`/admin/events/:id` and `/events/:id`): integer values like "Content size" get thousands separators via `number_with_delimiter`, and per-step `*_duration` stats render as human durations instead of raw floats.
- Stop long "Source URL", "UID", and "FreeFeed Post ID" values on post pages from clipping through the container: `StatItemComponent` gains a `truncate:` option that pairs `min-w-0` on the value cell with an ellipsis wrapper, and cropped values expose the full text in a hover `title`.
