### PR TITLE
Prevent clearing a feed's model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-09
 
+- Once you've picked a model for a feed, the "Select a model…" placeholder can't be chosen anymore — a feed can't be switched back to having no model.
 - Feed pages are less cluttered: the Recent Activity and Recent Posts sections only appear once there's something to show.
 - A feed that hasn't refreshed yet shows a dash in its stats instead of "Never".
 - Status badges now share one consistent look everywhere — softer colors with a subtle outline, the same style on feed, post, and admin pages.

--- a/app/components/feed_ai_settings_component.html.erb
+++ b/app/components/feed_ai_settings_component.html.erb
@@ -36,7 +36,7 @@
       <%= render PanelComponent.new do %>
         <div class="space-y-2">
           <%= form.label :ai_model, "Model", class: "block font-semibold text-heading" %>
-          <%= form.select :ai_model, model_options, { include_blank: "Select a model…" },
+          <%= form.select :ai_model, model_select_options, { selected: selected_model_id },
                           class: helpers.input_field_classes, disabled: !section_visible?,
                           data: { ai_settings_target: "modelSelect", key: "form.ai-model" } %>
           <% if form.object.errors[:ai_model].any? %>

--- a/app/components/feed_ai_settings_component.rb
+++ b/app/components/feed_ai_settings_component.rb
@@ -63,6 +63,17 @@ class FeedAiSettingsComponent < ViewComponent::Base
     (models_by_credential[selected_credential_id] || []).map { |model| [model["name"], model["id"]] }
   end
 
+  # The blank row is a placeholder, not a choice: disabled (and hidden from the
+  # open list) so a feed can't be reverted to "no model" once one is picked. It
+  # still shows as the current value while `selected_model_id` is blank.
+  def model_select_options
+    [["Select a model…", "", { disabled: true, hidden: true }]] + model_options
+  end
+
+  def selected_model_id
+    model_options.any? { |_name, id| id == @feed.ai_model } ? @feed.ai_model : ""
+  end
+
   # True when the feed's saved model can no longer be picked — it dropped out of
   # the matrix ∩ the credential's live snapshot — so the form should nudge the
   # user to re-pick before re-enabling.

--- a/app/javascript/controllers/ai_settings_controller.js
+++ b/app/javascript/controllers/ai_settings_controller.js
@@ -34,7 +34,9 @@ export default class extends Controller {
   }
 
   // Rebuild the model <select> from the chosen credential's models, keeping
-  // the current pick if it's still on offer.
+  // the current pick if it's still on offer. The placeholder is disabled so a
+  // pick can't be cleared by hand, but assigning value = "" below still
+  // selects it when the previous pick isn't offered by the new provider.
   refreshModels() {
     if (!this.hasModelSelectTarget || !this.hasCredentialSelectTarget) return
 
@@ -42,7 +44,7 @@ export default class extends Controller {
     const previous = this.modelSelectTarget.value
     const keep = models.some((model) => model.id === previous) ? previous : ""
 
-    const options = ['<option value="">Select a model…</option>']
+    const options = ['<option value="" disabled hidden>Select a model…</option>']
     models.forEach((model) => {
       options.push(`<option value="${this._escape(model.id)}">${this._escape(model.name)}</option>`)
     })

--- a/test/components/feed_ai_settings_component_test.rb
+++ b/test/components/feed_ai_settings_component_test.rb
@@ -91,6 +91,22 @@ class FeedAiSettingsComponentTest < ViewComponent::TestCase
     assert_equal credential.id.to_s, component(ai_feed(ai_credential: unverified_credential)).selected_credential_id
   end
 
+  test "#model_select_options should lead with a disabled hidden placeholder" do
+    options = component(ai_feed(ai_credential: credential)).model_select_options
+    assert_equal ["Select a model…", "", { disabled: true, hidden: true }], options.first
+    assert_equal [["Claude Sonnet 4.6", "claude-sonnet-4-6"]], options.drop(1)
+  end
+
+  test "#selected_model_id should return the saved model when it's still offered" do
+    feed = ai_feed(ai_credential: credential, ai_model: "claude-sonnet-4-6")
+    assert_equal "claude-sonnet-4-6", component(feed).selected_model_id
+  end
+
+  test "#selected_model_id should be blank when the saved model isn't offered" do
+    feed = ai_feed(ai_credential: credential, ai_model: "claude-opus-4-7")
+    assert_equal "", component(feed).selected_model_id
+  end
+
   test "#model_unavailable? should be true when the saved model is no longer offered" do
     feed = ai_feed(ai_credential: credential, ai_model: "removed-model")
     assert component(feed).model_unavailable?

--- a/test/integration/feed_ai_settings_test.rb
+++ b/test/integration/feed_ai_settings_test.rb
@@ -70,6 +70,30 @@ class FeedAiSettingsTest < ActionDispatch::IntegrationTest
     assert_select "select[data-key='form.ai-model'] option[selected][value='claude-sonnet-4-6']", text: "Claude Sonnet 4.6"
   end
 
+  test "#edit should render the model placeholder as disabled so a pick can't be cleared" do
+    sign_in_as(user)
+
+    get edit_feed_path(ai_feed)
+
+    assert_select "select[data-key='form.ai-model'] option[value=''][disabled][hidden]", text: "Select a model…"
+    assert_select "select[data-key='form.ai-model'] option[value=''][selected]", false
+  end
+
+  test "#edit should select the placeholder when the saved model is no longer offered" do
+    sign_in_as(user)
+    stale_feed = create(:feed,
+                        user: user,
+                        feed_profile_key: "llm",
+                        ai_credential: credential,
+                        ai_model: "removed-model",
+                        params: { "prompt" => "https://no-rss.example.com" })
+
+    get edit_feed_path(stale_feed)
+
+    assert_select "select[data-key='form.ai-model'] option[value=''][selected][disabled]", text: "Select a model…"
+    assert_select "select[data-key='form.ai-model'] option[selected]", count: 1
+  end
+
   test "#edit should list only capability-matrix models in the model select" do
     sign_in_as(user)
 


### PR DESCRIPTION
Changes:

- The "Select a model…" placeholder in the feed form's model dropdown is now disabled and hidden, so once a model is picked the feed can't be switched back to having no model
- The placeholder still shows while nothing is selected — including when the saved model is no longer offered — so the existing re-pick flow is unchanged
- The client-side model list rebuild on provider change renders the same placeholder

A selectable blank option made an undefined form state reachable after a valid pick, which never makes sense for an AI-backed feed. Server-side validation already rejects a blank model, so submitting with the placeholder still showing keeps its existing error.