### PR TITLE
Add Changelog page to account menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-10
 
+- You can now catch up on what's new right in the app: there's a Changelog page in your account menu.
 - You can now follow Bluesky accounts: paste a bsky.app profile link, and their posts get reposted with pictures included.
 - Enabling an AI feed that's missing a working AI credential or a model now explains what's left to set up instead of failing with an error page.
 - Telegram feeds now tell you clearly when a channel has no public web preview (restricted, private, or not a channel), instead of quietly showing no posts.

--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -1,0 +1,5 @@
+class ChangelogsController < ApplicationController
+  def show
+    @sections = Changelog.load.sections
+  end
+end

--- a/app/helpers/changelog_helper.rb
+++ b/app/helpers/changelog_helper.rb
@@ -1,0 +1,16 @@
+module ChangelogHelper
+  # Entries are plain text except for `backtick` spans, which become <code>.
+  # Splitting on the capture group yields alternating text/code parts, and
+  # safe_join escapes the text ones.
+  def changelog_entry(text)
+    parts = text.split(/`([^`]+)`/).map.with_index do |part, index|
+      index.odd? ? tag.code(part, class: "font-mono text-sm") : part
+    end
+
+    safe_join(parts)
+  end
+
+  def changelog_date(date)
+    date.strftime("%B %-d, %Y")
+  end
+end

--- a/app/models/changelog.rb
+++ b/app/models/changelog.rb
@@ -1,0 +1,35 @@
+# Parses CHANGELOG.md into dated sections of user-facing entries. The file
+# format is line-based by convention: `## YYYY-MM-DD` headings with one-line
+# bullets under each; anything else (title, intro prose) is skipped.
+class Changelog
+  Section = Data.define(:date, :entries)
+
+  DATE_HEADING = /\A## (\d{4}-\d{2}-\d{2})\s*\z/
+  ENTRY = /\A- (.+)\z/
+
+  def self.load
+    new(Rails.root.join("CHANGELOG.md").read)
+  end
+
+  attr_reader :sections
+
+  def initialize(markdown)
+    @sections = parse(markdown)
+  end
+
+  private
+
+  def parse(markdown)
+    sections = []
+
+    markdown.each_line(chomp: true) do |line|
+      if (heading = line.match(DATE_HEADING))
+        sections << Section.new(date: Date.iso8601(heading[1]), entries: [])
+      elsif (entry = line.match(ENTRY)) && sections.any?
+        sections.last.entries << entry[1]
+      end
+    end
+
+    sections
+  end
+end

--- a/app/views/changelogs/show.html.erb
+++ b/app/views/changelogs/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, "Changelog" %>
+
+<div class="space-y-8">
+  <%= render PageHeaderComponent.new(title: "Changelog") do |header| %>
+    <% header.with_context_paragraph do %>
+      What's new in Feeder — the latest features, fixes, and improvements.
+    <% end %>
+  <% end %>
+
+  <div class="space-y-8" data-key="changelog.sections">
+    <% @sections.each do |section| %>
+      <section>
+        <h2 class="text-2xl font-semibold mb-3 text-heading"><%= changelog_date(section.date) %></h2>
+        <ul class="list-disc space-y-2 pl-5 text-body">
+          <% section.entries.each do |entry| %>
+            <li><%= changelog_entry(entry) %></li>
+          <% end %>
+        </ul>
+      </section>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -31,6 +31,9 @@
             <li>
               <%= link_to "Invites", invites_path, class: "block px-4 py-2 text-sm text-heading hover:bg-surface-sunken" %>
             </li>
+            <li>
+              <%= link_to "Changelog", changelog_path, class: "block px-4 py-2 text-sm text-heading hover:bg-surface-sunken" %>
+            </li>
           </ul>
           <ul class="py-2">
             <li>
@@ -123,13 +126,22 @@
               aria: (current_page?(ai_credentials_path) ? { current: "page" } : nil) %>
           <%= link_to "Invites", invites_path,
               class: class_names(
-                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading rounded-b-lg",
+                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
                 {
                   "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => current_page?(invites_path),
                   "text-heading" => !current_page?(invites_path)
                 }
               ),
               aria: (current_page?(invites_path) ? { current: "page" } : nil) %>
+          <%= link_to "Changelog", changelog_path,
+              class: class_names(
+                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading rounded-b-lg",
+                {
+                  "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => current_page?(changelog_path),
+                  "text-heading" => !current_page?(changelog_path)
+                }
+              ),
+              aria: (current_page?(changelog_path) ? { current: "page" } : nil) %>
         </div>
 
         <%# Mobile: List group 3 - Sign Out %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
     resources :feeds, only: [:index, :show]
   end
 
