### PR TITLE
Simplify spec-005 code after review

### DIFF
--- a/app/components/candidate_option_component.rb
+++ b/app/components/candidate_option_component.rb
@@ -9,13 +9,9 @@ class CandidateOptionComponent < ViewComponent::Base
     @selected = selected
   end
 
-  def before_render
-    assign_verdict
-  end
-
   private
 
-  attr_reader :candidate, :input, :badge_text, :note
+  attr_reader :candidate, :input
 
   def profile_key
     candidate.profile_key
@@ -43,9 +39,12 @@ class CandidateOptionComponent < ViewComponent::Base
 
   # Every shown candidate passed its self-test; badge the post count and note an
   # empty-but-valid source.
-  def assign_verdict
+  def badge_text
     count = candidate.posts_found
-    @badge_text = count.zero? ? "Tested" : "Tested · #{count} #{'post'.pluralize(count)}"
-    @note = "No posts yet. We'll pick up new ones as they're published." if count.zero?
+    count.zero? ? "Tested" : "Tested · #{count} #{'post'.pluralize(count)}"
+  end
+
+  def note
+    "No posts yet. We'll pick up new ones as they're published." if candidate.posts_found.zero?
   end
 end

--- a/app/components/feed_ai_settings_component.rb
+++ b/app/components/feed_ai_settings_component.rb
@@ -47,7 +47,7 @@ class FeedAiSettingsComponent < ViewComponent::Base
   end
 
   def ai_profile_keys
-    FeedProfile.all.select { |key| FeedProfile.depends_on_ai?(key) }
+    FeedProfile.ai_profile_keys
   end
 
   def selected_credential_id

--- a/app/controllers/concerns/state_polling.rb
+++ b/app/controllers/concerns/state_polling.rb
@@ -14,7 +14,7 @@ module StatePolling
   # Server-side deadline, set just before the client's final poll so that poll
   # still renders the outcome instead of leaving the spinner frozen. The first
   # poll is immediate, so the last lands at (max_polls - 1) * interval.
-  def polling_timeout
-    ((polling_max_polls - 2) * polling_interval_ms).fdiv(1000).seconds
+  def polling_timeout(max_polls = polling_max_polls)
+    ((max_polls - 2) * polling_interval_ms).fdiv(1000).seconds
   end
 end

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -4,11 +4,10 @@ class FeedIdentificationsController < ApplicationController
   before_action :require_authentication
 
   rate_limit to: 10, within: 1.minute, by: -> { Current.user.id }, only: :create, with: -> {
-    render turbo_stream: turbo_stream.replace(
-      "feed-form",
-      partial: "feeds/identification_error",
-      locals: base_locals.merge(url: params[:url].presence || params[:prompt], error: "Too many identification attempts. Please wait before trying again.")
-    ), status: :too_many_requests
+    render identification_error(
+      url: params[:url].presence || params[:prompt],
+      error: "Too many identification attempts. Please wait before trying again."
+    ).merge(status: :too_many_requests)
   }
 
   def create
@@ -48,11 +47,7 @@ class FeedIdentificationsController < ApplicationController
     original_url = feed_identification.persisted? ? feed_identification.input : raw_url
     feed_identification.destroy if feed_identification.persisted?
 
-    render turbo_stream: turbo_stream.replace(
-      "feed-form",
-      partial: "feeds/form_collapsed",
-      locals: { url: original_url }
-    )
+    render feed_form_stream("form_collapsed", url: original_url)
   end
 
   private
@@ -151,14 +146,14 @@ class FeedIdentificationsController < ApplicationController
     end
   end
 
-  def identification_error(error:, heading: "Feed identification failed")
-    {
-      turbo_stream: turbo_stream.replace(
-        "feed-form",
-        partial: "feeds/identification_error",
-        locals: base_locals.merge(url: raw_url, error: error, heading: heading)
-      )
-    }
+  # Every response in this flow swaps the same "feed-form" frame; partial names
+  # are relative to feeds/.
+  def feed_form_stream(partial, **locals)
+    { turbo_stream: turbo_stream.replace("feed-form", partial: "feeds/#{partial}", locals: locals) }
+  end
+
+  def identification_error(error:, heading: "Feed identification failed", url: raw_url)
+    feed_form_stream("identification_error", **base_locals, url: url, error: error, heading: heading)
   end
 
   # When re-detecting an existing deterministic feed the engine is fixed, so the
@@ -187,34 +182,16 @@ class FeedIdentificationsController < ApplicationController
   # Transient: nothing connected. Retrying is the primary path; the bridge is a
   # secondary escape so the state can't dead-end (spec §7).
   def couldnt_reach_retry
-    {
-      turbo_stream: turbo_stream.replace(
-        "feed-form",
-        partial: "feeds/identification_retry",
-        locals: base_locals.merge(url: raw_url)
-      )
-    }
+    feed_form_stream("identification_retry", **base_locals, url: raw_url)
   end
 
   def identification_loading
-    {
-      turbo_stream: turbo_stream.replace(
-        "feed-form",
-        partial: "feeds/identification_loading",
-        locals: base_locals.merge(url: source_url)
-      )
-    }
+    feed_form_stream("identification_loading", **base_locals, url: source_url)
   end
 
   def identification_success(feed, candidates: [], source_changed: false, profile_changed: false)
-    {
-      turbo_stream: turbo_stream.replace(
-        "feed-form",
-        partial: "feeds/form_expanded",
-        locals: { feed: feed, candidates: candidates, edit_mode: editing?,
-                  source_changed: source_changed, profile_changed: profile_changed }
-      )
-    }
+    feed_form_stream("form_expanded", feed: feed, candidates: candidates, edit_mode: editing?,
+                                      source_changed: source_changed, profile_changed: profile_changed)
   end
 
   # The feed being edited (spec §4 source re-detection), or nil in the creation

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -119,7 +119,7 @@ class FeedIdentificationsController < ApplicationController
   def handle_success_status
     suggested = feed_identification.suggested_candidate
     profile_key = suggested&.profile_key
