### PR TITLE
Add Reddit vote-data retrieval + curl maintenance interface

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,6 +23,8 @@ jobs:
       # Optional LLM provider keys for the capability probe job.
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
+      # Optional bearer token for the curl/agent maintenance interface.
+      MAINTENANCE_JOB_TOKEN: ${{ secrets.MAINTENANCE_JOB_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.kamal/secrets.staging
+++ b/.kamal/secrets.staging
@@ -20,3 +20,8 @@ PRIVATE_KEY_PEM=$(printenv CF_ORIGIN_KEY | grep . || { echo "CF_ORIGIN_KEY is re
 # when these are absent from the deploying environment.
 ANTHROPIC_API_KEY=$(printenv ANTHROPIC_API_KEY)
 MOONSHOT_API_KEY=$(printenv MOONSHOT_API_KEY)
+
+# Bearer token for the curl/agent maintenance interface (Maintenance::
+# BaseController). Optional on purpose: absent means the interface stays
+# disabled, so a deploy without it must not fail.
+MAINTENANCE_JOB_TOKEN=$(printenv MAINTENANCE_JOB_TOKEN)

--- a/app/controllers/maintenance/base_controller.rb
+++ b/app/controllers/maintenance/base_controller.rb
@@ -1,0 +1,39 @@
+module Maintenance
+  # Token-authenticated, plain-text interface for running maintenance jobs from
+  # the command line or an agent — curl-friendly, minimal output. Parallel to
+  # the session-based dev-area UI (Development::JobRunsController), not a
+  # replacement.
+  #
+  # Inert unless MAINTENANCE_JOB_TOKEN is set in the environment, so it exposes
+  # nothing wherever the secret isn't configured. Inherits ActionController::Base
+  # directly to skip the session auth and modern-browser gate that would reject a
+  # bare curl request.
+  class BaseController < ActionController::Base
+    skip_forgery_protection
+    before_action :authenticate_token!
+
+    rescue_from ActiveRecord::RecordNotFound do
+      render_text("not found", status: :not_found)
+    end
+
+    private
+
+    def authenticate_token!
+      token = ENV["MAINTENANCE_JOB_TOKEN"].to_s
+      return render_text("maintenance interface is disabled (no MAINTENANCE_JOB_TOKEN)", status: :not_found) if token.blank?
+
+      provided = request.headers["Authorization"].to_s.delete_prefix("Bearer ").strip
+      return if provided.present? && ActiveSupport::SecurityUtils.secure_compare(provided, token)
+
+      render_text("unauthorized", status: :unauthorized)
+    end
+
+    def render_text(body, status: :ok)
+      render plain: "#{body.to_s.chomp}\n", status: status
+    end
+
+    def find_job_class
+      JobRun.runnable_job(params[:job_id]) || raise(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/app/controllers/maintenance/jobs_controller.rb
+++ b/app/controllers/maintenance/jobs_controller.rb
@@ -1,0 +1,17 @@
+module Maintenance
+  class JobsController < BaseController
+    def index
+      names = JobRun::RUNNABLE_JOBS.map(&:name)
+      body = [
+        "Runnable maintenance jobs:",
+        *names.map { |name| "  #{name}" },
+        "",
+        "Run one:",
+        "  curl -sX POST -H 'Authorization: Bearer $MAINTENANCE_JOB_TOKEN' \\",
+        "    #{request.base_url}/maintenance/jobs/<JobClassName>/runs"
+      ].join("\n")
+
+      render_text(body)
+    end
+  end
+end

--- a/app/controllers/maintenance/runs_controller.rb
+++ b/app/controllers/maintenance/runs_controller.rb
@@ -1,0 +1,28 @@
+module Maintenance
+  # Runs a maintenance job synchronously and returns its recorded events as
+  # plain text, so one curl call both triggers the job and shows the result.
+  # Probe jobs are short and side-effect-free, which is what makes an inline run
+  # the right fit here (unlike the dev UI, which enqueues).
+  class RunsController < BaseController
+    def create
+      job_class = find_job_class
+      job = job_class.new
+      run = JobRun.create!(job_class: job_class.name, job_id: job.job_id)
+
+      begin
+        job.perform_now
+      rescue StandardError => e
+        # RecordsJobRun has already marked the run failed; report and still
+        # render the run so the caller sees whatever events were recorded.
+        Rails.error.report(e, context: { job_class: job_class.name })
+      end
+
+      render_text(JobRunReport.new(run.reload).to_text)
+    end
+
+    def show
+      run = JobRun.where(job_class: find_job_class.name).find(params[:id])
+      render_text(JobRunReport.new(run).to_text)
+    end
+  end
+end

--- a/app/jobs/reddit_retrieval_probe_job.rb
+++ b/app/jobs/reddit_retrieval_probe_job.rb
@@ -1,0 +1,25 @@
+# Live-checks Reddit vote-data retrieval from the deployed environment and
+# records the outcome as JobRun events. See RedditRetrievalProbe for what the
+# checks establish. Launched from the dev-area jobs runner; takes no arguments.
+class RedditRetrievalProbeJob < ApplicationJob
+  include RecordsJobRun
+
+  queue_as :default
+
+  def perform
+    outcome = RedditRetrievalProbe.run
+
+    outcome[:results].each do |result|
+      record_event(type: "job.reddit_retrieval_probe.check",
+                   message: "#{result[:check]}: #{result[:status]} (#{result[:seconds]}s) — #{result[:note]}",
+                   level: result[:status] == "FAIL" ? :warning : :info,
+                   **result)
+    end
+
+    summary = outcome[:results].map { |r| "#{r[:check]}=#{r[:status]}" }.join(" ")
+    record_event(type: "job.reddit_retrieval_probe.completed",
+                 message: summary,
+                 level: outcome[:passed] ? :info : :warning,
+                 passed: outcome[:passed])
+  end
+end

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -4,6 +4,7 @@ class JobRun < ApplicationRecord
   RUNNABLE_JOBS = [
     AnthropicCapabilityProbeJob,
     KimiCapabilityProbeJob,
+    RedditRetrievalProbeJob,
     PurgeExpiredEventsJob
   ].freeze
 

--- a/app/services/maintenance/job_run_report.rb
+++ b/app/services/maintenance/job_run_report.rb
@@ -1,0 +1,43 @@
+module Maintenance
+  # Renders a JobRun and its recorded events as compact plain text for the
+  # curl/agent maintenance interface — one line per event, evidence indented
+  # beneath it, no HTML or framing noise.
+  class JobRunReport
+    def initialize(run)
+      @run = run
+    end
+
+    def to_text
+      [header, "", *event_lines].join("\n")
+    end
+
+    private
+
+    def header
+      "#{@run.job_class} — run ##{@run.id} — #{@run.status}#{duration_suffix}"
+    end
+
+    def duration_suffix
+      return "" unless @run.started_at && @run.finished_at
+
+      " (#{(@run.finished_at - @run.started_at).round(1)}s)"
+    end
+
+    def event_lines
+      @run.events.order(:created_at, :id).flat_map { |event| format_event(event) }
+    end
+
+    # "!" flags anything above info so failures are scannable at a glance.
+    def format_event(event)
+      marker = event.level.to_s == "info" ? " " : "!"
+      [" #{marker} #{event.message}", *evidence_lines(event)]
+    end
+
+    def evidence_lines(event)
+      evidence = event.metadata["evidence"]
+      return [] if evidence.blank?
+
+      Array(evidence).map { |item| "      • #{item.to_s[0, 300]}" }
+    end
+  end
+end

--- a/app/services/reddit/votes_fetcher.rb
+++ b/app/services/reddit/votes_fetcher.rb
@@ -1,0 +1,95 @@
+module Reddit
+  # Reads public vote stats for a Reddit post without an API key, OAuth, or
+  # registration.
+  #
+  # Reddit exposes a JSON view of any page by appending ".json" to its URL.
+  # A single post URL returns a two-element array — [post_listing,
+  # comments_listing] — and a subreddit/listing URL returns one listing object.
+  # Either way the post data lives under data.children[].data, which carries the
+  # vote fields the RSS feed omits (score, ups, upvote_ratio, num_comments).
+  #
+  # Two caveats shape any use of this data:
+  # - Counts are intentionally "fuzzed" by Reddit, so treat them as approximate.
+  # - Reddit serves 403 to unauthenticated requests from datacenter IPs, so
+  #   whether this works at all depends on the egress IP. The retrieval probe
+  #   (RedditRetrievalProbeJob) exists to answer that question per environment.
+  class VotesFetcher
+    USER_AGENT = "feeder-reddit-votes/0.1 (https://github.com/dreikanter/f2)".freeze
+
+    class Error < StandardError; end
+
+    # Raised for a non-2xx response; carries the numeric status so callers
+    # (notably the probe) can record it as evidence.
+    class HttpError < Error
+      attr_reader :status
+
+      def initialize(status)
+        @status = status
+        super("HTTP #{status}")
+      end
+    end
+
+    Stats = Data.define(:id, :title, :author, :score, :ups, :upvote_ratio, :num_comments, :permalink) do
+      def to_s
+        "[#{score} pts | #{(upvote_ratio.to_f * 100).round}% up | #{num_comments} comments] #{title}"
+      end
+    end
+
+    def initialize(http_client: HttpClient.build)
+      @http_client = http_client
+    end
+
+    # Stats for a single post given its URL or permalink.
+    def post(url)
+      payload = get_json(json_url(url))
+      child = children(payload.is_a?(Array) ? payload.first : payload).first
+      raise Error, "No post found at #{url}" unless child
+
+      build_stats(child)
+    end
+
+    # Stats for every post in a subreddit/user listing (e.g. r/ruby/top).
+    def listing(url)
+      children(get_json(json_url(url))).map { |child| build_stats(child) }
+    end
+
+    private
+
+    attr_reader :http_client
+
+    def json_url(url)
+      base = url.to_s.strip.sub(/[#?].*\z/, "").chomp("/")
+      base.end_with?(".json") ? base : "#{base}.json"
+    end
+
+    def get_json(url)
+      response = http_client.get(url, headers: { "User-Agent" => USER_AGENT, "Accept" => "application/json" })
+      raise HttpError, response.status unless response.success?
+
+      JSON.parse(response.body)
+    rescue HttpClient::Error => e
+      raise Error, e.message
+    rescue JSON::ParserError => e
+      raise Error, "Invalid JSON: #{e.message}"
+    end
+
+    def children(listing)
+      listing.dig("data", "children") || []
+    end
+
+    def build_stats(child)
+      data = child.fetch("data")
+
+      Stats.new(
+        id: data["id"],
+        title: data["title"],
+        author: data["author"],
+        score: data["score"],
+        ups: data["ups"],
+        upvote_ratio: data["upvote_ratio"],
+        num_comments: data["num_comments"],
+        permalink: data["permalink"] && "https://www.reddit.com#{data['permalink']}"
+      )
+    end
+  end
+end

--- a/app/services/reddit_retrieval_probe.rb
+++ b/app/services/reddit_retrieval_probe.rb
@@ -1,0 +1,96 @@
+# Live probe for Reddit vote-data retrieval (companion to LlmCapabilityProbe).
+#
+# The open question for Reddit::VotesFetcher isn't the parsing — that's unit
+# tested — but whether the ".json" endpoint is reachable at all from a given
+# egress IP. Reddit serves 403 to unauthenticated requests from datacenter IPs,
+# and the sandbox/CI environment is blocked, so this only gets a real answer
+# when run from the deployed host via the dev-area jobs runner
+# (RedditRetrievalProbeJob). Every check records its HTTP status and a sample of
+# what came back as JobRun events, so the verdict — and the evidence behind it —
+# survives without a transcript to chase.
+#
+# The checks are chosen to localize a failure, not just report one:
+# - listing / single_post exercise the real fetcher against the JSON API.
+# - old_reddit tests an alternate host, in case one is blocked and the other not.
+# - rss_control fetches the RSS feed the app already uses; RSS 200 with JSON 403
+#   means "JSON specifically is blocked", while both 403 means the IP is blocked
+#   outright.
+module RedditRetrievalProbe
+  SUBREDDIT = "programming".freeze
+  LISTING_URL = "https://www.reddit.com/r/#{SUBREDDIT}/top.json?t=week&limit=5".freeze
+  OLD_LISTING_URL = "https://old.reddit.com/r/#{SUBREDDIT}/top.json?t=week&limit=5".freeze
+  RSS_URL = "https://www.reddit.com/r/#{SUBREDDIT}/new.rss".freeze
+
+  def self.run(...) = Runner.new(...).run
+
+  class Runner
+    CHECKS = %w[listing single_post old_reddit rss_control].freeze
+
+    def initialize(fetcher: Reddit::VotesFetcher.new, http_client: HttpClient.build, checks: CHECKS)
+      @fetcher = fetcher
+      @http_client = http_client
+      @checks = checks
+      @results = []
+      @first_permalink = nil
+    end
+
+    # Returns { results:, passed: }. Mirrors LlmCapabilityProbe::Runner: every
+    # check is attempted, failures are recorded rather than raised.
+    def run
+      @checks.each { |check| record(check) { send("check_#{check}") } }
+      { results: @results, passed: @results.none? { |r| r[:status] == "FAIL" } }
+    end
+
+    private
+
+    def record(check)
+      started = Time.current
+      outcome = yield
+      @results << outcome.merge(check: check, seconds: (Time.current - started).round(1))
+    rescue StandardError => e
+      @results << { check: check, status: "FAIL", note: "#{e.class}: #{e.message.to_s[0, 300]}",
+                    evidence: nil, seconds: (Time.current - started).round(1) }
+    end
+
+    def check_listing
+      posts = @fetcher.listing(LISTING_URL)
+      scored = posts.select { |p| p.score.is_a?(Numeric) }
+      @first_permalink = posts.first&.permalink
+      evidence = scored.first(3).map(&:to_s)
+
+      if scored.empty?
+        { status: "FAIL", note: "no posts with a numeric score", evidence: posts.first(3).map(&:to_s) }
+      else
+        { status: "PASS", note: "#{scored.size} scored posts", evidence: evidence }
+      end
+    end
+
+    def check_single_post
+      return { status: "SKIP", note: "listing returned no permalink to follow", evidence: nil } if @first_permalink.blank?
+
+      stats = @fetcher.post(@first_permalink)
+      if stats.score.is_a?(Numeric)
+        { status: "PASS", note: "score=#{stats.score}, comments=#{stats.num_comments}", evidence: stats.to_s }
+      else
+        { status: "FAIL", note: "post payload had no numeric score", evidence: stats.to_s }
+      end
+    end
+
+    def check_old_reddit
+      status = raw_status(OLD_LISTING_URL)
+      pass = status == 200
+      { status: pass ? "PASS" : "FAIL", note: "old.reddit.com/.json → HTTP #{status}", evidence: nil }
+    end
+
+    # RSS is the app's current Reddit route; a 200 here isolates the JSON block.
+    def check_rss_control
+      status = raw_status(RSS_URL)
+      pass = status == 200
+      { status: pass ? "PASS" : "FAIL", note: "new.rss → HTTP #{status}", evidence: nil }
+    end
+
+    def raw_status(url)
+      @http_client.get(url, headers: { "User-Agent" => Reddit::VotesFetcher::USER_AGENT }).status
+    end
+  end
+end

--- a/app/services/reddit_retrieval_probe.rb
+++ b/app/services/reddit_retrieval_probe.rb
@@ -19,12 +19,28 @@ module RedditRetrievalProbe
   SUBREDDIT = "programming".freeze
   LISTING_URL = "https://www.reddit.com/r/#{SUBREDDIT}/top.json?t=week&limit=5".freeze
   OLD_LISTING_URL = "https://old.reddit.com/r/#{SUBREDDIT}/top.json?t=week&limit=5".freeze
+  API_URL = "https://api.reddit.com/r/#{SUBREDDIT}/top?t=week&limit=5".freeze
   RSS_URL = "https://www.reddit.com/r/#{SUBREDDIT}/new.rss".freeze
+
+  BROWSER_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " \
+               "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36".freeze
+
+  # Diagnostic matrix for the JSON 403: staging gets RSS 200 but .json 403 with
+  # the same IP+UA, so each strategy isolates a candidate cause (the Accept
+  # header, a datacenter-flagged UA, the host) to find an authless route or rule
+  # one out. PASS if any strategy returns 200.
+  JSON_STRATEGIES = [
+    { label: "ua+accept-json", url: LISTING_URL, ua: Reddit::VotesFetcher::USER_AGENT, accept: "application/json" },
+    { label: "ua-only",        url: LISTING_URL, ua: Reddit::VotesFetcher::USER_AGENT, accept: nil },
+    { label: "browser-ua",     url: LISTING_URL, ua: BROWSER_UA, accept: nil },
+    { label: "browser+rawjson", url: "#{LISTING_URL}&raw_json=1", ua: BROWSER_UA, accept: "application/json" },
+    { label: "api.reddit.com", url: API_URL, ua: BROWSER_UA, accept: "application/json" }
+  ].freeze
 
   def self.run(...) = Runner.new(...).run
 
   class Runner
-    CHECKS = %w[listing single_post old_reddit rss_control].freeze
+    CHECKS = %w[listing single_post old_reddit rss_control strategies].freeze
 
     def initialize(fetcher: Reddit::VotesFetcher.new, http_client: HttpClient.build, checks: CHECKS)
       @fetcher = fetcher
@@ -87,6 +103,23 @@ module RedditRetrievalProbe
       status = raw_status(RSS_URL)
       pass = status == 200
       { status: pass ? "PASS" : "FAIL", note: "new.rss → HTTP #{status}", evidence: nil }
+    end
+
+    # Tries each authless JSON strategy and reports its HTTP status as evidence.
+    def check_strategies
+      results = JSON_STRATEGIES.map do |strategy|
+        headers = { "User-Agent" => strategy[:ua] }
+        headers["Accept"] = strategy[:accept] if strategy[:accept]
+        status = begin
+          @http_client.get(strategy[:url], headers: headers).status
+        rescue HttpClient::Error => e
+          e.message[0, 60]
+        end
+        "#{strategy[:label]} → #{status}"
+      end
+
+      any_ok = results.any? { |line| line.end_with?("→ 200") }
+      { status: any_ok ? "PASS" : "FAIL", note: any_ok ? "an authless strategy works" : "all JSON strategies blocked", evidence: results }
     end
 
     def raw_status(url)

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -128,3 +128,6 @@ env:
     # .kamal/secrets.staging.
     - ANTHROPIC_API_KEY
     - MOONSHOT_API_KEY
+    # Bearer token for the curl/agent maintenance interface; optional — the
+    # interface is inert when unset. See .kamal/secrets.staging.
+    - MAINTENANCE_JOB_TOKEN

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,15 @@ Rails.application.routes.draw do
     end
   end
 
+  # Token-authenticated, plain-text interface for running maintenance jobs via
+  # curl/an agent (Maintenance::BaseController). Inert unless
+  # MAINTENANCE_JOB_TOKEN is set.
+  namespace :maintenance do
+    resources :jobs, only: :index do
+      resources :runs, only: [:create, :show]
+    end
+  end
+
   constraints ->(req) {
     session = Session.find_by(id: req.cookie_jar.signed[:session_id])
     session&.user&.dev?

--- a/script/reddit_retrieval_probe.rb
+++ b/script/reddit_retrieval_probe.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# CLI for RedditRetrievalProbe (see app/services/reddit_retrieval_probe.rb).
+# The dev-area jobs runner (RedditRetrievalProbeJob) is the primary way to run
+# this on the deployed host; this wrapper covers local one-off runs.
+#
+# Usage:
+#   bundle exec ruby script/reddit_retrieval_probe.rb
+#   bundle exec ruby script/reddit_retrieval_probe.rb --checks listing,rss_control
+#
+# Note: Reddit 403s unauthenticated requests from datacenter IPs, so a run from
+# a blocked network (sandbox/CI) reports FAIL — that is the probe working, not a
+# bug. Run it where the app is deployed to learn whether that egress is allowed.
+
+require "optparse"
+require_relative "../config/environment"
+
+options = { checks: RedditRetrievalProbe::Runner::CHECKS }
+OptionParser.new do |parser|
+  parser.on("--checks LIST", "Comma-separated subset of: #{RedditRetrievalProbe::Runner::CHECKS.join(',')}") do |v|
+    options[:checks] = v.split(",").map(&:strip) & RedditRetrievalProbe::Runner::CHECKS
+  end
+end.parse!
+
+outcome = RedditRetrievalProbe.run(checks: options[:checks])
+
+puts "\nReddit retrieval probe"
+outcome[:results].each { |r| puts format("  %-12s %-4s %5ss  %s", r[:check], r[:status], r[:seconds], r[:note]) }
+puts JSON.pretty_generate(outcome[:results])
+exit(outcome[:passed] ? 0 : 1)

--- a/test/integration/maintenance/jobs_test.rb
+++ b/test/integration/maintenance/jobs_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class Maintenance::JobsTest < ActionDispatch::IntegrationTest
+  TOKEN = "test-maintenance-token".freeze
+
+  setup do
+    @previous_token = ENV["MAINTENANCE_JOB_TOKEN"]
+    ENV["MAINTENANCE_JOB_TOKEN"] = TOKEN
+  end
+
+  teardown do
+    ENV["MAINTENANCE_JOB_TOKEN"] = @previous_token
+  end
+
+  def auth
+    { "Authorization" => "Bearer #{TOKEN}" }
+  end
+
+  test "is disabled with 404 when no token is configured" do
+    ENV["MAINTENANCE_JOB_TOKEN"] = nil
+    get maintenance_jobs_path, headers: auth
+    assert_response :not_found
+  end
+
+  test "rejects a missing token" do
+    get maintenance_jobs_path
+    assert_response :unauthorized
+  end
+
+  test "rejects a wrong token" do
+    get maintenance_jobs_path, headers: { "Authorization" => "Bearer nope" }
+    assert_response :unauthorized
+  end
+
+  test "index lists the runnable jobs as plain text" do
+    get maintenance_jobs_path, headers: auth
+
+    assert_response :success
+    assert_equal "text/plain", response.media_type
+    assert_includes response.body, "RedditRetrievalProbeJob"
+    assert_includes response.body, "/maintenance/jobs/"
+  end
+
+  test "create runs the job inline and returns its events as text" do
+    outcome = {
+      results: [
+        { check: "listing", status: "PASS", note: "2 scored posts", evidence: ["[1423 pts | 97% up | 218 comments] Ruby 3.4"], seconds: 0.3 },
+        { check: "rss_control", status: "FAIL", note: "new.rss → HTTP 403", evidence: nil, seconds: 0.1 }
+      ],
+      passed: false
+    }
+
+    assert_difference -> { JobRun.count } => 1 do
+      RedditRetrievalProbe.stub(:run, outcome) do
+        post maintenance_job_runs_path("RedditRetrievalProbeJob"), headers: auth
+      end
+    end
+
+    assert_response :success
+    # The job completes (status succeeded); probe FAILs surface as events, not a
+    # raised error.
+    assert_equal "succeeded", JobRun.last.status
+    assert_includes response.body, "RedditRetrievalProbeJob — run ##{JobRun.last.id}"
+    assert_includes response.body, "listing: PASS"
+    assert_includes response.body, "[1423 pts | 97% up | 218 comments] Ruby 3.4"
+    assert_includes response.body, "rss_control: FAIL"
+    assert_includes response.body, "listing=PASS rss_control=FAIL"
+  end
+
+  test "create rejects an unregistered job" do
+    post maintenance_job_runs_path("Kernel"), headers: auth
+    assert_response :not_found
+  end
+
+  test "show renders a past run scoped to its job" do
+    run = create(:job_run, job_class: "RedditRetrievalProbeJob", status: "succeeded")
+    create(:event, subject: run, type: "job.reddit_retrieval_probe.completed", level: :info, message: "listing=PASS")
+
+    get maintenance_job_run_path("RedditRetrievalProbeJob", run.id), headers: auth
+
+    assert_response :success
+    assert_includes response.body, "run ##{run.id}"
+    assert_includes response.body, "listing=PASS"
+  end
+end

--- a/test/jobs/reddit_retrieval_probe_job_test.rb
+++ b/test/jobs/reddit_retrieval_probe_job_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class RedditRetrievalProbeJobTest < ActiveJob::TestCase
+  def job
+    @job ||= RedditRetrievalProbeJob.new
+  end
+
+  def job_run
+    @job_run ||= create(:job_run, job_class: "RedditRetrievalProbeJob", job_id: job.job_id)
+  end
+
+  test "should register as a runnable job" do
+    assert_includes JobRun::RUNNABLE_JOBS, RedditRetrievalProbeJob
+  end
+
+  test "#perform should record one event per check plus a summary" do
+    job_run
+
+    outcome = {
+      results: [
+        { check: "listing", status: "PASS", note: "2 scored posts", evidence: ["[100 pts]"], seconds: 0.3 },
+        { check: "rss_control", status: "FAIL", note: "new.rss → HTTP 403", evidence: nil, seconds: 0.1 }
+      ],
+      passed: false
+    }
+
+    RedditRetrievalProbe.stub(:run, outcome) do
+      job.perform_now
+    end
+
+    checks = Event.for_subject(job_run).where(type: "job.reddit_retrieval_probe.check").order(:id)
+    assert_equal 2, checks.count
+    assert_predicate checks.first, :info?
+    assert_predicate checks.second, :warning?
+    assert_includes checks.second.message, "rss_control: FAIL"
+
+    summary = Event.for_subject(job_run).find_by(type: "job.reddit_retrieval_probe.completed")
+    assert_includes summary.message, "listing=PASS rss_control=FAIL"
+    assert_equal false, summary.metadata["passed"]
+    assert_predicate summary, :warning?
+  end
+
+  test "#perform should mark the summary info when every check passes" do
+    job_run
+    outcome = { results: [{ check: "listing", status: "PASS", note: "ok", evidence: [], seconds: 0.1 }], passed: true }
+
+    RedditRetrievalProbe.stub(:run, outcome) do
+      job.perform_now
+    end
+
+    summary = Event.for_subject(job_run).find_by(type: "job.reddit_retrieval_probe.completed")
+    assert_predicate summary, :info?
+    assert_equal true, summary.metadata["passed"]
+  end
+end

--- a/test/services/reddit/votes_fetcher_test.rb
+++ b/test/services/reddit/votes_fetcher_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class Reddit::VotesFetcherTest < ActiveSupport::TestCase
+  POST_BODY = JSON.generate([
+    { "kind" => "Listing", "data" => { "children" => [
+      { "kind" => "t3", "data" => {
+        "id" => "1abc234",
+        "title" => "Ruby 3.4 released",
+        "author" => "rubydev",
+        "score" => 1423,
+        "ups" => 1423,
+        "upvote_ratio" => 0.97,
+        "num_comments" => 218,
+        "permalink" => "/r/ruby/comments/1abc234/ruby_34_released/"
+      } }
+    ] } },
+    { "kind" => "Listing", "data" => { "children" => [] } }
+  ])
+
+  LISTING_BODY = JSON.generate(
+    "kind" => "Listing",
+    "data" => { "children" => [
+      { "kind" => "t3", "data" => { "id" => "a1", "title" => "First", "score" => 10, "ups" => 10, "upvote_ratio" => 0.9, "num_comments" => 1, "permalink" => "/r/ruby/comments/a1/first/" } },
+      { "kind" => "t3", "data" => { "id" => "b2", "title" => "Second", "score" => 20, "ups" => 20, "upvote_ratio" => 0.8, "num_comments" => 2, "permalink" => "/r/ruby/comments/b2/second/" } }
+    ] }
+  )
+
+  test "#post should extract vote stats from a single-post payload" do
+    stats = fetcher(POST_BODY).post("https://www.reddit.com/r/ruby/comments/1abc234/ruby_34_released/")
+
+    assert_equal "1abc234", stats.id
+    assert_equal 1423, stats.score
+    assert_equal 0.97, stats.upvote_ratio
+    assert_equal 218, stats.num_comments
+    assert_equal "https://www.reddit.com/r/ruby/comments/1abc234/ruby_34_released/", stats.permalink
+  end
+
+  test "#post should append .json to the requested URL" do
+    client = stub_client(POST_BODY)
+    Reddit::VotesFetcher.new(http_client: client).post("https://www.reddit.com/r/ruby/comments/1abc234/ruby_34_released/")
+    assert_equal "https://www.reddit.com/r/ruby/comments/1abc234/ruby_34_released.json", client.last_url
+  end
+
+  test "#post should not double-append .json" do
+    client = stub_client(POST_BODY)
+    Reddit::VotesFetcher.new(http_client: client).post("https://www.reddit.com/r/ruby/comments/1abc234/x.json")
+    assert_equal "https://www.reddit.com/r/ruby/comments/1abc234/x.json", client.last_url
+  end
+
+  test "#post should strip query and fragment before appending .json" do
+    client = stub_client(POST_BODY)
+    Reddit::VotesFetcher.new(http_client: client).post("https://www.reddit.com/r/ruby/comments/1abc234/x/?utm=1#top")
+    assert_equal "https://www.reddit.com/r/ruby/comments/1abc234/x.json", client.last_url
+  end
+
+  test "#listing should return stats for every child" do
+    stats = fetcher(LISTING_BODY).listing("https://www.reddit.com/r/ruby/top/")
+
+    assert_equal %w[First Second], stats.map(&:title)
+    assert_equal [10, 20], stats.map(&:score)
+  end
+
+  test "#post should raise HttpError carrying the status on a non-2xx response" do
+    error = assert_raises(Reddit::VotesFetcher::HttpError) do
+      fetcher("blocked", status: 403).post("https://www.reddit.com/r/ruby/comments/x/")
+    end
+    assert_equal 403, error.status
+    assert_equal "HTTP 403", error.message
+  end
+
+  test "#post should raise when no post is present" do
+    body = JSON.generate([{ "data" => { "children" => [] } }, { "data" => { "children" => [] } }])
+    assert_raises(Reddit::VotesFetcher::Error) do
+      fetcher(body).post("https://www.reddit.com/r/ruby/comments/x/")
+    end
+  end
+
+  test "Stats#to_s should render a compact human summary" do
+    stats = Reddit::VotesFetcher::Stats.new(id: "x", title: "Hi", author: "a", score: 42, ups: 42, upvote_ratio: 0.955, num_comments: 3, permalink: nil)
+    assert_equal "[42 pts | 96% up | 3 comments] Hi", stats.to_s
+  end
+
+  private
+
+  def fetcher(body, status: 200)
+    Reddit::VotesFetcher.new(http_client: stub_client(body, status: status))
+  end
+
+  def stub_client(body, status: 200)
+    StubClient.new(HttpClient::Response.new(status: status, body: body))
+  end
+
+  class StubClient
+    attr_reader :last_url
+
+    def initialize(response)
+      @response = response
+    end
+
+    def get(url, headers: {}, options: {})
+      @last_url = url
+      @response
+    end
+  end
+end

--- a/test/services/reddit_retrieval_probe_test.rb
+++ b/test/services/reddit_retrieval_probe_test.rb
@@ -13,8 +13,8 @@ class RedditRetrievalProbeTest < ActiveSupport::TestCase
     outcome = RedditRetrievalProbe.run(fetcher: fetcher, http_client: http)
 
     assert outcome[:passed]
-    assert_equal %w[listing single_post old_reddit rss_control], outcome[:results].map { |r| r[:check] }
-    assert_equal %w[PASS PASS PASS PASS], outcome[:results].map { |r| r[:status] }
+    assert_equal %w[listing single_post old_reddit rss_control strategies], outcome[:results].map { |r| r[:check] }
+    assert_equal %w[PASS PASS PASS PASS PASS], outcome[:results].map { |r| r[:status] }
   end
 
   test "single_post should follow the first permalink from the listing" do

--- a/test/services/reddit_retrieval_probe_test.rb
+++ b/test/services/reddit_retrieval_probe_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+class RedditRetrievalProbeTest < ActiveSupport::TestCase
+  def stats(score:, permalink: "https://www.reddit.com/r/programming/comments/x/t/", num_comments: 5)
+    Reddit::VotesFetcher::Stats.new(id: "x", title: "T", author: "a", score: score, ups: score,
+                                    upvote_ratio: 0.9, num_comments: num_comments, permalink: permalink)
+  end
+
+  test "should report PASS across checks when the JSON API is reachable" do
+    fetcher = FakeFetcher.new(listing: [stats(score: 100), stats(score: 50)], post: stats(score: 100))
+    http = FakeHttp.new(200)
+
+    outcome = RedditRetrievalProbe.run(fetcher: fetcher, http_client: http)
+
+    assert outcome[:passed]
+    assert_equal %w[listing single_post old_reddit rss_control], outcome[:results].map { |r| r[:check] }
+    assert_equal %w[PASS PASS PASS PASS], outcome[:results].map { |r| r[:status] }
+  end
+
+  test "single_post should follow the first permalink from the listing" do
+    fetcher = FakeFetcher.new(listing: [stats(score: 100, permalink: "https://www.reddit.com/r/programming/comments/abc/t/")], post: stats(score: 100))
+    RedditRetrievalProbe.run(fetcher: fetcher, http_client: FakeHttp.new(200))
+
+    assert_equal "https://www.reddit.com/r/programming/comments/abc/t/", fetcher.requested_post_url
+  end
+
+  test "single_post should SKIP when the listing yields no permalink" do
+    fetcher = FakeFetcher.new(listing: [], post: stats(score: 1))
+    outcome = RedditRetrievalProbe.run(fetcher: fetcher, http_client: FakeHttp.new(200), checks: %w[listing single_post])
+
+    single = outcome[:results].find { |r| r[:check] == "single_post" }
+    assert_equal "SKIP", single[:status]
+    assert_nil fetcher.requested_post_url
+  end
+
+  test "listing should FAIL when no post carries a numeric score" do
+    fetcher = FakeFetcher.new(listing: [stats(score: nil)], post: stats(score: 1))
+    outcome = RedditRetrievalProbe.run(fetcher: fetcher, http_client: FakeHttp.new(200), checks: %w[listing])
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_not outcome[:passed]
+  end
+
+  test "a check should record FAIL instead of raising when the fetcher errors" do
+    fetcher = FakeFetcher.new(listing: Reddit::VotesFetcher::HttpError.new(403), post: stats(score: 1))
+    outcome = RedditRetrievalProbe.run(fetcher: fetcher, http_client: FakeHttp.new(200), checks: %w[listing])
+
+    result = outcome[:results].first
+    assert_equal "FAIL", result[:status]
+    assert_includes result[:note], "403"
+  end
+
+  test "rss_control and old_reddit should reflect raw HTTP status" do
+    fetcher = FakeFetcher.new(listing: [stats(score: 1)], post: stats(score: 1))
+    outcome = RedditRetrievalProbe.run(fetcher: fetcher, http_client: FakeHttp.new(403), checks: %w[old_reddit rss_control])
+
+    assert_equal %w[FAIL FAIL], outcome[:results].map { |r| r[:status] }
+    assert(outcome[:results].all? { |r| r[:note].include?("403") })
+  end
+
+  class FakeFetcher
+    attr_reader :requested_post_url
+
+    def initialize(listing:, post:)
+      @listing = listing
+      @post = post
+    end
+
+    def listing(_url)
+      raise @listing if @listing.is_a?(StandardError)
+
+      @listing
+    end
+
+    def post(url)
+      @requested_post_url = url
+      raise @post if @post.is_a?(StandardError)
+
+      @post
+    end
+  end
+
+  class FakeHttp
+    def initialize(status)
+      @status = status
+    end
+
+    def get(_url, headers: {})
+      HttpClient::Response.new(status: @status, body: "")
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Add `Reddit::VotesFetcher` to read vote stats (score, ups, upvote ratio, comment count) from Reddit's public `.json` endpoint — no API key, OAuth, or registration
- Add a dev-area maintenance job (`RedditRetrievalProbeJob`) that live-checks retrieval from the deployed host and records each check's HTTP status and a sample result as `JobRun` events
- Add a token-authenticated, plain-text `maintenance` interface for running any registered maintenance job over `curl` and reading its events as compact text — no browser or DB access needed
- Wire an optional `MAINTENANCE_JOB_TOKEN` through the staging deploy

Reddit's RSS feed (what `RedditLoader` uses today) carries no vote data; the `.json` endpoint does. The catch is that Reddit serves 403 to unauthenticated requests from datacenter IPs, so whether the fetcher works at all depends on the egress IP — and the sandbox/CI environment is blocked. Rather than guess, the probe answers the question per environment, with checks chosen to localize a failure (JSON API vs. an alternate host vs. the RSS feed the app already fetches).

The maintenance interface exists so that probe can be run and observed from the command line: it mirrors the existing session-based dev jobs UI but authenticates with a bearer token and returns plain text, so a single `curl` both triggers a job and shows its result. It stays inert unless `MAINTENANCE_JOB_TOKEN` is set.

Parsing, probe, and interface logic are unit/integration tested; the live Reddit verdict comes from running the probe on staging.

References:

- Supersedes closed PR: #803

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyD8Mmw29izGGC4r6abZTQ)_