### PR TITLE
Add Bluesky feed profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-10
 
+- You can now follow Bluesky accounts: paste a bsky.app profile link or a handle, and their posts get reposted with pictures included.
 - Your events log now shows when a feed refresh is in progress; the entry is replaced by the result once the refresh finishes.
 
 ## 2026-07-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-10
 
-- You can now follow Bluesky accounts: paste a bsky.app profile link or a handle, and their posts get reposted with pictures included.
+- You can now follow Bluesky accounts: paste a bsky.app profile link, and their posts get reposted with pictures included.
 - Enabling an AI feed that's missing a working AI credential or a model now explains what's left to set up instead of failing with an error page.
 - Telegram feeds now tell you clearly when a channel has no public web preview (restricted, private, or not a channel), instead of quietly showing no posts.
 - Your events log now shows when a feed refresh is in progress; the entry is replaced by the result once the refresh finishes.

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -342,7 +342,7 @@ class FeedProfile
       input_shape: :url,
       depends_on_ai: false,
       matcher: "ProfileMatcher::BlueskyProfileMatcher",
-      parameter_schema: LOOSE_URL_PARAMETER_SCHEMA,
+      parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::BlueskyLoader", config: {} },
       processor: { class: "Processor::BlueskyProcessor", config: {} },
       normalizer: { class: "Normalizer::BlueskyNormalizer", config: {} },

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -335,6 +335,18 @@ class FeedProfile
       processor: { class: "Processor::TwitterProcessor", config: {} },
       normalizer: { class: "Normalizer::TwitterNormalizer", config: {} },
       title_extractor: "TitleExtractor::TwitterTitleExtractor"
+    },
+    "bluesky" => {
+      display_name: "Bluesky",
+      description: "Posts from a public Bluesky account, images included",
+      input_shape: :url,
+      depends_on_ai: false,
+      matcher: "ProfileMatcher::BlueskyProfileMatcher",
+      parameter_schema: LOOSE_URL_PARAMETER_SCHEMA,
+      loader: { class: "Loader::BlueskyLoader", config: {} },
+      processor: { class: "Processor::BlueskyProcessor", config: {} },
+      normalizer: { class: "Normalizer::BlueskyNormalizer", config: {} },
+      title_extractor: "TitleExtractor::BlueskyTitleExtractor"
     }
   }.freeze
 

--- a/app/services/loader/bluesky_loader.rb
+++ b/app/services/loader/bluesky_loader.rb
@@ -47,7 +47,8 @@ module Loader
     end
 
     def profile_url_actor(raw)
