### PR TITLE
Track and display AI spend in feed refresh events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-11
 
 - Disabled feeds are easier to spot in your feed list: their pause icon is now orange instead of gray.
+- Feed refresh entries in the events log now show what each AI run cost: the estimated spend appears next to the entry and in the event's stats.
 - Posts with an image over FreeFeed's upload size limit now publish without that image instead of failing entirely.
 
 ## 2026-07-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-11
 
 - Disabled feeds are easier to spot in your feed list: their pause icon is now orange instead of gray.
-- Feed refresh entries in the events log now show what each AI run cost: the estimated spend appears next to the entry and in the event's stats.
+- Feed refresh entries in the events log now show what each AI run cost — the estimated spend appears next to the entry, and the event page breaks it down per AI call.
 - Posts with an image over FreeFeed's upload size limit now publish without that image instead of failing entirely.
 
 ## 2026-07-10

--- a/app/components/feed_refresh_description_component.rb
+++ b/app/components/feed_refresh_description_component.rb
@@ -1,9 +1,10 @@
 # Describes a feed refresh run by its lifecycle status, appending the imported
-# posts count when there is one, e.g. "My Feed refreshed (+2 posts)".
+# posts count and the run's estimated AI spend when there are any,
+# e.g. "My Feed refreshed (+2 posts) (AI: $0.03)".
 class FeedRefreshDescriptionComponent < EventDescriptionComponent
   def call
-    suffix = posts_count_tag
-    suffix ? safe_join([super, suffix], " ") : super
+    suffixes = [posts_count_tag, spend_tag].compact
+    suffixes.any? ? safe_join([super, *suffixes], " ") : super
   end
 
   private
@@ -26,5 +27,17 @@ class FeedRefreshDescriptionComponent < EventDescriptionComponent
     return if count.zero?
 
     helpers.tag.span("(+#{helpers.pluralize(count, "post")})", class: "text-muted", data: { key: "events.posts_count" })
+  end
+
+  # Reads the stats snapshot rather than summing referenced LlmUsage rows, so
+  # the log page renders without extra per-row queries. Absent for runs that
+  # made no LLM calls; zero-cost calls still show, matching the honest-spend
+  # principle behind LlmUsage.
+  def spend_tag
+    cents = event.metadata.dig("stats", "llm_cost_cents")
+    return if cents.nil?
+
+    helpers.tag.span("(AI: #{helpers.number_to_currency(cents / 100.0)})",
+                     class: "text-muted", data: { key: "events.llm_cost" })
   end
 end

--- a/app/components/feed_refresh_description_component.rb
+++ b/app/components/feed_refresh_description_component.rb
@@ -1,5 +1,5 @@
-# Describes a feed refresh run by its lifecycle status, appending the imported
-# posts count and the run's estimated AI spend when there are any,
+# Describes a feed refresh by its lifecycle status, appending the imported
+# posts count and the run's AI spend when present,
 # e.g. "My Feed refreshed (+2 posts) (AI: $0.03)".
 class FeedRefreshDescriptionComponent < EventDescriptionComponent
   def call
@@ -29,10 +29,9 @@ class FeedRefreshDescriptionComponent < EventDescriptionComponent
     helpers.tag.span("(+#{helpers.pluralize(count, "post")})", class: "text-muted", data: { key: "events.posts_count" })
   end
 
-  # Reads the stats snapshot rather than summing referenced LlmUsage rows, so
-  # the log page renders without extra per-row queries. Absent for runs that
-  # made no LLM calls; zero-cost calls still show, matching the honest-spend
-  # principle behind LlmUsage.
+  # Reads the metadata snapshot, not the referenced rows, so the log renders
+  # without extra queries. Absent when the run made no LLM calls; a zero-cost
+  # call still shows.
   def spend_tag
     cents = event.metadata.dig("stats", "llm_cost_cents")
     return if cents.nil?

