### PR TITLE
Prune and prevent dangling event_references

### DIFF
--- a/.database_consistency.todo.yml
+++ b/.database_consistency.todo.yml
@@ -28,9 +28,6 @@ Event:
     MissingDependentDestroyChecker:
       enabled: false
 EventReference:
-  event:
-    ForeignKeyChecker:
-      enabled: false
   index_event_references_on_event_and_reference:
     # wontfix: rows are created via insert_all (FeedRefreshWorkflow), which
     # skips validations — a uniqueness validator would never run.

--- a/app/models/llm_usage.rb
+++ b/app/models/llm_usage.rb
@@ -6,6 +6,10 @@ class LlmUsage < ApplicationRecord
   belongs_to :feed, optional: true
   belongs_to :ai_credential, optional: true
 
+  # No FK backs the polymorphic reference, so clean these up on destroy to
+  # avoid dangling event_references.
+  has_many :event_references, as: :reference, dependent: :delete_all
+
   enum :stage, { loader: 0, processor: 1, normalizer: 2 }
   enum :purpose, { scheduled_run: 0, preview: 1 }
   enum :outcome, {

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -21,6 +21,10 @@ class Post < ApplicationRecord
   belongs_to :feed
   belongs_to :feed_entry
 
+  # No FK backs the polymorphic reference, so clean these up on destroy to
+  # avoid dangling event_references.
+  has_many :event_references, as: :reference, dependent: :delete_all
+
   validates :uid, presence: true
   validates :uid, uniqueness: { scope: :feed_id }
   validates :published_at, presence: true

--- a/db/migrate/20260712000001_convert_primary_keys_to_uuidv7.rb
+++ b/db/migrate/20260712000001_convert_primary_keys_to_uuidv7.rb
@@ -127,15 +127,36 @@ class ConvertPrimaryKeysToUuidv7 < ActiveRecord::Migration[8.2]
 
   # Retype a column via a temporary sibling: fill it from the id map (a plain
   # UPDATE join, since ALTER ... USING forbids subqueries), then swap types.
-  # Unmatched rows (NULL fk, orphan-free by construction) stay NULL.
+  # A nullable column keeps the NULL for unmatched rows; a NOT NULL one can't,
+  # so its dangling rows are pruned first (see prune_dangling_rows).
   def rewrite_column(table, column, to, join)
     quoted = quote_table_name(table)
     scratch = "uuidv7_migration_#{column}"
 
     execute("ALTER TABLE #{quoted} ADD COLUMN #{scratch} #{to}")
     execute("UPDATE #{quoted} SET #{scratch} = m.new_id FROM #{quote_table_name(map_table)} m WHERE #{join}")
+    prune_dangling_rows(table, column, scratch)
     execute("ALTER TABLE #{quoted} ALTER COLUMN #{column} TYPE #{to} USING #{scratch}")
     execute("ALTER TABLE #{quoted} DROP COLUMN #{scratch}")
+  end
+
+  # Polymorphic and unconstrained references have no foreign key, so a row can
+  # outlive its target (e.g. an event_reference to a since-deleted post). Such a
+  # row has no id to remap to and can't take NULL in a NOT NULL column, so drop
+  # it. PKs and enforced FKs always resolve, so nothing is pruned for them.
+  def prune_dangling_rows(table, column, scratch)
+    return if column_nullable?(table, column)
+
+    execute("DELETE FROM #{quote_table_name(table)} WHERE #{scratch} IS NULL")
+  end
+
+  def column_nullable?(table, column)
+    select_value(<<~SQL) == "YES"
+      SELECT is_nullable FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name = #{quote(table)}
+        AND column_name = #{quote(column)}
+    SQL
   end
 
   def restore_sequence(table)

--- a/db/migrate/20260713120000_add_events_foreign_key_to_event_references.rb
+++ b/db/migrate/20260713120000_add_events_foreign_key_to_event_references.rb
@@ -1,0 +1,9 @@
+class AddEventsForeignKeyToEventReferences < ActiveRecord::Migration[8.2]
+  # event_references.event_id had no database foreign key, so a deleted event
+  # could leave dangling rows (only app-level dependent: :delete_all guarded it).
+  # Runs after the uuidv7 conversion, which prunes any pre-existing orphans, so
+  # the constraint validates cleanly.
+  def change
+    add_foreign_key :event_references, :events, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_12_000001) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -451,6 +451,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_12_000001) do
   add_foreign_key "access_token_details", "access_tokens"
   add_foreign_key "access_tokens", "users"
   add_foreign_key "ai_credentials", "users"
+  add_foreign_key "event_references", "events", on_delete: :cascade
   add_foreign_key "events", "users"
   add_foreign_key "feed_entries", "feeds"
   add_foreign_key "feed_entry_uids", "feeds", on_delete: :cascade

--- a/test/models/event_reference_test.rb
+++ b/test/models/event_reference_test.rb
@@ -9,6 +9,10 @@ class EventReferenceTest < ActiveSupport::TestCase
     @post ||= create(:post)
   end
 
+  def llm_usage
+    @llm_usage ||= create(:llm_usage)
+  end
+
   test "should create reference linking an event to a record" do
     reference = EventReference.create!(event: event, reference: post)
 
@@ -32,13 +36,19 @@ class EventReferenceTest < ActiveSupport::TestCase
     assert reference.errors.of_kind?(:reference, :blank)
   end
 
-  test "should survive deletion of the referenced record" do
+  test "should be deleted when its referenced post is deleted" do
     reference = EventReference.create!(event: event, reference: post)
+
     post.destroy!
 
-    reference.reload
+    assert_not EventReference.exists?(reference.id)
+  end
 
-    assert_equal "Post", reference.reference_type
-    assert_nil reference.reference
+  test "should be deleted when its referenced llm usage is deleted" do
+    reference = EventReference.create!(event: event, reference: llm_usage)
+
+    llm_usage.destroy!
+
+    assert_not EventReference.exists?(reference.id)
   end
 end


### PR DESCRIPTION
Changes:

- Prune dangling polymorphic/unconstrained references before the type swap in the UUIDv7 conversion migration, so a `NOT NULL` reference column whose target was deleted no longer aborts the migration. This is what killed the #982 staging deploy.
- Add a foreign key on `event_references.event_id → events` (`on_delete: :cascade`); it previously had none, so only the app-level `dependent: :delete_all` guarded it.
- Add `has_many :event_references, as: :reference, dependent: :delete_all` to `Post` and `LlmUsage` so deleting a target cleans up its references (the polymorphic side can't take a foreign key).

The staging deploy of #982 failed because `event_references.reference_id` is `NOT NULL` and polymorphic, so it has no foreign key and staging accumulated rows pointing at since-deleted posts. The id map has no entry for a missing target, so the remap left `NULL` and the `ALTER … TYPE` of the `NOT NULL` column failed ("column contains null values"). The migration now drops those dangling rows before the swap — for `NOT NULL` columns only; nullable columns keep the `NULL`, and PKs and enforced foreign keys always resolve.

The hardening then prevents new dangling rows from forming. This is a deliberate behavior change: references no longer survive deletion of their referenced record, so a feed-refresh event's post count now reflects only posts that still exist. The relevant test and the resolved `database_consistency` baseline entry are updated.

References:

- Related PR: #982