### PR TITLE
Clean up redundant indexes and constraints in InitialSchema

### DIFF
--- a/.database_consistency.todo.yml
+++ b/.database_consistency.todo.yml
@@ -7,19 +7,11 @@
 # underlying issue is fixed. Regenerating this file with `database_consistency -g`
 # drops these comments, so prefer editing it by hand.
 ---
-AccessToken:
-  index_access_tokens_on_user_id:
-    RedundantIndexChecker:
-      enabled: false
 AccessTokenDetail:
   index_access_token_details_on_access_token_id:
     # wontfix: one row per token, written only through the has_one by
     # AccessTokenValidationService; the DB constraint is the right guard.
     UniqueIndexChecker:
-      enabled: false
-AiCredential:
-  index_ai_credentials_on_user_id:
-    RedundantIndexChecker:
       enabled: false
 Event:
   user:
@@ -48,18 +40,7 @@ Feed:
   name+user_id:
     MissingUniqueIndexChecker:
       enabled: false
-FeedEntry:
-  index_feed_entries_on_feed_id:
-    RedundantIndexChecker:
-      enabled: false
-FeedEntryUid:
-  index_feed_entry_uids_on_feed_id:
-    RedundantIndexChecker:
-      enabled: false
 FeedIdentification:
-  index_feed_identifications_on_user_id:
-    RedundantIndexChecker:
-      enabled: false
   index_feed_identifications_on_user_id_and_input:
     # wontfix: rows are system-managed via find_or_create_by!; the unique
     # index backs the race, user input never hits this validation.
@@ -78,9 +59,6 @@ FeedPreview:
     # validator would raise RecordInvalid instead and break that pattern.
     UniqueIndexChecker:
       enabled: false
-  index_feed_previews_on_user_id:
-    RedundantIndexChecker:
-      enabled: false
   params_digest:
     # wontfix: assigned by before_validation :assign_params_digest, so a
     # presence validator would be dead code.
@@ -91,21 +69,6 @@ JobRun:
     # wontfix: job_id is ActiveJob's generated UUID on a dev-tooling table;
     # nothing user-supplied to validate.
     UniqueIndexChecker:
-      enabled: false
-LlmUsage:
-  index_llm_usages_on_feed_id:
-    RedundantIndexChecker:
-      enabled: false
-  index_llm_usages_on_user_id:
-    RedundantIndexChecker:
-      enabled: false
-Permission:
-  index_permissions_on_user_id:
-    RedundantIndexChecker:
-      enabled: false
-Post:
-  index_posts_on_feed_id:
-    RedundantIndexChecker:
       enabled: false
 RateLimit::Bucket:
   index_rate_limit_buckets_on_key:
@@ -125,8 +88,6 @@ User:
     UniqueIndexChecker:
       enabled: false
   invite:
-    ForeignKeyCascadeChecker:
-      enabled: false
     MissingIndexChecker:
       enabled: false
   password_digest:
@@ -137,7 +98,4 @@ User:
     # wontfix: set by before_save :set_password_updated_at whenever the
     # password digest changes.
     NullConstraintChecker:
-      enabled: false
-  unconfirmed_email:
-    MissingIndexFindByChecker:
       enabled: false

--- a/db/migrate/20260713120000_initial_schema.rb
+++ b/db/migrate/20260713120000_initial_schema.rb
@@ -21,7 +21,6 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.string "freefeed_user_id"
       t.index ["freefeed_user_id"], name: "index_access_tokens_on_freefeed_user_id"
       t.index ["user_id", "name"], name: "index_access_tokens_on_user_id_and_name", unique: true
-      t.index ["user_id"], name: "index_access_tokens_on_user_id"
     end
 
     create_table "ai_credentials", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -37,7 +36,6 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.jsonb "available_models", default: [], null: false
       t.index ["user_id", "provider", "display_name"], name: "index_ai_credentials_on_user_id_and_provider_and_display_name", unique: true
       t.index ["user_id", "state"], name: "index_ai_credentials_on_user_id_and_state"
-      t.index ["user_id"], name: "index_ai_credentials_on_user_id"
     end
 
     create_table "event_references", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -78,7 +76,6 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.string "uid", null: false
       t.datetime "updated_at", null: false
       t.index ["feed_id", "uid"], name: "index_feed_entries_on_feed_id_and_uid", unique: true
-      t.index ["feed_id"], name: "index_feed_entries_on_feed_id"
     end
 
     create_table "feed_entry_uids", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -88,7 +85,6 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.string "uid", null: false
       t.datetime "updated_at", null: false
       t.index ["feed_id", "uid"], name: "index_feed_entry_uids_on_feed_id_and_uid", unique: true
-      t.index ["feed_id"], name: "index_feed_entry_uids_on_feed_id"
       t.index ["imported_at"], name: "index_feed_entry_uids_on_imported_at"
     end
 
@@ -102,7 +98,6 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.string "input", null: false
       t.uuid "user_id", null: false
       t.index ["user_id", "input"], name: "index_feed_identifications_on_user_id_and_input", unique: true