--- a/app/components/llm_usage_list_item_component.rb
+++ b/app/components/llm_usage_list_item_component.rb
@@ -1,0 +1,82 @@
+# One row of an event's per-call AI usage breakdown: the model and stage, the
+# token counts, and the call's cost and outcome.
+class LlmUsageListItemComponent < ListItemComponent
+  # Non-success outcomes still cost money, so each is shown with a badge that
+  # matches how the alert palette signals its severity elsewhere.
+  OUTCOME_COLORS = {
+    "success" => :success,
+    "schema_error" => :danger,
+    "provider_error" => :danger,
+    "rate_limited" => :warning,
+    "timeout" => :warning
+  }.freeze
+
+  def initialize(usage:)
+    super()
+    @usage = usage
+  end
+
+  def before_render
+    with_primary { primary_line }
+    with_secondary { token_summary }
+    with_trailing { trailing_line }
+  end
+
+  private
+
+  attr_reader :usage
+
+  def li_data
+    { key: "events.llm_usage", llm_usage_id: usage.id }
+  end
+
+  def primary_line
+    helpers.tag.div(class: "flex min-w-0 items-baseline gap-2") do
+      helpers.safe_join([
+        helpers.tag.span(usage.model, class: "truncate font-medium text-heading", data: { key: "events.llm_usage.model" }),
+        stage_label
+      ].compact)
+    end
+  end
+
+  def stage_label
+    return if usage.stage.blank?
+
+    helpers.tag.span(usage.stage.humanize(capitalize: false),
+                     class: "shrink-0 text-sm text-muted", data: { key: "events.llm_usage.stage" })
+  end
+
+  # Cached tokens are only worth the extra clause when a call actually reused
+  # cache — most don't, and a "· 0 cached" tail is pure noise.
+  def token_summary
+    parts = [
+      "#{helpers.number_with_delimiter(usage.input_tokens)} in",
+      "#{helpers.number_with_delimiter(usage.output_tokens)} out"
+    ]
+    cached = usage.cache_read_tokens + usage.cache_write_tokens
+    parts << "#{helpers.number_with_delimiter(cached)} cached" if cached.positive?
+
+    helpers.tag.span(parts.join(" · "), class: "text-sm text-muted tabular-nums", data: { key: "events.llm_usage.tokens" })
+  end
+
+  def trailing_line
+    helpers.tag.div(class: "flex shrink-0 items-center gap-3") do
+      helpers.safe_join([
+        helpers.tag.span(formatted_cost, class: "text-sm font-medium tabular-nums text-heading", data: { key: "events.llm_usage.cost" }),
+        outcome_badge
+      ])
+    end
+  end
+
+  def formatted_cost
+    helpers.number_to_currency(usage.cost_estimate_cents / 100.0)
+  end
+
+  def outcome_badge
+    render(BadgeComponent.new(
+      text: usage.outcome.humanize,
+      color: OUTCOME_COLORS.fetch(usage.outcome, :neutral),
+      key: "events.llm_usage.outcome"
+    ))
+  end
+end

--- a/app/components/llm_usages_list_component.rb
+++ b/app/components/llm_usages_list_component.rb
@@ -1,0 +1,10 @@
+class LlmUsagesListComponent < ListComponent
+  def initialize(usages:)
+    super()
+    @usages = usages
+  end
+
+  def before_render
+    @usages.each { |usage| with_item(LlmUsageListItemComponent.new(usage: usage)) }
+  end
+end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -2,6 +2,7 @@ class Admin::EventsController < ApplicationController
   include EventFiltering
   include EventCursorPagination
   include EventReferencedPosts
+  include EventReferencedLlmUsages
 
   def index
     authorize Event
@@ -18,6 +19,7 @@ class Admin::EventsController < ApplicationController
     authorize Event
     @event = Event.find(params[:id])
     @referenced_posts = referenced_posts(@event)
+    @referenced_llm_usages = referenced_llm_usages(@event)
     @previous_event = previous_event(@event)
     @next_event = next_event(@event)
   end

