### PR TITLE
Skip attachments over FreeFeed upload limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-11
+
+- Posts with an image over FreeFeed's upload size limit now publish without that image instead of failing entirely.
+
 ## 2026-07-10
 
 - You can now catch up on what's new right in the app: there's a Changelog page in your account menu.

--- a/app/services/freefeed_publisher.rb
+++ b/app/services/freefeed_publisher.rb
@@ -92,11 +92,7 @@ class FreefeedPublisher
   def upload_attachments
     return [] if post.attachment_urls.blank?
 
-    post.attachment_urls.map do |url|
-      io, content_type = FileBuffer.new.load(url)
-      attachment = client.create_attachment_from_io(io, content_type: content_type)
-      attachment[:id]
-    end
+    post.attachment_urls.filter_map { |url| upload_attachment(url) }
   rescue RateLimit::Throttled
     raise # let the job reschedule; don't bury it as a publish failure
   rescue FreefeedClient::UnauthorizedError
@@ -105,6 +101,16 @@ class FreefeedPublisher
     raise SourceContentError, "Failed to upload attachments: #{e.message}"
   rescue => e
     raise PublishError, "Failed to upload attachments: #{e.message}"
+  end
+
+  # A file over the server's upload limit is a source-content problem, not an
+  # app fault: skip it and publish the post with the remaining attachments.
+  def upload_attachment(url)
+    io, content_type = FileBuffer.new.load(url)
+    client.create_attachment_from_io(io, content_type: content_type)[:id]
+  rescue FreefeedClient::PayloadTooLargeError => e
+    Rails.logger.warn "Skipping oversized attachment #{url} for post #{post.id}: #{e.message}"
+    nil
   end
 
   def create_freefeed_post(attachment_ids)

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -11,6 +11,10 @@ class FreefeedClient
   # UnauthorizedError so callers don't mistake it for a dead token and disable it.
   class ForbiddenError < Error; end
   class NotFoundError < Error; end
+  # The server rejected an upload for exceeding its size limit (HTTP 413).
+  # The limit is server-configured, so callers detect it from the response
+  # rather than pre-checking against a hardcoded size.
+  class PayloadTooLargeError < Error; end
 
   USER_AGENT = "FreeFeed-Rails-Client".freeze
 
@@ -199,6 +203,9 @@ class FreefeedClient
       # Preserve the server's message ("Account '<name>' was not found") so the
       # caller can explain a vanished/renamed target group.
       raise NotFoundError, parse_error(response) || "Resource not found"
+    when 413
+      # Preserve the server's message (it states the actual size limit).
+      raise PayloadTooLargeError, parse_error(response) || "Payload too large"
     when 429
       handle_too_many_requests(response)
     else

--- a/test/lib/freefeed_client_publisher_test.rb
+++ b/test/lib/freefeed_client_publisher_test.rb
@@ -57,6 +57,18 @@ class FreefeedClientPublisherTest < ActiveSupport::TestCase
     end
   end
 
+  test "create_attachment raises PayloadTooLargeError carrying the server message on 413" do
+    file_path = file_fixture("test_image.jpg")
+
+    stub_request(:post, "#{@host}/v1/attachments")
+      .to_return(status: 413, body: { err: "This 'image' file is too large (the maximum size is 52428800 bytes)" }.to_json)
+
+    error = assert_raises(FreefeedClient::PayloadTooLargeError) do
+      @client.create_attachment(file_path.to_s)
+    end
+    assert_equal "This 'image' file is too large (the maximum size is 52428800 bytes)", error.message
+  end
+
   test "create_post creates post successfully" do
     post_response = {
       "posts" => {

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -582,6 +582,68 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
     end
   end
 
+  test "#publish should skip an attachment rejected as too large and publish with the rest" do
+    huge_url = "https://example.com/huge.png"
+    small_url = "https://example.com/small.jpg"
+    post = post_with_content("Post with images", attachment_urls: [huge_url, small_url])
+
+    stub_request(:get, huge_url)
+      .to_return(status: 200, body: "huge_image_data", headers: { "Content-Type" => "image/png" })
+    stub_request(:get, small_url)
+      .to_return(status: 200, body: "small_image_data", headers: { "Content-Type" => "image/jpeg" })
+
+    stub_request(:post, "#{access_token.host}/v1/attachments")
+      .to_return(
+        { status: 413, body: { err: "This 'image' file is too large (the maximum size is 52428800 bytes)" }.to_json },
+        { status: 201, body: { attachments: { id: "attachment_ok" } }.to_json }
+      )
+
+    post_stub = stub_request(:post, "#{access_token.host}/v4/posts")
+      .with(
+        body: {
+          post: {
+            body: "Post with images",
+            attachments: ["attachment_ok"]
+          },
+          meta: {
+            feeds: ["testgroup"]
+          }
+        }.to_json
+      )
+      .to_return(status: 201, body: { posts: { id: "freefeed_post_123" } }.to_json)
+
+    assert_equal "freefeed_post_123", FreefeedPublisher.new(post).publish
+    assert_requested post_stub
+    assert_predicate post.reload, :published?
+  end
+
+  test "#publish should publish without attachments when every attachment is too large" do
+    huge_url = "https://example.com/huge.png"
+    post = post_with_content("Post with huge image", attachment_urls: [huge_url])
+
+    stub_request(:get, huge_url)
+      .to_return(status: 200, body: "huge_image_data", headers: { "Content-Type" => "image/png" })
+    stub_request(:post, "#{access_token.host}/v1/attachments")
+      .to_return(status: 413, body: { err: "This 'image' file is too large (the maximum size is 52428800 bytes)" }.to_json)
+
+    post_stub = stub_request(:post, "#{access_token.host}/v4/posts")
+      .with(
+        body: {
+          post: {
+            body: "Post with huge image"
+          },
+          meta: {
+            feeds: ["testgroup"]
+          }
+        }.to_json
+      )
+      .to_return(status: 201, body: { posts: { id: "freefeed_post_123" } }.to_json)
+
+    assert_equal "freefeed_post_123", FreefeedPublisher.new(post).publish
+    assert_requested post_stub
+    assert_predicate post.reload, :published?
+  end
+
   test "#publish should raise SourceContentError when an attachment cannot be downloaded" do
     image_url = "https://example.com/missing.jpg"
     post = post_with_content("Post with missing image", attachment_urls: [image_url])


### PR DESCRIPTION
Changes:

- FreefeedClient now raises a dedicated `PayloadTooLargeError` when the server rejects an upload with HTTP 413, preserving the server's message.
- FreefeedPublisher skips an attachment rejected as too large (with a logged warning) and publishes the post with the remaining ones, instead of failing the whole post.

A source image over FreeFeed's size limit is an expected external condition, like a 404ing attachment — not an app fault. Previously it failed the entire post (losing the content and every other attachment) and paged error tracking (Honeybadger fault 131942713). The limit is server-configured, so it's detected from the 413 response rather than pre-checked against a hardcoded size.