-      segments = raw.sub(%r{\Ahttps?://}i, "").split("/").reject(&:empty?)
+      path = raw.sub(%r{\Ahttps?://}i, "").split(/[?#]/).first.to_s
+      segments = path.split("/").reject(&:empty?)
       return "" unless HOSTS.include?(segments.first.to_s.downcase)
 
       segments.second.to_s.casecmp?("profile") ? segments.third.to_s : ""

--- a/app/services/loader/bluesky_loader.rb
+++ b/app/services/loader/bluesky_loader.rb
@@ -2,8 +2,8 @@ module Loader
   # Fetches a Bluesky author's timeline through the public AppView API
   # (public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed). It is documented,
   # needs no API key or login, and carries full-size image URLs — unlike the
-  # profile's native RSS feed, which is text-only. Accepts a bsky.app profile
-  # URL, an @handle, a bare handle, or a DID.
+  # profile's native RSS feed, which is text-only. Accepts a full bsky.app
+  # profile URL identifying the account by handle or DID.
   class BlueskyLoader < Base
     API_URL = "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed".freeze
     HOSTS = %w[bsky.app www.bsky.app].freeze
@@ -16,7 +16,7 @@ module Loader
     def load
       identifier = actor
       unless identifier.match?(HANDLE) || identifier.match?(DID)
-        raise Loader::Error, "Could not determine Bluesky handle from #{feed.url.inspect}"
+        raise Loader::Error, "Expected a bsky.app profile URL, got #{feed.url.inspect}"
       end
 
       response = http_client.get(feed_url(identifier), headers: { "Accept" => "application/json" })
@@ -35,18 +35,13 @@ module Loader
       "#{API_URL}?#{URI.encode_www_form(actor: identifier, filter: "posts_no_replies")}"
     end
 
+    # The account's handle or DID from a bsky.app/profile/<actor> URL. Only
+    # the full URL form is accepted — bare handles are ambiguous (and the
+    # params schema requires a URI anyway).
     def actor
       raw = feed.url.to_s.strip
-      return raw.delete_prefix("@") if raw.start_with?("@")
+      return "" unless raw.match?(%r{\Ahttps?://}i)
 
-      if raw.match?(%r{\Ahttps?://}i) || HOSTS.any? { |host| raw.downcase.start_with?("#{host}/") }
-        profile_url_actor(raw)
-      else
-        raw.split("/").first.to_s
-      end
-    end
-
-    def profile_url_actor(raw)
       path = raw.sub(%r{\Ahttps?://}i, "").split(/[?#]/).first.to_s
       segments = path.split("/").reject(&:empty?)
       return "" unless HOSTS.include?(segments.first.to_s.downcase)

--- a/app/services/loader/bluesky_loader.rb
+++ b/app/services/loader/bluesky_loader.rb
@@ -1,0 +1,76 @@
+module Loader
+  # Fetches a Bluesky author's timeline through the public AppView API
+  # (public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed). It is documented,
+  # needs no API key or login, and carries full-size image URLs — unlike the
+  # profile's native RSS feed, which is text-only. Accepts a bsky.app profile
+  # URL, an @handle, a bare handle, or a DID.
+  class BlueskyLoader < Base
+    API_URL = "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed".freeze
+    HOSTS = %w[bsky.app www.bsky.app].freeze
+    # AT Protocol identifiers: a handle is a domain name (two labels minimum),
+    # a DID is did:<method>:<identifier>.
+    HANDLE = /\A[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)+\z/
+    DID = /\Adid:[a-z]+:[a-zA-Z0-9._:%-]+\z/
+    DEFAULT_MAX_REDIRECTS = 3
+
+    def load
+      identifier = actor
+      unless identifier.match?(HANDLE) || identifier.match?(DID)
+        raise Loader::Error, "Could not determine Bluesky handle from #{feed.url.inspect}"
+      end
+
+      response = http_client.get(feed_url(identifier), headers: { "Accept" => "application/json" })
+      raise Loader::Error, error_message(response) unless response.success?
+
+      response.body
+    rescue HttpClient::Error => e
+      raise Loader::Error, e.message
+    end
+
+    private
+
+    # posts_no_replies keeps the timeline to top-level posts; reposts still
+    # come through and are dropped by the processor.
+    def feed_url(identifier)
+      "#{API_URL}?#{URI.encode_www_form(actor: identifier, filter: "posts_no_replies")}"
+    end
+
+    def actor
+      raw = feed.url.to_s.strip
+      return raw.delete_prefix("@") if raw.start_with?("@")
+
+      if raw.match?(%r{\Ahttps?://}i) || HOSTS.any? { |host| raw.downcase.start_with?("#{host}/") }
+        profile_url_actor(raw)
+      else
+        raw.split("/").first.to_s
+      end
+    end
+
+    def profile_url_actor(raw)
+      segments = raw.sub(%r{\Ahttps?://}i, "").split("/").reject(&:empty?)
+      return "" unless HOSTS.include?(segments.first.to_s.downcase)
+
+      segments.second.to_s.casecmp?("profile") ? segments.third.to_s : ""
+    end
+
+    # The API answers errors with a JSON body whose message (e.g. "Profile
+    # not found") is more useful than the bare status code.
+    def error_message(response)
+      detail = parsed_error(response.body)
+      detail.present? ? "HTTP #{response.status}: #{detail}" : "HTTP #{response.status}"
+    end
+
+    def parsed_error(body)
+      parsed = JSON.parse(body.to_s)
+      parsed["message"] if parsed.is_a?(Hash)
+    rescue JSON::ParserError
+      nil
+    end
+
+    def http_client
+      @http_client ||= options.fetch(:http_client) do
+        HttpClient.build(max_redirects: options.fetch(:max_redirects, DEFAULT_MAX_REDIRECTS))
+      end
+    end
+  end
+end

--- a/app/services/normalizer/bluesky_normalizer.rb
+++ b/app/services/normalizer/bluesky_normalizer.rb
@@ -1,20 +1,22 @@
 module Normalizer
   # Maps a parsed Bluesky post into a Post: the post text becomes the content
-  # (with the bsky.app permalink appended, like the other profiles) and any
-  # embedded images, gallery items, or video thumbnails become attachments.
-  class BlueskyNormalizer < RssNormalizer
+  # with the bsky.app permalink appended, and any embedded images, gallery
+  # items, or video thumbnails become attachments. The permalink is always
+  # constructed by the processor, so unlike feed-sourced profiles no extra
+  # URL validation is needed beyond the base checks.
+  class BlueskyNormalizer < Base
     private
 
+    def normalize_source_url
+      raw_data["url"].to_s
+    end
+
     def normalize_content
-      raw_data["text"].to_s
+      post_content_with_url(raw_data["text"].to_s, source_url)
     end
 
     def normalize_attachment_urls
       Array(raw_data["images"]).uniq
-    end
-
-    def original_url
-      @original_url ||= raw_data["url"].to_s
     end
   end
 end

--- a/app/services/normalizer/bluesky_normalizer.rb
+++ b/app/services/normalizer/bluesky_normalizer.rb
@@ -1,0 +1,20 @@
+module Normalizer
+  # Maps a parsed Bluesky post into a Post: the post text becomes the content
+  # (with the bsky.app permalink appended, like the other profiles) and any
+  # embedded images, gallery items, or video thumbnails become attachments.
+  class BlueskyNormalizer < RssNormalizer
+    private
+
+    def normalize_content
+      raw_data["text"].to_s
+    end
+
+    def normalize_attachment_urls
+      Array(raw_data["images"]).uniq
+    end
+
+    def original_url
+      @original_url ||= raw_data["url"].to_s
+    end
+  end
+end

--- a/app/services/processor/bluesky_processor.rb
+++ b/app/services/processor/bluesky_processor.rb
@@ -1,0 +1,126 @@
+module Processor
+  # Parses a Bluesky getAuthorFeed JSON payload into FeedEntry objects. Only
+  # the author's own top-level posts survive: reposts (items carrying a
+  # `reason`) and replies are skipped. Truncated link text is expanded to the
+  # full target URL from the post's facets, and embedded images, gallery
+  # items, and video thumbnails are collected as attachment candidates.
+  class BlueskyProcessor < Base
+    LINK_FACET = "app.bsky.richtext.facet#link".freeze
+    # Placeholder the AppView serves when an account's handle no longer
+    # resolves; permalinks built from it are dead, the DID form works.
+    INVALID_HANDLE = "handle.invalid".freeze
+
+    def process
+      items = feed_items
+      Result.new(
+        entries: Array(items).filter_map { |item| build_entry(item) },
+        recognized: !items.nil?
+      )
+    end
+
+    private
+
+    # The feed array, or nil when the payload isn't a getAuthorFeed response.
+    def feed_items
+      parsed = JSON.parse(raw_data.to_s)
+      items = parsed.is_a?(Hash) ? parsed["feed"] : nil
+      items.is_a?(Array) ? items : nil
+    rescue JSON::ParserError
+      nil
+    end
+
+    def build_entry(item)
+      return nil if item["reason"].present? || item["reply"].present?
+
+      post = item["post"]
+      return nil unless post.is_a?(Hash)
+
+      uid = post["uri"].presence
+      return nil unless uid
+
+      published_at = parse_time(post.dig("record", "createdAt"))
+      return nil unless published_at
+
+      FeedEntry.new(
+        feed: feed,
+        uid: uid,
+        published_at: published_at,
+        status: :pending,
+        raw_data: {
+          "uid" => uid,
+          "url" => post_url(post),
+          "text" => post_text(post["record"] || {}),
+          "images" => embed_images(post["embed"] || {})
+        }
+      )
+    end
+
+    # The public permalink: bsky.app/profile/<actor>/post/<rkey>, where the
+    # rkey is the last segment of the post's at:// URI.
+    def post_url(post)
+      rkey = post["uri"].to_s.split("/").last
+      "https://bsky.app/profile/#{post_actor(post)}/post/#{rkey}"
+    end
+
+    def post_actor(post)
+      handle = post.dig("author", "handle").presence
+      handle = nil if handle == INVALID_HANDLE
+      handle || post.dig("author", "did")
+    end
+
+    # Bluesky truncates long URLs in the display text ("example.com/long-pa...")
+    # and carries the full target in a link facet addressed by byte range.
+    # Splice the full URLs back in, working bytewise from the end so earlier
+    # ranges stay valid.
+    def post_text(record)
+      text = record["text"].to_s
+      facets = link_facets(record)
+      return text if facets.empty?
+
+      bytes = text.dup.force_encoding(Encoding::BINARY)
+      facets.sort_by { |facet| -facet[:start] }.each do |facet|
+        next if facet[:start].negative? || facet[:start] >= facet[:stop] || facet[:stop] > bytes.bytesize
+
+        bytes[facet[:start]...facet[:stop]] = facet[:uri].dup.force_encoding(Encoding::BINARY)
+      end
+
+      expanded = bytes.force_encoding(Encoding::UTF_8)
+      expanded.valid_encoding? ? expanded : text
+    end
+
+    def link_facets(record)
+      Array(record["facets"]).filter_map do |facet|
+        index = facet["index"]
+        next unless index.is_a?(Hash)
+
+        uri = Array(facet["features"]).filter_map { |feature| feature["uri"] if feature["$type"] == LINK_FACET }.first
+        next if uri.blank?
+
+        { start: index["byteStart"].to_i, stop: index["byteEnd"].to_i, uri: uri }
+      end
+    end
+
+    def embed_images(embed)
+      case embed["$type"]
+      when "app.bsky.embed.images#view"
+        Array(embed["images"]).filter_map { |image| image["fullsize"] }
+      when "app.bsky.embed.gallery#view"
+        Array(embed["items"]).filter_map { |item| item["fullsize"] }
+      when "app.bsky.embed.video#view"
+        [embed["thumbnail"]].compact
+      when "app.bsky.embed.recordWithMedia#view"
+        embed_images(embed["media"] || {})
+      else
+        []
+      end.uniq
+    end
+
+    def parse_time(value)
+      return nil if value.blank?
+
+      Time.iso8601(value)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/services/processor/bluesky_processor.rb
+++ b/app/services/processor/bluesky_processor.rb
@@ -30,6 +30,7 @@ module Processor
     end
 
     def build_entry(item)
+      return nil unless item.is_a?(Hash)
       return nil if item["reason"].present? || item["reply"].present?
 
       post = item["post"]

--- a/app/services/profile_matcher/bluesky_profile_matcher.rb
+++ b/app/services/profile_matcher/bluesky_profile_matcher.rb
@@ -1,0 +1,27 @@
+module ProfileMatcher
+  # Matches public Bluesky profile URLs: bsky.app/profile/<handle-or-DID>.
+  # Other bsky.app paths (search, feeds, settings) fall through to the
+  # generic profiles.
+  class BlueskyProfileMatcher < Base
+    match_specificity 100
+
+    HOSTS = %w[bsky.app www.bsky.app].freeze
+    HANDLE = Loader::BlueskyLoader::HANDLE
+    DID = Loader::BlueskyLoader::DID
+
+    def match?
+      return false if input.blank?
+
+      uri = URI.parse(input.strip)
+      return false unless HOSTS.include?(uri.host)
+
+      segments = uri.path.to_s.split("/").reject(&:empty?)
+      return false unless segments.first == "profile"
+
+      actor = segments.second.to_s
+      actor.match?(HANDLE) || actor.match?(DID)
+    rescue URI::InvalidURIError
+      false
+    end
+  end
+end

--- a/app/services/title_extractor/bluesky_title_extractor.rb
+++ b/app/services/title_extractor/bluesky_title_extractor.rb
@@ -1,7 +1,7 @@
 module TitleExtractor
   # Suggests a feed title for a Bluesky account. Prefers the account's
   # display name from the fetched page's og:title, falling back to the
-  # @handle from the input.
+  # @handle taken from the profile URL.
   class BlueskyTitleExtractor < Base
     def title
       og_title.presence || handle.presence
@@ -19,7 +19,7 @@ module TitleExtractor
     end
 
     def handle
-      name = input.to_s.strip.sub(/\A@/, "").sub(%r{\Ahttps?://}i, "")
+      name = input.to_s.strip.sub(%r{\Ahttps?://}i, "")
                   .sub(%r{\A(?:www\.)?bsky\.app/profile/}i, "")
                   .split("/").first.to_s
       name.empty? ? "" : "@#{name}"

--- a/app/services/title_extractor/bluesky_title_extractor.rb
+++ b/app/services/title_extractor/bluesky_title_extractor.rb
@@ -1,0 +1,28 @@
+module TitleExtractor
+  # Suggests a feed title for a Bluesky account. Prefers the account's
+  # display name from the fetched page's og:title, falling back to the
+  # @handle from the input.
+  class BlueskyTitleExtractor < Base
+    def title
+      og_title.presence || handle.presence
+    end
+
+    private
+
+    def og_title
+      return nil if fetched_body.blank?
+
+      doc = Nokogiri::HTML.parse(fetched_body, nil, "UTF-8")
+      doc.at_css('meta[property="og:title"]')&.[]("content")&.strip
+    rescue StandardError
+      nil
+    end
+
+    def handle
+      name = input.to_s.strip.sub(/\A@/, "").sub(%r{\Ahttps?://}i, "")
+                  .sub(%r{\A(?:www\.)?bsky\.app/profile/}i, "")
+                  .split("/").first.to_s
+      name.empty? ? "" : "@#{name}"
+    end
+  end
+end

--- a/test/fixtures/files/feeds/bluesky/author_feed.json
+++ b/test/fixtures/files/feeds/bluesky/author_feed.json
@@ -1,0 +1,282 @@
+{
+  "feed": [
+    {
+      "post": {
+        "uri": "at://did:plc:testauthor/app.bsky.feed.post/3aaa",
+        "cid": "bafyaaa",
+        "author": {
+          "did": "did:plc:testauthor",
+          "handle": "testuser.bsky.social",
+          "displayName": "Test User"
+        },
+        "record": {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "2026-06-04T18:00:00.000Z",
+          "facets": [
+            {
+              "features": [
+                {
+                  "$type": "app.bsky.richtext.facet#link",
+                  "uri": "https://docs.bsky.app/get-started"
+                }
+              ],
+              "index": {
+                "byteStart": 14,
+                "byteEnd": 39
+              }
+            }
+          ],
+          "langs": ["en"],
+          "text": "Read our docs docs.bsky.app/get-star... today"
+        },
+        "replyCount": 2,
+        "repostCount": 3,
+        "likeCount": 10,
+        "indexedAt": "2026-06-04T18:00:05.000Z",
+        "labels": []
+      }
+    },
+    {
+      "post": {
+        "uri": "at://did:plc:testauthor/app.bsky.feed.post/3bbb",
+        "cid": "bafybbb",
+        "author": {
+          "did": "did:plc:testauthor",
+          "handle": "testuser.bsky.social",
+          "displayName": "Test User"
+        },
+        "record": {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "2026-06-04T19:00:00.000Z",
+          "embed": {
+            "$type": "app.bsky.embed.images",
+            "images": [
+              {
+                "alt": "First photo",
+                "image": { "$type": "blob", "ref": { "$link": "bafkphotoa" }, "mimeType": "image/jpeg", "size": 1000 }
+              },
+              {
+                "alt": "Second photo",
+                "image": { "$type": "blob", "ref": { "$link": "bafkphotob" }, "mimeType": "image/jpeg", "size": 1000 }
+              }
+            ]
+          },
+          "langs": ["en"],
+          "text": "Photo time"
+        },
+        "embed": {
+          "$type": "app.bsky.embed.images#view",
+          "images": [
+            {
+              "thumb": "https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:testauthor/bafkphotoa",
+              "fullsize": "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkphotoa",
+              "alt": "First photo",
+              "aspectRatio": { "height": 1000, "width": 1500 }
+            },
+            {
+              "thumb": "https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:testauthor/bafkphotob",
+              "fullsize": "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkphotob",
+              "alt": "Second photo",
+              "aspectRatio": { "height": 1000, "width": 1500 }
+            }
+          ]
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "likeCount": 5,
+        "indexedAt": "2026-06-04T19:00:05.000Z",
+        "labels": []
+      }
+    },
+    {
+      "post": {
+        "uri": "at://did:plc:testauthor/app.bsky.feed.post/3ccc",
+        "cid": "bafyccc",
+        "author": {
+          "did": "did:plc:testauthor",
+          "handle": "testuser.bsky.social",
+          "displayName": "Test User"
+        },
+        "record": {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "2026-06-04T20:00:00.000Z",
+          "langs": ["en"],
+          "text": "Watch this"
+        },
+        "embed": {
+          "$type": "app.bsky.embed.video#view",
+          "cid": "bafkvideoc",
+          "playlist": "https://video.bsky.app/watch/did%3Aplc%3Atestauthor/bafkvideoc/playlist.m3u8",
+          "thumbnail": "https://video.bsky.app/watch/did%3Aplc%3Atestauthor/bafkvideoc/thumbnail.jpg",
+          "aspectRatio": { "height": 1080, "width": 1920 }
+        },
+        "replyCount": 0,
+        "repostCount": 1,
+        "likeCount": 7,
+        "indexedAt": "2026-06-04T20:00:05.000Z",
+        "labels": []
+      }
+    },
+    {
+      "post": {
+        "uri": "at://did:plc:testauthor/app.bsky.feed.post/3ddd",
+        "cid": "bafyddd",
+        "author": {
+          "did": "did:plc:testauthor",
+          "handle": "testuser.bsky.social",
+          "displayName": "Test User"
+        },
+        "record": {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "2026-06-04T21:00:00.000Z",
+          "langs": ["en"],
+          "text": "Gallery day"
+        },
+        "embed": {
+          "$type": "app.bsky.embed.gallery#view",
+          "items": [
+            {
+              "$type": "app.bsky.embed.gallery#viewImage",
+              "thumbnail": "https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:testauthor/bafkgallerya",
+              "fullsize": "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgallerya",
+              "alt": "Gallery one",
+              "aspectRatio": { "height": 1200, "width": 900 }
+            },
+            {
+              "$type": "app.bsky.embed.gallery#viewImage",
+              "thumbnail": "https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:testauthor/bafkgalleryb",
+              "fullsize": "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgalleryb",
+              "alt": "Gallery two",
+              "aspectRatio": { "height": 1200, "width": 900 }
+            }
+          ]
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "likeCount": 3,
+        "indexedAt": "2026-06-04T21:00:05.000Z",
+        "labels": []
+      }
+    },
+    {
+      "post": {
+        "uri": "at://did:plc:testauthor/app.bsky.feed.post/3eee",
+        "cid": "bafyeee",
+        "author": {
+          "did": "did:plc:testauthor",
+          "handle": "testuser.bsky.social",
+          "displayName": "Test User"
+        },
+        "record": {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "2026-06-04T22:00:00.000Z",
+          "langs": ["en"],
+          "text": "Quoting with a picture"
+        },
+        "embed": {
+          "$type": "app.bsky.embed.recordWithMedia#view",
+          "media": {
+            "$type": "app.bsky.embed.images#view",
+            "images": [
+              {
+                "thumb": "https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:testauthor/bafkquotepic",
+                "fullsize": "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkquotepic",
+                "alt": "Quote picture",
+                "aspectRatio": { "height": 800, "width": 800 }
+              }
+            ]
+          },
+          "record": {
+            "record": {
+              "uri": "at://did:plc:someoneelse/app.bsky.feed.post/3zzz",
+              "cid": "bafyzzz",
+              "author": {
+                "did": "did:plc:someoneelse",
+                "handle": "other.bsky.social",
+                "displayName": "Other User"
+              },
+              "value": {
+                "$type": "app.bsky.feed.post",
+                "createdAt": "2026-06-03T10:00:00.000Z",
+                "text": "The quoted post"
+              }
+            }
+          }
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "likeCount": 4,
+        "indexedAt": "2026-06-04T22:00:05.000Z",
+        "labels": []
+      }
+    },
+    {
+      "post": {
+        "uri": "at://did:plc:someoneelse/app.bsky.feed.post/3fff",
+        "cid": "bafyfff",
+        "author": {
+          "did": "did:plc:someoneelse",
+          "handle": "other.bsky.social",
+          "displayName": "Other User"
+        },
+        "record": {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "2026-06-05T10:00:00.000Z",
+          "langs": ["en"],
+          "text": "A post the author reposted"
+        },
+        "replyCount": 0,
+        "repostCount": 12,
+        "likeCount": 50,
+        "indexedAt": "2026-06-05T10:00:05.000Z",
+        "labels": []
+      },
+      "reason": {
+        "$type": "app.bsky.feed.defs#reasonRepost",
+        "by": {
+          "did": "did:plc:testauthor",
+          "handle": "testuser.bsky.social",
+          "displayName": "Test User"
+        },
+        "indexedAt": "2026-06-05T11:00:00.000Z"
+      }
+    },
+    {
+      "post": {
+        "uri": "at://did:plc:testauthor/app.bsky.feed.post/3ggg",
+        "cid": "bafyggg",
+        "author": {
+          "did": "did:plc:testauthor",
+          "handle": "testuser.bsky.social",
+          "displayName": "Test User"
+        },
+        "record": {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "2026-06-05T12:00:00.000Z",
+          "langs": ["en"],
+          "reply": {
+            "root": { "uri": "at://did:plc:someoneelse/app.bsky.feed.post/3yyy", "cid": "bafyyyy" },
+            "parent": { "uri": "at://did:plc:someoneelse/app.bsky.feed.post/3yyy", "cid": "bafyyyy" }
+          },
+          "text": "Replying to someone"
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "likeCount": 1,
+        "indexedAt": "2026-06-05T12:00:05.000Z",
+        "labels": []
+      },
+      "reply": {
+        "root": {
+          "uri": "at://did:plc:someoneelse/app.bsky.feed.post/3yyy",
+          "cid": "bafyyyy"
+        },
+        "parent": {
+          "uri": "at://did:plc:someoneelse/app.bsky.feed.post/3yyy",
+          "cid": "bafyyyy"
+        }
+      }
+    }
+  ],
+  "cursor": "2026-06-04T18:00:00.000Z"
+}

--- a/test/fixtures/files/feeds/bluesky/normalized.json
+++ b/test/fixtures/files/feeds/bluesky/normalized.json
@@ -1,0 +1,62 @@
+[
+  {
+    "attachment_urls": [],
+    "comments": [],
+    "content": "Read our docs https://docs.bsky.app/get-started today - https://bsky.app/profile/testuser.bsky.social/post/3aaa",
+    "published_at": "2026-06-04T18:00:00.000Z",
+    "source_url": "https://bsky.app/profile/testuser.bsky.social/post/3aaa",
+    "status": "enqueued",
+    "uid": "at://did:plc:testauthor/app.bsky.feed.post/3aaa",
+    "validation_errors": []
+  },
+  {
+    "attachment_urls": [
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkphotoa",
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkphotob"
+    ],
+    "comments": [],
+    "content": "Photo time - https://bsky.app/profile/testuser.bsky.social/post/3bbb",
+    "published_at": "2026-06-04T19:00:00.000Z",
+    "source_url": "https://bsky.app/profile/testuser.bsky.social/post/3bbb",
+    "status": "enqueued",
+    "uid": "at://did:plc:testauthor/app.bsky.feed.post/3bbb",
+    "validation_errors": []
+  },
+  {
+    "attachment_urls": [
+      "https://video.bsky.app/watch/did%3Aplc%3Atestauthor/bafkvideoc/thumbnail.jpg"
+    ],
+    "comments": [],
+    "content": "Watch this - https://bsky.app/profile/testuser.bsky.social/post/3ccc",
+    "published_at": "2026-06-04T20:00:00.000Z",
+    "source_url": "https://bsky.app/profile/testuser.bsky.social/post/3ccc",
+    "status": "enqueued",
+    "uid": "at://did:plc:testauthor/app.bsky.feed.post/3ccc",
+    "validation_errors": []
+  },
+  {
+    "attachment_urls": [
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgallerya",
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgalleryb"
+    ],
+    "comments": [],
+    "content": "Gallery day - https://bsky.app/profile/testuser.bsky.social/post/3ddd",
+    "published_at": "2026-06-04T21:00:00.000Z",
+    "source_url": "https://bsky.app/profile/testuser.bsky.social/post/3ddd",
+    "status": "enqueued",
+    "uid": "at://did:plc:testauthor/app.bsky.feed.post/3ddd",
+    "validation_errors": []
+  },
+  {
+    "attachment_urls": [
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkquotepic"
+    ],
+    "comments": [],
+    "content": "Quoting with a picture - https://bsky.app/profile/testuser.bsky.social/post/3eee",
+    "published_at": "2026-06-04T22:00:00.000Z",
+    "source_url": "https://bsky.app/profile/testuser.bsky.social/post/3eee",
+    "status": "enqueued",
+    "uid": "at://did:plc:testauthor/app.bsky.feed.post/3eee",
+    "validation_errors": []
+  }
+]

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -4,6 +4,7 @@ class FeedProfileTest < ActiveSupport::TestCase
   test ".all returns list of profile keys" do
     expected = [
       "aerostat",
+      "bluesky",
       "buni",
       "elementy",
       "json_feed",

--- a/test/services/loader/bluesky_loader_test.rb
+++ b/test/services/loader/bluesky_loader_test.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+
+class Loader::BlueskyLoaderTest < ActiveSupport::TestCase
+  FEED_BODY = '{"feed":[]}'.freeze
+
+  def mock_client(response: nil, error: nil)
+    response ||= HttpClient::Response.new(status: 200, body: FEED_BODY)
+    MockHttpClient.new(response: response, error: error)
+  end
+
+  def loader(input, http_client: nil)
+    feed = create(:feed, feed_profile_key: "bluesky", url: input)
+    opts = http_client ? { http_client: http_client } : {}
+    Loader::BlueskyLoader.new(feed, opts)
+  end
+
+  def expected_url(actor)
+    "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed" \
+      "?actor=#{actor}&filter=posts_no_replies"
+  end
+
+  test "#load should request the getAuthorFeed endpoint for a bare handle" do
+    client = mock_client
+    loader("testuser.bsky.social", http_client: client).load
+    assert_equal expected_url("testuser.bsky.social"), client.last_request_url
+  end
+
+  test "#load should strip a leading @ from the handle" do
+    client = mock_client
+    loader("@testuser.bsky.social", http_client: client).load
+    assert_equal expected_url("testuser.bsky.social"), client.last_request_url
+  end
+
+  test "#load should accept a bsky.app profile URL" do
+    client = mock_client
+    loader("https://bsky.app/profile/testuser.bsky.social", http_client: client).load
+    assert_equal expected_url("testuser.bsky.social"), client.last_request_url
+  end
+
+  test "#load should accept a schemeless bsky.app profile URL" do
+    client = mock_client
+    loader("bsky.app/profile/testuser.bsky.social", http_client: client).load
+    assert_equal expected_url("testuser.bsky.social"), client.last_request_url
+  end
+
+  test "#load should accept a profile URL with a DID and encode it" do
+    client = mock_client
+    loader("https://bsky.app/profile/did:plc:abc123", http_client: client).load
+    assert_equal expected_url("did%3Aplc%3Aabc123"), client.last_request_url
+  end
+
+  test "#load should treat a bare bsky.app input as the official account handle" do
+    client = mock_client
+    loader("@bsky.app", http_client: client).load
+    assert_equal expected_url("bsky.app"), client.last_request_url
+  end
+
+  test "#load should send a JSON Accept header" do
+    client = mock_client
+    loader("testuser.bsky.social", http_client: client).load
+    assert_equal "application/json", client.last_headers["Accept"]
+  end
+
+  test "#load should return the response body on success" do
+    assert_equal FEED_BODY, loader("testuser.bsky.social", http_client: mock_client).load
+  end
+
+  test "#load should surface the API error message on HTTP error" do
+    body = '{"error":"InvalidRequest","message":"Profile not found"}'
+    client = mock_client(response: HttpClient::Response.new(status: 400, body: body))
+    error = assert_raises(StandardError) { loader("testuser.bsky.social", http_client: client).load }
+    assert_equal "HTTP 400: Profile not found", error.message
+  end
+
+  test "#load should raise with the bare status when the error body is not JSON" do
+    client = mock_client(response: HttpClient::Response.new(status: 500, body: "oops"))
+    error = assert_raises(StandardError) { loader("testuser.bsky.social", http_client: client).load }
+    assert_equal "HTTP 500", error.message
+  end
+
+  test "#load should raise when the handle is not a domain" do
+    error = assert_raises(StandardError) { loader("justname", http_client: mock_client).load }
+    assert_match(/Could not determine/, error.message)
+  end
+
+  test "#load should raise for a bsky.app URL without a profile path" do
+    error = assert_raises(StandardError) { loader("https://bsky.app/search", http_client: mock_client).load }
+    assert_match(/Could not determine/, error.message)
+  end
+
+  private
+
+  class MockHttpClient
+    attr_reader :last_request_url, :last_headers
+
+    def initialize(response: nil, error: nil)
+      @response = response
+      @error = error
+    end
+
+    def get(url, headers: {}, options: {})
+      @last_request_url = url
+      @last_headers = headers
+      raise @error if @error
+      @response
+    end
+  end
+end

--- a/test/services/loader/bluesky_loader_test.rb
+++ b/test/services/loader/bluesky_loader_test.rb
@@ -8,8 +8,10 @@ class Loader::BlueskyLoaderTest < ActiveSupport::TestCase
     MockHttpClient.new(response: response, error: error)
   end
 
+  # Built, not created: the strict params schema rejects the non-URL inputs
+  # exercised by the rejection tests before the loader would ever see them.
   def loader(input, http_client: nil)
-    feed = create(:feed, feed_profile_key: "bluesky", url: input)
+    feed = build(:feed, feed_profile_key: "bluesky", url: input)
     opts = http_client ? { http_client: http_client } : {}
     Loader::BlueskyLoader.new(feed, opts)
   end
@@ -19,27 +21,9 @@ class Loader::BlueskyLoaderTest < ActiveSupport::TestCase
       "?actor=#{actor}&filter=posts_no_replies"
   end
 
-  test "#load should request the getAuthorFeed endpoint for a bare handle" do
-    client = mock_client
-    loader("testuser.bsky.social", http_client: client).load
-    assert_equal expected_url("testuser.bsky.social"), client.last_request_url
-  end
-
-  test "#load should strip a leading @ from the handle" do
-    client = mock_client
-    loader("@testuser.bsky.social", http_client: client).load
-    assert_equal expected_url("testuser.bsky.social"), client.last_request_url
-  end
-
-  test "#load should accept a bsky.app profile URL" do
+  test "#load should request the getAuthorFeed endpoint for a profile URL" do
     client = mock_client
     loader("https://bsky.app/profile/testuser.bsky.social", http_client: client).load
-    assert_equal expected_url("testuser.bsky.social"), client.last_request_url
-  end
-
-  test "#load should accept a schemeless bsky.app profile URL" do
-    client = mock_client
-    loader("bsky.app/profile/testuser.bsky.social", http_client: client).load
     assert_equal expected_url("testuser.bsky.social"), client.last_request_url
   end
 
@@ -55,43 +39,52 @@ class Loader::BlueskyLoaderTest < ActiveSupport::TestCase
     assert_equal expected_url("did%3Aplc%3Aabc123"), client.last_request_url
   end
 
-  test "#load should treat a bare bsky.app input as the official account handle" do
-    client = mock_client
-    loader("@bsky.app", http_client: client).load
-    assert_equal expected_url("bsky.app"), client.last_request_url
-  end
-
   test "#load should send a JSON Accept header" do
     client = mock_client
-    loader("testuser.bsky.social", http_client: client).load
+    loader("https://bsky.app/profile/testuser.bsky.social", http_client: client).load
     assert_equal "application/json", client.last_headers["Accept"]
   end
 
   test "#load should return the response body on success" do
-    assert_equal FEED_BODY, loader("testuser.bsky.social", http_client: mock_client).load
+    assert_equal FEED_BODY, loader("https://bsky.app/profile/testuser.bsky.social", http_client: mock_client).load
   end
 
   test "#load should surface the API error message on HTTP error" do
     body = '{"error":"InvalidRequest","message":"Profile not found"}'
     client = mock_client(response: HttpClient::Response.new(status: 400, body: body))
-    error = assert_raises(StandardError) { loader("testuser.bsky.social", http_client: client).load }
+    error = assert_raises(StandardError) { loader("https://bsky.app/profile/testuser.bsky.social", http_client: client).load }
     assert_equal "HTTP 400: Profile not found", error.message
   end
 
   test "#load should raise with the bare status when the error body is not JSON" do
     client = mock_client(response: HttpClient::Response.new(status: 500, body: "oops"))
-    error = assert_raises(StandardError) { loader("testuser.bsky.social", http_client: client).load }
+    error = assert_raises(StandardError) { loader("https://bsky.app/profile/testuser.bsky.social", http_client: client).load }
     assert_equal "HTTP 500", error.message
   end
 
-  test "#load should raise when the handle is not a domain" do
-    error = assert_raises(StandardError) { loader("justname", http_client: mock_client).load }
-    assert_match(/Could not determine/, error.message)
+  test "#load should reject a bare handle" do
+    error = assert_raises(StandardError) { loader("testuser.bsky.social", http_client: mock_client).load }
+    assert_match(/Expected a bsky\.app profile URL/, error.message)
   end
 
-  test "#load should raise for a bsky.app URL without a profile path" do
+  test "#load should reject an @handle" do
+    error = assert_raises(StandardError) { loader("@testuser.bsky.social", http_client: mock_client).load }
+    assert_match(/Expected a bsky\.app profile URL/, error.message)
+  end
+
+  test "#load should reject a profile URL with an invalid actor" do
+    error = assert_raises(StandardError) { loader("https://bsky.app/profile/justname", http_client: mock_client).load }
+    assert_match(/Expected a bsky\.app profile URL/, error.message)
+  end
+
+  test "#load should reject a bsky.app URL without a profile path" do
     error = assert_raises(StandardError) { loader("https://bsky.app/search", http_client: mock_client).load }
-    assert_match(/Could not determine/, error.message)
+    assert_match(/Expected a bsky\.app profile URL/, error.message)
+  end
+
+  test "#load should reject a non-bsky.app URL" do
+    error = assert_raises(StandardError) { loader("https://example.com/profile/testuser.bsky.social", http_client: mock_client).load }
+    assert_match(/Expected a bsky\.app profile URL/, error.message)
   end
 
   private

--- a/test/services/loader/bluesky_loader_test.rb
+++ b/test/services/loader/bluesky_loader_test.rb
@@ -43,6 +43,12 @@ class Loader::BlueskyLoaderTest < ActiveSupport::TestCase
     assert_equal expected_url("testuser.bsky.social"), client.last_request_url
   end
 
+  test "#load should ignore a query string on a profile URL" do
+    client = mock_client
+    loader("https://bsky.app/profile/testuser.bsky.social?ref=share", http_client: client).load
+    assert_equal expected_url("testuser.bsky.social"), client.last_request_url
+  end
+
   test "#load should accept a profile URL with a DID and encode it" do
     client = mock_client
     loader("https://bsky.app/profile/did:plc:abc123", http_client: client).load

--- a/test/services/normalizer/bluesky_normalizer_test.rb
+++ b/test/services/normalizer/bluesky_normalizer_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Normalizer::BlueskyNormalizerTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, feed_profile_key: "bluesky", url: "testuser.bsky.social")
+  end
+
+  def posts
+    @posts ||= Processor::BlueskyProcessor.new(feed, file_fixture("feeds/bluesky/author_feed.json").read)
+      .process.entries
+      .map { |entry| Normalizer::BlueskyNormalizer.new(entry).normalize }
+  end
+
+  test "#normalize should match the expected normalization result" do
+    assert_matches_snapshot(posts.map(&:normalized_attributes), snapshot: "feeds/bluesky/normalized.json")
+  end
+
+  test "#normalize should append the post permalink to the content" do
+    assert_includes posts.first.content, "https://bsky.app/profile/testuser.bsky.social/post/3aaa"
+  end
+
+  test "#normalize should expose embedded images as attachments" do
+    assert_equal [
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkphotoa",
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkphotob"
+    ], posts[1].attachment_urls
+  end
+
+  test "#normalize should expose video thumbnails as attachments" do
+    assert_equal ["https://video.bsky.app/watch/did%3Aplc%3Atestauthor/bafkvideoc/thumbnail.jpg"], posts[2].attachment_urls
+  end
+
+  test "#normalize should expose gallery items as attachments" do
+    assert_equal [
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgallerya",
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgalleryb"
+    ], posts[3].attachment_urls
+  end
+
+  test "#normalize should enqueue valid posts" do
+    assert(posts.all? { |post| post.status == "enqueued" })
+    assert(posts.all? { |post| post.validation_errors.empty? })
+  end
+end

--- a/test/services/normalizer/bluesky_normalizer_test.rb
+++ b/test/services/normalizer/bluesky_normalizer_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Normalizer::BlueskyNormalizerTest < ActiveSupport::TestCase
   def feed
-    @feed ||= create(:feed, feed_profile_key: "bluesky", url: "testuser.bsky.social")
+    @feed ||= create(:feed, feed_profile_key: "bluesky", url: "https://bsky.app/profile/testuser.bsky.social")
   end
 
   def posts

--- a/test/services/processor/bluesky_processor_test.rb
+++ b/test/services/processor/bluesky_processor_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Processor::BlueskyProcessorTest < ActiveSupport::TestCase
   def feed
-    @feed ||= create(:feed, feed_profile_key: "bluesky", url: "testuser.bsky.social")
+    @feed ||= create(:feed, feed_profile_key: "bluesky", url: "https://bsky.app/profile/testuser.bsky.social")
   end
 
   def sample_json

--- a/test/services/processor/bluesky_processor_test.rb
+++ b/test/services/processor/bluesky_processor_test.rb
@@ -147,6 +147,13 @@ class Processor::BlueskyProcessorTest < ActiveSupport::TestCase
     assert result.recognized?
   end
 
+  test "#process should skip feed items that are not objects" do
+    result = Processor::BlueskyProcessor.new(feed, '{"feed":["str",42,null]}').process
+
+    assert_equal [], result.entries
+    assert result.recognized?
+  end
+
   test "#process should recognize a real author feed payload" do
     assert Processor::BlueskyProcessor.new(feed, sample_json).process.recognized?
   end

--- a/test/services/processor/bluesky_processor_test.rb
+++ b/test/services/processor/bluesky_processor_test.rb
@@ -1,0 +1,170 @@
+require "test_helper"
+
+class Processor::BlueskyProcessorTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, feed_profile_key: "bluesky", url: "testuser.bsky.social")
+  end
+
+  def sample_json
+    @sample_json ||= file_fixture("feeds/bluesky/author_feed.json").read
+  end
+
+  def entries
+    @entries ||= Processor::BlueskyProcessor.new(feed, sample_json).process.entries
+  end
+
+  test "#process should create a FeedEntry per own post and skip reposts and replies" do
+    assert_equal 5, entries.size
+    assert entries.all? { |entry| entry.is_a?(FeedEntry) }
+    assert entries.all? { |entry| entry.status == "pending" }
+    assert_equal %w[3aaa 3bbb 3ccc 3ddd 3eee], entries.map { |entry| entry.uid.split("/").last }
+  end
+
+  test "#process should use the at:// URI as the uid" do
+    assert_equal "at://did:plc:testauthor/app.bsky.feed.post/3aaa", entries.first.uid
+  end
+
+  test "#process should build the permalink from the handle and rkey" do
+    assert_equal "https://bsky.app/profile/testuser.bsky.social/post/3aaa", entries.first.raw_data["url"]
+  end
+
+  test "#process should parse the post timestamp" do
+    assert_equal Time.utc(2026, 6, 4, 18, 0, 0), entries.first.published_at
+  end
+
+  test "#process should expand truncated link text from the facets" do
+    assert_equal "Read our docs https://docs.bsky.app/get-started today", entries.first.raw_data["text"]
+  end
+
+  test "#process should expand facet links addressed past multibyte characters" do
+    prefix = "🦋 look "
+    display = "example.com/a..."
+    payload = {
+      "feed" => [
+        {
+          "post" => {
+            "uri" => "at://did:plc:testauthor/app.bsky.feed.post/3hhh",
+            "author" => { "did" => "did:plc:testauthor", "handle" => "testuser.bsky.social" },
+            "record" => {
+              "createdAt" => "2026-06-04T18:00:00.000Z",
+              "text" => "#{prefix}#{display} now",
+              "facets" => [
+                {
+                  "features" => [{ "$type" => "app.bsky.richtext.facet#link", "uri" => "https://example.com/article" }],
+                  "index" => { "byteStart" => prefix.bytesize, "byteEnd" => prefix.bytesize + display.bytesize }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+
+    result = Processor::BlueskyProcessor.new(feed, payload.to_json).process
+    assert_equal "🦋 look https://example.com/article now", result.entries.first.raw_data["text"]
+  end
+
+  test "#process should keep the original text when facet offsets are out of range" do
+    payload = {
+      "feed" => [
+        {
+          "post" => {
+            "uri" => "at://did:plc:testauthor/app.bsky.feed.post/3iii",
+            "author" => { "did" => "did:plc:testauthor", "handle" => "testuser.bsky.social" },
+            "record" => {
+              "createdAt" => "2026-06-04T18:00:00.000Z",
+              "text" => "short",
+              "facets" => [
+                {
+                  "features" => [{ "$type" => "app.bsky.richtext.facet#link", "uri" => "https://example.com" }],
+                  "index" => { "byteStart" => 2, "byteEnd" => 99 }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+
+    result = Processor::BlueskyProcessor.new(feed, payload.to_json).process
+    assert_equal "short", result.entries.first.raw_data["text"]
+  end
+
+  test "#process should extract fullsize image URLs" do
+    assert_equal [
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkphotoa",
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkphotob"
+    ], entries[1].raw_data["images"]
+  end
+
+  test "#process should extract the video thumbnail URL" do
+    assert_equal ["https://video.bsky.app/watch/did%3Aplc%3Atestauthor/bafkvideoc/thumbnail.jpg"], entries[2].raw_data["images"]
+  end
+
+  test "#process should extract gallery item URLs" do
+    assert_equal [
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgallerya",
+      "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgalleryb"
+    ], entries[3].raw_data["images"]
+  end
+
+  test "#process should extract images from a quote post with media" do
+    assert_equal ["https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkquotepic"], entries[4].raw_data["images"]
+  end
+
+  test "#process should fall back to the DID permalink when the handle did not resolve" do
+    payload = {
+      "feed" => [
+        {
+          "post" => {
+            "uri" => "at://did:plc:testauthor/app.bsky.feed.post/3jjj",
+            "author" => { "did" => "did:plc:testauthor", "handle" => "handle.invalid" },
+            "record" => { "createdAt" => "2026-06-04T18:00:00.000Z", "text" => "hello" }
+          }
+        }
+      ]
+    }
+
+    result = Processor::BlueskyProcessor.new(feed, payload.to_json).process
+    assert_equal "https://bsky.app/profile/did:plc:testauthor/post/3jjj", result.entries.first.raw_data["url"]
+  end
+
+  test "#process should skip posts without a timestamp" do
+    payload = {
+      "feed" => [
+        {
+          "post" => {
+            "uri" => "at://did:plc:testauthor/app.bsky.feed.post/3kkk",
+            "author" => { "did" => "did:plc:testauthor", "handle" => "testuser.bsky.social" },
+            "record" => { "text" => "no createdAt" }
+          }
+        }
+      ]
+    }
+
+    result = Processor::BlueskyProcessor.new(feed, payload.to_json).process
+    assert_equal [], result.entries
+    assert result.recognized?
+  end
+
+  test "#process should recognize a real author feed payload" do
+    assert Processor::BlueskyProcessor.new(feed, sample_json).process.recognized?
+  end
+
+  test "#process should recognize a feed with no posts" do
+    result = Processor::BlueskyProcessor.new(feed, '{"feed":[]}').process
+
+    assert result.recognized?
+    assert_equal [], result.entries
+  end
+
+  test "#process should not recognize invalid JSON" do
+    assert_not Processor::BlueskyProcessor.new(feed, "{not json}").process.recognized?
+  end
+
+  test "#process should not recognize JSON without a feed array" do
+    assert_not Processor::BlueskyProcessor.new(feed, '{"posts":[]}').process.recognized?
+    assert_not Processor::BlueskyProcessor.new(feed, '{"feed":"nope"}').process.recognized?
+    assert_not Processor::BlueskyProcessor.new(feed, "[]").process.recognized?
+  end
+end

--- a/test/services/profile_matcher/bluesky_profile_matcher_test.rb
+++ b/test/services/profile_matcher/bluesky_profile_matcher_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class ProfileMatcher::BlueskyProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(url)
+    ProfileMatcher::BlueskyProfileMatcher.new(url)
+  end
+
+  test ".match_specificity should be 100" do
+    assert_equal 100, ProfileMatcher::BlueskyProfileMatcher.match_specificity
+  end
+
+  test ".profile_key should be bluesky" do
+    assert_equal "bluesky", ProfileMatcher::BlueskyProfileMatcher.profile_key
+  end
+
+  test "#match? should match a bsky.app profile URL" do
+    assert matcher("https://bsky.app/profile/testuser.bsky.social").match?
+  end
+
+  test "#match? should match a profile URL with a custom-domain handle" do
+    assert matcher("https://bsky.app/profile/example.com").match?
+  end
+
+  test "#match? should match a profile URL with a DID" do
+    assert matcher("https://bsky.app/profile/did:plc:abc123").match?
+  end
+
+  test "#match? should match a post URL by its profile segment" do
+    assert matcher("https://bsky.app/profile/testuser.bsky.social/post/3aaa").match?
+  end
+
+  test "#match? should not match other bsky.app paths" do
+    assert_not matcher("https://bsky.app/search").match?
+    assert_not matcher("https://bsky.app/feeds").match?
+    assert_not matcher("https://bsky.app/settings").match?
+  end
+
+  test "#match? should not match a profile path without an actor" do
+    assert_not matcher("https://bsky.app/profile/").match?
+  end
+
+  test "#match? should not match a profile whose actor is not a handle or DID" do
+    assert_not matcher("https://bsky.app/profile/justname").match?
+  end
+
+  test "#match? should not match the site root" do
+    assert_not matcher("https://bsky.app/").match?
+  end
+
+  test "#match? should not match non-bsky URLs" do
+    assert_not matcher("https://example.com/profile/testuser.bsky.social").match?
+  end
+
+  test "#match? should handle blank input" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+end

--- a/test/services/title_extractor/bluesky_title_extractor_test.rb
+++ b/test/services/title_extractor/bluesky_title_extractor_test.rb
@@ -14,11 +14,7 @@ class TitleExtractor::BlueskyTitleExtractorTest < ActiveSupport::TestCase
     assert_equal "@testuser.bsky.social", extractor("https://bsky.app/profile/testuser.bsky.social").title
   end
 
-  test "#title should fall back to the @handle from an @handle input" do
-    assert_equal "@testuser.bsky.social", extractor("@testuser.bsky.social").title
-  end
-
-  test "#title should fall back to the @handle from a bare handle" do
-    assert_equal "@testuser.bsky.social", extractor("testuser.bsky.social").title
+  test "#title should ignore extra path segments in the fallback" do
+    assert_equal "@testuser.bsky.social", extractor("https://bsky.app/profile/testuser.bsky.social/post/3aaa").title
   end
 end

--- a/test/services/title_extractor/bluesky_title_extractor_test.rb
+++ b/test/services/title_extractor/bluesky_title_extractor_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class TitleExtractor::BlueskyTitleExtractorTest < ActiveSupport::TestCase
+  def extractor(input, body = nil)
+    TitleExtractor::BlueskyTitleExtractor.new(input, body)
+  end
+
+  test "#title should use the og:title from the fetched page" do
+    body = '<html><head><meta property="og:title" content="Test User (@testuser.bsky.social)"></head></html>'
+    assert_equal "Test User (@testuser.bsky.social)", extractor("https://bsky.app/profile/testuser.bsky.social", body).title
+  end
+
+  test "#title should fall back to the @handle from a profile URL" do
+    assert_equal "@testuser.bsky.social", extractor("https://bsky.app/profile/testuser.bsky.social").title
+  end
+
+  test "#title should fall back to the @handle from an @handle input" do
+    assert_equal "@testuser.bsky.social", extractor("@testuser.bsky.social").title
+  end
+
+  test "#title should fall back to the @handle from a bare handle" do
+    assert_equal "@testuser.bsky.social", extractor("testuser.bsky.social").title
+  end
+end


### PR DESCRIPTION
Changes:

- New `bluesky` feed profile: follow a public Bluesky account via the documented, unauthenticated AppView API (`public.api.bsky.app` getAuthorFeed), chosen over the native profile RSS, which is text-only.
- Accepts a bsky.app profile URL (identifying the account by handle or DID); profile URLs are auto-detected.
- Keeps only the author's own top-level posts (reposts and replies are skipped), expands truncated link text from the post facets, and attaches images, gallery items, quote-post media, and video thumbnails.
- API error messages (e.g. "Profile not found") are surfaced in feed errors instead of bare status codes.

References:

- Closes #958