--- a/app/controllers/concerns/event_referenced_llm_usages.rb
+++ b/app/controllers/concerns/event_referenced_llm_usages.rb
@@ -1,0 +1,13 @@
+module EventReferencedLlmUsages
+  extend ActiveSupport::Concern
+
+  private
+
+  # The LLM calls this event accounts for, in call order. The matching stats
+  # snapshot (llm_calls/llm_cost_cents) already lives on the event; this is the
+  # per-call detail behind that total.
+  def referenced_llm_usages(event)
+    LlmUsage.where(id: event.event_references.where(reference_type: "LlmUsage").select(:reference_id))
+            .order(:started_at)
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,7 @@ class EventsController < ApplicationController
   include EventFiltering
   include EventCursorPagination
   include EventReferencedPosts
+  include EventReferencedLlmUsages
 
   MAX_RECENT_POSTS = 10
 
@@ -15,6 +16,7 @@ class EventsController < ApplicationController
   def show
     @event = owned_events.find(params[:id])
     @referenced_posts = referenced_posts(@event).limit(MAX_RECENT_POSTS)
+    @referenced_llm_usages = referenced_llm_usages(@event)
     @previous_event = adjacent_event(:older)
     @next_event = adjacent_event(:newer)
   end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -17,6 +17,8 @@ module EventsHelper
       time ? long_time_tag(time) : value
     elsif key.end_with?("_duration")
       format_event_duration(value.to_f)
+    elsif key.end_with?("_cents")
+      number_to_currency(value.to_f / 100.0)
     elsif value.is_a?(Integer)
       number_with_delimiter(value)
     else

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -76,11 +76,9 @@ class FeedRefreshWorkflow
     input
   end
 
-  # The dead run's LLM spend attaches to its interrupted event here or never:
-  # its usage rows fall outside every later run's window. The abandoned
-  # event's own started_at stat bounds them exactly — nothing ran between the
-  # death and this sweep (a later run would have swept the event already),
-  # and this run hasn't made any LLM calls yet.
+  # Attributes the dead run's spend to its interrupted event — here or never,
+  # since every later run's window starts after these rows. The event's own
+  # started_at stat bounds them exactly.
   def interrupt_abandoned_event(event)
     usage_rows = abandoned_llm_usage_rows(event)
     metadata = event.metadata.merge("status" => "interrupted")
@@ -345,10 +343,9 @@ class FeedRefreshWorkflow
     EventReference.insert_all(references_data)
   end
 
-  # This run's LLM audit rows, as [id, cost_estimate_cents] pairs. The
-  # started_at window is exact: the per-feed advisory lock serializes runs,
-  # and every other LlmUsage writer either uses the preview purpose or an
-  # unpersisted feed (nil feed_id), so no foreign rows can land in it.
+  # This run's usage rows as [id, cost_cents] pairs. The started_at window is
+  # exact: the advisory lock serializes runs per feed, and every other writer
+  # uses the preview purpose or an unpersisted feed.
   def run_llm_usage_rows
     return [] unless stats[:started_at]
 
@@ -357,8 +354,7 @@ class FeedRefreshWorkflow
         .pluck(:id, :cost_estimate_cents)
   end
 
-  # Skipped when the run made no LLM calls, so deterministic feeds don't get
-  # a noisy zero-spend stat on every refresh event.
+  # No calls, no stat — keeps deterministic feeds' events free of a noisy $0.
   def record_llm_usage_stats(usage_rows)
     return if usage_rows.empty?
 

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -280,6 +280,8 @@ class FeedRefreshWorkflow
   # started record.
   def complete_refresh_event(posts)
     @refresh_event.destroy!