-    source_key = FeedProfile.source_key_for(profile_key) || "url"
+    source_key = FeedProfile.source_key_for(profile_key)
 
     if editing?
       # Re-render the feed being edited with the proposed source + profile

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -25,7 +25,7 @@ class FeedPreviewsController < ApplicationController
   def show
     preview = locate_preview
     preview = start_run(preview) if needs_run?(preview)
-    preview.timeout! if (preview.pending? || preview.processing?) && preview.updated_at < preview_polling_timeout.ago
+    preview.timeout! if (preview.pending? || preview.processing?) && preview.updated_at < polling_timeout(preview_max_polls).ago
     render_state(preview, inert_while_running: true)
   end
 
@@ -35,7 +35,7 @@ class FeedPreviewsController < ApplicationController
     render_state(start_run(locate_preview))
   end
 
-  helper_method :preview_max_polls
+  helper_method :preview_max_polls, :state_partial
 
   private
 
@@ -44,10 +44,6 @@ class FeedPreviewsController < ApplicationController
   # poller (view) and the server-side timeout.
   def preview_max_polls
     FeedProfile.depends_on_ai?(profile_key) ? AI_PREVIEW_MAX_POLLS : polling_max_polls
-  end
-
-  def preview_polling_timeout
-    ((preview_max_polls - 2) * polling_interval_ms).fdiv(1000).seconds
   end
 
   def guard_preview
@@ -133,11 +129,9 @@ class FeedPreviewsController < ApplicationController
     FeedProfile.source_input_for(profile_key, preview_params).to_s.strip.blank?
   end
 
+  # Only reached after guard_preview confirmed the profile exists.
   def needs_credential_gate?
-    return false unless FeedProfile.exists?(profile_key)
-    return false unless FeedProfile.depends_on_ai?(profile_key)
-
-    !Current.user.ai_credentials.active.exists?
+    FeedProfile.depends_on_ai?(profile_key) && !Current.user.ai_credentials.active.exists?
   end
 
   def render_state(preview, inert_while_running: false)

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -130,8 +130,7 @@ class FeedPreviewsController < ApplicationController
   end
 
   def source_blank?
-    key = FeedProfile.source_key_for(profile_key) || "url"
-    preview_params[key].to_s.strip.blank?
+    FeedProfile.source_input_for(profile_key, preview_params).to_s.strip.blank?
   end
 
   def needs_credential_gate?

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -80,10 +80,8 @@ class FeedsController < ApplicationController
     if @feed.save
       cleanup_feed_identification(@feed.source_input) if @feed.source_input
 
-      if require_ai_credentials?
-        redirect_to new_ai_credential_path(feed_id: @feed.id)
-      elsif require_access_token?
-        redirect_to new_access_token_path(feed_id: @feed.id)
+      if (gate_path = setup_gate_path(@feed))
+        redirect_to gate_path
       elsif enable_feed?
         enable_and_respond(@feed)
       else
@@ -133,7 +131,7 @@ class FeedsController < ApplicationController
 
     # Unticked Enable on an enabled feed = pause request (gate flow skips this
     # because the gate only appears for drafts without usable credentials).
-    @feed.state = :disabled if @feed.enabled? && !enable_feed? && !require_ai_credentials? && !require_access_token?
+    @feed.state = :disabled if @feed.enabled? && !enable_feed? && setup_gate_path(@feed).nil?
 
     if @feed.save
       # Capture interval-change signal from the first save before the
@@ -142,10 +140,8 @@ class FeedsController < ApplicationController
       record_feed_disabled(@feed) if @feed.saved_change_to_state? && @feed.disabled?
       cleanup_feed_identification(@feed.source_input) if @feed.source_input
 
-      if require_ai_credentials?
-        redirect_to new_ai_credential_path(feed_id: @feed.id)
-      elsif require_access_token?
-        redirect_to new_access_token_path(feed_id: @feed.id)
+      if (gate_path = setup_gate_path(@feed))
+        redirect_to gate_path
       elsif enable_feed? && !@feed.enabled?
         promote_and_redirect(@feed, interval_changed)
       else
@@ -183,6 +179,16 @@ class FeedsController < ApplicationController
 
   def enable_feed?
     params[:enable_feed] == "1"
+  end
+
+  # The user clicked one of the "save draft and set up …" buttons: detour to
+  # that setup page instead of finishing on the feed.
+  def setup_gate_path(feed)
+    if require_ai_credentials?
+      new_ai_credential_path(feed_id: feed.id)
+    elsif require_access_token?
+      new_access_token_path(feed_id: feed.id)
+    end
   end
 
   def enable_and_respond(feed)
@@ -307,31 +313,9 @@ class FeedsController < ApplicationController
     policy_scope(Feed).find(params[:id])
   end
 
-  def feed_params
-    params.require(:feed).permit(
-      :url,
-      :name,
-      :feed_profile_key,
-      :description,
-      :target_group,
-      :access_token_id,
-      :ai_credential_id,
-      :ai_model,
-      :cron_expression,
-      :schedule_interval,
-      :import_after_enabled,
-      :import_after_date,
-      :import_after_time,
-      :images_only,
-      # Only the known source keys are accepted. Anything else inside the
-      # params hash would otherwise persist into `feeds.params` jsonb
-      # undetected. See the profile schemas.
-      params: [:url, :prompt]
-    )
-  end
-
+  # A new feed is a draft, so creation accepts the draft-editable set.
   def create_feed_params
-    feed_params
+    params.require(:feed).permit(*ALWAYS_PERMITTED_PARAMS, *DRAFT_ONLY_PERMITTED_PARAMS)
   end
 
   def update_feed_params
@@ -360,15 +344,9 @@ class FeedsController < ApplicationController
     FeedIdentification.find_by(user: current_user, input: input)&.destroy
   end
 
