### PR TITLE
Unify feed refresh events into a single lifecycle-tracked type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-10
+
+- Your events log now shows when a feed refresh is in progress; the entry is replaced by the result once the refresh finishes.
+
 ## 2026-07-09
 
 - Feed pages are less cluttered: the Recent Activity and Recent Posts sections only appear once there's something to show.

--- a/app/components/feed_refresh_description_component.rb
+++ b/app/components/feed_refresh_description_component.rb
@@ -1,7 +1,5 @@
-# Renders a feed refresh lifecycle event according to its metadata status
-# (started, completed, failed, interrupted). Completed refreshes append the
-# imported posts count, e.g. "My Feed refreshed (+2 posts)"; refreshes that
-# imported nothing render plain.
+# Describes a feed refresh run by its lifecycle status, appending the imported
+# posts count when there is one, e.g. "My Feed refreshed (+2 posts)".
 class FeedRefreshDescriptionComponent < EventDescriptionComponent
   def call
     suffix = posts_count_tag
@@ -10,8 +8,7 @@ class FeedRefreshDescriptionComponent < EventDescriptionComponent
 
   private
 
-  # Events created before the status lifecycle carry no status and read as
-  # completed, which is what they were.
+  # Events predating the status lifecycle have no status; they were completed runs.
   def description_key
     case event.metadata["status"]
     when "started" then "events.feed_refresh.started_description_html"

--- a/app/components/feed_refresh_description_component.rb
+++ b/app/components/feed_refresh_description_component.rb
@@ -1,5 +1,7 @@
-# Appends the imported posts count to a feed refresh description, e.g.
-# "My Feed refreshed (+2 posts)". Refreshes that imported nothing render plain.
+# Renders a feed refresh lifecycle event according to its metadata status
+# (started, completed, failed, interrupted). Completed refreshes append the
+# imported posts count, e.g. "My Feed refreshed (+2 posts)"; refreshes that
+# imported nothing render plain.
 class FeedRefreshDescriptionComponent < EventDescriptionComponent
   def call
     suffix = posts_count_tag
@@ -7,6 +9,17 @@ class FeedRefreshDescriptionComponent < EventDescriptionComponent
   end
 
   private
+
+  # Events created before the status lifecycle carry no status and read as
+  # completed, which is what they were.
+  def description_key
+    case event.metadata["status"]
+    when "started" then "events.feed_refresh.started_description_html"
+    when "failed" then "events.feed_refresh.failed_description_html"
+    when "interrupted" then "events.feed_refresh.interrupted_description_html"
+    else super
+    end
+  end
 
   def posts_count_tag
     count = event.event_references.count { |reference| reference.reference_type == "Post" }

--- a/app/components/feed_refresh_description_component.rb
+++ b/app/components/feed_refresh_description_component.rb
@@ -8,13 +8,16 @@ class FeedRefreshDescriptionComponent < EventDescriptionComponent
 
   private
 
-  # Events predating the status lifecycle have no status; they were completed runs.
+  # A nil status is a legacy event from before the lifecycle; those were
+  # completed runs. An unrecognized status must not fall through to the
+  # success copy.
   def description_key
     case event.metadata["status"]
     when "started" then "events.feed_refresh.started_description_html"
     when "failed" then "events.feed_refresh.failed_description_html"
     when "interrupted" then "events.feed_refresh.interrupted_description_html"
-    else super
+    when "completed", nil then super
+    else "events.feed_refresh.unknown_status_description_html"
     end
   end
 

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -55,7 +55,20 @@ class FeedRefreshWorkflow
 
   def initialize_workflow(*)
     record_started_at
+    interrupt_abandoned_refresh_events
     @refresh_event = create_refresh_event
+  end
+
+  # Only one refresh per feed runs at a time (FeedRefreshJob's advisory lock),
+  # so an event still "started" when a new run begins belongs to a run whose
+  # process died before it could finalize (deploy restart, OOM kill). Mark it
+  # so it doesn't read as in-progress forever.
+  def interrupt_abandoned_refresh_events
+    Event.where(type: "feed_refresh", subject: feed)
+         .where("metadata ->> 'status' = 'started'")
+         .find_each do |event|
+      event.update!(metadata: event.metadata.merge("status" => "interrupted"))
+    end
   end
 
   # A refresh may run for minutes, so its event is created up front and updated

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -59,10 +59,9 @@ class FeedRefreshWorkflow
     @refresh_event = create_refresh_event
   end
 
-  # Only one refresh per feed runs at a time (FeedRefreshJob's advisory lock),
-  # so an event still "started" when a new run begins belongs to a run whose
-  # process died before it could finalize (deploy restart, OOM kill). Mark it
-  # so it doesn't read as in-progress forever.
+  # FeedRefreshJob's advisory lock allows one refresh per feed at a time, so
+  # an event still "started" when a new run begins belongs to a run whose
+  # process died before finalizing.
   def interrupt_abandoned_refresh_events
     Event.where(type: "feed_refresh", subject: feed)
          .where("metadata ->> 'status' = 'started'")
@@ -71,10 +70,8 @@ class FeedRefreshWorkflow
     end
   end
 