+    usage_rows = run_llm_usage_rows
+    record_llm_usage_stats(usage_rows)
 
     event = Event.create!(
       type: "feed_refresh",
@@ -291,6 +293,7 @@ class FeedRefreshWorkflow
 
     @refresh_completed = true
     reference_posts(event, posts)
+    reference_llm_usages(event, usage_rows)
   end
 
   def reference_posts(event, posts)
@@ -301,6 +304,45 @@ class FeedRefreshWorkflow
         event_id: event.id,
         reference_type: "Post",
         reference_id: post.id,
+        created_at: event.created_at,
+        updated_at: event.created_at
+      }
+    end
+
+    EventReference.insert_all(references_data)
+  end
+
+  # This run's LLM audit rows, as [id, cost_estimate_cents] pairs. The
+  # started_at window is exact: the per-feed advisory lock serializes runs,
+  # and every other LlmUsage writer either uses the preview purpose or an
+  # unpersisted feed (nil feed_id), so no foreign rows can land in it.
+  def run_llm_usage_rows
+    return [] unless stats[:started_at]
+
+    feed.llm_usages.scheduled_run
+        .where(started_at: stats[:started_at]..)
+        .pluck(:id, :cost_estimate_cents)
+  end
+
+  # Skipped when the run made no LLM calls, so deterministic feeds don't get
+  # a noisy zero-spend stat on every refresh event.
+  def record_llm_usage_stats(usage_rows)
+    return if usage_rows.empty?
+
+    record_stats(
+      llm_calls: usage_rows.size,
+      llm_cost_cents: usage_rows.sum { |_id, cents| cents }
+    )
+  end
+
+  def reference_llm_usages(event, usage_rows)
+    return if usage_rows.empty?
+
+    references_data = usage_rows.map do |usage_id, _cents|
+      {
+        event_id: event.id,
+        reference_type: "LlmUsage",
+        reference_id: usage_id,
         created_at: event.created_at,
         updated_at: event.created_at
       }
@@ -323,8 +365,10 @@ class FeedRefreshWorkflow
     return if @refresh_completed
 
     @refresh_event&.destroy!
+    usage_rows = run_llm_usage_rows
+    record_llm_usage_stats(usage_rows)
 
-    Event.create!(
+    event = Event.create!(
       type: "feed_refresh",
       level: :error,
       subject: feed,
@@ -341,6 +385,8 @@ class FeedRefreshWorkflow
         }
       }
     )
+
+    reference_llm_usages(event, usage_rows)
   end
 
   # Persist this run's regime so the next scheduled run can skip a redundant

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -68,12 +68,45 @@ class FeedRefreshWorkflow
     feed.events.where(type: "feed_refresh")
         .where("metadata ->> 'status' = 'started'")
         .find_each do |event|
-      event.update!(level: :debug, metadata: event.metadata.merge("status" => "interrupted"))
+      interrupt_abandoned_event(event)
       Metrics.increment("feed_refresh_total", status: "interrupted", profile: feed.feed_profile_key)
       Rails.logger.info "Feed refresh interrupted for feed #{feed.id}: event #{event.id} was abandoned by a dead run"
     end
 
     input
+  end
+
+  # The dead run's LLM spend attaches to its interrupted event here or never:
+  # its usage rows fall outside every later run's window. The abandoned
+  # event's own started_at stat bounds them exactly — nothing ran between the
+  # death and this sweep (a later run would have swept the event already),
+  # and this run hasn't made any LLM calls yet.
+  def interrupt_abandoned_event(event)
+    usage_rows = abandoned_llm_usage_rows(event)
+    metadata = event.metadata.merge("status" => "interrupted")
+
+    if usage_rows.any?
+      metadata["stats"] = metadata.fetch("stats", {}).merge(
+        "llm_calls" => usage_rows.size,
+        "llm_cost_cents" => usage_rows.sum { |_id, cents| cents }
+      )
+    end
+
+    event.update!(level: :debug, metadata: metadata)
+    reference_llm_usages(event, usage_rows)
+  end
+
+  def abandoned_llm_usage_rows(event)
+    run_started_at = begin
+      Time.zone.parse(event.metadata.dig("stats", "started_at").to_s)
+    rescue ArgumentError
+      nil
+    end
+    return [] unless run_started_at
+
+    feed.llm_usages.scheduled_run
+        .where(started_at: run_started_at..)
+        .pluck(:id, :cost_estimate_cents)
   end
 
   # The in-flight record is user-visible and ephemeral: completion or failure

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -36,6 +36,13 @@
     </section>
   <% end %>
 
