### PR TITLE
Harden feed disable and detection-restart race paths

### DIFF
--- a/app/controllers/feed_statuses_controller.rb
+++ b/app/controllers/feed_statuses_controller.rb
@@ -41,9 +41,12 @@ class FeedStatusesController < ApplicationController
 
   def disable(feed)
     feed.with_lock do
-      feed.disabled!
-      record_feed_disabled(feed)
-      respond_with_status(feed, success: "Feed disabled.")
+      if feed.disable
+        record_feed_disabled(feed)
+        respond_with_status(feed, success: "Feed disabled.")
+      else
+        respond_with_status(feed, alert: "Cannot disable feed: #{feed.errors.full_messages.join('; ')}.")
+      end
     end
   end
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -240,8 +240,11 @@ class FeedsController < ApplicationController
     end
 
     identification = FeedIdentification.find_or_initialize_by(user: current_user, input: canonical_submitted_url)
-    identification.restart_detection!
-    FeedIdentificationJob.perform_later(current_user.id, canonical_submitted_url)
+    restarted = identification.restart_detection!
+    # A losing concurrent submit skips the enqueue: the winner that just
+    # created the row owns the in-flight detection, and both requests render
+    # the same checking state.
+    FeedIdentificationJob.perform_later(current_user.id, canonical_submitted_url) if restarted
 
     render_identification_state(attempted_url: canonical_submitted_url, checking: true)
   end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -241,9 +241,6 @@ class FeedsController < ApplicationController
 
     identification = FeedIdentification.find_or_initialize_by(user: current_user, input: canonical_submitted_url)
     restarted = identification.restart_detection!
-    # A losing concurrent submit skips the enqueue: the winner that just
-    # created the row owns the in-flight detection, and both requests render
-    # the same checking state.
     FeedIdentificationJob.perform_later(current_user.id, canonical_submitted_url) if restarted
 
     render_identification_state(attempted_url: canonical_submitted_url, checking: true)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -208,11 +208,14 @@ class Feed < ApplicationRecord
   # feed, and the in-memory state is rolled back to its persisted value so
   # re-renders reflect DB truth.
   def enable
-    self.state = :enabled
-    return true if save
+    transition_state(:enabled)
+  end
 
-    self.state = state_was
-    false
+  # Demote the feed to disabled with the same non-raising contract as #enable:
+  # a record that no longer passes the always-on validators surfaces errors
+  # instead of raising out of the controller.
+  def disable
+    transition_state(:disabled)
   end
 
   def can_be_previewed?
@@ -367,6 +370,14 @@ class Feed < ApplicationRecord
   end
 
   private
+
+  def transition_state(new_state)
+    self.state = new_state
+    return true if save
+
+    self.state = state_was
+    false
+  end
 
   # Mirrors ai_credential_required_when_enabled_ai_profile so the Enable button
   # never shows for an AI feed the enabled-state validators would reject.

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -211,9 +211,6 @@ class Feed < ApplicationRecord
     transition_state(:enabled)
   end
 
-  # Demote the feed to disabled with the same non-raising contract as #enable:
-  # a record that no longer passes the always-on validators surfaces errors
-  # instead of raising out of the controller.
   def disable
     transition_state(:disabled)
   end

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -125,6 +125,25 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Checking this feed"
   end
 
+  test "#create should not enqueue a duplicate detection when losing the restart race" do
+    sign_in_as(user)
+    url = "http://example.com/feed.xml"
+    winner = create(:feed_identification, user: user, input: url, started_at: Time.current).reload
+    # The loser's stale lookup result: it missed the winner's row, so its
+    # insert inside restart_detection! collides with the user+input unique index.
+    loser = FeedIdentification.new(user: user, input: url)
+
+    FeedIdentification.stub(:find_or_initialize_by, loser) do
+      assert_no_enqueued_jobs(only: FeedIdentificationJob) do
+        post feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      end
+    end
+
+    assert_response :success
+    assert_includes response.body, 'data-identification-state="checking"'
+    assert_equal winner.started_at, winner.reload.started_at, "the winner's detection should not be restarted"
+  end
+
   test "#create should freeze the entry form while detection runs" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"

