### PR TITLE
Extract shared selectedProfileKey form helper

### DIFF
--- a/app/javascript/controllers/ai_settings_controller.js
+++ b/app/javascript/controllers/ai_settings_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { selectedProfileKey } from "controllers/helpers/selected_profile_key"
 
 // Shows the AI Settings section only for AI-backed profiles (disabling its
 // selects while hidden so a non-AI feed submits no provider/model), and
@@ -27,7 +28,7 @@ export default class extends Controller {
   }
 
   refreshVisibility() {
-    const isAi = this.aiProfilesValue.includes(this._selectedProfileKey())
+    const isAi = this.aiProfilesValue.includes(selectedProfileKey(this.form))
     this.element.hidden = !isAi
     if (this.hasCredentialSelectTarget) this.credentialSelectTarget.disabled = !isAi
     if (this.hasModelSelectTarget) this.modelSelectTarget.disabled = !isAi
@@ -50,14 +51,6 @@ export default class extends Controller {
     })
     this.modelSelectTarget.innerHTML = options.join("")
     this.modelSelectTarget.value = keep
-  }
-
-  _selectedProfileKey() {
-    if (!this.form) return null
-    const checked = this.form.querySelector("input[name='feed[feed_profile_key]']:checked")
-    if (checked) return checked.value
-    const hidden = this.form.querySelector("input[type=hidden][name='feed[feed_profile_key]']")
-    return hidden ? hidden.value : null
   }
 
   _escape(value) {

--- a/app/javascript/controllers/helpers/selected_profile_key.js
+++ b/app/javascript/controllers/helpers/selected_profile_key.js
@@ -1,0 +1,10 @@
+// The profile key the feed form currently has selected: the checked radio
+// while the profile chooser is live, otherwise the hidden field that pins the
+// profile once it's fixed.
+export function selectedProfileKey(root) {
+  if (!root) return null
+  const checked = root.querySelector("input[name='feed[feed_profile_key]']:checked")
+  if (checked) return checked.value
+  const hidden = root.querySelector("input[type=hidden][name='feed[feed_profile_key]']")
+  return hidden ? hidden.value : null
+}

--- a/app/javascript/controllers/preview_button_controller.js
+++ b/app/javascript/controllers/preview_button_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { selectedProfileKey } from "controllers/helpers/selected_profile_key"
 
 // Drives the manual feed preview:
 // - keeps the button enabled only when a profile is selected and a source is
@@ -38,7 +39,7 @@ export default class extends Controller {
 
   open(event) {
     event?.preventDefault()
-    const profileKey = this._selectedProfileKey()
+    const profileKey = selectedProfileKey(this.element)
     if (!profileKey || !this._currentSource().trim() || !this.hasFrameTarget) return
 
     const sourceKey = this.sourceKeysValue[profileKey]
@@ -73,7 +74,7 @@ export default class extends Controller {
   // when it's ready. Mirrors the enable checks so the hint never disagrees with
   // the button (spec §4 nicety).
   _unavailableReason() {
-    const profileKey = this._selectedProfileKey()
+    const profileKey = selectedProfileKey(this.element)
     if (!profileKey) return "Pick a feed type to preview."
     if (!this._currentSource().trim()) {
       return this._isAiProfile(profileKey) ? "Add a prompt to preview." : "Add a source URL to preview."
@@ -95,13 +96,6 @@ export default class extends Controller {
   // AI feed's prompt) is present — then it's whatever the user has typed.
   _currentSource() {
     return this.hasSourceTarget ? this.sourceTarget.value : this.sourceValue
-  }
-
-  _selectedProfileKey() {
-    const checked = this.element.querySelector("input[name='feed[feed_profile_key]']:checked")
-    if (checked) return checked.value
-    const hidden = this.element.querySelector("input[type=hidden][name='feed[feed_profile_key]']")
-    return hidden ? hidden.value : null
   }
 
   _isAiProfile(profileKey) {


### PR DESCRIPTION
Changes:

- Move the duplicated checked-radio-or-hidden-field profile lookup from `preview_button_controller.js` and `ai_settings_controller.js` into a shared `controllers/helpers/selected_profile_key` module.

The helper takes the search root as an argument (`this.element` for the preview button, the enclosing form for AI settings), which also absorbs the null-form guard the AI settings copy carried. The file lives under `controllers/helpers/` so `pin_all_from` picks it up, while the Stimulus eager loader ignores it (no `_controller` suffix). Verified the importmap pins it as `controllers/helpers/selected_profile_key`.

References:

- Related issue: #955
