### PR TITLE
Compose import_after once in before_validation

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -49,6 +49,7 @@ class Feed < ApplicationRecord
   attr_accessor :source_verified
 
   after_update :create_schedule_on_enable
+  before_validation :compose_import_after_from_parts
 
   validates :name, uniqueness: { scope: :user_id }, length: { maximum: NAME_MAX_LENGTH }
   validates :name, presence: true, if: :enabled?
@@ -101,7 +102,10 @@ class Feed < ApplicationRecord
   # Form-facing accessors splitting import_after into a checkbox plus
   # separate date and time inputs. The checkbox drives everything: when it's
   # off, import_after resets to nil no matter what the date and time fields
-  # contain.
+  # contain. The setters only record their part; import_after itself is
+  # composed once in before_validation — composing on every part-write let
+  # earlier parts read fallbacks from a half-updated import_after, making the
+  # result depend on assignment order.
   def import_after_enabled
     return @import_after_enabled unless @import_after_enabled.nil?
 
@@ -109,8 +113,8 @@ class Feed < ApplicationRecord
   end
 
   def import_after_enabled=(value)
+    @import_after_parts_assigned = true
     @import_after_enabled = ActiveModel::Type::Boolean.new.cast(value) || false
-    recompose_import_after
   end
 
   def import_after_date
@@ -118,8 +122,8 @@ class Feed < ApplicationRecord
   end
 
   def import_after_date=(value)
+    @import_after_parts_assigned = true
     @import_after_date = value.to_s.strip
-    recompose_import_after
   end
 
   def import_after_time
@@ -127,8 +131,8 @@ class Feed < ApplicationRecord
   end
 
   def import_after_time=(value)
+    @import_after_parts_assigned = true
     @import_after_time = value.to_s.strip
-    recompose_import_after
   end
 
   # Link to the target group on its FreeFeed instance. Post#freefeed_url
@@ -380,7 +384,11 @@ class Feed < ApplicationRecord
     end
   end
 
-  def recompose_import_after
+  # Only touches import_after when the form parts were assigned, so saves that
+  # never saw the checkbox (state flips, background updates) leave it alone.
+  def compose_import_after_from_parts
+    return unless @import_after_parts_assigned
+
     self.import_after = compose_import_after
   end
 

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -996,6 +996,23 @@ class FeedTest < ActiveSupport::TestCase
     assert feed.valid?, feed.errors.full_messages.inspect
   end
 
+  test "should compose the same result regardless of part assignment order" do
+    feed = build(:feed)
+    feed.import_after_enabled = "1"
+    feed.import_after_date = "2026-01-15"
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+    assert_equal Time.zone.parse("2026-01-15 00:00"), feed.import_after
+  end
+
+  test "should leave import_after alone when the parts were never assigned" do
+    time = Time.utc(2026, 1, 15, 10, 30, 45)
+    feed = build(:feed, import_after: time)
+
+    assert feed.valid?, feed.errors.full_messages.inspect
+    assert_equal time, feed.import_after
+  end
+
   test "#record_refresh_failure! should bump the streak without disabling below the threshold" do
     feed = create(:feed, :enabled, consecutive_failures: 2)
 


### PR DESCRIPTION
Changes:

- The `import_after_enabled`/`date`/`time` setters now only record their part; `import_after` is composed once in a `before_validation` callback instead of on every part-write.
- Composition still only runs when a part was actually assigned, so saves that never saw the form (state flips, background updates) leave `import_after` untouched.

Per-setter recomposition had a hidden assignment-order dependency: an earlier part-write composed from a half-updated state, and later getters read their fallback from that polluted `import_after`. Concretely, assigning `enabled` before `date` (with no time) produced the current clock time instead of midnight. Slightly behavior-moving as flagged in the review: `import_after` now updates at validation time rather than at assignment.

References:

- Related issue: #955
