### PR TITLE
Add database_consistency schema checker

### DIFF
--- a/.database_consistency.todo.yml
+++ b/.database_consistency.todo.yml
@@ -1,3 +1,11 @@
+# Baseline for database_consistency (run in CI; see .github/workflows/ci.yml).
+# Every entry disables one pre-existing finding so CI only fails on new ones.
+#
+# Entries marked "wontfix" are false positives — the concern is covered by a
+# pattern the tool can't see (custom validators, callbacks, RecordNotUnique
+# rescues). The rest are real findings to burn down: delete an entry once the
+# underlying issue is fixed. Regenerating this file with `database_consistency -g`
+# drops these comments, so prefer editing it by hand.
 ---
 AccessToken:
   index_access_tokens_on_user_id:
@@ -5,6 +13,8 @@ AccessToken:
       enabled: false
 AccessTokenDetail:
   index_access_token_details_on_access_token_id:
+    # wontfix: one row per token, written only through the has_one by
+    # AccessTokenValidationService; the DB constraint is the right guard.
     UniqueIndexChecker:
       enabled: false
 AiCredential:
@@ -13,6 +23,8 @@ AiCredential:
       enabled: false
 Event:
   user:
+    # wontfix: there is no user-deletion flow; the FK on events.user_id
+    # safely blocks one until events are handled explicitly.
     MissingDependentDestroyChecker:
       enabled: false
 EventReference:
@@ -20,10 +32,14 @@ EventReference:
     ForeignKeyChecker:
       enabled: false
   index_event_references_on_event_and_reference:
+    # wontfix: rows are created via insert_all (FeedRefreshWorkflow), which
+    # skips validations — a uniqueness validator would never run.
     UniqueIndexChecker:
       enabled: false
 Feed:
   access_token:
+    # wontfix: AccessToken#disable_associated_feeds (before_destroy) nullifies
+    # feeds.access_token_id before the token row is deleted.
     MissingDependentDestroyChecker:
       enabled: false
   feed_profile_key:
@@ -48,6 +64,8 @@ FeedIdentification:
     RedundantIndexChecker:
       enabled: false
   index_feed_identifications_on_user_id_and_input:
+    # wontfix: rows are system-managed via find_or_create_by!; the unique
+    # index backs the race, user input never hits this validation.
     UniqueIndexChecker:
       enabled: false
 FeedPreview:
@@ -61,12 +79,17 @@ FeedPreview:
     ImplicitOrderingChecker:
       enabled: false
   index_feed_previews_on_owner_profile_digest:
+    # wontfix: FeedPreviewsController#start_run deliberately rescues
+    # RecordNotUnique to adopt a concurrent request's row; a uniqueness
+    # validator would raise RecordInvalid instead and break that pattern.
     UniqueIndexChecker:
       enabled: false
   index_feed_previews_on_user_id:
     RedundantIndexChecker:
       enabled: false
   params_digest:
+    # wontfix: assigned by before_validation :assign_params_digest, so a
+    # presence validator would be dead code.
     NullConstraintChecker:
       enabled: false
 Invite:
@@ -75,6 +98,8 @@ Invite:
       enabled: false
 JobRun:
   index_job_runs_on_job_id:
+    # wontfix: job_id is ActiveJob's generated UUID on a dev-tooling table;
+    # nothing user-supplied to validate.
     UniqueIndexChecker:
       enabled: false
 LlmUsage:
@@ -94,13 +119,19 @@ Post:
       enabled: false
 RateLimit::Bucket:
   index_rate_limit_buckets_on_key:
+    # wontfix: RateLimit uses Bucket.create_or_find_by!, which depends on the
+    # DB constraint raising; a uniqueness validator would defeat the pattern.
     UniqueIndexChecker:
       enabled: false
   key:
+    # wontfix: key is always supplied by the RateLimit service, never by
+    # user input.
     NullConstraintChecker:
       enabled: false
 User:
   index_users_on_email_address:
+    # wontfix: covered by the custom both_emails_are_globally_unique
+    # validator, which checks email_address and unconfirmed_email together.
     UniqueIndexChecker:
       enabled: false
   invite:
@@ -109,9 +140,12 @@ User:
     MissingIndexChecker:
       enabled: false
   password_digest:
+    # wontfix: managed by has_secure_password; never assigned directly.
     NullConstraintChecker:
       enabled: false
   password_updated_at:
+    # wontfix: set by before_save :set_password_updated_at whenever the
+    # password digest changes.
     NullConstraintChecker:
       enabled: false
   unconfirmed_email:

