### PR TITLE
Align feed enablement rules with validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-10
 
+- Enabling an AI feed that's missing a working AI credential or a model now explains what's left to set up instead of failing with an error page.
 - Your events log now shows when a feed refresh is in progress; the entry is replaced by the result once the refresh finishes.
 
 ## 2026-07-09

--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -20,15 +20,23 @@ class FeedStatusesController < ApplicationController
 
   def enable(feed)
     feed.with_lock do
-      if feed.can_be_enabled?
-        feed.enabled!
+      if feed.can_be_enabled? && feed.enable
         record_feed_enabled(feed)
         respond_with_status(feed, success: "Feed enabled.")
       else
-        missing_parts = feed_missing_enablement_parts(feed)
-        respond_with_status(feed, alert: "Cannot enable feed: missing #{missing_parts.join(' and ')}.")
+        respond_with_status(feed, alert: cannot_enable_alert(feed))
       end
     end
+  end
+
+  # can_be_enabled? mirrors the enabled-state validators, but they are separate
+  # rule sets: name the missing parts when we know them, and fall back to the
+  # validator messages for any residual drift instead of raising.
+  def cannot_enable_alert(feed)
+    missing_parts = feed_missing_enablement_parts(feed)
+    return "Cannot enable feed: missing #{missing_parts.join(' and ')}." if missing_parts.any?
+
+    "Cannot enable feed: #{feed.errors.full_messages.join('; ')}."
   end
 
   def disable(feed)

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -30,6 +30,10 @@ module FeedHelper
     missing_parts << "active access token" unless feed.access_token&.active?
     missing_parts << "target group" unless feed.target_group.present?
     missing_parts << "schedule" unless feed.cron_expression.present?
+    if FeedProfile.depends_on_ai?(feed.feed_profile_key)
+      missing_parts << "active AI credential" unless feed.ai_credential&.active?
+      missing_parts << "AI model" unless feed.ai_model.present?
+    end
     missing_parts
   end
 

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -195,7 +195,8 @@ class Feed < ApplicationRecord
   end
 
   def can_be_enabled?
-    name.present? && access_token&.active? && target_group.present? && feed_profile_present? && cron_expression.present?
+    name.present? && access_token&.active? && target_group.present? && feed_profile_present? &&
+      cron_expression.present? && ai_enablement_requirements_met?
   end
 
   # Promote the feed to enabled, running the enabled-state validators. If
@@ -362,6 +363,14 @@ class Feed < ApplicationRecord
   end
 
   private
+
+  # Mirrors ai_credential_required_when_enabled_ai_profile so the Enable button
+  # never shows for an AI feed the enabled-state validators would reject.
+  def ai_enablement_requirements_met?
+    return true unless FeedProfile.depends_on_ai?(feed_profile_key)
+
+    ai_credential&.active? && ai_model.present?
+  end
 
   # Records a feed_auto_disabled event stamped with the streak length, so the
   # activity log shows how many failures it took.

--- a/test/controllers/feed_statuses_controller_test.rb
+++ b/test/controllers/feed_statuses_controller_test.rb
@@ -173,6 +173,34 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "disabled", feed_with_inactive_token.state
   end
 
+  test "#update should not enable an AI feed without an AI credential" do
+    sign_in_as(user)
+    ai_feed = create(:feed, user: user, feed_profile_key: "llm", params: { "prompt" => "ruby news" })
+
+    patch feed_status_path(ai_feed), params: { status: "enabled" }
+
+    assert_redirected_to ai_feed
+    follow_redirect!
+    assert_includes response.body, "Cannot enable feed: missing active AI credential and AI model"
+
+    ai_feed.reload
+    assert_equal "disabled", ai_feed.state
+  end
+
+  test "#update should surface validation errors instead of raising when rules drift" do
+    sign_in_as(user)
+    feed.update_column(:params, {})
+
+    patch feed_status_path(feed), params: { status: "enabled" }
+
+    assert_redirected_to feed
+    follow_redirect!
+    assert_includes response.body, "Cannot enable feed: missing source"
+
+    feed.reload
+    assert_equal "disabled", feed.state
+  end
+
   test "#update should redirect to login when not authenticated" do
     patch feed_status_path(feed), params: { status: "enabled" }
     assert_redirected_to new_session_url

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -49,6 +49,33 @@ class FeedHelperTest < ActionView::TestCase
     assert_includes result, "name"
   end
 