+  <% if @referenced_llm_usages.any? %>
+    <section class="space-y-4" data-key="events.ai_usage">
+      <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.llm_usage.section_title") %></h2>
+      <%= render LlmUsagesListComponent.new(usages: @referenced_llm_usages) %>
+    </section>
+  <% end %>
+
   <% if (stats = @event.metadata&.fetch("stats", nil)).present? %>
     <section class="space-y-4" data-key="events.stats">
       <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.metadata.stats.section_title") %></h2>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -36,6 +36,13 @@
     </section>
   <% end %>
 
+  <% if @referenced_llm_usages.any? %>
+    <section class="space-y-4" data-key="events.ai_usage">
+      <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.llm_usage.section_title") %></h2>
+      <%= render LlmUsagesListComponent.new(usages: @referenced_llm_usages) %>
+    </section>
+  <% end %>
+
   <% if (stats = @event.metadata&.fetch("stats", nil)).present? %>
     <section class="space-y-4" data-key="events.stats">
       <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.metadata.stats.section_title") %></h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,4 +121,6 @@ en:
         new_posts: "New posts"
         llm_calls: "AI calls"
         llm_cost_cents: "Estimated AI spend"
+    llm_usage:
+      section_title: "AI usage"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,4 +119,6 @@ en:
         total_duration: "Duration"
         new_entries: "New entries"
         new_posts: "New posts"
+        llm_calls: "AI calls"
+        llm_cost_cents: "Estimated AI spend"
 

--- a/test/components/feed_refresh_description_component_test.rb
+++ b/test/components/feed_refresh_description_component_test.rb
@@ -40,6 +40,55 @@ class FeedRefreshDescriptionComponentTest < ViewComponent::TestCase
     assert_nil result.css("[data-key='events.posts_count']").first
   end
 
+  def event_with_spend(cents, **attributes)
+    Event.create!(
+      type: "feed_refresh",
+      level: :info,
+      subject: feed,
+      user: user,
+      metadata: { status: "completed", stats: { llm_calls: 2, llm_cost_cents: cents } },
+      **attributes
+    )
+  end
+
+  test "#call should append the estimated AI spend" do
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: event_with_spend(3)))
+
+    assert_equal "(AI: $0.03)", result.css("[data-key='events.llm_cost']").first&.text
+  end
+
+  test "#call should show a zero spend when calls were made but cost nothing" do
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: event_with_spend(0)))
+
+    assert_equal "(AI: $0.00)", result.css("[data-key='events.llm_cost']").first&.text
+  end
+
+  test "#call should append both the posts count and the AI spend" do
+    event = event_with_spend(12)
+    create(:event_reference, event: event, reference: create(:post, feed: feed))
+
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: event))
+
+    assert_equal "(+1 post)", result.css("[data-key='events.posts_count']").first&.text
+    assert_equal "(AI: $0.12)", result.css("[data-key='events.llm_cost']").first&.text
+  end
+
+  test "#call should omit the spend when the run made no LLM calls" do
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: refresh_event))
+
+    assert_nil result.css("[data-key='events.llm_cost']").first
+  end
+
+  test "#call should append the spend to a failed refresh" do
+    event = event_with_spend(5, level: :error, message: "Connection timeout")
+    event.update!(metadata: event.metadata.merge("status" => "failed"))
+
+    result = render_inline(FeedRefreshDescriptionComponent.new(event: event))
+
+    assert_includes result.to_html, "couldn't refresh"
+    assert_equal "(AI: $0.05)", result.css("[data-key='events.llm_cost']").first&.text
+  end
+
   def event_with_status(status, **attributes)
     Event.create!(
       type: "feed_refresh",

--- a/test/components/llm_usage_list_item_component_test.rb
+++ b/test/components/llm_usage_list_item_component_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+require "view_component/test_case"
+
+class LlmUsageListItemComponentTest < ViewComponent::TestCase
+  def usage
+    @usage ||= create(:llm_usage, model: "claude-sonnet-4-6", stage: :loader,
+                                  input_tokens: 1_000, output_tokens: 500, cost_estimate_cents: 3)
+  end
+
+  def render_usage(record = usage)
+    render_inline(LlmUsageListItemComponent.new(usage: record))
+  end
+
+  test "#render should show the model and stage" do
+    result = render_usage
+
+    assert_equal "claude-sonnet-4-6", result.css("[data-key='events.llm_usage.model']").text
+    assert_equal "loader", result.css("[data-key='events.llm_usage.stage']").text
+  end
+
+  test "#render should summarize input and output tokens" do
+    result = render_usage
+
+    tokens = result.css("[data-key='events.llm_usage.tokens']").text
+    assert_equal "1,000 in · 500 out", tokens
+  end
+
+  test "#render should append cached tokens only when the call reused cache" do
+    cached = create(:llm_usage, input_tokens: 10, output_tokens: 5,
+                                cache_read_tokens: 200, cache_write_tokens: 40)
+
+    result = render_usage(cached)
+
+    assert_equal "10 in · 5 out · 240 cached", result.css("[data-key='events.llm_usage.tokens']").text
+  end
+
+  test "#render should format the call cost as currency" do
+    result = render_usage
+
+    assert_equal "$0.03", result.css("[data-key='events.llm_usage.cost']").text
+  end
+
+  test "#render should badge a successful outcome" do
+    result = render_usage
+
+    assert_equal "Success", result.css("[data-key='events.llm_usage.outcome']").text
+  end
+
+  test "#render should badge a failed outcome" do
+    failed = create(:llm_usage, outcome: :provider_error)
+
+    result = render_usage(failed)
+
+    assert_equal "Provider error", result.css("[data-key='events.llm_usage.outcome']").text
+  end
+end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -306,6 +306,31 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='events.imported_posts']", false
   end
 