-  # `#create` only produces `enabled` or `draft` today (the disabled branch is
-  # kept as a defensive fallback for any future caller that lands here in the
-  # disabled state; `#update` doesn't share this helper).
   def success_message_for(feed)
     if feed.enabled?
       "Feed created and enabled."
-    elsif feed.disabled?
-      "Feed '#{feed.name}' was successfully created but is currently disabled. " \
-        "Enable it from the feed page when you're ready to start importing posts."
     else
       "Feed saved as draft. Continue setup from your feeds list when ready."
     end

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -64,23 +64,11 @@ module FeedHelper
   end
 
   def feed_summary_line(active_count:, inactive_count:, draft_count:)
-    active_part = pluralize_count(active_count, "active feed")
-    inactive_part = pluralize_count(inactive_count, "inactive feed")
-    draft_part = pluralize_count(draft_count, "draft feed")
-
-    parts = [active_part, inactive_part, draft_part].compact
+    counts = { "active feed" => active_count, "inactive feed" => inactive_count, "draft feed" => draft_count }
+    parts = counts.reject { |_label, count| count.zero? }
+                  .map { |label, count| pluralize(count, label) }
     return nil if parts.empty?
 
     "You have #{parts.to_sentence}"
-  end
-
-  private
-
-  def pluralize_count(count, label)
-    return nil if count.zero?
-
-    noun = label.split.last
-    base = label.remove(/\sfeed\z/)
-    "#{count} #{base} #{noun.pluralize(count)}"
   end
 end

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -30,8 +30,6 @@ class AiCredential < ApplicationRecord
   before_validation :assign_name_if_blank, on: :create
   before_destroy :disable_dependent_feeds
 
-  scope :for_provider, ->(provider) { where(provider: provider) }
-
   def default?
     user.default_ai_credential_id == id
   end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -9,10 +9,6 @@ class Feed < ApplicationRecord
     invalid_posts_count
   ].freeze
 