+  test "#feed_missing_enablement_parts should include AI credential and model for an AI feed" do
+    feed = build(:feed, feed_profile_key: "llm", params: { "prompt" => "ruby news" },
+                        ai_credential: nil, ai_model: nil)
+    result = feed_missing_enablement_parts(feed)
+
+    assert_includes result, "active AI credential"
+    assert_includes result, "AI model"
+  end
+
+  test "#feed_missing_enablement_parts should report an inactive AI credential" do
+    credential = create(:ai_credential, :inactive)
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "ruby news" }, ai_credential: credential, ai_model: "claude-sonnet-4-6")
+    result = feed_missing_enablement_parts(feed)
+
+    assert_equal ["active AI credential"], result
+  end
+
+  test "#feed_missing_enablement_parts should be empty for a ready AI feed" do
+    credential = create(:ai_credential, :active)
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "ruby news" }, ai_credential: credential, ai_model: "claude-sonnet-4-6")
+    result = feed_missing_enablement_parts(feed)
+
+    assert_equal [], result
+  end
+
   test "#feed_status_icon should render enabled icon" do
     feed = build(:feed, :enabled)
 

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -375,6 +375,37 @@ class FeedTest < ActiveSupport::TestCase
     assert_not feed.can_be_enabled?
   end
 
+  test "#can_be_enabled? returns false for an AI feed without a credential" do
+    feed = build(:feed, feed_profile_key: "llm", params: { "prompt" => "ruby news" },
+                        ai_credential: nil, ai_model: "claude-sonnet-4-6")
+
+    assert_not feed.can_be_enabled?
+  end
+
+  test "#can_be_enabled? returns false for an AI feed with an inactive credential" do
+    credential = create(:ai_credential, :inactive)
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "ruby news" }, ai_credential: credential, ai_model: "claude-sonnet-4-6")
+
+    assert_not feed.can_be_enabled?
+  end
+
+  test "#can_be_enabled? returns false for an AI feed without a model" do
+    credential = create(:ai_credential, :active)
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "ruby news" }, ai_credential: credential, ai_model: nil)
+
+    assert_not feed.can_be_enabled?
+  end
+
+  test "#can_be_enabled? returns true for an AI feed with an active credential and a model" do
+    credential = create(:ai_credential, :active)
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "ruby news" }, ai_credential: credential, ai_model: "claude-sonnet-4-6")
+
+    assert feed.can_be_enabled?
+  end
+
   test "#can_be_previewed? should be true for a non-AI profile with a source" do
     feed = build(:feed, feed_profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
 


### PR DESCRIPTION
Changes:

- `Feed#can_be_enabled?` now requires an active AI credential and a chosen model for AI-backed feeds, matching the enabled-state validators, so the Enable button no longer shows for a feed that can't actually be enabled.
- `feed_missing_enablement_parts` lists the missing AI credential/model, so the failure message explains what's left to set up.
- `FeedStatusesController#enable` uses `Feed#enable` (validating, non-raising) instead of `enabled!`, so any residual drift between the button rule and the validators renders an alert instead of a 500.

The three enablement rule sets (`can_be_enabled?`, the missing-parts helper, the enabled-state validations) stay hand-maintained; this closes the gap that raised in production paths and makes future drift degrade gracefully. The presence-vs-active access-token rule in the validators is left as-is — that's the product decision called out in #955.

References:

- Related issue: #955