-      t.index ["user_id"], name: "index_feed_identifications_on_user_id"
     end
 
     create_table "feed_metrics", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -133,7 +128,6 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.index ["created_at"], name: "index_feed_previews_on_created_at"
       t.index ["status"], name: "index_feed_previews_on_status"
       t.index ["user_id", "feed_profile_key", "params_digest"], name: "index_feed_previews_on_owner_profile_digest", unique: true
-      t.index ["user_id"], name: "index_feed_previews_on_user_id"
     end
 
     create_table "feed_schedules", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -214,11 +208,9 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.text "error_message"
       t.index ["ai_credential_id"], name: "index_llm_usages_on_ai_credential_id"
       t.index ["feed_id", "started_at"], name: "index_llm_usages_on_feed_id_and_started_at"
-      t.index ["feed_id"], name: "index_llm_usages_on_feed_id"
       t.index ["profile_key", "started_at"], name: "index_llm_usages_on_profile_key_and_started_at"
       t.index ["purpose", "started_at"], name: "index_llm_usages_on_purpose_and_started_at"
       t.index ["user_id", "started_at"], name: "index_llm_usages_on_user_id_and_started_at"
-      t.index ["user_id"], name: "index_llm_usages_on_user_id"
     end
 
     create_table "permissions", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -227,7 +219,6 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.datetime "updated_at", null: false
       t.uuid "user_id", null: false
       t.index ["user_id", "name"], name: "index_permissions_on_user_id_and_name", unique: true
-      t.index ["user_id"], name: "index_permissions_on_user_id"
     end
 
     create_table "posts", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -249,7 +240,6 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.index ["feed_id", "reposted_at"], name: "index_posts_on_feed_id_and_reposted_at"
       t.index ["feed_id", "status"], name: "index_posts_on_feed_id_and_status"
       t.index ["feed_id", "uid"], name: "index_posts_on_feed_id_and_uid", unique: true
-      t.index ["feed_id"], name: "index_posts_on_feed_id"
       t.index ["reposted_at"], name: "index_posts_on_reposted_at", order: "DESC NULLS LAST"
       t.index ["status"], name: "index_posts_on_status"
     end
@@ -432,6 +422,7 @@ class InitialSchema < ActiveRecord::Migration[8.2]
       t.index ["email_address"], name: "index_users_on_email_address", unique: true
       t.index ["email_deactivated_at"], name: "index_users_on_email_deactivated_at"
       t.index ["state"], name: "index_users_on_state"
+      t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email", where: "(unconfirmed_email IS NOT NULL)"
     end
 
     add_foreign_key "access_token_details", "access_tokens"
@@ -449,7 +440,7 @@ class InitialSchema < ActiveRecord::Migration[8.2]
     add_foreign_key "feeds", "ai_credentials", on_delete: :nullify
     add_foreign_key "feeds", "users"
     add_foreign_key "invites", "users", column: "created_by_user_id"
-    add_foreign_key "invites", "users", column: "invited_user_id"
+    add_foreign_key "invites", "users", column: "invited_user_id", on_delete: :nullify
     add_foreign_key "llm_usages", "ai_credentials", on_delete: :nullify
     add_foreign_key "llm_usages", "feeds"
     add_foreign_key "llm_usages", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.string "freefeed_user_id"
     t.index ["freefeed_user_id"], name: "index_access_tokens_on_freefeed_user_id"
     t.index ["user_id", "name"], name: "index_access_tokens_on_user_id_and_name", unique: true
-    t.index ["user_id"], name: "index_access_tokens_on_user_id"
   end
 
   create_table "ai_credentials", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -51,7 +50,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.jsonb "available_models", default: [], null: false
     t.index ["user_id", "provider", "display_name"], name: "index_ai_credentials_on_user_id_and_provider_and_display_name", unique: true
     t.index ["user_id", "state"], name: "index_ai_credentials_on_user_id_and_state"
-    t.index ["user_id"], name: "index_ai_credentials_on_user_id"
   end
 
   create_table "event_references", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -92,7 +90,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.string "uid", null: false
     t.datetime "updated_at", null: false
     t.index ["feed_id", "uid"], name: "index_feed_entries_on_feed_id_and_uid", unique: true
-    t.index ["feed_id"], name: "index_feed_entries_on_feed_id"
   end
 
   create_table "feed_entry_uids", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -102,7 +99,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.string "uid", null: false
     t.datetime "updated_at", null: false
     t.index ["feed_id", "uid"], name: "index_feed_entry_uids_on_feed_id_and_uid", unique: true
-    t.index ["feed_id"], name: "index_feed_entry_uids_on_feed_id"
     t.index ["imported_at"], name: "index_feed_entry_uids_on_imported_at"
   end
 
@@ -116,7 +112,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.string "input", null: false
     t.uuid "user_id", null: false
     t.index ["user_id", "input"], name: "index_feed_identifications_on_user_id_and_input", unique: true