-  # Timezone for all cron expression evaluation
-  # Must match config.time_zone in config/application.rb
-  FEED_CRON_TIMEZONE = "UTC".freeze
-
   SCHEDULE_INTERVALS = {
     "10m" => { cron: "*/10 * * * *", display: "10 minutes" },
     "20m" => { cron: "*/20 * * * *", display: "20 minutes" },
@@ -108,10 +104,6 @@ class Feed < ApplicationRecord
 
   def schedule_interval=(key)
     self.cron_expression = SCHEDULE_INTERVALS.dig(key, :cron)
-  end
-
-  def schedule_display
-    SCHEDULE_INTERVALS.dig(schedule_interval, :display) || cron_expression
   end
 
   # Form-facing accessors splitting import_after into a checkbox plus

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -174,10 +174,7 @@ class Feed < ApplicationRecord
   # the underlying input shape. Driven by the profile's declared source key so
   # smuggled keys in the params jsonb can't disguise the real source.
   def source_input
-    return nil if params.blank?
-
-    key = FeedProfile.source_key_for(feed_profile_key) || "url"
-    params[key]
+    FeedProfile.source_input_for(feed_profile_key, params)
   end
 
   # Whether the user's source is a URL rather than a free-text prompt.
@@ -552,7 +549,7 @@ class Feed < ApplicationRecord
   def source_input_changed_in_place?
     return false unless params_changed?
 
-    key = FeedProfile.source_key_for(feed_profile_key) || "url"
+    key = FeedProfile.source_key_for(feed_profile_key)
     before, after = params_change
     before&.dig(key) != after&.dig(key)
   end

--- a/app/models/feed_identification/candidate.rb
+++ b/app/models/feed_identification/candidate.rb
@@ -1,6 +1,6 @@
 class FeedIdentification
   # Wraps a persisted detection candidate (a JSONB hash) so callers read intent
-  # (passed?/failed?/…) instead of indexing raw string keys.
+  # (failed?/unreachable?/…) instead of indexing raw string keys.
   class Candidate
     def initialize(attributes)
       @attributes = attributes
@@ -16,10 +16,6 @@ class FeedIdentification
 
     def posts_found
       @attributes["posts_found"].to_i
-    end
-
-    def passed?
-      test_status == "passed"
     end
 
     def failed?

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -26,15 +26,8 @@ class FeedPreview < ApplicationRecord
   # JSON-encode the parts before hashing so their boundaries are unambiguous:
   # otherwise ["ab", "c"] and ["a", "bc"] would hash alike.
   def self.digest_for(feed_profile_key, params, ai_credential_id = nil, ai_model = nil)
-    parts = [source_input(feed_profile_key, params), ai_credential_id, ai_model]
+    parts = [FeedProfile.source_input_for(feed_profile_key, params), ai_credential_id, ai_model]
     Digest::SHA256.hexdigest(parts.to_json)
-  end
-
-  # The user-facing source value for a profile, selected by its declared
-  # source key (url, prompt, …) — independent of input_shape.
-  def self.source_input(feed_profile_key, params)
-    key = FeedProfile.source_key_for(feed_profile_key) || "url"
-    (params || {})[key]
   end
 
   # Transitions to :failed only if still non-terminal. Rotating run_id makes the

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -518,6 +518,11 @@ class FeedProfile
       !!PROFILES.dig(key, :depends_on_ai)
     end
 
+    # @return [Array<String>] keys of the AI-backed profiles
+    def ai_profile_keys
+      PROFILES.keys.select { |key| depends_on_ai?(key) }
+    end
+
     # Returns the JSON Schema describing the feed's params hash
     # @param key [String] the profile key
     # @return [Hash, nil] the parameter schema (nil if profile not found)

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -533,10 +533,20 @@ class FeedProfile
     # The params key holding the feed's source input (e.g. "url", "prompt").
     # Derived from the profile's single required param, so the storage key is
     # independent of input_shape (which an `:any` profile can't double as).
+    # Unknown profiles fall back to "url".
     # @param key [String] the profile key
-    # @return [String, nil] the source params key, or nil if profile not found
+    # @return [String] the source params key
     def source_key_for(key)
-      PROFILES.dig(key, :parameter_schema, "required")&.first
+      PROFILES.dig(key, :parameter_schema, "required")&.first || "url"
+    end
+
+    # The user-facing source value stored in a params hash, read by the
+    # profile's source key.
+    # @param key [String] the profile key
+    # @param params [Hash, nil] a feed/preview params hash
+    # @return [String, nil] the source value
+    def source_input_for(key, params)
+      (params || {})[source_key_for(key)]
     end
 
     # @param key [String] the profile key

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -70,11 +70,5 @@ class LlmProvider
     def find(name)
       PROVIDERS.fetch(name.to_s)
     end
-
-    def exists?(name)
-      return false if name.nil?
-
-      PROVIDERS.key?(name.to_s)
-    end
   end
 end

--- a/app/services/feed_preview_workflow.rb
+++ b/app/services/feed_preview_workflow.rb
@@ -50,7 +50,9 @@ class FeedPreviewWorkflow
   end
 
   def load_feed_contents(temp_feed)
-    loader = temp_feed.loader_instance
+    # `purpose` reaches LlmUsage via the loader's call context, so AI spend
+    # from previews is distinguishable from scheduled runs.
+    loader = temp_feed.loader_instance(purpose: :preview)
     raw_data = loader.load
 
     record_stats(content_size: raw_data.size)

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -74,10 +74,9 @@ class FeedRefreshWorkflow
     processed_entries = feed.processor_instance(raw_data).process.entries
     record_stats(total_entries: processed_entries.size)
 
-    unidentified_count = processed_entries.count { |entry| entry.uid.blank? }
-    record_stats(unidentified_entries: unidentified_count) if unidentified_count.positive?
+    identified_entries, unidentified_entries = processed_entries.partition { |entry| entry.uid.present? }
+    record_stats(unidentified_entries: unidentified_entries.size) if unidentified_entries.any?
 
-    identified_entries = processed_entries.reject { |entry| entry.uid.blank? }
     @digest_period = digest_period_for(identified_entries)
     identified_entries
   end

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -97,14 +97,11 @@ module LlmCapabilityProbe
 
       def ruby_llm_provider = :anthropic
 
-      # Production shape: LlmClient::Adapter::Anthropic#web_params.
-      def web_params(_model)
-        {
-          tools: [
-            { type: "web_search_20260209", name: "web_search" },
-            { type: "web_fetch_20260209", name: "web_fetch", citations: { enabled: false } }
-          ]
-        }
+      # Delegated so the probe qualifies exactly what production sends; the
+      # search-only/fetch-only variants below stay probe-local (production has
+      # no such split).
+      def web_params(model)
+        LlmClient::Adapter::Anthropic.new.web_params(model)
       end
 
       def web_search_params(_model)

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -22,33 +22,11 @@ class LlmClient
   ProviderResponse = Data.define(:payload, :input_tokens, :output_tokens, :cache_write_tokens, :cache_read_tokens)
 
   class << self
-    def for(target, provider = nil)
-      credential = resolve_credential(target, provider)
+    def for(target)
+      credential = target.is_a?(AiCredential) ? target : target.ai_credential
       raise CredentialMissing, "no active credential found" if credential.nil?
 
       new(credential)
-    end
-
-    private
-
-    def resolve_credential(target, provider)
-      case target
-      when AiCredential
-        target
-      when Feed
-        target.ai_credential || default_credential_for(target.user, provider || LlmProvider.names.first)
-      when User
-        default_credential_for(target, provider)
-      end
-    end
-
-    def default_credential_for(user, provider)
-      return nil if provider.blank?
-
-      default = user.default_ai_credential
-      return default if default&.active? && default.provider == provider
-
-      user.ai_credentials.active.where(provider: provider).order(:id).first
     end
   end
 

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -179,16 +179,7 @@ class LlmClient
     tokens = response || ProviderResponse.new(
       payload: nil, input_tokens: 0, output_tokens: 0, cache_write_tokens: 0, cache_read_tokens: 0
     )
-    cost = LlmClient::RateTable.cost_for(
-      provider: credential.provider,
-      model: ctx.model,
-      usage: LlmClient::RateTable::Usage.new(
-        input_tokens: tokens.input_tokens,
-        output_tokens: tokens.output_tokens,
-        cache_write_tokens: tokens.cache_write_tokens,
-        cache_read_tokens: tokens.cache_read_tokens
-      )
-    )
+    cost = LlmClient::RateTable.cost_for(provider: credential.provider, model: ctx.model, usage: tokens)
 
     LlmUsage.create!(
       user: credential.user,

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -134,8 +134,8 @@ class LlmClient
     )
     # System prompt is the privileged instruction channel; the user prompt sent
     # by #ask travels as a separate user-role message (spec §8).
-    chat.with_instructions(system) if system.present? && chat.respond_to?(:with_instructions)
-    chat.with_schema(output_schema) if output_schema.present? && chat.respond_to?(:with_schema)
+    chat.with_instructions(system) if system.present?
+    chat.with_schema(output_schema) if output_schema.present?
     adapter.apply_web(chat, model) if web
 
     response = chat.ask(prompt)

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -13,7 +13,7 @@ class LlmClient
       # (e.g. client-side tools).
       def apply_web(chat, model)
         params = web_params(model)
-        chat.with_params(**params) if params.present? && chat.respond_to?(:with_params)
+        chat.with_params(**params) if params.present?
       end
 
       # True when one web+schema call returns grounded, schema-valid JSON; false

--- a/app/services/llm_client/adapter/moonshot.rb
+++ b/app/services/llm_client/adapter/moonshot.rb
@@ -8,7 +8,7 @@ class LlmClient
       FENCE = /\A```[a-z]*\n?(.*?)\n?```\z/m
 
       def apply_web(chat, _model)
-        chat.with_tool(LlmClient::Tools::WebFetch) if chat.respond_to?(:with_tool)
+        chat.with_tool(LlmClient::Tools::WebFetch)
       end
 
       def unwrap_json(text)

--- a/app/services/llm_client/rate_table.rb
+++ b/app/services/llm_client/rate_table.rb
@@ -14,13 +14,6 @@ class LlmClient::RateTable
     :cache_read_per_million
   )
 
