### PR TITLE
Tolerate concurrent insert when restarting detection

### DIFF
--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -26,8 +26,11 @@ class FeedIdentificationsController < ApplicationController
     return present_outcome if settled_identification?
 
     if feed_identification.new_record? || feed_identification.failed? || retryable_unreachable?
-      feed_identification.restart_detection!
-      FeedIdentificationJob.perform_later(Current.user.id, source_url)
+      restarted = feed_identification.restart_detection!
+      # A losing concurrent submit skips the enqueue: the winner that just
+      # created the row owns the in-flight detection, and both requests render
+      # the same checking state.
+      FeedIdentificationJob.perform_later(Current.user.id, source_url) if restarted
     end
 
     render(entry_form(url: source_url, checking: true))

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -12,8 +12,16 @@ class FeedIdentification < ApplicationRecord
   # Reset the row to a fresh in-flight detection. Shared by the creation entry
   # and the edit-source re-detection so both clear stale candidates/errors the
   # same way; the caller enqueues FeedIdentificationJob.
+  #
+  # Two concurrent submits can both look the row up before either inserts; the
+  # loser's insert then hits the user+input unique index. Returns false in that
+  # case — the winner's detection is already in flight, so the stale copy
+  # should be discarded — and true when this call (re)started detection.
   def restart_detection!
     update!(status: :processing, started_at: Time.current, candidates: [], error: nil)
+    true
+  rescue ActiveRecord::RecordNotUnique
+    false
   end
 
   # The candidate the chooser preselects and the new-feed form is built from: the

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -42,6 +42,29 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     refute_predicate identification, :invalid_processing?
   end
 
+  test "#restart_detection! should reset the row to a fresh in-flight detection" do
+    identification = create(:feed_identification, :failed, user: user)
+
+    assert identification.restart_detection!
+
+    identification.reload
+    assert_predicate identification, :processing?
+    assert_not_nil identification.started_at
+    assert_equal [], identification.candidates
+    assert_nil identification.error
+  end
+
+  test "#restart_detection! should return false after losing the insert race" do
+    winner = create(:feed_identification, user: user, started_at: Time.current).reload
+    # The loser's stale lookup result: it missed the winner's row, so its
+    # insert collides with the user+input unique index.
+    loser = FeedIdentification.new(user: user, input: winner.input)
+
+    assert_not loser.restart_detection!
+    assert_predicate loser, :new_record?
+    assert_equal winner.started_at, winner.reload.started_at, "the winner's detection should not be restarted"
+  end
+
 
   def identification(candidates)
     FeedIdentification.new(user: user, input: "https://example.com/feed.xml", candidates: candidates)


### PR DESCRIPTION
Changes:

- `FeedIdentification#restart_detection!` now rescues the `RecordNotUnique` from its own insert and returns false, signalling that a concurrent request created the row first and owns the in-flight detection.
- `FeedIdentificationsController#create` skips the job enqueue in that case; both requests render the same checking state.
- Model tests exercise the real collision — a real insert against the `user_id + input` unique index by a stale record built directly — with no stubbing of the objects under test.

Two concurrent submits can both see no row for the URL; the loser's insert then hits the unique index. The rescue removed in #953 never worked — it called `reload` on an unpersisted record. Handling the race at the model level keeps the controller linear and makes the behavior testable without doubles: the losing state is constructed, not simulated.

References:

- Related issue: #955