### PR TITLE
Migrate to rails_semantic_logger appenders API

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,14 +31,15 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Structured JSON logs to STDOUT for the Vector accessory to ship to
-  # VictoriaLogs (docs/victorialogs.md). The file appender is off since Kamal
-  # only captures STDOUT; request_id becomes a named tag.
+  # VictoriaLogs (docs/victorialogs.md). Declaring an appender replaces the
+  # gem's default file appender, which Kamal wouldn't capture anyway;
+  # request_id becomes a named tag.
   config.log_tags = [:request_id]
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info").to_sym
-  config.rails_semantic_logger.format = :json
   config.rails_semantic_logger.semantic = true
-  config.rails_semantic_logger.add_file_appender = false
-  config.semantic_logger.add_appender(io: $stdout, level: config.log_level, formatter: :json)
+  config.rails_semantic_logger.appenders do |appenders|
+    appenders.add(io: $stdout, level: config.log_level, formatter: :json)
+  end
 
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"


### PR DESCRIPTION
Changes:

- Declare the production stdout JSON appender via `config.rails_semantic_logger.appenders` instead of the deprecated `format=` / `add_file_appender=` options and the manual `config.semantic_logger.add_appender` call

rails_semantic_logger 5.0.0 deprecates the old options, which produced two deprecation warnings on every deploy. Declaring the appender through the new block API replaces the gem's default file appender, so behavior is unchanged: JSON logs to STDOUT for Vector to ship to VictoriaLogs.

The two remaining "loaded before application initialization" warnings in the deploy log originate inside the gem itself (its engine force-loads `action_controller/live` and `ActionView::Base` from `after_initialize`); no released or master-branch version fixes this yet, so they need an upstream fix rather than an app-side change.