-  Usage = Data.define(
-    :input_tokens,
-    :output_tokens,
-    :cache_write_tokens,
-    :cache_read_tokens
-  )
-
   class << self
     def rate_for(provider:, model:)
       entry = table.dig(provider.to_s, model.to_s)
@@ -35,7 +28,8 @@ class LlmClient::RateTable
     end
 
     # Returns the cost of the call in integer cents to match
-    # LlmUsage#cost_estimate_cents. An unknown model returns 0.
+    # LlmUsage#cost_estimate_cents. An unknown model returns 0. `usage` is
+    # anything with the four token-count readers (e.g. a ProviderResponse).
     def cost_for(provider:, model:, usage:)
       rate = rate_for(provider: provider, model: model)
       return 0 unless rate

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -21,9 +21,7 @@ module Loader
 
       raise StandardError, "LlmLoader payload missing 'items' array" unless payload.is_a?(Hash) && payload["items"].is_a?(Array)
 
-      items = payload["items"]
-      limit = options[:limit]
-      limit ? items.first(limit) : items
+      payload["items"]
     end
 
     private

--- a/app/services/normalizer/llm_normalizer.rb
+++ b/app/services/normalizer/llm_normalizer.rb
@@ -1,15 +1,8 @@
 module Normalizer
-  # Normalizer for AI-backed profiles. Two modes, selected by the
-  # profile's normalizer config:
-  #
-  # * Passthrough (no `prompt_template`): the raw_data already has all
-  #   universal-post fields; map them straight onto Post. Used by the `llm`
-  #   profile, where the AI work happens at the loader stage.
-  #
-  # * LLM rewrite (`prompt_template` present in config): runs raw_data
-  #   through `LlmClient` so a second prompt can clean up / translate /
-  #   summarise the content before it lands in Post. Reserved for future
-  #   rewrite profiles; the current `llm` profile doesn't use this branch.
+  # Normalizer for the AI extraction profile. The AI work happens at the
+  # loader stage, so raw_data already carries the universal-post fields
+  # (FeedProfile::UNIVERSAL_OUTPUT_SCHEMA); this maps them straight onto
+  # Post. No LLM call happens here.
   class LlmNormalizer < Base
     private
 
@@ -30,30 +23,19 @@ module Normalizer
       truncate_text(raw_data["body"].to_s)
     end
 
-    # Model-emitted image URLs are fetched server-side at publish time, so a
-    # bad one is a §8 SSRF/local-file risk. Keep only public http(s) URLs and
-    # drop the rest (drop the attachment, never the post).
+    # Base#attachment_urls filters non-public URLs at the choke point (§8).
     def normalize_attachment_urls
-      Array(raw_data["images"]).map(&:to_s).select { |url| PublicUrl.safe?(url) }
+      Array(raw_data["images"]).map(&:to_s)
     end
 
     def normalize_comments
       Array(raw_data["supplementary"]).map(&:to_s)
     end
 
-    def normalize_published_at(value)
-      return value if value.is_a?(Time) || value.is_a?(ActiveSupport::TimeWithZone)
-      return Time.current if value.blank?
-
-      Time.parse(value.to_s)
-    rescue ArgumentError
-      Time.current
-    end
-
     def validate_content
       errors = []
-      errors << "missing source_url" if normalize_source_url.blank? && !digest?
-      errors << "missing content" if normalize_content.blank?
+      errors << "missing source_url" if source_url.blank? && !digest?
+      errors << "missing content" if content.blank?
       errors.concat(images_only_errors)
       errors
     end

--- a/app/services/processor/passthrough_processor.rb
+++ b/app/services/processor/passthrough_processor.rb
@@ -8,6 +8,7 @@ module Processor
       entries = items.filter_map do |item|
         next unless item.is_a?(Hash)
 
+        item = item.deep_stringify_keys
         FeedEntry.new(
           feed: feed,
           # A digest item (source_url: null) gets a period uid; a feed-style
@@ -17,9 +18,9 @@ module Processor
           uid: Uid::Resolver.call(item, clock: Time.current),
           # AI-extracted items rarely come with a reliable published_at;
           # fall back to the current time so downstream invariants hold.
-          published_at: parse_time(item["published_at"] || item[:published_at]) || Time.current,
+          published_at: parse_time(item["published_at"]) || Time.current,
           status: :pending,
-          raw_data: item.deep_stringify_keys
+          raw_data: item
         )
       end
       Result.new(entries: entries, recognized: true)

--- a/app/services/uid/resolver.rb
+++ b/app/services/uid/resolver.rb
@@ -53,7 +53,7 @@ module Uid
     end
 
     def initialize(item, clock)
-      @item = item.is_a?(Hash) ? item : {}
+      @item = item.is_a?(Hash) ? item.transform_keys(&:to_s) : {}
       @clock = clock
     end
 
@@ -72,17 +72,11 @@ module Uid
     # missing key is malformed and an empty/unusable string is dropped — neither
     # is reinterpreted as a digest (spec §3's "unusable ≠ null").
     def digest?
-      return false unless item.key?("source_url") || item.key?(:source_url)
-
-      source_url_value.nil?
-    end
-
-    def source_url_value
-      item.key?("source_url") ? item["source_url"] : item[:source_url]
+      item.key?("source_url") && item["source_url"].nil?
     end
 
     def deep_link
