### PR TITLE
Default generators to UUID primary keys

### DIFF
--- a/.database_consistency.todo.yml
+++ b/.database_consistency.todo.yml
@@ -75,9 +75,6 @@ FeedPreview:
   feed_profile_key:
     ColumnPresenceChecker:
       enabled: false
-  id:
-    ImplicitOrderingChecker:
-      enabled: false
   index_feed_previews_on_owner_profile_digest:
     # wontfix: FeedPreviewsController#start_run deliberately rescues
     # RecordNotUnique to adopt a concurrent request's row; a uniqueness
@@ -91,10 +88,6 @@ FeedPreview:
     # wontfix: assigned by before_validation :assign_params_digest, so a
     # presence validator would be dead code.
     NullConstraintChecker:
-      enabled: false
-Invite:
-  id:
-    ImplicitOrderingChecker:
       enabled: false
 JobRun:
   index_job_runs_on_job_id:

--- a/app/components/events_list_component.rb
+++ b/app/components/events_list_component.rb
@@ -82,6 +82,6 @@ class EventsListComponent < ViewComponent::Base
   end
 
   def last_event_id
-    @events.map(&:id).max || 0
+    @events.map(&:id).max
   end
 end

--- a/app/controllers/concerns/event_cursor_pagination.rb
+++ b/app/controllers/concerns/event_cursor_pagination.rb
@@ -29,9 +29,9 @@ module EventCursorPagination
   def events_page
     scope = events_scope.includes(:user, :subject, :event_references)
 
-    if before_cursor.positive?
+    if before_cursor
       scope.where(cursor_condition("<", before_cursor)).order(created_at: :desc, id: :desc).limit(events_page_size)
-    elsif after_cursor.positive?
+    elsif after_cursor
       scope.where(cursor_condition(">", after_cursor)).order(created_at: :asc, id: :asc).limit(events_page_size).reverse
     else
       scope.order(created_at: :desc, id: :desc).limit(events_page_size)
@@ -91,14 +91,14 @@ module EventCursorPagination
   end
 
   def cursor_present?
-    before_cursor.positive? || after_cursor.positive?
+    before_cursor.present? || after_cursor.present?
   end
 
   def before_cursor
-    params[:before].to_i
+    event_cursor(:before)
   end
 
   def after_cursor
-    params[:after].to_i
+    event_cursor(:after)
   end
 end

--- a/app/controllers/concerns/event_streaming.rb
+++ b/app/controllers/concerns/event_streaming.rb
@@ -1,6 +1,8 @@
 module EventStreaming
   extend ActiveSupport::Concern
 
+  UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
   included do
     class_attribute :events_page_size, default: 25
     class_attribute :brief_events_limit, default: 15
@@ -17,11 +19,21 @@ module EventStreaming
   end
 
   def new_events?
-    after_id < events_scope.maximum(:id).to_i
+    scope = events_scope
+    scope = scope.where("id > ?", after_id) if after_id
+    scope.exists?
   end
 
   def after_id
-    params[:after_id].to_i
+    event_cursor(:after_id)
+  end
+
+  # Event ids are uuids, but cursors arrive as untrusted params. Anything that
+  # isn't a well-formed uuid (a stale link, a hand-edited "0") becomes nil, so
+  # the id comparisons below never feed Postgres an invalid uuid.
+  def event_cursor(key)
+    value = params[key].to_s
+    value if value.match?(UUID_FORMAT)
   end
 
   def render_events_stream

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  # PKs are UUIDv7, which is time-ordered, so ordering by id is chronological.
+  # Make that explicit for finder methods (.first/.last, batching) and Postgres.
+  self.implicit_order_column = "id"
 end

--- a/app/views/development/components/show.html.erb
+++ b/app/views/development/components/show.html.erb
@@ -531,8 +531,8 @@
       <h2 class="border-b border-border pb-2 text-xl font-semibold text-heading">Event description</h2>
       <p class="text-body">Renders a human-readable summary of a system event, usually inside an alert that matches its severity.</p>
 