+  test "#show should list the AI calls referenced by the event" do
+    sign_in_as user
+    feed = create(:feed, user: user)
+    event = create(:event, type: "feed_refresh", user: user, subject: feed)
+    usage = create(:llm_usage, user: user, feed: feed, model: "claude-sonnet-4-6", cost_estimate_cents: 3)
+    create(:event_reference, event: event, reference: usage)
+
+    get event_path(event)
+
+    assert_response :success
+    assert_select "[data-key='events.ai_usage']"
+    assert_select "[data-llm-usage-id='#{usage.id}']"
+    assert_select "[data-key='events.llm_usage.model']", text: "claude-sonnet-4-6"
+  end
+
+  test "#show should not render the AI usage section without references" do
+    sign_in_as user
+    event = create(:event, type: "feed_refresh", user: user)
+
+    get event_path(event)
+
+    assert_response :success
+    assert_select "[data-key='events.ai_usage']", false
+  end
+
   test "#show should render an owned event even with list filter params" do
     sign_in_as user
     event = create(:event, type: "feed_refresh", user: user)

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -46,6 +46,12 @@ class EventsHelperTest < ActionView::TestCase
     assert_equal "1m 35s", format_stat_value("persist_posts_duration", 95.0)
   end
 
+  test "#format_stat_value should format _cents keys as currency" do
+    assert_equal "$0.03", format_stat_value("llm_cost_cents", 3)
+    assert_equal "$12.00", format_stat_value("llm_cost_cents", 1200)
+    assert_equal "$0.00", format_stat_value("llm_cost_cents", 0)
+  end
+
   test "#format_stat_value should return value as-is for other keys" do
     assert_equal "foo", format_stat_value("some_key", "foo")
   end

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -469,6 +469,105 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal "active", credential.reload.state
   end
 