-      raw = (item["source_url"] || item[:source_url]).to_s.strip
+      raw = item["source_url"].to_s.strip
       return if raw.empty?
 
       uri = parse_http(raw)

--- a/app/views/feed_previews/show.html.erb
+++ b/app/views/feed_previews/show.html.erb
@@ -21,14 +21,7 @@
         polling_max_polls_value: preview_max_polls
       }) do %>
     <div id="feed-preview-body" data-polling-target="content">
-      <% case preview.status %>
-      <% when "ready" %>
-        <%= render "feed_previews/ready", preview: preview %>
-      <% when "failed" %>
-        <%= render "feed_previews/failed", preview: preview %>
-      <% else %>
-        <%= render "feed_previews/processing", preview: preview %>
-      <% end %>
+      <%= render(**state_partial(preview)) %>
     </div>
     <div data-polling-target="timeoutMessage" hidden>
       <div class="rounded-lg border border-danger-subtle bg-danger-subtle px-4 py-3 text-danger-strong space-y-3"

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (edit_mode: false, feed: @feed, candidates: [], source_changed: false, profile_changed: false) %>
+<%# locals: (edit_mode: false, feed:, candidates: [], source_changed: false, profile_changed: false) %>
 <% active_tokens = Current.user.access_tokens.active.order(:host) %>
 <%# The chooser is a real choice only with two or more working candidates; one
     working candidate is shown as a read-only annotation (spec §7). In edit mode

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -7,9 +7,9 @@
 <%
   preview_source_keys =
     if show_chooser
-      candidates.to_h { |c| [c["profile_key"], FeedProfile.source_key_for(c["profile_key"]) || "url"] }
+      candidates.to_h { |c| [c["profile_key"], FeedProfile.source_key_for(c["profile_key"])] }
     else
-      { feed.feed_profile_key => (FeedProfile.source_key_for(feed.feed_profile_key) || "url") }
+      { feed.feed_profile_key => FeedProfile.source_key_for(feed.feed_profile_key) }
     end
 %>
 

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -23,7 +23,7 @@
      data-preview-button-endpoint-value="<%= feed_preview_path %>"
      data-preview-button-source-value="<%= feed.source_input %>"
      data-preview-button-source-keys-value="<%= preview_source_keys.to_json %>"
-     data-preview-button-ai-profiles-value="<%= FeedProfile.all.select { |key| FeedProfile.depends_on_ai?(key) }.to_json %>"
+     data-preview-button-ai-profiles-value="<%= FeedProfile.ai_profile_keys.to_json %>"
      data-preview-button-modal-id-value="feed-preview-modal">
   <%= form_with model: feed,
                 url: (edit_mode ? feed_path(feed) : feeds_path),

--- a/app/views/feeds/_identification_error.html.erb
+++ b/app/views/feeds/_identification_error.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (url:, error:, heading:, feed_id: nil, cancel_path: nil, edit_mode: false) %>
 <div id="feed-form"
      data-identification-state="error"
      class="rounded-lg border border-border bg-surface px-6 py-8 shadow-sm space-y-6">
@@ -7,7 +8,7 @@
         <%= icon("triangle-alert", css_class: "size-5 text-danger") %>
       </div>
       <div class="ml-3">
-        <h3 class="text-sm font-medium text-danger-strong"><%= local_assigns.fetch(:heading, "Feed identification failed") %></h3>
+        <h3 class="text-sm font-medium text-danger-strong"><%= heading %></h3>
         <div class="mt-2 text-sm text-danger-strong">
           <p><%= error %></p>
         </div>
@@ -16,8 +17,8 @@
   </div>
 
   <%= form_with url: feed_identifications_path, method: :post, class: "space-y-4" do |f| %>
-    <% if local_assigns[:feed_id].present? %>
-      <%= hidden_field_tag :feed_id, local_assigns[:feed_id] %>
+    <% if feed_id.present? %>
+      <%= hidden_field_tag :feed_id, feed_id %>
     <% end %>
     <div class="space-y-2">
       <%= f.label :url, "Source link", class: "block font-semibold text-heading" %>
@@ -29,7 +30,7 @@
 
   <%# Editing a deterministic feed keeps the engine fixed (spec §4), so the AI
       bridge is offered only in the creation flow. %>
-  <% unless local_assigns.fetch(:edit_mode, false) %>
+  <% unless edit_mode %>
     <div class="space-y-2" data-key="identification.ai-bridge">
       <%= button_to "Follow with AI instead", feed_identifications_path,
                     params: { prompt: url },
@@ -38,5 +39,5 @@
     </div>
   <% end %>
 
-  <%= link_to "Cancel", local_assigns.fetch(:cancel_path, feeds_path), class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
+  <%= link_to "Cancel", cancel_path || feeds_path, class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
 </div>

--- a/app/views/feeds/_identification_loading.html.erb
+++ b/app/views/feeds/_identification_loading.html.erb
@@ -1,5 +1,4 @@
 <%# locals: (url:, feed_id: nil, cancel_path: nil, edit_mode: false) %>
-<% feed_id = local_assigns.fetch(:feed_id, nil) %>
 <%# Polling marks its host aria-busy while checking, and the global
     [aria-busy="true"] rule makes that subtree non-interactive. This card holds
     the Cancel button, so opt out of the busy state to keep it clickable. %>
@@ -19,10 +18,10 @@
     <p class="font-semibold text-heading">Checking this feed…</p>
     <p class="text-body">This usually takes a few seconds.</p>
   </div>
-  <% if local_assigns.fetch(:edit_mode, false) %>
+  <% if edit_mode %>
     <%# Editing keeps the current source live until a new one is confirmed, so
         Cancel just returns to the feed rather than tearing down the entry flow. %>
-    <%= link_to "Cancel", local_assigns.fetch(:cancel_path, feeds_path),
+    <%= link_to "Cancel", cancel_path || feeds_path,
                 data: { turbo_frame: "_top", key: "loading.cancel" },
                 class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-body shadow-sm transition hover:bg-surface-muted cursor-pointer" %>
   <% else %>

