### PR TITLE
Consolidate badge styling with semantic color tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-09
+
+- Status badges now share one consistent look everywhere — softer colors with a subtle outline, the same style on feed, post, and admin pages.
+
 ## 2026-07-08
 
 - Long source URLs and UIDs on post pages no longer spill outside the page — they're neatly cropped with an ellipsis, and hovering a cropped UID shows the full value.

--- a/app/components/admin/user_details_component.rb
+++ b/app/components/admin/user_details_component.rb
@@ -1,8 +1,8 @@
 class Admin::UserDetailsComponent < ViewComponent::Base
   STATUS_BADGES = {
-    "inactive" => { label: "Pending confirmation", classes: "bg-warning-subtle text-warning-strong ring-warning/20" },
-    "active" => { label: "Active", classes: "bg-success-subtle text-success-strong ring-success/20" },
-    "suspended" => { label: "Suspended", classes: "bg-danger-subtle text-danger-strong ring-danger/20" }
+    "inactive" => { label: "Pending confirmation", color: :warning },
+    "active" => { label: "Active", color: :success },
+    "suspended" => { label: "Suspended", color: :danger }
   }.freeze
 
   def initialize(user:, stats:)
@@ -29,12 +29,8 @@ class Admin::UserDetailsComponent < ViewComponent::Base
   end
 
   def status_badge
-    badge = STATUS_BADGES.fetch(@user.state) { { label: @user.state.humanize, classes: "bg-surface-muted text-heading ring-muted/20" } }
-    helpers.tag.span(
-      badge[:label],
-      class: "inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset #{badge[:classes]}",
-      data: { key: "user_details.status" }
-    )
+    badge = STATUS_BADGES.fetch(@user.state) { { label: @user.state.humanize, color: :neutral } }
+    render(BadgeComponent.new(text: badge[:label], color: badge[:color], key: "user_details.status"))
   end
 
   def permissions_value

--- a/app/components/admin/user_email_status_component.rb
+++ b/app/components/admin/user_email_status_component.rb
@@ -22,7 +22,7 @@ class Admin::UserEmailStatusComponent < ViewComponent::Base
   end
 
   def status_badge
-    helpers.tag.span("Deactivated", class: "inline-flex items-center rounded-md bg-warning-subtle px-2 py-1 text-xs font-medium text-warning-strong ring-1 ring-inset ring-warning/20")
+    render(BadgeComponent.new(text: "Deactivated", color: :warning))
   end
 
   def time_value(time)

--- a/app/components/ai_credential_list_item_component.rb
+++ b/app/components/ai_credential_list_item_component.rb
@@ -47,7 +47,7 @@ class AiCredentialListItemComponent < ListItemComponent
   def default_badge
     return unless credential.default?
 
-    render(BadgeComponent.new(text: "Default", color: :blue, key: "ai_credential.default-badge"))
+    render(BadgeComponent.new(text: "Default", color: :info, key: "ai_credential.default-badge"))
   end
 
   def secondary_element

--- a/app/components/badge_component.rb
+++ b/app/components/badge_component.rb
@@ -1,17 +1,13 @@
 class BadgeComponent < ViewComponent::Base
   COLOR_CLASSES = {
-    blue: "bg-blue-100 text-blue-800",
-    gray: "bg-gray-100 text-gray-800",
-    red: "bg-red-100 text-red-800",
-    green: "bg-green-100 text-green-800",
-    yellow: "bg-yellow-100 text-yellow-800",
-    orange: "bg-orange-100 text-orange-800",
-    indigo: "bg-indigo-100 text-indigo-800",
-    purple: "bg-purple-100 text-purple-800",
-    pink: "bg-pink-100 text-pink-800"
+    neutral: "bg-surface-muted text-heading ring-muted/20",
+    info: "bg-brand-subtle text-brand-strong ring-brand/20",
+    success: "bg-success-subtle text-success-strong ring-success/20",
+    warning: "bg-warning-subtle text-warning-strong ring-warning/20",
+    danger: "bg-danger-subtle text-danger-strong ring-danger/20"
   }.freeze
 