+  resource :changelog, only: :show
   resource :settings, only: :show
 
   namespace :settings do

--- a/test/controllers/changelogs_controller_test.rb
+++ b/test/controllers/changelogs_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ChangelogsControllerTest < ActionDispatch::IntegrationTest
+  def user
+    @user ||= create(:user)
+  end
+
+  test "should redirect to login when not authenticated" do
+    get changelog_url
+    assert_redirected_to new_session_path
+  end
+
+  test "should show changelog when authenticated" do
+    sign_in_as user
+    get changelog_url
+
+    assert_response :success
+    assert_select "h1", text: "Changelog"
+    assert_select '[data-key="changelog.sections"] section h2', minimum: 1
+    assert_select '[data-key="changelog.sections"] section li', minimum: 1
+  end
+end

--- a/test/helpers/changelog_helper_test.rb
+++ b/test/helpers/changelog_helper_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class ChangelogHelperTest < ActionView::TestCase
+  include ChangelogHelper
+
+  test "#changelog_entry should wrap backtick spans in code tags" do
+    result = changelog_entry("Links with `http` or `https` now match.")
+
+    assert_equal "Links with <code class=\"font-mono text-sm\">http</code> " \
+      "or <code class=\"font-mono text-sm\">https</code> now match.", result
+  end
+
+  test "#changelog_entry should escape HTML in plain text" do
+    result = changelog_entry("Posts with <script> tags & quotes.")
+
+    assert_equal "Posts with &lt;script&gt; tags &amp; quotes.", result
+  end
+
+  test "#changelog_entry should escape HTML inside code spans" do
+    result = changelog_entry("Use `<details>` for that.")
+
+    assert_equal "Use <code class=\"font-mono text-sm\">&lt;details&gt;</code> for that.", result
+  end
+
+  test "#changelog_entry should leave an unmatched backtick as-is" do
+    assert_equal "A stray ` backtick.", changelog_entry("A stray ` backtick.")
+  end
+
+  test "#changelog_date should format the date for reading" do
+    assert_equal "July 3, 2026", changelog_date(Date.new(2026, 7, 3))
+  end
+end

--- a/test/models/changelog_test.rb
+++ b/test/models/changelog_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class ChangelogTest < ActiveSupport::TestCase
+  test "#sections should group entries under date headings" do
+    markdown = <<~MARKDOWN
+      # Changelog
+
+      User-facing changes, newest first.
+
+      ## 2026-07-10
+
+      - First entry.
+      - Second entry.
+
+      ## 2026-07-09
+
+      - Older entry.
+    MARKDOWN
+
+    sections = Changelog.new(markdown).sections
+
+    assert_equal 2, sections.size
+    assert_equal Date.new(2026, 7, 10), sections.first.date
+    assert_equal ["First entry.", "Second entry."], sections.first.entries
+    assert_equal Date.new(2026, 7, 9), sections.last.date
+    assert_equal ["Older entry."], sections.last.entries
+  end
+
+  test "#sections should ignore bullets before the first date heading" do
+    markdown = <<~MARKDOWN
+      - Stray bullet.
+
+      ## 2026-07-10
+
+      - Real entry.
+    MARKDOWN
+
+    sections = Changelog.new(markdown).sections
+
+    assert_equal 1, sections.size
+    assert_equal ["Real entry."], sections.first.entries
+  end
+
+  test "#sections should be empty when there are no date headings" do
+    assert_empty Changelog.new("# Changelog\n\nNothing yet.\n").sections
+  end
+
+  test "#sections should skip non-date second-level headings" do
+    markdown = <<~MARKDOWN
+      ## Unreleased
+
+      - Not dated.
+
+      ## 2026-07-10
+
+      - Dated entry.
+    MARKDOWN
+
+    sections = Changelog.new(markdown).sections
+
+    assert_equal 1, sections.size
+    assert_equal ["Dated entry."], sections.first.entries
+  end
+
+  test ".load should parse the project changelog" do
+    sections = Changelog.load.sections
+
+    assert sections.any?
+    assert sections.all? { |section| section.entries.any? }
+  end
+end


### PR DESCRIPTION
Changes:

- Add a `/changelog` page that renders `CHANGELOG.md` grouped by date, matching the app typography
- Add a Changelog link to the user menu (desktop dropdown and mobile list), under Invites

The changelog format is fixed by convention (`## YYYY-MM-DD` headings with one-line bullets), so entries are parsed with a small purpose-built parser instead of a markdown gem. Backtick spans render as inline code; everything else is escaped.