-    t.index ["user_id"], name: "index_feed_identifications_on_user_id"
   end
 
   create_table "feed_metrics", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -147,7 +142,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.index ["created_at"], name: "index_feed_previews_on_created_at"
     t.index ["status"], name: "index_feed_previews_on_status"
     t.index ["user_id", "feed_profile_key", "params_digest"], name: "index_feed_previews_on_owner_profile_digest", unique: true
-    t.index ["user_id"], name: "index_feed_previews_on_user_id"
   end
 
   create_table "feed_schedules", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -228,11 +222,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.text "error_message"
     t.index ["ai_credential_id"], name: "index_llm_usages_on_ai_credential_id"
     t.index ["feed_id", "started_at"], name: "index_llm_usages_on_feed_id_and_started_at"
-    t.index ["feed_id"], name: "index_llm_usages_on_feed_id"
     t.index ["profile_key", "started_at"], name: "index_llm_usages_on_profile_key_and_started_at"
     t.index ["purpose", "started_at"], name: "index_llm_usages_on_purpose_and_started_at"
     t.index ["user_id", "started_at"], name: "index_llm_usages_on_user_id_and_started_at"
-    t.index ["user_id"], name: "index_llm_usages_on_user_id"
   end
 
   create_table "permissions", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -241,7 +233,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false
     t.index ["user_id", "name"], name: "index_permissions_on_user_id_and_name", unique: true
-    t.index ["user_id"], name: "index_permissions_on_user_id"
   end
 
   create_table "posts", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -263,7 +254,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.index ["feed_id", "reposted_at"], name: "index_posts_on_feed_id_and_reposted_at"
     t.index ["feed_id", "status"], name: "index_posts_on_feed_id_and_status"
     t.index ["feed_id", "uid"], name: "index_posts_on_feed_id_and_uid", unique: true
-    t.index ["feed_id"], name: "index_posts_on_feed_id"
     t.index ["reposted_at"], name: "index_posts_on_reposted_at", order: "DESC NULLS LAST"
     t.index ["status"], name: "index_posts_on_status"
   end
@@ -446,6 +436,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["email_deactivated_at"], name: "index_users_on_email_deactivated_at"
     t.index ["state"], name: "index_users_on_state"
+    t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email", where: "(unconfirmed_email IS NOT NULL)"
   end
 
   add_foreign_key "access_token_details", "access_tokens"
@@ -463,7 +454,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
   add_foreign_key "feeds", "ai_credentials", on_delete: :nullify
   add_foreign_key "feeds", "users"
   add_foreign_key "invites", "users", column: "created_by_user_id"
-  add_foreign_key "invites", "users", column: "invited_user_id"
+  add_foreign_key "invites", "users", column: "invited_user_id", on_delete: :nullify
   add_foreign_key "llm_usages", "ai_credentials", on_delete: :nullify
   add_foreign_key "llm_usages", "feeds"
   add_foreign_key "llm_usages", "users"


### PR DESCRIPTION
Changes:

- Remove 10 single-column foreign-key indexes from `InitialSchema` that a composite index already covers by its leading column.
- Add a partial index on `users.unconfirmed_email`.
- Give the `invites.invited_user_id` foreign key `on_delete: :nullify`.
- Drop the matching `database_consistency` baseline entries.

Addresses the cheap, safe findings from `.database_consistency.todo.yml`, each evaluated against how the app actually behaves rather than applied because the tool flagged it:

- **Redundant indexes** — each was auto-created by Rails' `t.references … index: true` default; a later composite (`(user_id, name)`, `(feed_id, status)`, …) leads with the same column and already serves both lookups and FK-enforcement, so the single-column copy is pure write/storage overhead.
- **`unconfirmed_email` index** — the resend-webhook lookup (`find_by`) and the global email-uniqueness validator both query it unindexed. Partial (`WHERE unconfirmed_email IS NOT NULL`) because it's set only mid email-change.
- **`invited_user_id` FK** — `User has_one :invite, dependent: :nullify` deliberately keeps the invite and unlinks it; user deletion is a real, tested operation, so the DB FK is aligned to `:nullify`. The column is nullable, so this is valid.

Rather than a follow-up migration that recreates those indexes and immediately drops them, the cleanup is folded into the squashed `InitialSchema` so a fresh database is correct from the start (no create-then-drop). `db/schema.rb` reflects the result and round-trips byte-for-byte from `InitialSchema`.

Deferred (each needs a data check or semantics decision, not a mechanical fix): the `feed_profile_key` NOT NULL constraint (its presence validation is unconditional, but existing rows need checking first), the `has_one` unique indexes, and the `feed_previews.ai_credential_id` FK. Remaining baseline entries are genuine wontfix false positives.

Deploy note: existing databases already have `InitialSchema` recorded as applied, so this change does not re-run there. Staging needs a one-time manual reconciliation (dropping the redundant indexes, adding the `unconfirmed_email` index, and altering the FK) — run from the Rails console. Fresh databases build clean from `schema.rb`.

References:

- Related PR: #987