-  def initialize(text:, color: :blue, key: nil)
+  def initialize(text:, color: :neutral, key: nil)
     @text = text
     @color = color
     @key = key
@@ -25,8 +21,8 @@ class BadgeComponent < ViewComponent::Base
 
   def badge_classes
     [
-      "text-xs font-medium px-2.5 py-0.5 rounded",
-      COLOR_CLASSES[@color] || COLOR_CLASSES[:blue]
+      "inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset",
+      COLOR_CLASSES[@color] || COLOR_CLASSES[:neutral]
     ].join(" ")
   end
 

--- a/app/components/candidate_option_component.html.erb
+++ b/app/components/candidate_option_component.html.erb
@@ -5,10 +5,10 @@
     <span class="flex flex-wrap items-center gap-2">
       <span class="font-semibold text-heading"><%= display_name %></span>
       <% if badge_text %>
-        <%= render BadgeComponent.new(text: badge_text, color: :green, key: "candidate.#{profile_key}.status") %>
+        <%= render BadgeComponent.new(text: badge_text, color: :success, key: "candidate.#{profile_key}.status") %>
       <% end %>
       <% if selected? %>
-        <%= render BadgeComponent.new(text: "Suggested", color: :blue, key: "candidate.suggested-badge") %>
+        <%= render BadgeComponent.new(text: "Suggested", color: :info, key: "candidate.suggested-badge") %>
       <% end %>
     </span>
     <span class="text-body text-sm"><%= description %></span>

--- a/app/components/event_details_component.rb
+++ b/app/components/event_details_component.rb
@@ -78,7 +78,7 @@ class EventDetailsComponent < ViewComponent::Base
 
   def expires_status_badge
     if @event.expired?
-      helpers.tag.span("Expired", class: "inline-flex items-center rounded-md bg-danger-subtle px-2 py-1 text-xs font-medium text-danger-strong ring-1 ring-inset ring-danger/20")
+      render(BadgeComponent.new(text: "Expired", color: :danger))
     else
       helpers.tag.span("(in #{helpers.short_time_ago(@event.expires_at)})", class: "text-muted")
     end

--- a/app/components/post_list_item_component.rb
+++ b/app/components/post_list_item_component.rb
@@ -49,7 +49,7 @@ class PostListItemComponent < ListItemComponent
   end
 
   def withdrawn_badge
-    render(BadgeComponent.new(text: "Withdrawn", color: :gray)) if withdrawn?
+    render(BadgeComponent.new(text: "Withdrawn", color: :neutral)) if withdrawn?
   end
 
   # The status sits leftmost and is always present, so every following item

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,21 +1,4 @@
 module EventsHelper
-  LEVEL_BADGES = {
-    "debug" => { class: "badge bg-secondary", char: "D" },
-    "info" => { class: "badge bg-primary", char: "I" },
-    "warning" => { class: "badge bg-warning", char: "W" },
-    "error" => { class: "badge bg-danger", char: "E" }
-  }.freeze
-
-  def level_badge(level)
-    badge = LEVEL_BADGES.fetch(level.to_s, LEVEL_BADGES["debug"])
-    content_tag(:span, badge[:char], class: "#{badge[:class]} font-monospace", title: level.humanize)
-  end
-
-  def level_badge_full(level)
-    badge = LEVEL_BADGES.fetch(level.to_s, LEVEL_BADGES["debug"])
-    content_tag(:span, level.humanize, class: badge[:class])
-  end
-
   # Explains where the current page sits in the log without leaning on page
   # numbers: the offset is how many newer events come before what's shown.
   def events_offset_summary(offset, system_wide: false)

--- a/app/helpers/feed_entry_helper.rb
+++ b/app/helpers/feed_entry_helper.rb
@@ -2,11 +2,11 @@ module FeedEntryHelper
   def feed_entry_status_badge_color(status)
     case status.to_s
     when "pending"
-      :blue
+      :info
     when "processed"
-      :green
+      :success
     else
-      :gray
+      :neutral
     end
   end
 end

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -37,9 +37,9 @@ module FeedHelper
 
   def feed_status_badge(feed)
     case feed.state.to_sym