-      <% sample_feed = Feed.first || Feed.new(id: 1, name: "Sample Feed") %>
-      <% sample_token = AccessToken.first || AccessToken.new(id: 1, name: "Sample Token") %>
+      <% sample_feed = Feed.first || Feed.new(id: SecureRandom.uuid, name: "Sample Feed") %>
+      <% sample_token = AccessToken.first || AccessToken.new(id: SecureRandom.uuid, name: "Sample Token") %>
 
       <div class="space-y-3">
         <%= render AlertComponent.new(variant: :info) do %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,13 @@ module F2Rails
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    # Default new models to UUIDv7 primary keys. UUIDv7 is time-ordered, so
+    # inserts stay at the right edge of the index like a bigint sequence, and
+    # ids are opaque and non-enumerable in URLs.
+    config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid
+    end
+
     # Configure ActiveJob to use SolidQueue
     config.active_job.queue_adapter = :solid_queue
 

--- a/db/migrate/20260712000001_convert_primary_keys_to_uuidv7.rb
+++ b/db/migrate/20260712000001_convert_primary_keys_to_uuidv7.rb
@@ -1,0 +1,172 @@
+class ConvertPrimaryKeysToUuidv7 < ActiveRecord::Migration[8.2]
+  # Gem-owned Solid tables (Queue/Cache/Cable) stay bigint.
+  SKIP_PREFIXES = %w[solid_queue_ solid_cache_ solid_cable_ ar_internal schema_].freeze
+
+  # Tables already on uuid PKs (created with gen_random_uuid, i.e. v4). Their
+  # keys stay; only the default moves to the time-ordered generator.
+  ALREADY_UUID = %w[feed_previews invites].freeze
+
+  # Polymorphic id columns can't be resolved from a foreign key, so their
+  # target table is chosen per row from the sibling type column.
+  POLYMORPHIC = { "events" => %w[subject], "event_references" => %w[reference] }.freeze
+
+  # Columns that reference another table by convention but carry no database
+  # foreign key, so foreign_keys introspection never surfaces them.
+  UNCONSTRAINED_REFERENCES = {
+    "feed_previews" => { "ai_credential_id" => "ai_credentials" },
+    "event_references" => { "event_id" => "events" }
+  }.freeze
+
+  def up
+    convert!(
+      to: "uuid",
+      map_type: "uuid",
+      new_id_sql: "uuidv7()",
+      pk_default: "uuidv7()"
+    )
+
+    ALREADY_UUID.each { |table| set_id_default(table, "uuidv7()") }
+  end
+
+  def down
+    ALREADY_UUID.each { |table| set_id_default(table, "gen_random_uuid()") }
+
+    # Regenerate sequential bigints in creation order (uuidv7 sorts by
+    # creation time, so row_number reproduces the original ordering) and
+    # restore an owned sequence so inserts auto-increment again.
+    convert!(
+      to: "bigint",
+      map_type: "bigint",
+      new_id_sql: "row_number() OVER (ORDER BY id)",
+      pk_default: nil
+    )
+  end
+
+  private
+
+  # Reversible core: rewrites every convertible PK and referencing column from
+  # one id type to the other while preserving rows, relationships, and indexes.
+  def convert!(to:, map_type:, new_id_sql:, pk_default:)
+    pk_tables = pk_convertible_tables
+    # Every app table's foreign keys must be dropped before any referenced PK
+    # changes type and re-added after — including the already-uuid tables,
+    # whose fk columns still point at the tables being converted.
+    fks = application_tables.flat_map { |table| foreign_keys(table).map { |fk| [table, fk] } }
+
+    build_id_map(pk_tables, map_type, new_id_sql)
+
+    fks.each { |(table, fk)| remove_foreign_key(table, name: fk.name) }
+
+    pk_tables.each { |table| convert_primary_key(table, to, pk_default) }
+    fks.each { |(table, fk)| convert_reference(table, fk.column, fk.to_table, to) }
+    UNCONSTRAINED_REFERENCES.each do |table, columns|
+      columns.each { |column, target| convert_reference(table, column, target, to) }
+    end
+    convert_polymorphic_columns(to)
+
+    fks.each { |(table, fk)| add_foreign_key(table, fk.to_table, **foreign_key_options(fk)) }
+
+    execute("DROP TABLE #{quote_table_name(map_table)}")
+  end
+
+  def application_tables
+    connection.tables.reject { |table| SKIP_PREFIXES.any? { |prefix| table.start_with?(prefix) } }
+  end
+
+  # App tables whose PK is retyped: all except the already-uuid ones.
+  def pk_convertible_tables
+    application_tables - ALREADY_UUID
+  end
+
+  def build_id_map(tables, map_type, new_id_sql)
+    execute(<<~SQL)
+      CREATE TABLE #{quote_table_name(map_table)} (
+        table_name text NOT NULL,
+        model_name text NOT NULL,
+        old_id #{old_id_type} NOT NULL,
+        new_id #{map_type} NOT NULL,
+        PRIMARY KEY (table_name, old_id)
+      )
+    SQL
+
+    tables.each do |table|
+      execute(<<~SQL)
+        INSERT INTO #{quote_table_name(map_table)} (table_name, model_name, old_id, new_id)
+        SELECT #{quote(table)}, #{quote(table.classify)}, id, #{new_id_sql}
+        FROM #{quote_table_name(table)}
+      SQL
+    end
+  end
+
+  def convert_primary_key(table, to, pk_default)
+    sequence = select_value("SELECT pg_get_serial_sequence(#{quote(table)}, 'id')")
+    execute("ALTER TABLE #{quote_table_name(table)} ALTER COLUMN id DROP DEFAULT")
+    rewrite_column(table, "id", to, "m.table_name = #{quote(table)} AND m.old_id = #{qualified(table, 'id')}")
+    execute("DROP SEQUENCE IF EXISTS #{sequence}") if sequence
+
+    if pk_default
+      execute("ALTER TABLE #{quote_table_name(table)} ALTER COLUMN id SET DEFAULT #{pk_default}")
+    else
+      restore_sequence(table)
+    end
+  end
+
+  def convert_reference(table, column, target_table, to)
+    join = "m.table_name = #{quote(target_table)} AND m.old_id = #{qualified(table, column)}"
+    rewrite_column(table, column, to, join)
+  end
+
+  def convert_polymorphic_columns(to)
+    POLYMORPHIC.each do |table, names|
+      names.each do |name|
+        join = "m.model_name = #{qualified(table, "#{name}_type")} AND m.old_id = #{qualified(table, "#{name}_id")}"
+        rewrite_column(table, "#{name}_id", to, join)
+      end
+    end
+  end
+
+  # Retype a column via a temporary sibling: fill it from the id map (a plain
+  # UPDATE join, since ALTER ... USING forbids subqueries), then swap types.
+  # Unmatched rows (NULL fk, orphan-free by construction) stay NULL.
+  def rewrite_column(table, column, to, join)
+    quoted = quote_table_name(table)
+    scratch = "uuidv7_migration_#{column}"
+
+    execute("ALTER TABLE #{quoted} ADD COLUMN #{scratch} #{to}")
+    execute("UPDATE #{quoted} SET #{scratch} = m.new_id FROM #{quote_table_name(map_table)} m WHERE #{join}")
+    execute("ALTER TABLE #{quoted} ALTER COLUMN #{column} TYPE #{to} USING #{scratch}")
+    execute("ALTER TABLE #{quoted} DROP COLUMN #{scratch}")
+  end
+
+  def restore_sequence(table)
+    quoted = quote_table_name(table)
+    sequence = "#{table}_id_seq"
+    execute("CREATE SEQUENCE #{sequence} OWNED BY #{quoted}.id")
+    execute("SELECT setval(#{quote(sequence)}, GREATEST(COALESCE((SELECT MAX(id) FROM #{quoted}), 0), 1))")
+    execute("ALTER TABLE #{quoted} ALTER COLUMN id SET DEFAULT nextval(#{quote(sequence)}::regclass)")
+  end
+
+  def foreign_key_options(fk)
+    options = { column: fk.column, primary_key: fk.primary_key, name: fk.name }
+    options[:on_delete] = fk.on_delete if fk.on_delete
+    options
+  end
+
+  def set_id_default(table, expression)
+    execute("ALTER TABLE #{quote_table_name(table)} ALTER COLUMN id SET DEFAULT #{expression}")
+  end
+
+  def qualified(table, column)
+    "#{quote_table_name(table)}.#{column}"
+  end
+
+  def old_id_type
+    # Both directions map from the type we're leaving; the "from" PK is bigint
+    # on up and uuid on down. Read it off an arbitrary convertible table.
+    connection.columns(pk_convertible_tables.first).find { |c| c.name == "id" }.sql_type
+  end
+
+  def map_table
+    "pk_id_map"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_12_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
-  create_table "access_token_details", force: :cascade do |t|
-    t.bigint "access_token_id", null: false
+  create_table "access_token_details", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.uuid "access_token_id", null: false
     t.datetime "created_at", null: false
     t.jsonb "data", default: {}, null: false
     t.datetime "updated_at", null: false
     t.index ["access_token_id"], name: "index_access_token_details_on_access_token_id", unique: true
   end
 