+  def usage_writing_loader(test_feed, rss, cost_cents: 3)
+    loader = Object.new
+    loader.define_singleton_method(:load) do
+      FactoryBot.create(:llm_usage, user: test_feed.user, feed: test_feed,
+                         started_at: Time.current, finished_at: Time.current,
+                         cost_estimate_cents: cost_cents)
+      rss
+    end
+    loader
+  end
+
+  test "#execute should reference the run's LLM usage on the completed event" do
+    test_feed = create(:feed, :enabled, feed_profile_key: "rss")
+    prior_usage = create(:llm_usage, user: test_feed.user, feed: test_feed, started_at: 1.minute.ago)
+
+    test_feed.stub(:loader_instance, usage_writing_loader(test_feed, empty_rss)) do
+      FeedRefreshWorkflow.new(test_feed).execute
+    end
+
+    event = Event.find_by!(subject: test_feed, type: "feed_refresh")
+    run_usage = test_feed.llm_usages.where.not(id: prior_usage.id).sole
+
+    assert_equal "completed", event.metadata["status"]
+    assert_equal 1, event.metadata.dig("stats", "llm_calls")
+    assert_equal 3, event.metadata.dig("stats", "llm_cost_cents")
+    assert_equal [run_usage], event.references
+  end
+
+  test "#execute should reference the run's LLM usage on the failed event" do
+    test_feed = create(:feed, :enabled, feed_profile_key: "rss")
+
+    loader = Object.new
+    loader.define_singleton_method(:load) do
+      FactoryBot.create(:llm_usage, user: test_feed.user, feed: test_feed,
+                         started_at: Time.current, finished_at: Time.current,
+                         cost_estimate_cents: 5, outcome: :provider_error)
+      raise LlmClient::ProviderError, "server error"
+    end
+
+    test_feed.stub(:loader_instance, loader) do
+      assert_raises(LlmClient::ProviderError) { FeedRefreshWorkflow.new(test_feed).execute }
+    end
+
+    event = Event.find_by!(subject: test_feed, type: "feed_refresh")
+
+    assert_equal "failed", event.metadata["status"]
+    assert_equal 1, event.metadata.dig("stats", "llm_calls")
+    assert_equal 5, event.metadata.dig("stats", "llm_cost_cents")
+    assert_equal test_feed.llm_usages.to_a, event.references
+  end
+
+  test "#execute should not ignore zero-cost LLM calls" do
+    test_feed = create(:feed, :enabled, feed_profile_key: "rss")
+
+    test_feed.stub(:loader_instance, usage_writing_loader(test_feed, empty_rss, cost_cents: 0)) do
+      FeedRefreshWorkflow.new(test_feed).execute
+    end
+
+    event = Event.find_by!(subject: test_feed, type: "feed_refresh")
+
+    assert_equal 1, event.metadata.dig("stats", "llm_calls")
+    assert_equal 0, event.metadata.dig("stats", "llm_cost_cents")
+  end
+
+  test "#execute should record no LLM usage stats for a run without LLM calls" do
+    test_feed = create(:feed, :enabled, url: "https://example.com/feed.xml", feed_profile_key: "rss")
+    WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
+
+    FeedRefreshWorkflow.new(test_feed).execute
+
+    event = Event.find_by!(subject: test_feed, type: "feed_refresh")
+
+    assert_equal "completed", event.metadata["status"]
+    assert_not event.metadata["stats"].key?("llm_calls")
+    assert_not event.metadata["stats"].key?("llm_cost_cents")
+    assert_empty event.event_references
+  end
+
+  test "#execute should not associate preview usage written during the run" do
+    test_feed = create(:feed, :enabled, feed_profile_key: "rss")
+    rss = empty_rss
+
+    preview_loader = Object.new
+    preview_loader.define_singleton_method(:load) do
+      FactoryBot.create(:llm_usage, user: test_feed.user, feed: test_feed, purpose: :preview,
+                         started_at: Time.current, finished_at: Time.current)
+      rss
+    end
+
+    test_feed.stub(:loader_instance, preview_loader) do
+      FeedRefreshWorkflow.new(test_feed).execute
+    end
+
+    event = Event.find_by!(subject: test_feed, type: "feed_refresh")
+
+    assert_not event.metadata["stats"].key?("llm_calls")
+    assert_empty event.event_references
+  end
+
   test "#execute should handle normalization errors gracefully" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
 

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -744,6 +744,38 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
                  "the rest of the abandoned event's metadata stays intact"
   end
 
