### PR TITLE
Limit feed AI usage stats to last 30 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-13
+
+- AI usage stats on feed pages now cover the last 30 days instead of all time, so the numbers reflect recent activity.
+
 ## 2026-07-11
 
 - Disabled feeds are easier to spot in your feed list: their pause icon is now orange instead of gray.

--- a/app/components/feed_llm_stats_component.rb
+++ b/app/components/feed_llm_stats_component.rb
@@ -25,14 +25,14 @@ class FeedLlmStatsComponent < ViewComponent::Base
     @layout_items ||= [
       {
         key: "ai_calls",
-        label: "AI calls",
-        label_short: "AI calls",
+        label: "AI calls (last #{period_in_days} days)",
+        label_short: "AI calls (#{period_in_days} days)",
         value: helpers.number_with_delimiter(call_count)
       },
       {
         key: "estimated_spend",
-        label: "Estimated spend",
-        label_short: "Spend",
+        label: "Estimated spend (last #{period_in_days} days)",
+        label_short: "Spend (#{period_in_days} days)",
         value: formatted_cost
       }
     ]
@@ -55,11 +55,19 @@ class FeedLlmStatsComponent < ViewComponent::Base
   end
 
   def call_count
-    @call_count ||= @feed.llm_usages.count
+    @call_count ||= usages.count
   end
 
   def total_cost_cents
-    @total_cost_cents ||= @feed.llm_usages.sum(:cost_estimate_cents)
+    @total_cost_cents ||= usages.sum(:cost_estimate_cents)
+  end
+
+  def usages
+    @feed.llm_usages.within_stats_period
+  end
+
+  def period_in_days
+    LlmUsage::STATS_PERIOD.in_days.to_i
   end
 
   def formatted_cost

--- a/app/controllers/admin/feeds_controller.rb
+++ b/app/controllers/admin/feeds_controller.rb
@@ -14,7 +14,7 @@ class Admin::FeedsController < ApplicationController
     authorize [:admin, @feed]
     @recent_posts = recent_posts(@feed)
     @recent_events = recent_events(@feed)
-    @has_llm_usages = @feed.llm_usages.exists?
+    @has_llm_usages = @feed.llm_usages.within_stats_period.exists?
   end
 
   private

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -66,7 +66,7 @@ class FeedsController < ApplicationController
     authorize @feed
     @recent_posts = recent_posts(@feed)
     @recent_events = recent_events(@feed)
-    @has_llm_usages = @feed.llm_usages.exists?
+    @has_llm_usages = @feed.llm_usages.within_stats_period.exists?
   end
 
   def edit

--- a/app/models/llm_usage.rb
+++ b/app/models/llm_usage.rb
@@ -2,9 +2,16 @@
 # regardless of outcome so users see the true cost of AI features
 # including failed calls.
 class LlmUsage < ApplicationRecord
+  # Usage rows are subject to retention pruning, so aggregate stats in the UI
+  # must cover a bounded window rather than all time — all-time totals would
+  # silently shrink as old rows expire.
+  STATS_PERIOD = 30.days
+
   belongs_to :user
   belongs_to :feed, optional: true
   belongs_to :ai_credential, optional: true
+
+  scope :within_stats_period, -> { where(created_at: STATS_PERIOD.ago..) }
 
   # No FK backs the polymorphic reference, so clean these up on destroy to
   # avoid dangling event_references.

--- a/test/components/feed_llm_stats_component_test.rb
+++ b/test/components/feed_llm_stats_component_test.rb
@@ -29,20 +29,30 @@ class FeedLlmStatsComponentTest < ViewComponent::TestCase
     assert_equal "$0.40", value.text.strip
   end
 
+  test "#render should exclude usages older than the stats period" do
+    create(:llm_usage, feed: feed_with_usages, user: feed_with_usages.user,
+           cost_estimate_cents: 100, created_at: LlmUsage::STATS_PERIOD.ago - 1.day)
+
+    result = render_inline(FeedLlmStatsComponent.new(feed: feed_with_usages))
+
+    assert_equal "2", result.css('[data-key="llm_stats.ai_calls.value"]').first.text.strip
+    assert_equal "$0.40", result.css('[data-key="llm_stats.estimated_spend.value"]').first.text.strip
+  end
+
   test "#render should include mobile layout with full labels" do
     result = render_inline(FeedLlmStatsComponent.new(feed: feed))
 
     assert_not_nil result.css(".md\\:hidden").first