-  create_table "access_tokens", force: :cascade do |t|
+  create_table "access_tokens", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "encrypted_token"
     t.string "host", null: false
@@ -31,15 +31,15 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.string "owner"
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.uuid "user_id", null: false
     t.string "freefeed_user_id"
     t.index ["freefeed_user_id"], name: "index_access_tokens_on_freefeed_user_id"
     t.index ["user_id", "name"], name: "index_access_tokens_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_access_tokens_on_user_id"
   end
 
-  create_table "ai_credentials", force: :cascade do |t|
-    t.bigint "user_id", null: false
+  create_table "ai_credentials", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
     t.string "provider", null: false
     t.string "display_name", null: false
     t.jsonb "credential_data", default: {}, null: false
@@ -54,27 +54,27 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["user_id"], name: "index_ai_credentials_on_user_id"
   end
 
-  create_table "event_references", force: :cascade do |t|
-    t.bigint "event_id", null: false
+  create_table "event_references", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.uuid "event_id", null: false
     t.string "reference_type", null: false
-    t.bigint "reference_id", null: false
+    t.uuid "reference_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["event_id", "reference_type", "reference_id"], name: "index_event_references_on_event_and_reference", unique: true
     t.index ["reference_type", "reference_id"], name: "index_event_references_on_reference"
   end
 