-    when :draft    then BadgeComponent.new(text: "Draft", color: :gray, key: "feed.#{feed.id}.draft_badge")
-    when :disabled then BadgeComponent.new(text: "Disabled", color: :yellow, key: "feed.#{feed.id}.disabled_badge")
-    when :enabled  then BadgeComponent.new(text: "Enabled", color: :green, key: "feed.#{feed.id}.enabled_badge")
+    when :draft    then BadgeComponent.new(text: "Draft", color: :neutral, key: "feed.#{feed.id}.draft_badge")
+    when :disabled then BadgeComponent.new(text: "Disabled", color: :warning, key: "feed.#{feed.id}.disabled_badge")
+    when :enabled  then BadgeComponent.new(text: "Enabled", color: :success, key: "feed.#{feed.id}.enabled_badge")
     end
   end
 

--- a/app/helpers/job_runs_helper.rb
+++ b/app/helpers/job_runs_helper.rb
@@ -1,27 +1,27 @@
 module JobRunsHelper
   JOB_RUN_STATUS_COLORS = {
-    "queued" => :gray,
-    "running" => :blue,
-    "succeeded" => :green,
-    "failed" => :red
+    "queued" => :neutral,
+    "running" => :info,
+    "succeeded" => :success,
+    "failed" => :danger
   }.freeze
 
   def job_run_status_badge(run)
     render BadgeComponent.new(
       text: run.status,
-      color: JOB_RUN_STATUS_COLORS.fetch(run.status, :gray),
+      color: JOB_RUN_STATUS_COLORS.fetch(run.status, :neutral),
       key: "development.job_runs.#{run.id}.status"
     )
   end
 
   EVENT_LEVEL_COLORS = {
-    "debug" => :gray,
-    "info" => :blue,
-    "warning" => :orange,
-    "error" => :red
+    "debug" => :neutral,
+    "info" => :info,
+    "warning" => :warning,
+    "error" => :danger
   }.freeze
 
   def event_level_badge(event)
-    render BadgeComponent.new(text: event.level, color: EVENT_LEVEL_COLORS.fetch(event.level, :gray))
+    render BadgeComponent.new(text: event.level, color: EVENT_LEVEL_COLORS.fetch(event.level, :neutral))
   end
 end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -29,15 +29,15 @@ module PostHelper
   def post_status_badge_color(status)
     case status.to_s
     when "enqueued"
-      :blue
+      :info
     when "published"
-      :green
+      :success
     when "failed"
-      :red
+      :danger
     when "rejected"
-      :orange
+      :warning
     else
-      :gray
+      :neutral
     end
   end
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -27,7 +27,7 @@
                   <span class="text-muted">(admin)</span>
                 <% end %>
                 <% if user.email_deactivated? %>
-                  <span class="ml-2 inline-flex items-center rounded-md bg-warning-subtle px-2 py-1 text-xs font-medium text-warning-strong ring-1 ring-inset ring-warning/20">email bounced</span>
+                  <span class="ml-2"><%= render BadgeComponent.new(text: "email bounced", color: :warning) %></span>
                 <% end %>
               </td>
               <td class="px-6 py-4 whitespace-nowrap"><%= user.name %></td>

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -311,15 +311,11 @@
       <h2 class="border-b border-border pb-2 text-xl font-semibold text-heading">Badge</h2>
       <p class="text-body">Small status labels. Color carries meaning — green for healthy, red for problems, gray for neutral.</p>
       <div class="flex flex-wrap gap-2">
-        <%= render BadgeComponent.new(text: "Active", color: :green) %>
-        <%= render BadgeComponent.new(text: "Paused", color: :gray) %>
-        <%= render BadgeComponent.new(text: "Error", color: :red) %>
-        <%= render BadgeComponent.new(text: "Syncing", color: :blue) %>
-        <%= render BadgeComponent.new(text: "Pending", color: :yellow) %>
-        <%= render BadgeComponent.new(text: "Beta", color: :orange) %>
-        <%= render BadgeComponent.new(text: "Indigo", color: :indigo) %>
-        <%= render BadgeComponent.new(text: "Purple", color: :purple) %>
-        <%= render BadgeComponent.new(text: "Pink", color: :pink) %>
+        <%= render BadgeComponent.new(text: "Active", color: :success) %>
+        <%= render BadgeComponent.new(text: "Paused", color: :neutral) %>
+        <%= render BadgeComponent.new(text: "Error", color: :danger) %>
+        <%= render BadgeComponent.new(text: "Syncing", color: :info) %>
+        <%= render BadgeComponent.new(text: "Pending", color: :warning) %>
       </div>
     </section>
 

