### PR TITLE
Fail Telegram feeds without a public web preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-10
 
 - Enabling an AI feed that's missing a working AI credential or a model now explains what's left to set up instead of failing with an error page.
+- Telegram feeds now tell you clearly when a channel has no public web preview (restricted, private, or not a channel), instead of quietly showing no posts.
 - Your events log now shows when a feed refresh is in progress; the entry is replaced by the result once the refresh finishes.
 
 ## 2026-07-09

--- a/app/services/loader/telegram_loader.rb
+++ b/app/services/loader/telegram_loader.rb
@@ -4,7 +4,8 @@ module Loader
   # Telegram renders recent channel posts — text and photos — as plain HTML
   # on this preview page, with no API key or login. We reuse it instead of
   # the MTProto API, which keeps the integration simple and free; the trade-off
-  # is that channels which disabled their public web preview return no posts.
+  # is that channels without a public web preview (restricted content, groups,
+  # private channels) cannot be loaded at all.
   #
   # Accepts the channel as a full URL (https://t.me/examplechannel,
   # https://t.me/s/examplechannel), a short form (t.me/examplechannel), an
@@ -14,6 +15,11 @@ module Loader
     HOSTS = %w[t.me telegram.me www.t.me].freeze
     USERNAME = /\A[A-Za-z0-9_]{2,64}\z/
     DEFAULT_MAX_REDIRECTS = 3
+
+    # Container class of the message wall, present on every preview page (even
+    # for channels with no posts yet). When a channel has no public preview,
+    # t.me redirects to the plain info page, which lacks this container.
+    PREVIEW_MARKER = "tgme_channel_history".freeze
 
     # t.me serves the lightweight preview markup to ordinary desktop browsers.
     USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " \
@@ -26,12 +32,24 @@ module Loader
       response = http_client.get("#{PREVIEW_BASE}/#{name}", headers: { "User-Agent" => USER_AGENT })
       raise Loader::Error, "HTTP #{response.status}" unless response.success?
 
+      ensure_preview_page!(response.body, name)
       response.body
     rescue HttpClient::Error => e
       raise Loader::Error, e.message
     end
 
     private
+
+    # A missing message wall means t.me silently served something other than
+    # the preview — the info page of a preview-less channel, group, or user,
+    # or telegram.org for an unclaimed name. Without this check such feeds
+    # would look like valid channels that never post.
+    def ensure_preview_page!(body, name)
+      return if body.to_s.include?(PREVIEW_MARKER)
+
+      raise Loader::Error,
+            "No public web preview for #{name}: it may be restricted, private, or not a channel"
+    end
 
     def channel_name
       raw = feed.url.to_s.strip.sub(/\A@/, "").sub(%r{\Ahttps?://}i, "")

--- a/test/services/loader/telegram_loader_test.rb
+++ b/test/services/loader/telegram_loader_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 
 class Loader::TelegramLoaderTest < ActiveSupport::TestCase
-  PREVIEW_BODY = "<html>telegram preview</html>"
+  PREVIEW_BODY = '<html><section class="tgme_channel_history js-message_history"></section></html>'
+  INFO_PAGE_BODY = '<html><div class="tgme_page_extra">12 subscribers</div></html>'
 
   def mock_client(response: nil, error: nil)
     response ||= HttpClient::Response.new(status: 200, body: PREVIEW_BODY)
@@ -63,6 +64,16 @@ class Loader::TelegramLoaderTest < ActiveSupport::TestCase
   test "#load should raise when the channel cannot be determined" do
     error = assert_raises(StandardError) { loader("https://t.me/", http_client: mock_client).load }
     assert_match(/Could not determine/, error.message)
+  end
+
+  test "#load should raise when the channel has no public web preview" do
+    client = mock_client(response: HttpClient::Response.new(status: 200, body: INFO_PAGE_BODY))
+    error = assert_raises(Loader::Error) { loader("examplechannel", http_client: client).load }
+    assert_match(/No public web preview for examplechannel/, error.message)
+  end
+
+  test "#load should accept a preview page with no posts yet" do
+    assert_equal PREVIEW_BODY, loader("examplechannel", http_client: mock_client).load
   end
 
   private


### PR DESCRIPTION
Changes:

- Telegram feeds now fail with a clear error when a channel has no public web preview (restricted content, groups, private channels, unclaimed names), instead of quietly yielding an empty feed

The Telegram integration itself (scraping the `t.me/s/<channel>` preview page) already shipped and matches the approach used across the ecosystem (RSSHub, RSS-Bridge). The research in #957 confirmed this is the most robust credential-free option and identified one MVP gap: t.me 302-redirects preview-less channels to the plain info page, which the loader followed silently, so such feeds looked like valid channels that never post. The loader now verifies the fetched page carries the message-history container every real preview page has, and raises a clear `Loader::Error` otherwise, which surfaces in feed previews and refresh events.

References:

- Closes #957