--- a/app/views/feeds/_identification_retry.html.erb
+++ b/app/views/feeds/_identification_retry.html.erb
@@ -1,6 +1,4 @@
 <%# locals: (url: nil, feed_id: nil, cancel_path: nil, edit_mode: false) %>
-<% feed_id = local_assigns.fetch(:feed_id, nil) %>
-<% edit_mode = local_assigns.fetch(:edit_mode, false) %>
 <%# The transient "couldn't reach" state (spec §7): retrying is the primary
     path, with the AI bridge as a secondary escape so it can't dead-end. Marked
     as an identification state so polling stops here. %>
@@ -35,5 +33,5 @@
     <% end %>
   </div>
 
-  <%= link_to "Cancel", local_assigns.fetch(:cancel_path, feeds_path), class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
+  <%= link_to "Cancel", cancel_path || feeds_path, class: "inline-block text-sm font-medium text-muted transition hover:text-body", data: { key: "identification.cancel" } %>
 </div>

--- a/lib/http_client/faraday_adapter.rb
+++ b/lib/http_client/faraday_adapter.rb
@@ -35,10 +35,10 @@ module HttpClient
     private
 
     def perform_request(method, url, body: nil, headers: {}, options: {})
-      validate_url = options.fetch(:validate_url, self.options[:validate_url])
-      ensure_public_url!(url, validate_url) if validate_url
+      opts = self.options.merge(options)
+      ensure_public_url!(url, opts[:validate_url]) if opts[:validate_url]
 
-      connection = build_connection(options)
+      connection = build_connection(opts)
 
       response = connection.send(method) do |request|
         request.url url
@@ -61,20 +61,18 @@ module HttpClient
       raise Error, "HTTP error: #{e.message}"
     end
 
-    def build_connection(request_options)
-      timeout = request_options.fetch(:timeout, options[:timeout])
-      follow_redirects = request_options.fetch(:follow_redirects, options[:follow_redirects])
-      max_redirects = request_options.fetch(:max_redirects, options[:max_redirects])
-      validate_url = request_options.fetch(:validate_url, options[:validate_url])
-
+    # `opts` is the merged instance + per-request options from perform_request,
+    # so the initial-URL check and the redirect guard read the same
+    # validate_url — the two halves of the SSRF defense can't diverge.
+    def build_connection(opts)
       Faraday.new do |config|
         config.request :multipart
-        config.options.timeout = timeout
-        config.options.open_timeout = timeout
+        config.options.timeout = opts[:timeout]
+        config.options.open_timeout = opts[:timeout]
 
-        if follow_redirects
-          redirect_options = { limit: max_redirects }
-          redirect_options[:callback] = redirect_guard(validate_url) if validate_url
+        if opts[:follow_redirects]
+          redirect_options = { limit: opts[:max_redirects] }
+          redirect_options[:callback] = redirect_guard(opts[:validate_url]) if opts[:validate_url]
           config.response :follow_redirects, **redirect_options
         end
 

--- a/test/models/feed_identification/candidate_test.rb
+++ b/test/models/feed_identification/candidate_test.rb
@@ -18,7 +18,6 @@ class FeedIdentification::CandidateTest < ActiveSupport::TestCase
   end
 
   test "status predicates should reflect test_status" do
-    assert candidate("test_status" => "passed").passed?
     assert candidate("test_status" => "failed").failed?
     assert candidate("test_status" => "unreachable").unreachable?
   end
@@ -33,7 +32,6 @@ class FeedIdentification::CandidateTest < ActiveSupport::TestCase
   test "status predicates should be false when no verdict is present" do
     subject = candidate({})
 
-    assert_not subject.passed?
     assert_not subject.failed?
     assert_not subject.unreachable?
   end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -620,18 +620,6 @@ class FeedTest < ActiveSupport::TestCase
     assert_nil feed.cron_expression
   end
 
-  test "#schedule_display should return display name for standard interval" do
-    feed = build(:feed, cron_expression: "0 * * * *")
-
-    assert_equal "1 hour", feed.schedule_display
-  end
-
-  test "#schedule_display should return cron expression for non-standard interval" do
-    feed = build(:feed, cron_expression: "15 3 * * *")
-
-    assert_equal "15 3 * * *", feed.schedule_display
-  end
-
   # Preview is optional and does not gate enabling.
   def preview_user
     @preview_user ||= create(:user)

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -12,18 +12,6 @@ class LlmProviderTest < ActiveSupport::TestCase
     assert_includes LlmProvider.names, "openrouter"
   end
 
-  test "#exists? should return true for registered providers" do
-    assert LlmProvider.exists?("anthropic")
-    assert LlmProvider.exists?(:anthropic)
-    assert LlmProvider.exists?("openrouter")
-    assert LlmProvider.exists?(:openrouter)
-  end
-
-  test "#exists? should return false for unknown providers" do
-    refute LlmProvider.exists?("does-not-exist")
-    refute LlmProvider.exists?(nil)
-  end
-
   test "#find should return the anthropic provider instance" do
     provider = LlmProvider.find("anthropic")
     assert_kind_of LlmProvider, provider

--- a/test/services/feed_preview_workflow_test.rb
+++ b/test/services/feed_preview_workflow_test.rb
@@ -65,6 +65,21 @@ class FeedPreviewWorkflowTest < ActiveSupport::TestCase
     assert_respond_to workflow, :execute
   end
 
+  test "#load_feed_contents should run the loader with the preview purpose" do
+    captured = nil
+    loader = Object.new
+    loader.define_singleton_method(:load) { [] }
+    temp_feed = Object.new
+    temp_feed.define_singleton_method(:loader_instance) do |options = {}|
+      captured = options
+      loader
+    end
+
+    workflow.send(:load_feed_contents, temp_feed)
+
+    assert_equal({ purpose: :preview }, captured)
+  end
+
   test ".const_get should expose PREVIEW_POSTS_LIMIT constant" do
     assert_equal 10, FeedPreview::PREVIEW_POSTS_LIMIT
   end