-  create_table "events", force: :cascade do |t|
+  create_table "events", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at"
     t.integer "level", default: 1, null: false
     t.text "message", default: "", null: false
     t.jsonb "metadata", default: {}, null: false
-    t.bigint "subject_id"
+    t.uuid "subject_id"
     t.string "subject_type"
     t.string "type", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
+    t.uuid "user_id"
     t.index ["created_at", "id"], name: "index_events_on_created_at_and_id"
     t.index ["expires_at"], name: "index_events_on_expires_at", where: "(expires_at IS NOT NULL)"
     t.index ["level", "created_at"], name: "index_events_on_level_and_created_at"
@@ -83,9 +83,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 
-  create_table "feed_entries", force: :cascade do |t|
+  create_table "feed_entries", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.bigint "feed_id", null: false
+    t.uuid "feed_id", null: false
     t.datetime "published_at"
     t.jsonb "raw_data"
     t.integer "status", default: 0
@@ -95,9 +95,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["feed_id"], name: "index_feed_entries_on_feed_id"
   end
 
-  create_table "feed_entry_uids", force: :cascade do |t|
+  create_table "feed_entry_uids", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.bigint "feed_id", null: false
+    t.uuid "feed_id", null: false
     t.datetime "imported_at", null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
@@ -106,7 +106,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["imported_at"], name: "index_feed_entry_uids_on_imported_at"
   end
 
-  create_table "feed_identifications", force: :cascade do |t|
+  create_table "feed_identifications", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.jsonb "candidates", default: [], null: false
     t.datetime "created_at", null: false
     t.text "error"
@@ -114,15 +114,15 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.string "input", null: false
-    t.bigint "user_id", null: false
+    t.uuid "user_id", null: false
     t.index ["user_id", "input"], name: "index_feed_identifications_on_user_id_and_input", unique: true
     t.index ["user_id"], name: "index_feed_identifications_on_user_id"
   end
 
