### PR TITLE
Hide empty Recent Activity and Recent Posts sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-09
 
 - Feed pages are less cluttered: the Recent Activity and Recent Posts sections only appear once there's something to show.
+- A feed that hasn't refreshed yet shows a dash in its stats instead of "Never".
 
 ## 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-09
+
+- Feed pages are less cluttered: the Recent Activity and Recent Posts sections only appear once there's something to show.
+
 ## 2026-07-08
 
 - Long source URLs and UIDs on post pages no longer spill outside the page — they're neatly cropped with an ellipsis, and hovering a cropped UID shows the full value.

--- a/app/components/feed_stats_component.rb
+++ b/app/components/feed_stats_component.rb
@@ -80,7 +80,7 @@ class FeedStatsComponent < ViewComponent::Base
   end
 
   def last_refresh_value
-    last_refreshed_at ? helpers.short_time_ago_tag(last_refreshed_at) : "Never"
+    last_refreshed_at ? helpers.short_time_ago_tag(last_refreshed_at) : "–"
   end
 
   def most_recent_repost_value

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -16,30 +16,26 @@
     </section>
   <% end %>
 
-  <section class="space-y-4">
-    <div class="flex items-center justify-between">
-      <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
-      <% if @recent_events.any? %>
+  <% if @recent_events.any? %>
+    <section class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
         <%= link_to "View all", events_path(filter: { subject_type: "Feed", subject_id: @feed.id }), class: "text-sm font-semibold text-brand hover:text-brand-hover", data: { key: "feed.events.view_all" } %>
-      <% end %>
-    </div>
-    <%= render EventsListComponent.new(events: @recent_events) %>
-  </section>
+      </div>
+      <%= render EventsListComponent.new(events: @recent_events) %>
+    </section>
+  <% end %>
 
-  <section class="space-y-4">
-    <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-      <h2 class="text-2xl font-semibold mb-0 text-heading">Recent Posts</h2>
-      <% if @recent_posts.any? %>
+  <% if @recent_posts.any? %>
+    <section class="space-y-4">
+      <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <h2 class="text-2xl font-semibold mb-0 text-heading">Recent Posts</h2>
         <%= link_to "View all posts", posts_path(feed_id: @feed.id), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover text-sm" %>
-      <% end %>
-    </div>
+      </div>
 
-    <% if @recent_posts.any? %>
       <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false) %>
-    <% else %>
-      <%= render EmptyStateComponent.new("No posts imported yet from this feed") %>
-    <% end %>
-  </section>
+    </section>
+  <% end %>
 </div>
 
 <% if @feed.target_group.present? %>

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -73,7 +73,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     result = render_inline(FeedStatsComponent.new(feed: feed_without_data))
 
     last_refresh_value = result.css('[data-key="stats.last_refresh.value"]').first.text
-    assert_equal "Never", last_refresh_value
+    assert_equal "–", last_refresh_value
 
     most_recent_value = result.css('[data-key="stats.most_recent_repost.value"]').first.text
     assert_equal "–", most_recent_value

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -551,6 +551,34 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='events.error_count']", text: "(10 failures in a row)"
   end
 
+  test "#show should not render recent activity section when feed has no events" do
+    sign_in_as(user)
+
+    get feed_url(feed)
+
+    assert_response :success
+    assert_select "h2", text: "Recent Activity", count: 0
+  end
+
+  test "#show should render a recent posts section with the feed's posts" do
+    create(:post, feed: feed)
+    sign_in_as(user)
+
+    get feed_url(feed)
+
+    assert_response :success
+    assert_select "h2", text: "Recent Posts", count: 1
+  end
+
+  test "#show should not render recent posts section when feed has no posts" do
+    sign_in_as(user)
+
+    get feed_url(feed)
+
+    assert_response :success
+    assert_select "h2", text: "Recent Posts", count: 0
+  end
+
   test "#show should return not found for other user's feed" do
     sign_in_as(user)
     get feed_url(other_feed)


### PR DESCRIPTION
Changes:

- Recent Activity section only renders when the feed has events
- Recent Posts section only renders when the feed has posts
- Feed stats now show "–" instead of "Never" for feeds that haven't refreshed yet
- Added tests to verify sections are hidden when empty

The feed page is now less cluttered by hiding sections that have no content to display. This improves the visual hierarchy and focuses attention on relevant information.