+  test "#execute should attach the dead run's LLM usage to its interrupted event" do
+    test_feed = create(:feed, :enabled, url: "https://example.com/feed.xml", feed_profile_key: "rss")
+    WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)
+
+    abandoned = Event.create!(
+      type: "feed_refresh",
+      level: :info,
+      subject: test_feed,
+      user: test_feed.user,
+      metadata: { status: "started", stats: { started_at: 10.minutes.ago.iso8601 } }
+    )
+    create(:llm_usage, user: test_feed.user, feed: test_feed, started_at: 11.minutes.ago,
+                       cost_estimate_cents: 7)
+    dead_run_usage = create(:llm_usage, user: test_feed.user, feed: test_feed,
+                            started_at: 9.minutes.ago, cost_estimate_cents: 40)
+
+    FeedRefreshWorkflow.new(test_feed).execute
+
+    abandoned.reload
+    assert_equal "interrupted", abandoned.metadata["status"]
+    assert_equal 1, abandoned.metadata.dig("stats", "llm_calls")
+    assert_equal 40, abandoned.metadata.dig("stats", "llm_cost_cents")
+    assert_equal [dead_run_usage], abandoned.references,
+                 "only the dead run's rows attach; an earlier run's row stays out"
+
+    completed = Event.where(subject: test_feed, type: "feed_refresh")
+                     .where("metadata ->> 'status' = 'completed'").sole
+    assert_not completed.metadata["stats"].key?("llm_calls"),
+               "the sweeping run must not absorb the dead run's spend"
+    assert_empty completed.event_references
+  end
+
   test "#execute should not touch other feeds' started events" do
     test_feed = create(:feed, url: "https://example.com/feed.xml", feed_profile_key: "rss")
     other_feed = create(:feed)

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -533,6 +533,30 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     assert_equal 0, event.metadata.dig("stats", "llm_cost_cents")
   end
 
+  test "#execute should sum cost across a run's LLM calls" do
+    test_feed = create(:feed, :enabled, feed_profile_key: "rss")
+    rss = empty_rss
+
+    loader = Object.new
+    loader.define_singleton_method(:load) do
+      FactoryBot.create(:llm_usage, user: test_feed.user, feed: test_feed,
+                         started_at: Time.current, finished_at: Time.current, cost_estimate_cents: 2)
+      FactoryBot.create(:llm_usage, user: test_feed.user, feed: test_feed,
+                         started_at: Time.current, finished_at: Time.current, cost_estimate_cents: 5)
+      rss
+    end
+
+    test_feed.stub(:loader_instance, loader) do
+      FeedRefreshWorkflow.new(test_feed).execute
+    end
+
+    event = Event.find_by!(subject: test_feed, type: "feed_refresh")
+
+    assert_equal 2, event.metadata.dig("stats", "llm_calls")
+    assert_equal 7, event.metadata.dig("stats", "llm_cost_cents")
+    assert_equal test_feed.llm_usages.to_a, event.references
+  end
+
   test "#execute should record no LLM usage stats for a run without LLM calls" do
     test_feed = create(:feed, :enabled, url: "https://example.com/feed.xml", feed_profile_key: "rss")
     WebMock.stub_request(:get, test_feed.url).to_return(body: empty_rss, status: 200)


### PR DESCRIPTION
Changes:

- Feed refresh events now link the LLM usage records from that run, reusing the event-reference mechanism that already ties imported posts to their refresh event.
- The events log shows each AI refresh's estimated spend next to the entry (e.g. "refreshed (+2 posts) (AI: $0.03)"), and the event page lists the run's AI call count and estimated spend in its stats.
- A run killed mid-refresh has its spend attributed to the interrupted event, so per-run costs stay accounted for even when a worker dies.

The AI Usage section on the feed page already showed a cumulative total; this brings the same spend down to the level of an individual refresh. Runs are matched to their usage rows by the run's time window, which is exact because a per-feed advisory lock serializes refreshes and preview/identification calls are recorded under a different purpose. No schema changes were needed — the existing usage and event-reference models already supported this.