-  create_table "feed_metrics", force: :cascade do |t|
+  create_table "feed_metrics", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.date "date", null: false
-    t.bigint "feed_id", null: false
+    t.uuid "feed_id", null: false
     t.integer "invalid_posts_count", default: 0, null: false
     t.integer "posts_count", default: 0, null: false
     t.datetime "updated_at", null: false
@@ -131,18 +131,18 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["feed_id", "date"], name: "index_feed_metrics_on_feed_id_and_date", unique: true
   end
 
-  create_table "feed_previews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "feed_previews", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.jsonb "data"
     t.string "feed_profile_key"
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.uuid "user_id", null: false
     t.jsonb "params", default: {}, null: false
     t.string "params_digest", null: false
     t.datetime "ready_at"
     t.string "run_id"
-    t.bigint "ai_credential_id"
+    t.uuid "ai_credential_id"
     t.string "ai_model"
     t.index ["created_at"], name: "index_feed_previews_on_created_at"
     t.index ["status"], name: "index_feed_previews_on_status"
@@ -150,9 +150,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["user_id"], name: "index_feed_previews_on_user_id"
   end
 
-  create_table "feed_schedules", force: :cascade do |t|
+  create_table "feed_schedules", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.bigint "feed_id", null: false
+    t.uuid "feed_id", null: false
     t.datetime "last_run_at"
     t.datetime "next_run_at"
     t.datetime "updated_at", null: false
@@ -160,8 +160,8 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["feed_id"], name: "index_feed_schedules_on_feed_id"
   end
 
-  create_table "feeds", force: :cascade do |t|
-    t.bigint "access_token_id"
+  create_table "feeds", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.uuid "access_token_id"
     t.datetime "created_at", null: false
     t.string "cron_expression"
     t.string "description", default: "", null: false
@@ -172,8 +172,8 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.integer "state", default: 0, null: false
     t.string "target_group", limit: 80
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.bigint "ai_credential_id"
+    t.uuid "user_id", null: false
+    t.uuid "ai_credential_id"
     t.integer "consecutive_failures", default: 0, null: false
     t.boolean "images_only", default: false, null: false
     t.integer "imported_posts_count", default: 0, null: false
@@ -184,16 +184,16 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["user_id"], name: "index_feeds_on_user_id"
   end
 
-  create_table "invites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "invites", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.bigint "created_by_user_id", null: false
-    t.bigint "invited_user_id"
+    t.uuid "created_by_user_id", null: false
+    t.uuid "invited_user_id"
     t.datetime "updated_at", null: false
     t.index ["created_by_user_id"], name: "index_invites_on_created_by_user_id"
     t.index ["invited_user_id"], name: "index_invites_on_invited_user_id"
   end
 
-  create_table "job_runs", force: :cascade do |t|
+  create_table "job_runs", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.string "job_class", null: false
     t.string "status", default: "queued", null: false
     t.string "job_id"
@@ -205,10 +205,10 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["job_id"], name: "index_job_runs_on_job_id", unique: true
   end
 
-  create_table "llm_usages", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "feed_id"
-    t.bigint "ai_credential_id"
+  create_table "llm_usages", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "feed_id"
+    t.uuid "ai_credential_id"
     t.string "profile_key"
     t.integer "stage"
     t.string "provider", null: false
@@ -235,22 +235,22 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["user_id"], name: "index_llm_usages_on_user_id"
   end
 
-  create_table "permissions", force: :cascade do |t|
+  create_table "permissions", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.uuid "user_id", null: false
     t.index ["user_id", "name"], name: "index_permissions_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_permissions_on_user_id"
   end
 
-  create_table "posts", force: :cascade do |t|
+  create_table "posts", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.text "attachment_urls", default: [], null: false, array: true
     t.text "comments", default: [], null: false, array: true
     t.text "content", default: "", null: false
     t.datetime "created_at", null: false
-    t.bigint "feed_entry_id", null: false
-    t.bigint "feed_id", null: false
+    t.uuid "feed_entry_id", null: false
+    t.uuid "feed_id", null: false
     t.string "freefeed_post_id"
     t.datetime "published_at", null: false
     t.string "source_url"
