### PR TITLE
Derive target-group reason codes from one list

### DIFF
--- a/app/components/feed_target_group_unavailable_description_component.rb
+++ b/app/components/feed_target_group_unavailable_description_component.rb
@@ -1,11 +1,9 @@
 # Renders why a feed was turned off, from the deterministic reason code in the
 # event metadata. Unknown or missing codes fall back to generic copy.
 class FeedTargetGroupUnavailableDescriptionComponent < EventDescriptionComponent
-  # Reason codes we have specific copy for. Anything else uses the default line.
-  KNOWN_REASONS = %w[
-    group_not_found
-    posting_denied
-  ].freeze
+  # Reason codes we have specific copy for — the publisher's taxonomy, so the
+  # two lists can't drift. Anything else uses the default line.
+  KNOWN_REASONS = FreefeedPublisher::TargetGroupUnavailableError::REASONS.map(&:to_s).freeze
 
   def call
     I18n.t(

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -19,6 +19,11 @@ class FreefeedPublisher
     # The destination group no longer exists (deleted or renamed).
     GROUP_NOT_FOUND = :group_not_found
 
+    # The full reason taxonomy. The event description component derives its
+    # known-reason list (and locale copy is keyed) from this, so a new code
+    # only needs to be added here and translated.
+    REASONS = [POSTING_DENIED, GROUP_NOT_FOUND].freeze
+
     attr_reader :reason, :server_message
 
     def initialize(reason:, server_message: nil)

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -106,6 +106,13 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     assert_includes result, "its FreeFeed group is no longer available"
   end
 
+  test "should have specific copy for every reason in the publisher taxonomy" do
+    FreefeedPublisher::TargetGroupUnavailableError::REASONS.each do |reason|
+      assert I18n.exists?("events.feed_target_group_unavailable.reasons.#{reason}"),
+             "missing locale copy for reason #{reason}"
+    end
+  end
+
   test "#call should never expose the raw API response for target-group-unavailable events" do
     event = Event.create!(
       type: "feed_target_group_unavailable",


### PR DESCRIPTION
Changes:

- `FreefeedPublisher::TargetGroupUnavailableError` now declares its full reason taxonomy in a `REASONS` constant.
- `FeedTargetGroupUnavailableDescriptionComponent::KNOWN_REASONS` is derived from it instead of duplicating the codes as string literals.
- A test guards that every code in the taxonomy has specific locale copy, so the locale file can't silently drift either.

A new reason code now only needs to be added to the error class and translated — the component picks it up automatically.

References:

- Related issue: #955