--- a/test/controllers/feed_statuses_controller_test.rb
+++ b/test/controllers/feed_statuses_controller_test.rb
@@ -201,6 +201,24 @@ class FeedStatusesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "disabled", feed.state
   end
 
+  test "#update should surface validation errors instead of raising when disabling a drifted feed" do
+    sign_in_as(user)
+    create(:feed, user: user, name: "taken")
+    enabled_feed = create(:feed, :enabled, user: user)
+    enabled_feed.update_column(:name, "taken")
+
+    assert_no_difference("Event.where(type: 'feed_disabled').count") do
+      patch feed_status_path(enabled_feed), params: { status: "disabled" }
+    end
+
+    assert_redirected_to enabled_feed
+    follow_redirect!
+    assert_includes response.body, "Cannot disable feed"
+
+    enabled_feed.reload
+    assert_equal "enabled", enabled_feed.state
+  end
+
   test "#update should redirect to login when not authenticated" do
     patch feed_status_path(feed), params: { status: "enabled" }
     assert_redirected_to new_session_url

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -916,6 +916,25 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "feed_id=#{feed.id}"
   end
 
+  test "#update should not enqueue a duplicate detection when losing the restart race" do
+    sign_in_as(user)
+    new_url = "https://example.com/new-feed.xml"
+    winner = create(:feed_identification, user: user, input: new_url, started_at: Time.current).reload
+    # The loser's stale lookup result: it missed the winner's row, so its
+    # insert inside restart_detection! collides with the user+input unique index.
+    loser = FeedIdentification.new(user: user, input: new_url)
+
+    FeedIdentification.stub(:find_or_initialize_by, loser) do
+      assert_no_enqueued_jobs(only: FeedIdentificationJob) do
+        patch feed_url(feed), params: { feed: { params: { url: new_url } } }
+      end
+    end
+
+    assert_response :success
+    assert_includes response.body, 'data-identification-state="checking"'
+    assert_equal winner.started_at, winner.reload.started_at, "the winner's detection should not be restarted"
+  end
+
   test "#update should re-render the edit form with a hint when the new source isn't a link" do
     sign_in_as(user)
     original_url = feed.url

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -904,6 +904,26 @@ class FeedTest < ActiveSupport::TestCase
     assert_not_empty feed.errors
   end
 
+  test "#disable should demote an enabled feed to disabled state" do
+    feed = create(:feed, :enabled)
+
+    assert feed.disable
+    assert_predicate feed, :disabled?
+    assert_predicate feed.reload, :disabled?
+  end
+
+  test "#disable should return false and roll back in-memory state on validation failure" do
+    user = create(:user)
+    create(:feed, user: user, name: "taken")
+    feed = create(:feed, :enabled, user: user)
+    feed.update_column(:name, "taken")
+
+    assert_not feed.disable
+    assert_predicate feed, :enabled?, "in-memory state should be rolled back to persisted value"
+    assert_predicate feed.reload, :enabled?
+    assert_not_empty feed.errors
+  end
+
   test "#target_group_url should return the group URL when token and group are present" do
     feed = create(:feed, target_group: "testgroup")
 


### PR DESCRIPTION
Changes:

- Honor `restart_detection!`'s return value in the edit-source re-detection path, so a losing concurrent submit no longer enqueues a duplicate detection job; the losing path is now covered by controller tests at both call sites
- Add `Feed#disable` with the same non-raising contract as `#enable`, and switch `FeedStatusesController#disable` off the raising `disabled!` — a record failing an always-on validator now renders an alert instead of a 500

Follows up two gaps found while verifying #955 against the code: the second `restart_detection!` call site that #968 missed, and the raising disable path mirroring the pattern #966 removed from the enable side.

References:

- Related issue: #955
- Related PR: #966
- Related PR: #968