### PR TITLE
Hide empty Recent Activity and Recent Posts sections on admin feed page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-10
 
 - You can now follow Bluesky accounts: paste a bsky.app profile link, and their posts get reposted with pictures included.
+- Admin feed pages now match regular feed pages: empty Recent Activity and Recent Posts sections stay hidden, and heading spacing is consistent.
 - Enabling an AI feed that's missing a working AI credential or a model now explains what's left to set up instead of failing with an error page.
 - Telegram feeds now tell you clearly when a channel has no public web preview (restricted, private, or not a channel), instead of quietly showing no posts.
 - Your events log now shows when a feed refresh is in progress; the entry is replaced by the result once the refresh finishes.

--- a/app/views/admin/feeds/show.html.erb
+++ b/app/views/admin/feeds/show.html.erb
@@ -18,23 +18,23 @@
     </section>
   <% end %>
 
-  <section class="space-y-4">
-    <div class="flex items-center justify-between">
-      <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
-      <% if @recent_events.any? %>
+  <% if @recent_events.any? %>
+    <section class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
         <%= link_to "View all", admin_events_path(filter: { subject_type: "Feed", subject_id: @feed.id }), class: "text-sm font-semibold text-brand hover:text-brand-hover", data: { key: "feed.events.view_all" } %>
-      <% end %>
-    </div>
-    <%= render Admin::EventsListComponent.new(events: @recent_events) %>
-  </section>
+      </div>
+      <%= render Admin::EventsListComponent.new(events: @recent_events) %>
+    </section>
+  <% end %>
 
-  <section class="space-y-4">
-    <h2 class="text-2xl font-semibold mb-0 text-heading">Recent Posts</h2>
+  <% if @recent_posts.any? %>
+    <section class="space-y-4">
+      <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <h2 class="text-2xl font-semibold mb-0 text-heading">Recent Posts</h2>
+      </div>
 
-    <% if @recent_posts.any? %>
       <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false, item_component: ReadonlyPostListItemComponent) %>
-    <% else %>
-      <%= render EmptyStateComponent.new("No posts imported yet from this feed") %>
-    <% end %>
-  </section>
+    </section>
+  <% end %>
 </div>

--- a/test/controllers/admin/feeds_controller_test.rb
+++ b/test/controllers/admin/feeds_controller_test.rb
@@ -61,6 +61,48 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", post_path(post), count: 0
   end
 
+  test "#show should render a recent activity section with the feed's events" do
+    login_as(admin_user)
+    feed = create(:feed, user: create(:user))
+    create(:event, subject: feed, user: feed.user)
+
+    get admin_feed_path(feed)
+
+    assert_response :success
+    assert_select "h2", text: "Recent Activity", count: 1
+  end
+
+  test "#show should not render recent activity section when feed has no events" do
+    login_as(admin_user)
+    feed = create(:feed, user: create(:user))
+
+    get admin_feed_path(feed)
+
+    assert_response :success
+    assert_select "h2", text: "Recent Activity", count: 0
+  end
+
+  test "#show should render a recent posts section with the feed's posts" do
+    login_as(admin_user)
+    feed = create(:feed, user: create(:user))
+    create(:post, feed: feed)
+
+    get admin_feed_path(feed)
+
+    assert_response :success
+    assert_select "h2", text: "Recent Posts", count: 1
+  end
+
+  test "#show should not render recent posts section when feed has no posts" do
+    login_as(admin_user)
+    feed = create(:feed, user: create(:user))
+
+    get admin_feed_path(feed)
+
+    assert_response :success
+    assert_select "h2", text: "Recent Posts", count: 0
+  end
+
   test "should redirect non-admin users from show" do
     login_as(regular_user)
     feed = create(:feed, user: create(:user))


### PR DESCRIPTION
Changes:

- Hide the Recent Activity and Recent Posts sections on the admin feed page when there's nothing to show, matching the regular feed page
- Wrap the Recent Posts heading in the same header row as on the regular feed page, so spacing under both headings is consistent
- Add controller tests covering section visibility, and a changelog entry

The admin feed page previously always rendered both sections with empty-state placeholders, and its Recent Posts heading spacing diverged from Recent Activity. The two show views are now structurally identical apart from admin-specific routes and components.

References:

- Related PR: #952