@@ -268,7 +268,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["status"], name: "index_posts_on_status"
   end
 
-  create_table "rate_limit_buckets", force: :cascade do |t|
+  create_table "rate_limit_buckets", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.string "key", null: false
     t.jsonb "data", default: {}, null: false
     t.datetime "blocked_until"
@@ -277,12 +277,12 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["key"], name: "index_rate_limit_buckets_on_key", unique: true
   end
 
-  create_table "sessions", force: :cascade do |t|
+  create_table "sessions", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "ip_address"
     t.datetime "updated_at", null: false
     t.string "user_agent"
-    t.bigint "user_id", null: false
+    t.uuid "user_id", null: false
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
@@ -428,7 +428,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.integer "available_invites", default: 0, null: false
     t.datetime "created_at", null: false
     t.string "email_address", null: false
@@ -441,7 +441,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
     t.datetime "suspended_at"
     t.string "unconfirmed_email"
     t.datetime "updated_at", null: false
-    t.bigint "default_ai_credential_id"
+    t.uuid "default_ai_credential_id"
     t.index ["default_ai_credential_id"], name: "index_users_on_default_ai_credential_id"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["email_deactivated_at"], name: "index_users_on_email_deactivated_at"

--- a/test/components/event_list_item_component_test.rb
+++ b/test/components/event_list_item_component_test.rb
@@ -223,7 +223,7 @@ class EventListItemComponentTest < ViewComponent::TestCase
 
   test "#call should omit the subject hover title when the subject is gone" do
     event = create(:event, user: user)
-    event.update!(subject_type: "Feed", subject_id: 12_345)
+    event.update!(subject_type: "Feed", subject_id: SecureRandom.uuid)
 
     result = render_admin_item(event)
 

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -213,9 +213,10 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should render admin events turbo stream" do
     login_as(admin_user)
-    event = create(:event, type: "NewAdminEvent")
+    cursor_event = create(:event, type: "OldAdminEvent")
+    create(:event, type: "NewAdminEvent")
 
-    get admin_events_path(format: :turbo_stream), params: { after_id: event.id - 1 }
+    get admin_events_path(format: :turbo_stream), params: { after_id: cursor_event.id }
 
     assert_response :success
     assert_equal Mime[:turbo_stream], response.media_type
@@ -249,12 +250,13 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   test "should show recorded subject when subject missing" do
     login_as(admin_user)
     event = create(:event, type: "MissingSubjectEvent", subject: nil)
-    event.update!(subject_type: "Post", subject_id: 42)
+    missing_id = SecureRandom.uuid
+    event.update!(subject_type: "Post", subject_id: missing_id)
 
     get admin_events_path
 
     assert_response :success
-    assert_select '[data-key="events.subject"]', text: "Post#42"
+    assert_select '[data-key="events.subject"]', text: "Post##{missing_id}"
   end
 
   test "should filter events by subject_type" do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -17,11 +17,11 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "#index should render new user events as turbo stream" do
     sign_in_as user
-    create(:event, type: "old_event", user: user)
-    event = create(:event, type: "new_event", user: user)
+    old_event = create(:event, type: "old_event", user: user)
+    create(:event, type: "new_event", user: user)
     create(:event, type: "other_event", user: other_user)
 
-    get events_path(format: :turbo_stream), params: { after_id: event.id - 1 }
+    get events_path(format: :turbo_stream), params: { after_id: old_event.id }
 
     assert_response :success
     assert_equal Mime[:turbo_stream], response.media_type

--- a/test/controllers/statuses_controller_test.rb
+++ b/test/controllers/statuses_controller_test.rb
@@ -155,8 +155,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     get status_path
     assert_response :success
     assert_select "h2", "Recent Activity"
-    assert_not_nil css_select('[data-event-id="%d"]' % event1.id).first
-    assert_not_nil css_select('[data-event-id="%d"]' % event2.id).first
+    assert_not_nil css_select('[data-event-id="%s"]' % event1.id).first
+    assert_not_nil css_select('[data-event-id="%s"]' % event2.id).first
   end
 
   test "#show should display empty recent events section when no events" do