--- a/test/components/badge_component_test.rb
+++ b/test/components/badge_component_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+require "view_component/test_case"
+
+class BadgeComponentTest < ViewComponent::TestCase
+  test "#call should render text with badge styling" do
+    result = render_inline(BadgeComponent.new(text: "Enabled", color: :success))
+
+    badge = result.at_css("span")
+    assert_equal "Enabled", badge.text
+    assert_includes badge["class"], "ring-1 ring-inset"
+    assert_includes badge["class"], "bg-success-subtle"
+    assert_includes badge["class"], "text-success-strong"
+  end
+
+  test "#call should default to neutral color" do
+    result = render_inline(BadgeComponent.new(text: "Draft"))
+
+    assert_includes result.at_css("span")["class"], "bg-surface-muted"
+  end
+
+  test "#call should fall back to neutral for unknown color" do
+    result = render_inline(BadgeComponent.new(text: "Draft", color: :chartreuse))
+
+    assert_includes result.at_css("span")["class"], "bg-surface-muted"
+  end
+
+  test "#call should set data-key when key is given" do
+    result = render_inline(BadgeComponent.new(text: "Enabled", color: :success, key: "feed.1.enabled_badge"))
+
+    assert_not_nil result.at_css("[data-key='feed.1.enabled_badge']")
+  end
+
+  test "#call should omit data-key when key is missing" do
+    result = render_inline(BadgeComponent.new(text: "Enabled", color: :success))
+
+    assert_nil result.at_css("span")["data-key"]
+  end
+end

--- a/test/components/candidate_option_component_test.rb
+++ b/test/components/candidate_option_component_test.rb
@@ -17,7 +17,7 @@ class CandidateOptionComponentTest < ViewComponent::TestCase
 
     badge = result.at_css("[data-key='candidate.rss.status']")
     assert_equal "Tested · 3 posts", badge.text.strip
-    assert_includes badge["class"], "green"
+    assert_includes badge["class"], "bg-success-subtle"
   end
 
   test "#render should singularize a single post" do

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -3,68 +3,6 @@ require "test_helper"
 class EventsHelperTest < ActionView::TestCase
   include TimeHelper
 
-  test "#level_badge should return single character badge with correct styling" do
-    badge = level_badge("info")
-
-    assert_includes badge, "I"
-    assert_includes badge, "badge bg-primary"
-    assert_includes badge, "font-monospace"
-    assert_includes badge, 'title="Info"'
-  end
-
-  test "#level_badge should handle all level types" do
-    debug_badge = level_badge("debug")
-    info_badge = level_badge("info")
-    warning_badge = level_badge("warning")
-    error_badge = level_badge("error")
-
-    assert_includes debug_badge, "D"
-    assert_includes debug_badge, "bg-secondary"
-
-    assert_includes info_badge, "I"
-    assert_includes info_badge, "bg-primary"
-
-    assert_includes warning_badge, "W"
-    assert_includes warning_badge, "bg-warning"
-
-    assert_includes error_badge, "E"
-    assert_includes error_badge, "bg-danger"
-  end
-
-  test "#level_badge should fall back to debug for unknown level" do
-    badge = level_badge("unknown")
-
-    assert_includes badge, "D"
-    assert_includes badge, "bg-secondary"
-  end
-
-  test "#level_badge_full should return full word badge with correct styling" do
-    badge = level_badge_full("info")
-
-    assert_includes badge, "Info"
-    assert_includes badge, "badge bg-primary"
-    refute_includes badge, "font-monospace"
-  end
-
-  test "#level_badge_full should handle all level types" do
-    debug_badge = level_badge_full("debug")
-    info_badge = level_badge_full("info")
-    warning_badge = level_badge_full("warning")
-    error_badge = level_badge_full("error")
-
-    assert_includes debug_badge, "Debug"
-    assert_includes debug_badge, "bg-secondary"
-
-    assert_includes info_badge, "Info"
-    assert_includes info_badge, "bg-primary"
-
-    assert_includes warning_badge, "Warning"
-    assert_includes warning_badge, "bg-warning"
-
-    assert_includes error_badge, "Error"
-    assert_includes error_badge, "bg-danger"
-  end
-
   test "#format_event_duration should format seconds under a minute" do
     assert_equal "3.2s", format_event_duration(3.2)
     assert_equal "59.0s", format_event_duration(59.0)