--- a/.database_consistency.todo.yml
+++ b/.database_consistency.todo.yml
@@ -1,0 +1,119 @@
+---
+AccessToken:
+  index_access_tokens_on_user_id:
+    RedundantIndexChecker:
+      enabled: false
+AccessTokenDetail:
+  index_access_token_details_on_access_token_id:
+    UniqueIndexChecker:
+      enabled: false
+AiCredential:
+  index_ai_credentials_on_user_id:
+    RedundantIndexChecker:
+      enabled: false
+Event:
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+EventReference:
+  event:
+    ForeignKeyChecker:
+      enabled: false
+  index_event_references_on_event_and_reference:
+    UniqueIndexChecker:
+      enabled: false
+Feed:
+  access_token:
+    MissingDependentDestroyChecker:
+      enabled: false
+  feed_profile_key:
+    ColumnPresenceChecker:
+      enabled: false
+  feed_schedule:
+    MissingIndexChecker:
+      enabled: false
+  name+user_id:
+    MissingUniqueIndexChecker:
+      enabled: false
+FeedEntry:
+  index_feed_entries_on_feed_id:
+    RedundantIndexChecker:
+      enabled: false
+FeedEntryUid:
+  index_feed_entry_uids_on_feed_id:
+    RedundantIndexChecker:
+      enabled: false
+FeedIdentification:
+  index_feed_identifications_on_user_id:
+    RedundantIndexChecker:
+      enabled: false
+  index_feed_identifications_on_user_id_and_input:
+    UniqueIndexChecker:
+      enabled: false
+FeedPreview:
+  ai_credential:
+    ForeignKeyChecker:
+      enabled: false
+  feed_profile_key:
+    ColumnPresenceChecker:
+      enabled: false
+  id:
+    ImplicitOrderingChecker:
+      enabled: false
+  index_feed_previews_on_owner_profile_digest:
+    UniqueIndexChecker:
+      enabled: false
+  index_feed_previews_on_user_id:
+    RedundantIndexChecker:
+      enabled: false
+  params_digest:
+    NullConstraintChecker:
+      enabled: false
+Invite:
+  id:
+    ImplicitOrderingChecker:
+      enabled: false
+JobRun:
+  index_job_runs_on_job_id:
+    UniqueIndexChecker:
+      enabled: false
+LlmUsage:
+  index_llm_usages_on_feed_id:
+    RedundantIndexChecker:
+      enabled: false
+  index_llm_usages_on_user_id:
+    RedundantIndexChecker:
+      enabled: false
+Permission:
+  index_permissions_on_user_id:
+    RedundantIndexChecker:
+      enabled: false
+Post:
+  index_posts_on_feed_id:
+    RedundantIndexChecker:
+      enabled: false
+RateLimit::Bucket:
+  index_rate_limit_buckets_on_key:
+    UniqueIndexChecker:
+      enabled: false
+  key:
+    NullConstraintChecker:
+      enabled: false
+User:
+  index_users_on_email_address:
+    UniqueIndexChecker:
+      enabled: false
+  invite:
+    ForeignKeyCascadeChecker:
+      enabled: false
+    MissingIndexChecker:
+      enabled: false
+  password_digest:
+    NullConstraintChecker:
+      enabled: false
+  password_updated_at:
+    NullConstraintChecker:
+      enabled: false
+  unconfirmed_email:
+    MissingIndexFindByChecker:
+      enabled: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,15 @@ jobs:
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test
 
+      # Reuses the migrated test database from the step above. Pre-existing
+      # findings are baselined in .database_consistency.todo.yml, so this only
+      # fails on newly introduced model/schema inconsistencies.
+      - name: Check model/schema consistency
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+        run: bundle exec database_consistency -c .database_consistency.todo.yml
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ group :development, :test do
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
 
+  # Detect inconsistencies between models and DB schema [https://github.com/djezzzl/database_consistency]
+  gem "database_consistency", require: false
+
   gem "ruby-lsp"
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
+    database_consistency (3.0.5)
+      activerecord (>= 3.2)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -568,6 +570,7 @@ DEPENDENCIES
   brakeman
   cov-loupe
   cssbundling-rails
+  database_consistency
   debug
   dotenv
   factory_bot_rails


### PR DESCRIPTION
Adds the gem (development group, require: false) and a generated todo baseline that grandfathers all 34 current findings, so a future CI run only fails on newly introduced model/schema inconsistencies.