-  # A refresh may run for minutes, so its event is created up front and updated
-  # in place as the run finishes (see complete/fail below). Debug level keeps
-  # the in-flight record out of the user event feed; completion promotes it to
-  # a user-visible level.
+  # Debug level keeps the in-flight record out of the user event feed;
+  # completion promotes it to a user-visible level.
   def create_refresh_event
     Event.create!(
       type: "feed_refresh",
@@ -299,8 +296,8 @@ class FeedRefreshWorkflow
     feed.ai_credential.disable_credential_and_feeds(last_error: error.message)
   end
 
-  # The started event normally exists by the time an error can surface; the
-  # create fallback covers failures in steps preceding initialize_workflow.
+  # The create fallback covers failures in steps preceding initialize_workflow,
+  # before the started event exists.
   def fail_refresh_event(error)
     attributes = {
       level: :error,

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -2,6 +2,7 @@ class FeedRefreshWorkflow
   include Workflow
   include StatsRecorder
 
+  step :interrupt_abandoned_refresh_events
   step :skip_current_digest_period
   step :initialize_workflow
   step :load_feed_contents
@@ -55,19 +56,23 @@ class FeedRefreshWorkflow
 
   def initialize_workflow(*)
     record_started_at
-    interrupt_abandoned_refresh_events
     @refresh_event = create_refresh_event
   end
 
   # FeedRefreshJob's advisory lock allows one refresh per feed at a time, so
   # an event still "started" when a new run begins belongs to a run whose
-  # process died before finalizing.
-  def interrupt_abandoned_refresh_events
-    Event.where(type: "feed_refresh", subject: feed)
-         .where("metadata ->> 'status' = 'started'")
-         .find_each do |event|
+  # process died before finalizing. Runs as the first step — before the digest
+  # skip — so even runs that halt still sweep.
+  def interrupt_abandoned_refresh_events(input = nil)
+    feed.events.where(type: "feed_refresh")
+        .where("metadata ->> 'status' = 'started'")
+        .find_each do |event|
       event.update!(metadata: event.metadata.merge("status" => "interrupted"))
+      Metrics.increment("feed_refresh_total", status: "interrupted", profile: feed.feed_profile_key)
+      Rails.logger.info "Feed refresh interrupted for feed #{feed.id}: event #{event.id} was abandoned by a dead run"
     end
+
+    input
   end
 
   # Debug level keeps the in-flight record out of the user event feed;
@@ -270,6 +275,7 @@ class FeedRefreshWorkflow
 
   def complete_refresh_event(posts)
     @refresh_event.update!(level: :info, metadata: { status: "completed", stats: stats })
+    @refresh_completed = true
     reference_posts(@refresh_event, posts)
   end
 
@@ -296,10 +302,13 @@ class FeedRefreshWorkflow
     feed.ai_credential.disable_credential_and_feeds(last_error: error.message)
   end
 
-  # The create fallback covers failures in steps preceding initialize_workflow,
-  # before the started event exists.
+  # A failure after completion (e.g. metrics recording) must not rewrite the
+  # completed run's record; the error still propagates to the job. A nil event
+  # means event persistence itself was failing — nothing to update.
   def fail_refresh_event(error)
-    attributes = {
+    return if @refresh_completed
+
+    @refresh_event&.update!(
       level: :error,
       message: error.message,
       metadata: {
@@ -312,13 +321,7 @@ class FeedRefreshWorkflow
           backtrace: error.backtrace
         }
       }
-    }
-
-    if @refresh_event
-      @refresh_event.update!(attributes)
-    else
-      Event.create!(type: "feed_refresh", subject: feed, user: feed.user, **attributes)
-    end
+    )
   end
 
   # Persist this run's regime so the next scheduled run can skip a redundant

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -30,7 +30,7 @@ class FeedRefreshWorkflow
     Metrics.increment("feed_refresh_total", status: "error", profile: feed.feed_profile_key)
     record_error_stats(error, current_step: current_step)
     disable_credential_on_auth_error(error)
-    create_feed_refresh_error_event(error)
+    fail_refresh_event(error)
     feed.record_refresh_failure!
   end
 
@@ -55,6 +55,21 @@ class FeedRefreshWorkflow
 
   def initialize_workflow(*)
     record_started_at
+    @refresh_event = create_refresh_event
+  end
+
+  # A refresh may run for minutes, so its event is created up front and updated
+  # in place as the run finishes (see complete/fail below). Debug level keeps
+  # the in-flight record out of the user event feed; completion promotes it to
+  # a user-visible level.
+  def create_refresh_event
+    Event.create!(
+      type: "feed_refresh",
+      level: :debug,
+      subject: feed,
+      user: feed.user,
+      metadata: { status: "started", stats: stats }
+    )
   end
 
   def load_feed_contents(*)
@@ -219,7 +234,7 @@ class FeedRefreshWorkflow
     feed.reset_refresh_failures!
     record_digest_period
     Metrics.increment("feed_refresh_total", status: "ok", profile: feed.feed_profile_key)
-    create_feed_refresh_stats_event(posts)
+    complete_refresh_event(posts)
 
     # Record daily metrics (sparse data - only if there's activity)
     posts_count = posts.count { |p| p.enqueued? || p.published? }
@@ -243,17 +258,9 @@ class FeedRefreshWorkflow
     record_stats(stats_key => duration)
   end
 
-  def create_feed_refresh_stats_event(posts)
-    event = Event.create!(
-      type: "feed_refresh",
-      level: :info,
-      subject: feed,
-      user: feed.user,
-      metadata: { stats: stats }
-    )
-
-    reference_posts(event, posts)
-    event
+  def complete_refresh_event(posts)
+    @refresh_event.update!(level: :info, metadata: { status: "completed", stats: stats })
+    reference_posts(@refresh_event, posts)
   end
 
   def reference_posts(event, posts)
@@ -279,14 +286,14 @@ class FeedRefreshWorkflow
     feed.ai_credential.disable_credential_and_feeds(last_error: error.message)
   end
 
-  def create_feed_refresh_error_event(error)
-    Event.create!(
-      type: "feed_refresh_error",
+  # The started event normally exists by the time an error can surface; the
+  # create fallback covers failures in steps preceding initialize_workflow.
+  def fail_refresh_event(error)
+    attributes = {
       level: :error,
-      subject: feed,
-      user: feed.user,
       message: error.message,
       metadata: {
+        status: "failed",
         stats: stats,
         error: {
           class: error.class.name,
@@ -295,7 +302,13 @@ class FeedRefreshWorkflow
           backtrace: error.backtrace
         }
       }
-    )
+    }
+
+    if @refresh_event
+      @refresh_event.update!(attributes)
+    else
+      Event.create!(type: "feed_refresh", subject: feed, user: feed.user, **attributes)
+    end
   end
 
   # Persist this run's regime so the next scheduled run can skip a redundant

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -62,12 +62,13 @@ class FeedRefreshWorkflow
   # FeedRefreshJob's advisory lock allows one refresh per feed at a time, so
   # an event still "started" when a new run begins belongs to a run whose
   # process died before finalizing. Runs as the first step — before the digest
-  # skip — so even runs that halt still sweep.
+  # skip — so even runs that halt still sweep. Demoting to debug takes the dead
+  # run's "in progress" record out of the user event feed.
   def interrupt_abandoned_refresh_events(input = nil)
     feed.events.where(type: "feed_refresh")
         .where("metadata ->> 'status' = 'started'")
         .find_each do |event|
-      event.update!(metadata: event.metadata.merge("status" => "interrupted"))
+      event.update!(level: :debug, metadata: event.metadata.merge("status" => "interrupted"))
       Metrics.increment("feed_refresh_total", status: "interrupted", profile: feed.feed_profile_key)
       Rails.logger.info "Feed refresh interrupted for feed #{feed.id}: event #{event.id} was abandoned by a dead run"
     end
@@ -75,12 +76,13 @@ class FeedRefreshWorkflow
     input
   end
 
-  # Debug level keeps the in-flight record out of the user event feed;
-  # completion promotes it to a user-visible level.
+  # The in-flight record is user-visible and ephemeral: completion or failure
+  # deletes it and creates the permanent outcome event in its place, so each
+  # run leaves exactly one lasting record.
   def create_refresh_event
     Event.create!(
       type: "feed_refresh",
-      level: :debug,
+      level: :info,
       subject: feed,
       user: feed.user,
       metadata: { status: "started", stats: stats }
@@ -273,10 +275,22 @@ class FeedRefreshWorkflow
     record_stats(stats_key => duration)
   end
 
+  # Delete before create: the terminal event's fresh id is what makes open
+  # event pages re-render, and that re-render must no longer include the
+  # started record.
   def complete_refresh_event(posts)
-    @refresh_event.update!(level: :info, metadata: { status: "completed", stats: stats })
+    @refresh_event.destroy!
+
+    event = Event.create!(
+      type: "feed_refresh",
+      level: :info,
+      subject: feed,
+      user: feed.user,
+      metadata: { status: "completed", stats: stats }
+    )
+
     @refresh_completed = true
-    reference_posts(@refresh_event, posts)
+    reference_posts(event, posts)
   end
 
   def reference_posts(event, posts)
@@ -302,14 +316,19 @@ class FeedRefreshWorkflow
     feed.ai_credential.disable_credential_and_feeds(last_error: error.message)
   end
 
-  # A failure after completion (e.g. metrics recording) must not rewrite the
-  # completed run's record; the error still propagates to the job. A nil event
-  # means event persistence itself was failing — nothing to update.
+  # The @refresh_completed guard keeps the invariant of at most one terminal
+  # event per run: a failure after completion (e.g. metrics recording) must
+  # not add a contradictory failed record.
   def fail_refresh_event(error)
     return if @refresh_completed
 
-    @refresh_event&.update!(
+    @refresh_event&.destroy!
+
+    Event.create!(
+      type: "feed_refresh",
       level: :error,
+      subject: feed,
+      user: feed.user,
       message: error.message,
       metadata: {
         status: "failed",

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -539,7 +539,7 @@
           <%= render EventDescriptionComponent.for(Event.new(type: "feed_refresh", level: :info, subject: sample_feed)) %>
         <% end %>
         <%= render AlertComponent.new(variant: :error) do %>
-          <%= render EventDescriptionComponent.for(Event.new(type: "feed_refresh_error", level: :error, subject: sample_feed, message: "Connection timeout", metadata: { error: { stage: "load_feed_contents" } })) %>
+          <%= render EventDescriptionComponent.for(Event.new(type: "feed_refresh", level: :error, subject: sample_feed, message: "Connection timeout", metadata: { "status" => "failed", "error" => { "stage" => "load_feed_contents" } })) %>
         <% end %>
         <%= render AlertComponent.new(variant: :info) do %>
           <%= render EventDescriptionComponent.for(Event.new(type: "feed_refresh_skipped", level: :debug, subject: sample_feed, metadata: { period: Date.current.iso8601 })) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,9 +53,9 @@ en:
     feed_refresh:
       name: "Feed refreshed"
       description_html: "%{subject_link} refreshed"
-    feed_refresh_error:
-      name: "Feed refresh failed"
-      description_html: "%{subject_link} couldn't refresh; %{message}"
+      started_description_html: "%{subject_link} refresh is in progress"
+      failed_description_html: "%{subject_link} couldn't refresh; %{message}"
+      interrupted_description_html: "%{subject_link} refresh was interrupted before it finished"
     feed_refresh_skipped:
       name: "Feed refresh skipped"
       description_html: "%{subject_link} already produced this period's digest, so the scheduled refresh was skipped"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
       started_description_html: "%{subject_link} refresh is in progress"
       failed_description_html: "%{subject_link} couldn't refresh; %{message}"
       interrupted_description_html: "%{subject_link} refresh was interrupted"
+      unknown_status_description_html: "%{subject_link} refresh status is unknown"
     feed_refresh_skipped:
       name: "Feed refresh skipped"
       description_html: "%{subject_link} already produced this period's digest, so the scheduled refresh was skipped"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,7 @@ en:
       description_html: "%{subject_link} refreshed"
       started_description_html: "%{subject_link} refresh is in progress"
       failed_description_html: "%{subject_link} couldn't refresh; %{message}"
-      interrupted_description_html: "%{subject_link} refresh was interrupted before it finished"
+      interrupted_description_html: "%{subject_link} refresh was interrupted"
     feed_refresh_skipped:
       name: "Feed refresh skipped"
       description_html: "%{subject_link} already produced this period's digest, so the scheduled refresh was skipped"

--- a/db/migrate/20260709120000_unify_feed_refresh_event_types.rb
+++ b/db/migrate/20260709120000_unify_feed_refresh_event_types.rb
@@ -2,18 +2,15 @@
 # in metadata, replacing the separate feed_refresh_error type. Fold existing
 # events into that shape.
 class UnifyFeedRefreshEventTypes < ActiveRecord::Migration[8.2]
+  # Legacy success events keep a nil status: nothing distinguishes it from
+  # "completed" (the renderer treats both as a finished run), so backfilling
+  # would rewrite the largest event cohort for no behavioral change.
   def up
     execute <<~SQL
       UPDATE events
       SET type = 'feed_refresh',
           metadata = jsonb_set(metadata, '{status}', '"failed"', true)
       WHERE type = 'feed_refresh_error'
-    SQL
-
-    execute <<~SQL
-      UPDATE events
-      SET metadata = jsonb_set(metadata, '{status}', '"completed"', true)
-      WHERE type = 'feed_refresh' AND metadata ->> 'status' IS NULL
     SQL
   end
 

--- a/db/migrate/20260709120000_unify_feed_refresh_event_types.rb
+++ b/db/migrate/20260709120000_unify_feed_refresh_event_types.rb
@@ -1,0 +1,35 @@
+# Feed refresh runs are now tracked as a single feed_refresh event per run
+# with a lifecycle status in metadata (started/completed/failed/interrupted)
+# instead of separate feed_refresh/feed_refresh_error types. Fold existing
+# events into the new shape so queries and rendering see uniform data.
+class UnifyFeedRefreshEventTypes < ActiveRecord::Migration[8.2]
+  def up
+    execute <<~SQL
+      UPDATE events
+      SET type = 'feed_refresh',
+          metadata = jsonb_set(metadata, '{status}', '"failed"', true)
+      WHERE type = 'feed_refresh_error'
+    SQL
+
+    execute <<~SQL
+      UPDATE events
+      SET metadata = jsonb_set(metadata, '{status}', '"completed"', true)
+      WHERE type = 'feed_refresh' AND metadata ->> 'status' IS NULL
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE events
+      SET type = 'feed_refresh_error',
+          metadata = metadata - 'status'
+      WHERE type = 'feed_refresh' AND metadata ->> 'status' = 'failed'
+    SQL
+
+    execute <<~SQL
+      UPDATE events
+      SET metadata = metadata - 'status'
+      WHERE type = 'feed_refresh' AND metadata ->> 'status' = 'completed'
+    SQL
+  end
+end

--- a/db/migrate/20260709120000_unify_feed_refresh_event_types.rb
+++ b/db/migrate/20260709120000_unify_feed_refresh_event_types.rb
@@ -1,7 +1,6 @@
-# Feed refresh runs are now tracked as a single feed_refresh event per run
-# with a lifecycle status in metadata (started/completed/failed/interrupted)
-# instead of separate feed_refresh/feed_refresh_error types. Fold existing
-# events into the new shape so queries and rendering see uniform data.
+# Refresh runs are now one feed_refresh event per run with a lifecycle status
+# in metadata, replacing the separate feed_refresh_error type. Fold existing
+# events into that shape.
 class UnifyFeedRefreshEventTypes < ActiveRecord::Migration[8.2]
   def up
     execute <<~SQL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_07_130000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -228,6 +228,7 @@ if Rails.env.development?
         user_id: feed.user_id,
         message: "Feed refresh completed for #{feed.name}",
         metadata: {
+          status: "completed",
           stats: {
             started_at: (base_time - 2.hours).iso8601,
             completed_at: (base_time - 2.hours + 3.seconds).iso8601,
@@ -243,13 +244,14 @@ if Rails.env.development?
       # Add an error event for one feed
       if feed == Feed.first
         events << {
-          type: "feed_refresh_error",
+          type: "feed_refresh",
           level: :error,
           subject_type: "Feed",
           subject_id: feed.id,
           user_id: feed.user_id,
           message: "Feed refresh failed at load_feed_contents: Connection timeout",
           metadata: {
+            status: "failed",
             stats: { started_at: (base_time - 5.hours).iso8601 },
             error: {
               class: "Net::ReadTimeout",
@@ -268,8 +270,8 @@ if Rails.env.development?
     events_needed = 75 - Event.count - events.length
 
     event_templates = [
-      { type: "feed_refresh", level: :info, weight: 40 },
-      { type: "feed_refresh_error", level: :error, weight: 5 },
+      { type: "feed_refresh", level: :info, status: "completed", weight: 40 },
+      { type: "feed_refresh", level: :error, status: "failed", weight: 5 },
       { type: "email_sent", level: :info, weight: 15 },
       { type: "email_delivered", level: :info, weight: 15 },
       { type: "email_opened", level: :info, weight: 10 },
@@ -294,32 +296,25 @@ if Rails.env.development?
         feed = feeds_array.sample
         next unless feed
 
-        events << {
+        refresh_event = {
           type: template[:type],
           level: template[:level],
           subject_type: "Feed",
           subject_id: feed.id,
           user_id: feed.user_id,
-          message: "Feed refresh completed for #{feed.name}",
-          metadata: { stats: { new_entries: rand(0..5), new_posts: rand(0..3) } },
           created_at: time,
           updated_at: time
         }
-      when "feed_refresh_error"
-        feed = feeds_array.sample
-        next unless feed
 
-        events << {
-          type: template[:type],
-          level: template[:level],
-          subject_type: "Feed",
-          subject_id: feed.id,
-          user_id: feed.user_id,
-          message: "Feed refresh failed at #{['load_feed_contents', 'process_feed_contents', 'publish_posts'].sample}: #{['Connection timeout', 'Invalid XML', 'Rate limit exceeded'].sample}",
-          metadata: { error: { class: "StandardError", message: "Error occurred" } },
-          created_at: time,
-          updated_at: time
-        }
+        if template[:status] == "failed"
+          refresh_event[:message] = "Feed refresh failed at #{['load_feed_contents', 'process_feed_contents', 'publish_posts'].sample}: #{['Connection timeout', 'Invalid XML', 'Rate limit exceeded'].sample}"
+          refresh_event[:metadata] = { status: "failed", error: { class: "StandardError", message: "Error occurred" } }
+        else
+          refresh_event[:message] = "Feed refresh completed for #{feed.name}"
+          refresh_event[:metadata] = { status: "completed", stats: { new_entries: rand(0..5), new_posts: rand(0..3) } }
+        end
+
+        events << refresh_event
       else
         events << {
           type: template[:type],

--- a/script/refresh_job_example.rb
+++ b/script/refresh_job_example.rb
@@ -103,7 +103,7 @@ begin
     end
   end
 
-  latest_event = feed.events.where(type: ["feed_refresh_stats", "feed_refresh_error"]).order(:created_at).last
+  latest_event = feed.events.where(type: "feed_refresh").order(:created_at).last
 
   if latest_event
     puts

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -143,15 +143,15 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
 
   test "#call should include the error message for refresh errors" do
     event = Event.create!(
-      type: "feed_refresh_error",
+      type: "feed_refresh",
       level: :error,
       subject: feed,
       user: user,
       message: "Connection timeout",
-      metadata: { error: { stage: "load_feed_contents" } }
+      metadata: { status: "failed", error: { stage: "load_feed_contents" } }
     )
 
-    result = render_inline(EventDescriptionComponent.new(event: event))
+    result = render_inline(EventDescriptionComponent.for(event))
 
     assert_includes result.to_html, "Test Feed"
     assert_includes result.to_html, "couldn't refresh"
@@ -249,15 +249,15 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
   test "#call should escape HTML in error messages" do
     feed = create(:feed, user: user, name: "Test Feed")
     event = Event.create!(
-      type: "feed_refresh_error",
+      type: "feed_refresh",
       level: :error,
       subject: feed,
       user: user,
       message: "<script>alert('xss')</script>",
-      metadata: {}
+      metadata: { status: "failed" }
     )
 
-    result = render_inline(EventDescriptionComponent.new(event: event))
+    result = render_inline(EventDescriptionComponent.for(event))
 
     assert_not_includes result.to_html, "<script>"
     assert_includes result.to_html, "&lt;script&gt;"

--- a/test/components/feed_refresh_description_component_test.rb
+++ b/test/components/feed_refresh_description_component_test.rb
@@ -39,4 +39,43 @@ class FeedRefreshDescriptionComponentTest < ViewComponent::TestCase
     assert_includes result.to_html, "refreshed"
     assert_nil result.css("[data-key='events.posts_count']").first
   end
+
+  def event_with_status(status, **attributes)
+    Event.create!(
+      type: "feed_refresh",
+      level: :debug,
+      subject: feed,
+      user: user,
+      metadata: { status: status },
+      **attributes
+    )
+  end
+
+  test "#call should describe a started refresh as in progress" do
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: event_with_status("started")))
+
+    assert_includes result.to_html, "Test Feed"
+    assert_includes result.to_html, "in progress"
+  end
+
+  test "#call should describe a failed refresh with its message" do
+    event = event_with_status("failed", level: :error, message: "Connection timeout")
+
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: event))
+
+    assert_includes result.to_html, "couldn't refresh"
+    assert_includes result.to_html, "Connection timeout"
+  end
+
+  test "#call should describe an interrupted refresh" do
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: event_with_status("interrupted")))
+
+    assert_includes result.to_html, "interrupted"
+  end
+
+  test "#call should treat events without a status as completed" do
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: refresh_event))
+
+    assert_includes result.to_html, "refreshed"
+  end
 end

--- a/test/components/feed_refresh_description_component_test.rb
+++ b/test/components/feed_refresh_description_component_test.rb
@@ -78,4 +78,11 @@ class FeedRefreshDescriptionComponentTest < ViewComponent::TestCase
 
     assert_includes result.to_html, "refreshed"
   end
+
+  test "#call should render an unrecognized status as unknown rather than success" do
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: event_with_status("cancelled")))
+
+    assert_includes result.to_html, "status is unknown"
+    assert_not_includes result.to_html, "refreshed"
+  end
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -199,10 +199,10 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
   test "#index should filter user events by type" do
     sign_in_as user
     create(:event, type: "feed_refresh", user: user)
-    create(:event, type: "feed_refresh_error", user: user)
+    create(:event, type: "feed_auto_disabled", user: user)
     create(:event, type: "post_withdrawn", user: user)
 
-    get events_path(format: :turbo_stream), params: { after_id: 0, filter: { type: %w[feed_refresh feed_refresh_error] } }
+    get events_path(format: :turbo_stream), params: { after_id: 0, filter: { type: %w[feed_refresh feed_auto_disabled] } }
 
     assert_response :success
     assert_select "[data-key='events.entry']", count: 2

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -579,7 +579,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 1, events.count
   end
 
-  test "#execute should create a started event and complete it in place" do
+  test "#execute should replace the started event with a completed event" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 
     # A local, because the singleton method's body resolves methods against the
@@ -597,13 +597,16 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
     assert_not_nil in_flight_event, "the event should exist before loading starts"
     assert_equal "started", in_flight_event.metadata["status"]
-    assert_equal "debug", in_flight_event.level
+    assert_equal "info", in_flight_event.level, "the in-flight record should be user-visible"
     assert in_flight_event.metadata["stats"]["started_at"].present?
 
-    completed_event = in_flight_event.reload
+    assert_not Event.exists?(in_flight_event.id), "the started event should be deleted on completion"
+
+    events = Event.where(subject: test_feed, type: "feed_refresh")
+    assert_equal 1, events.count
+    completed_event = events.first
     assert_equal "completed", completed_event.metadata["status"]
     assert_equal "info", completed_event.level
-    assert_equal 1, Event.where(subject: test_feed, type: "feed_refresh").count
   end
 
   test "#execute should keep the completed event when a post-completion step fails" do
@@ -625,7 +628,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     abandoned_started_at = 1.day.ago
     abandoned = Event.create!(
       type: "feed_refresh",
-      level: :debug,
+      level: :info,
       subject: test_feed,
       user: test_feed.user,
       metadata: { status: "started", stats: { started_at: abandoned_started_at.iso8601 } }
@@ -637,7 +640,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
     abandoned.reload
     assert_equal "interrupted", abandoned.metadata["status"]
-    assert_equal "debug", abandoned.level
+    assert_equal "debug", abandoned.level, "the dead run's record should leave the user event feed"
     assert_equal abandoned_started_at.iso8601, abandoned.metadata.dig("stats", "started_at"),
                  "the rest of the abandoned event's metadata stays intact"
   end
@@ -648,7 +651,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
     other_started = Event.create!(
       type: "feed_refresh",
-      level: :debug,
+      level: :info,
       subject: other_feed,
       user: other_feed.user,
       metadata: { status: "started" }
@@ -918,7 +921,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       feed = digest_feed_with_schedule(last_digest_period: Time.current.utc.to_date)
       abandoned = Event.create!(
         type: "feed_refresh",
-        level: :debug,
+        level: :info,
         subject: feed,
         user: feed.user,
         metadata: { status: "started" }

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -28,6 +28,13 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       )
   end
 
+  def empty_rss
+    <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0"><channel><title>Empty</title></channel></rss>
+    RSS
+  end
+
   test "#initialize should set feed and stats" do
     workflow = FeedRefreshWorkflow.new(feed)
 
@@ -37,6 +44,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
   test ".workflow_steps should list expected sequence" do
     expected_steps = [
+      :interrupt_abandoned_refresh_events,
       :skip_current_digest_period,
       :initialize_workflow,
       :load_feed_contents,
@@ -550,17 +558,6 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
 
     workflow = FeedRefreshWorkflow.new(test_feed)
 
-    # Empty RSS with no items
-    empty_rss = <<~RSS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0">
-        <channel>
-          <title>Empty Feed</title>
-          <description>No items</description>
-        </channel>
-      </rss>
-    RSS
-
     WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
 
     # No enqueued posts means the publish chain must not be kicked
@@ -585,16 +582,15 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
   test "#execute should create a started event and complete it in place" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 
-    empty_rss = <<~RSS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0"><channel><title>Empty</title></channel></rss>
-    RSS
+    # A local, because the singleton method's body resolves methods against the
+    # loader object, not the test case.
+    rss_body = empty_rss
 
     in_flight_event = nil
     loader = Object.new
     loader.define_singleton_method(:load) do
       in_flight_event = Event.find_by(subject: test_feed, type: "feed_refresh")
-      empty_rss
+      rss_body
     end
 
     test_feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(test_feed).execute }
@@ -610,21 +606,31 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 1, Event.where(subject: test_feed, type: "feed_refresh").count
   end
 
+  test "#execute should keep the completed event when a post-completion step fails" do
+    test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
+    WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
+
+    FeedMetric.stub(:record, proc { raise ActiveRecord::StatementInvalid.new("Database error") }) do
+      assert_raises(ActiveRecord::StatementInvalid) { FeedRefreshWorkflow.new(test_feed).execute }
+    end
+
+    event = Event.find_by(subject: test_feed, type: "feed_refresh")
+    assert_equal "completed", event.metadata["status"]
+    assert_equal "info", event.level
+  end
+
   test "#execute should mark an abandoned started event as interrupted" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 
+    abandoned_started_at = 1.day.ago
     abandoned = Event.create!(
       type: "feed_refresh",
       level: :debug,
       subject: test_feed,
       user: test_feed.user,
-      metadata: { status: "started", stats: { started_at: 1.day.ago.iso8601 } }
+      metadata: { status: "started", stats: { started_at: abandoned_started_at.iso8601 } }
     )
 
-    empty_rss = <<~RSS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0"><channel><title>Empty</title></channel></rss>
-    RSS
     WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
 
     FeedRefreshWorkflow.new(test_feed).execute
@@ -632,7 +638,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     abandoned.reload
     assert_equal "interrupted", abandoned.metadata["status"]
     assert_equal "debug", abandoned.level
-    assert_equal 1.day.ago.to_date.iso8601, abandoned.metadata.dig("stats", "started_at")[0, 10],
+    assert_equal abandoned_started_at.iso8601, abandoned.metadata.dig("stats", "started_at"),
                  "the rest of the abandoned event's metadata stays intact"
   end
 
@@ -655,16 +661,36 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       metadata: { status: "completed" }
     )
 
-    empty_rss = <<~RSS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0"><channel><title>Empty</title></channel></rss>
-    RSS
     WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
 
     FeedRefreshWorkflow.new(test_feed).execute
 
     assert_equal "started", other_started.reload.metadata["status"]
     assert_equal "completed", completed.reload.metadata["status"]
+  end
+
+  test "#execute should leave a prior failed event untouched and start a new lifecycle" do
+    test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
+
+    failed = Event.create!(
+      type: "feed_refresh",
+      level: :error,
+      subject: test_feed,
+      user: test_feed.user,
+      message: "Connection timeout",
+      metadata: { status: "failed" }
+    )
+
+    WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
+
+    FeedRefreshWorkflow.new(test_feed).execute
+
+    assert_equal "failed", failed.reload.metadata["status"]
+    assert_equal "error", failed.level
+
+    events = Event.where(subject: test_feed, type: "feed_refresh").order(:id)
+    assert_equal 2, events.count
+    assert_equal "completed", events.last.metadata["status"]
   end
 
   test "#records should create feed metrics when posts are imported" do
@@ -746,15 +772,6 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
   test "#execute should skip metrics when no posts are imported" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 
-    empty_rss = <<~RSS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0">
-        <channel>
-          <title>Empty Feed</title>
-        </channel>
-      </rss>
-    RSS
-
     WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
 
     freeze_time do
@@ -779,10 +796,6 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
   test "#execute should reset the failure streak after a successful refresh" do
     test_feed = create(:feed, :enabled, url: "https://example.com/feed.xml",
                                          feed_profile_key: "rss", consecutive_failures: 3)
-    empty_rss = <<~RSS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0"><channel><title>Empty</title></channel></rss>
-    RSS
     WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
 
     FeedRefreshWorkflow.new(test_feed).execute
@@ -897,6 +910,25 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       assert_equal 0, loader.load_count, "the LLM loader must not run when skipping"
       assert_equal 0, feed.posts.count
       assert_equal 1, Event.where(subject: feed, type: "feed_refresh_skipped", level: "debug").count
+    end
+  end
+
+  test "#execute should sweep abandoned events even when the digest skip halts the run" do
+    freeze_time do
+      feed = digest_feed_with_schedule(last_digest_period: Time.current.utc.to_date)
+      abandoned = Event.create!(
+        type: "feed_refresh",
+        level: :debug,
+        subject: feed,
+        user: feed.user,
+        metadata: { status: "started" }
+      )
+      loader = counting_loader([{ "source_url" => nil, "body" => "roundup" }])
+
+      feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(feed).execute }
+
+      assert_equal 0, loader.load_count, "the run must still skip"
+      assert_equal "interrupted", abandoned.reload.metadata["status"]
     end
   end
 

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -123,9 +123,11 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert workflow.stats[:completed_at]
     assert workflow.stats[:total_duration] >= 0
 
-    # Verify stats event was created
+    # Verify stats event was created and promoted to a user-visible level
     events = Event.where(subject: test_feed, type: "feed_refresh")
     assert_equal 1, events.count
+    assert_equal "completed", events.first.metadata["status"]
+    assert_equal "info", events.first.level
     assert_equal 2, events.first.metadata["stats"]["new_posts"]
 
     # Verify each new post is referenced by the refresh event
@@ -337,10 +339,11 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert workflow.stats[:started_at]
     assert_equal :load_feed_contents, workflow.stats[:failed_at_step]
 
-    # Verify error event was created
-    events = Event.where(subject: test_feed, type: "feed_refresh_error")
+    # Verify the started event was updated in place with the failure
+    events = Event.where(subject: test_feed, type: "feed_refresh")
     assert_equal 1, events.count
     error_event = events.first
+    assert_equal "failed", error_event.metadata["status"]
     assert_equal "error", error_event.level
     assert_match(/execution expired/, error_event.message)
     assert_equal "Loader::Error", error_event.metadata["error"]["class"]
@@ -366,10 +369,11 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 0, Post.where(feed: test_feed).count
 
     # Verify error event was created
-    error_events = Event.where(subject: test_feed, type: "feed_refresh_error")
+    error_events = Event.where(subject: test_feed, type: "feed_refresh")
     assert_equal 1, error_events.count
 
     error_event = error_events.first
+    assert_equal "failed", error_event.metadata["status"]
     assert_equal "error", error_event.level
     assert error_event.message.present?
     assert_equal "Feedjira::NoParserAvailable", error_event.metadata["error"]["class"]
@@ -433,7 +437,9 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal "Unauthorized", credential.last_error
     assert_equal "disabled", test_feed.reload.state
 
-    assert_equal 1, Event.where(subject: test_feed, type: "feed_refresh_error").count
+    failed_events = Event.where(subject: test_feed, type: "feed_refresh")
+    assert_equal 1, failed_events.count
+    assert_equal "failed", failed_events.first.metadata["status"]
     deactivated_event = Event.find_by(subject: credential, type: "ai_credential_deactivated")
     assert_not_nil deactivated_event
     assert_equal "warning", deactivated_event.level
@@ -491,9 +497,10 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 1, FeedEntry.where(feed: test_feed).count
 
     # Verify error event was created
-    events = Event.where(subject: test_feed, type: "feed_refresh_error")
+    events = Event.where(subject: test_feed, type: "feed_refresh")
     assert_equal 1, events.count
     error_event = events.first
+    assert_equal "failed", error_event.metadata["status"]
     assert error_event.message.present?
   end
 
@@ -529,9 +536,10 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
       assert_equal :persist_entries, workflow.stats[:failed_at_step]
 
       # Verify error event was created
-      events = Event.where(subject: test_feed, type: "feed_refresh_error")
+      events = Event.where(subject: test_feed, type: "feed_refresh")
       assert_equal 1, events.count
       error_event = events.first
+      assert_equal "failed", error_event.metadata["status"]
       assert_match(/Database error/, error_event.message)
       assert_equal "ActiveRecord::StatementInvalid", error_event.metadata["error"]["class"]
     end
@@ -572,6 +580,34 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     # Should still create success event
     events = Event.where(subject: test_feed, type: "feed_refresh")
     assert_equal 1, events.count
+  end
+
+  test "#execute should create a started event and complete it in place" do
+    test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
+
+    empty_rss = <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0"><channel><title>Empty</title></channel></rss>
+    RSS
+
+    in_flight_event = nil
+    loader = Object.new
+    loader.define_singleton_method(:load) do
+      in_flight_event = Event.find_by(subject: test_feed, type: "feed_refresh")
+      empty_rss
+    end
+
+    test_feed.stub(:loader_instance, loader) { FeedRefreshWorkflow.new(test_feed).execute }
+
+    assert_not_nil in_flight_event, "the event should exist before loading starts"
+    assert_equal "started", in_flight_event.metadata["status"]
+    assert_equal "debug", in_flight_event.level
+    assert in_flight_event.metadata["stats"]["started_at"].present?
+
+    completed_event = in_flight_event.reload
+    assert_equal "completed", completed_event.metadata["status"]
+    assert_equal "info", completed_event.level
+    assert_equal 1, Event.where(subject: test_feed, type: "feed_refresh").count
   end
 
   test "#records should create feed metrics when posts are imported" do

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -610,6 +610,63 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 1, Event.where(subject: test_feed, type: "feed_refresh").count
   end
 
+  test "#execute should mark an abandoned started event as interrupted" do
+    test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
+
+    abandoned = Event.create!(
+      type: "feed_refresh",
+      level: :debug,
+      subject: test_feed,
+      user: test_feed.user,
+      metadata: { status: "started", stats: { started_at: 1.day.ago.iso8601 } }
+    )
+
+    empty_rss = <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0"><channel><title>Empty</title></channel></rss>
+    RSS
+    WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
+
+    FeedRefreshWorkflow.new(test_feed).execute
+
+    abandoned.reload
+    assert_equal "interrupted", abandoned.metadata["status"]
+    assert_equal "debug", abandoned.level
+    assert_equal 1.day.ago.to_date.iso8601, abandoned.metadata.dig("stats", "started_at")[0, 10],
+                 "the rest of the abandoned event's metadata stays intact"
+  end
+
+  test "#execute should not touch other feeds' started events" do
+    test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
+    other_feed = create(:feed)
+
+    other_started = Event.create!(
+      type: "feed_refresh",
+      level: :debug,
+      subject: other_feed,
+      user: other_feed.user,
+      metadata: { status: "started" }
+    )
+    completed = Event.create!(
+      type: "feed_refresh",
+      level: :info,
+      subject: test_feed,
+      user: test_feed.user,
+      metadata: { status: "completed" }
+    )
+
+    empty_rss = <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0"><channel><title>Empty</title></channel></rss>
+    RSS
+    WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
+
+    FeedRefreshWorkflow.new(test_feed).execute
+
+    assert_equal "started", other_started.reload.metadata["status"]
+    assert_equal "completed", completed.reload.metadata["status"]
+  end
+
   test "#records should create feed metrics when posts are imported" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 


### PR DESCRIPTION
Changes:

- Track each feed refresh with a pair of events: a user-visible "refresh is in progress" event created at run start, replaced by a fresh outcome event (completed or failed) when the run finishes
- Fold the separate `feed_refresh_error` type into `feed_refresh` with a lifecycle status (`started`/`completed`/`failed`/`interrupted`) in metadata, with a migration converting existing events
- Sweep events abandoned by dead runs to `interrupted` — demoted out of the user feed — at the start of the next run, with metrics and logging
- Render each lifecycle status with its own description; unrecognized statuses render as unknown instead of success

Creating the outcome as a fresh event (rather than updating the started record in place) keeps live event pages updating — the polling watermark only advances on new row ids — and gives the events log completion-time ordering. The sweep is race-free because FeedRefreshJob's advisory lock allows one refresh per feed at a time.