### PR TITLE
Handle nil RubyLLM provider resolution as known error

### DIFF
--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -104,11 +104,21 @@ class LlmClient
   # Single seam tests stub. Calls the provider's models listing endpoint.
   # Resolves through LlmProvider because registry names don't always match
   # RubyLLM's provider keys (Moonshot rides on :openai); resolving the raw
-  # name returns nil for those providers.
+  # name returns nil for those providers. A nil resolve (e.g. a RubyLLM
+  # upgrade renaming a key) must surface as a known error class — a bare
+  # NoMethodError escapes the validation job's rescue and strands the
+  # credential in "validating".
   def fetch_provider_models
-    RubyLLM::Provider.resolve(credential.llm_provider.ruby_llm_provider)
-                     .new(credential.ruby_llm_context.config)
-                     .list_models
+    key = credential.llm_provider.ruby_llm_provider
+    provider_class = RubyLLM::Provider.resolve(key)
+
+    if provider_class.nil?
+      error = ProviderError.new("unknown RubyLLM provider: #{key}")
+      Rails.error.report(error, context: { credential_id: credential.id, provider: credential.provider })
+      raise error
+    end
+
+    provider_class.new(credential.ruby_llm_context.config).list_models
   end
 
   # Map RubyLLM's Model::Info to a compact, stable hash. We keep only the

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -103,11 +103,9 @@ class LlmClient
 
   # Single seam tests stub. Calls the provider's models listing endpoint.
   # Resolves through LlmProvider because registry names don't always match
-  # RubyLLM's provider keys (Moonshot rides on :openai); resolving the raw
-  # name returns nil for those providers. A nil resolve (e.g. a RubyLLM
-  # upgrade renaming a key) must surface as a known error class — a bare
-  # NoMethodError escapes the validation job's rescue and strands the
-  # credential in "validating".
+  # RubyLLM's provider keys (Moonshot rides on :openai). A nil resolve must
+  # become a known error class: anything else escapes the validation job's
+  # rescue and strands the credential in "validating".
   def fetch_provider_models
     key = credential.llm_provider.ruby_llm_provider
     provider_class = RubyLLM::Provider.resolve(key)

--- a/test/jobs/ai_credential_validation_job_test.rb
+++ b/test/jobs/ai_credential_validation_job_test.rb
@@ -64,9 +64,19 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
     assert_equal "inactive", credential.reload.state
   end
 
-  # No LlmClient stubbing: goes through the real client so a transport error
-  # the client fails to map to LlmClient::Error would escape the job's rescue
+  # No LlmClient stubbing: goes through the real client so an error the
+  # client fails to map to LlmClient::Error would escape the job's rescue
   # and strand the credential in "validating".
+  test "#perform should not strand credential in validating when the provider key does not resolve" do
+    RubyLLM::Provider.stub(:resolve, nil) do
+      AiCredentialValidationJob.perform_now(credential)
+    end
+
+    credential.reload
+    assert_equal "inactive", credential.state
+    assert_match "unknown RubyLLM provider", credential.last_error
+  end
+
   test "#perform should not strand credential in validating when the provider is unreachable" do
     moonshot = create(:ai_credential, user: user, state: :pending, provider: "moonshot",
                       credential_data: { "api_key" => "sk-moon-test" })

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -294,6 +294,15 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_raises(LlmClient::ProviderError) { client.available_models }
   end
 
+  test "#available_models should raise ProviderError when the RubyLLM provider key does not resolve" do
+    client = LlmClient.new(credential)
+
+    RubyLLM::Provider.stub(:resolve, nil) do
+      error = assert_raises(LlmClient::ProviderError) { client.available_models }
+      assert_match "unknown RubyLLM provider", error.message
+    end
+  end
+
   test "#available_models should call the provider models endpoint with the credential api_key" do
     client = LlmClient.new(credential)
 


### PR DESCRIPTION
Changes:

- Guard `LlmClient#fetch_provider_models` against `RubyLLM::Provider.resolve` returning nil: raise a reported `ProviderError` instead of crashing with `NoMethodError`
- Add tests covering the nil resolve at both the client and the validation job level

Follow-up to the Moonshot credential validation crash (Honeybadger fault 132419662). The key mismatch that triggered it was fixed in #946, but the failure class stayed unguarded: any future nil resolve (e.g. a RubyLLM upgrade renaming a provider key) would raise `NoMethodError` past the job's `LlmClient::Error` rescue and strand the credential in "validating". Now it surfaces as a known error, so the job marks the credential inactive with the error recorded.

References:

- Related PR: #946