--- a/test/services/llm_client/rate_table_test.rb
+++ b/test/services/llm_client/rate_table_test.rb
@@ -5,7 +5,8 @@ class LlmClient::RateTableTest < ActiveSupport::TestCase
   teardown { LlmClient::RateTable.reload! }
 
   def usage(input: 0, output: 0, cache_write: 0, cache_read: 0)
-    LlmClient::RateTable::Usage.new(
+    LlmClient::ProviderResponse.new(
+      payload: nil,
       input_tokens: input,
       output_tokens: output,
       cache_write_tokens: cache_write,

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -65,20 +65,11 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal credential, client.credential
   end
 
-  test ".for should resolve a user+provider to the active default credential" do
-    create(:ai_credential, :active, user: user)
-    default = create(:ai_credential, :active, :default, user: user)
-
-    client = LlmClient.for(user, "anthropic")
-
-    assert_equal default, client.credential
-  end
-
-  test ".for should raise CredentialMissing when no active credential exists" do
-    create(:ai_credential, :inactive, user: user)
+  test ".for should raise CredentialMissing for a feed without a credential" do
+    orphan = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/feed.xml" })
 
     assert_raises(LlmClient::CredentialMissing) do
-      LlmClient.for(user, "anthropic")
+      LlmClient.for(orphan)
     end
   end
 

--- a/test/services/loader/llm_loader_test.rb
+++ b/test/services/loader/llm_loader_test.rb
@@ -45,7 +45,7 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
       end
 
       def call(ctx, **opts)
-        @calls << opts.merge(model: ctx.model)
+        @calls << opts.merge(model: ctx.model, purpose: ctx.purpose)
         payload = opts[:output_schema] ? @structured : @gathered
         LlmClient::Result.new(payload: payload, usage_id: @calls.size)
       end
@@ -124,6 +124,20 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
 
     assert_equal [], result
     assert_equal 1, client.calls.size, "structure call must be skipped on an empty gather"
+  end
+
+  test "#load should carry the purpose option onto the call context" do
+    client = fake_client(structured: { "items" => [] })
+    Loader::LlmLoader.new(feed, llm_client: client, purpose: :preview).load
+
+    assert_equal [:preview], client.calls.map { |c| c[:purpose] }
+  end
+
+  test "#load should default the call purpose to scheduled_run" do
+    client = fake_client(structured: { "items" => [] })
+    Loader::LlmLoader.new(feed, llm_client: client).load
+
+    assert_equal [:scheduled_run], client.calls.map { |c| c[:purpose] }
   end
 
   test "#load should raise when the structured payload is missing the items key" do

--- a/test/services/loader/llm_loader_test.rb
+++ b/test/services/loader/llm_loader_test.rb
@@ -126,13 +126,6 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
     assert_equal 1, client.calls.size, "structure call must be skipped on an empty gather"
   end
 
-  test "#load should respect the limit option" do
-    items = (1..10).map { |i| { "title" => "Post #{i}", "source_url" => "https://example.com/#{i}" } }
-    loader = Loader::LlmLoader.new(feed, llm_client: fake_client(structured: { "items" => items }), limit: 3)
-
-    assert_equal 3, loader.load.size
-  end
-
   test "#load should raise when the structured payload is missing the items key" do
     loader = Loader::LlmLoader.new(feed, llm_client: fake_client(structured: { "wrong" => "shape" }))
 

--- a/test/services/normalizer/llm_normalizer_test.rb
+++ b/test/services/normalizer/llm_normalizer_test.rb
@@ -89,6 +89,15 @@ class Normalizer::LlmNormalizerTest < ActiveSupport::TestCase
     assert_includes post.validation_errors, "no_images"
   end
 
+  test "#normalize should clamp a future published_at to now" do
+    entry = feed_entry
+    entry.published_at = 2.days.from_now
+
+    post = Normalizer::LlmNormalizer.new(entry).normalize
+
+    assert_operator post.published_at, :<=, Time.current
+  end
+
   test "#normalize should keep only public http(s) attachment URLs" do
     images = [
       "https://cdn.example.com/ok.png",   # public — kept


### PR DESCRIPTION
Changes:

- Remove dead code the spec-005 work left behind: `LlmClient.for`'s unused user+provider resolution and default-credential fallback, `LlmLoader`'s `limit` option, `AiCredential.for_provider`, `LlmProvider.exists?`, `Candidate#passed?`, `Feed#schedule_display`, and the `FEED_CRON_TIMEZONE` constant.
- Cut duplication: one `feed_form_stream` helper for the six turbo-stream responses in the identifications controller, a shared `setup_gate_path` for the create/update credential-token detours, `FeedProfile.source_key_for`/`source_input_for` as the single source-lookup (the `|| "url"` fallback lived at all seven call sites), `FeedProfile.ai_profile_keys`, one polling-deadline formula, and one preview status→partial mapping.
- Drop non-practical generality: `LlmNormalizer`'s comment described an LLM-rewrite mode that never existed, its `PublicUrl` filter duplicated the Base choke point, and its `normalize_published_at` override only ever received an AR datetime — deleting it also restores the future-date clamp every other profile gets. `Uid::Resolver` and `PassthroughProcessor` now stringify item keys once instead of dual string/symbol lookups in four places.
- Make a few things honest rather than smaller: the inert `respond_to?` guards on RubyLLM chat methods would silently drop the system prompt or schema on interface drift; the capability probe now delegates its Anthropic web params to the production adapter instead of a hand-synced copy; previews now record `purpose: preview` on `LlmUsage` (the enum value previously had no writer).

Net −158 lines across 38 files. Every commit is atomic and green (2951 tests, RuboCop, herb).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Nt593x51C7hzTnY3FMuCP)_