-    assert_equal "AI calls", result.css(".md\\:hidden [data-key=\"llm_stats.ai_calls.label\"]").first.text
-    assert_equal "Estimated spend", result.css(".md\\:hidden [data-key=\"llm_stats.estimated_spend.label\"]").first.text
+    assert_equal "AI calls (last 30 days)", result.css(".md\\:hidden [data-key=\"llm_stats.ai_calls.label\"]").first.text
+    assert_equal "Estimated spend (last 30 days)", result.css(".md\\:hidden [data-key=\"llm_stats.estimated_spend.label\"]").first.text
   end
 
   test "#render should include desktop layout with short labels" do
     result = render_inline(FeedLlmStatsComponent.new(feed: feed))
 
     assert_not_nil result.css(".hidden.md\\:flex").first
-    assert_equal "AI calls", result.css(".hidden.md\\:flex [data-key=\"llm_stats.ai_calls.label\"]").first.text
-    assert_equal "Spend", result.css(".hidden.md\\:flex [data-key=\"llm_stats.estimated_spend.label\"]").first.text
+    assert_equal "AI calls (30 days)", result.css(".hidden.md\\:flex [data-key=\"llm_stats.ai_calls.label\"]").first.text
+    assert_equal "Spend (30 days)", result.css(".hidden.md\\:flex [data-key=\"llm_stats.estimated_spend.label\"]").first.text
   end
 
   test "#render should show zero when no usages" do

--- a/test/controllers/admin/feeds_controller_test.rb
+++ b/test/controllers/admin/feeds_controller_test.rb
@@ -103,6 +103,28 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h2", text: "Recent Posts", count: 0
   end
 
+  test "#show should render AI usage section when feed has usages within the stats period" do
+    login_as(admin_user)
+    feed = create(:feed, user: create(:user))
+    create(:llm_usage, feed: feed, user: feed.user)
+
+    get admin_feed_path(feed)
+
+    assert_response :success
+    assert_select "h2", text: "AI Usage", count: 1
+  end
+
+  test "#show should not render AI usage section when all usages are older than the stats period" do
+    login_as(admin_user)
+    feed = create(:feed, user: create(:user))
+    create(:llm_usage, feed: feed, user: feed.user, created_at: LlmUsage::STATS_PERIOD.ago - 1.day)
+
+    get admin_feed_path(feed)
+
+    assert_response :success
+    assert_select "h2", text: "AI Usage", count: 0
+  end
+
   test "should redirect non-admin users from show" do
     login_as(regular_user)
     feed = create(:feed, user: create(:user))

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -538,6 +538,26 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h2", text: "Stats", count: 1
   end
 
+  test "#show should render AI usage section when feed has usages within the stats period" do
+    create(:llm_usage, feed: feed, user: user)
+    sign_in_as(user)
+
+    get feed_url(feed)
+
+    assert_response :success
+    assert_select "h2", text: "AI Usage", count: 1
+  end
+
+  test "#show should not render AI usage section when all usages are older than the stats period" do
+    create(:llm_usage, feed: feed, user: user, created_at: LlmUsage::STATS_PERIOD.ago - 1.day)
+    sign_in_as(user)
+
+    get feed_url(feed)
+
+    assert_response :success
+    assert_select "h2", text: "AI Usage", count: 0
+  end
+
   test "#show should render a recent activity section with the feed's events" do
     create(:event, type: "feed_auto_disabled", subject: feed, user: user, level: :warning,
                    message: "", metadata: { error_count: Feed::MAX_CONSECUTIVE_FAILURES })

--- a/test/models/llm_usage_test.rb
+++ b/test/models/llm_usage_test.rb
@@ -40,6 +40,16 @@ class LlmUsageTest < ActiveSupport::TestCase
     assert usage.valid?
   end
 
+  test ".within_stats_period should include only usages created within the period" do
+    recent = create(:llm_usage, user: user)
+    stale = create(:llm_usage, user: user, created_at: LlmUsage::STATS_PERIOD.ago - 1.day)
+
+    result = LlmUsage.within_stats_period
+
+    assert_includes result, recent
+    assert_not_includes result, stale
+  end
+
   test "should belong to a feed when provided" do
     feed = create(:feed,
                   user: user,


### PR DESCRIPTION
Changes:

- Feed pages (user and admin) now show AI call count and estimated spend for the last 30 days instead of all-time totals
- Stat labels state the time window
- The AI Usage section is hidden when a feed has no AI activity within the window

All-time totals would silently shrink once usage records start being pruned by the upcoming retention policy, so feed-level stats now cover a bounded window. The window lives in one place (`LlmUsage::STATS_PERIOD`) so the retention period can be kept comfortably larger than it. Per-run spend in the events log is unaffected — it reads event metadata snapshots, not usage rows.

References:

- Related PR: #981