@@ -178,8 +178,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path
     assert_response :success
-    assert_not_nil css_select('[data-event-id="%d"]' % user_event.id).first
-    assert css_select('[data-event-id="%d"]' % other_event.id).empty?
+    assert_not_nil css_select('[data-event-id="%s"]' % user_event.id).first
+    assert css_select('[data-event-id="%s"]' % other_event.id).empty?
   end
 
   test "#show should exclude debug level events" do
@@ -190,8 +190,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path
     assert_response :success
-    assert_not_nil css_select('[data-event-id="%d"]' % info_event.id).first
-    assert css_select('[data-event-id="%d"]' % debug_event.id).empty?
+    assert_not_nil css_select('[data-event-id="%s"]' % info_event.id).first
+    assert css_select('[data-event-id="%s"]' % debug_event.id).empty?
   end
 
   test "#show should exclude expired events" do
@@ -202,8 +202,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path
     assert_response :success
-    assert_not_nil css_select('[data-event-id="%d"]' % active_event.id).first
-    assert css_select('[data-event-id="%d"]' % expired_event.id).empty?
+    assert_not_nil css_select('[data-event-id="%s"]' % active_event.id).first
+    assert css_select('[data-event-id="%s"]' % expired_event.id).empty?
   end
 
   test "#show should limit recent events to the initial limit" do
@@ -228,8 +228,8 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
 
     get status_path, params: { filter: { type: ["feed_refresh"] } }
     assert_response :success
-    assert_not_nil css_select('[data-event-id="%d"]' % refresh_event.id).first
-    assert css_select('[data-event-id="%d"]' % withdrawn_event.id).empty?
+    assert_not_nil css_select('[data-event-id="%s"]' % refresh_event.id).first
+    assert css_select('[data-event-id="%s"]' % withdrawn_event.id).empty?
   end
 
   test "#show should carry the active filter into the polling endpoint" do

--- a/test/models/ai_credential_test.rb
+++ b/test/models/ai_credential_test.rb
@@ -47,7 +47,7 @@ class AiCredentialTest < ActiveSupport::TestCase
     credential = create(:ai_credential, user: user, credential_data: { "api_key" => "sk-ant-secret-12345" })
 
     raw = ActiveRecord::Base.connection.select_value(
-      "SELECT credential_data FROM ai_credentials WHERE id = #{credential.id}"
+      "SELECT credential_data FROM ai_credentials WHERE id = #{ActiveRecord::Base.connection.quote(credential.id)}"
     )
     refute_includes raw.to_s, "sk-ant-secret-12345"
     assert_equal "sk-ant-secret-12345", credential.reload.credential_data["api_key"]

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -97,7 +97,7 @@ class LlmClientTest < ActiveSupport::TestCase
 
       assert_kind_of LlmClient::Result, result
       assert_equal({ "items" => [{ "title" => "Post 1" }] }, result.payload)
-      assert_kind_of Integer, result.usage_id
+      assert_kind_of String, result.usage_id
     end
 
     usage = LlmUsage.last

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,19 @@ SimpleCov.start "rails"
 
 require_relative "../config/environment"
 require "rails/test_help"
+
+# Rails gives uuid fixtures name-based (v5) ids that sort arbitrarily against the
+# uuidv7 ids created rows get, breaking `Model.last`/`order(:id)` in tests. Force
+# fixture ids into a fixed, always-earlier range so fixtures precede created rows.
+module OrderableUuidFixtures
+  def identify(label, column_type = :integer)
+    return super unless column_type == :uuid
+
+    "00000000-0000-7000-8000-#{Digest::MD5.hexdigest(label.to_s)[0, 12]}"
+  end
+end
+ActiveRecord::FixtureSet.singleton_class.prepend(OrderableUuidFixtures)
+
 require "webmock/minitest"
 require "minitest/mock"
 require "super_diff"


### PR DESCRIPTION
New models get uuid keys by default so ids are opaque and non-enumerable in URLs. UUIDv7 is time-ordered, keeping inserts at the index's right edge.