--- a/test/helpers/feed_entry_helper_test.rb
+++ b/test/helpers/feed_entry_helper_test.rb
@@ -3,15 +3,15 @@ require "test_helper"
 class FeedEntryHelperTest < ActionView::TestCase
   include FeedEntryHelper
 
-  test "#feed_entry_status_badge_color should return blue for pending" do
-    assert_equal :blue, feed_entry_status_badge_color("pending")
+  test "#feed_entry_status_badge_color should return info for pending" do
+    assert_equal :info, feed_entry_status_badge_color("pending")
   end
 
-  test "#feed_entry_status_badge_color should return green for processed" do
-    assert_equal :green, feed_entry_status_badge_color("processed")
+  test "#feed_entry_status_badge_color should return success for processed" do
+    assert_equal :success, feed_entry_status_badge_color("processed")
   end
 
-  test "#feed_entry_status_badge_color should return gray for unknown status" do
-    assert_equal :gray, feed_entry_status_badge_color("unknown")
+  test "#feed_entry_status_badge_color should return neutral for unknown status" do
+    assert_equal :neutral, feed_entry_status_badge_color("unknown")
   end
 end

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -124,7 +124,7 @@ class FeedHelperTest < ActionView::TestCase
     result = feed_status_badge(feed)
 
     assert_equal "Enabled", result.instance_variable_get(:@text)
-    assert_equal :green, result.instance_variable_get(:@color)
+    assert_equal :success, result.instance_variable_get(:@color)
   end
 
   test "#feed_status_badge should render disabled badge for disabled feed" do
@@ -132,7 +132,7 @@ class FeedHelperTest < ActionView::TestCase
     result = feed_status_badge(feed)
 
     assert_equal "Disabled", result.instance_variable_get(:@text)
-    assert_equal :yellow, result.instance_variable_get(:@color)
+    assert_equal :warning, result.instance_variable_get(:@color)
   end
 
   test "#feed_status_badge should render draft badge for draft feed" do
@@ -140,7 +140,7 @@ class FeedHelperTest < ActionView::TestCase
     result = feed_status_badge(feed)
 
     assert_equal "Draft", result.instance_variable_get(:@text)
-    assert_equal :gray, result.instance_variable_get(:@color)
+    assert_equal :neutral, result.instance_variable_get(:@color)
   end
 
   test "#feed_actions_menu_items should list refresh, edit, purge, and delete for an enabled feed" do


### PR DESCRIPTION
Changes:

- Refactored `BadgeComponent` to use semantic color tokens (`:neutral`, `:info`, `:success`, `:warning`, `:danger`) instead of raw Tailwind palette shades
- Updated all badge color references across helpers and components to use the new semantic tokens
- Simplified badge styling with consistent `ring-1 ring-inset` outline and subtle background/text color pairs
- Removed obsolete `level_badge` and `level_badge_full` helper methods from `EventsHelper` (replaced by `BadgeComponent`)
- Replaced inline badge HTML with `BadgeComponent` calls in `Admin::UserDetailsComponent` and `Admin::UserEmailStatusComponent`
- Updated component showcase to demonstrate the five semantic badge colors
- Added comprehensive test coverage for `BadgeComponent` with the new color system

This consolidates badge styling across the application to use a single, consistent design system with semantic color tokens, making it easier to maintain and update badge appearance globally.
