### PR TITLE
Add search auth errors and injectable search tool

### DIFF
--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -43,6 +43,9 @@ class LlmClient
 
     begin
       response = invoke_provider(model: ctx.model, prompt: prompt, output_schema: output_schema, web: web, system: system)
+    rescue WebSearchProvider::AuthError => e
+      write_usage(ctx, outcome: :provider_error, started_at: started_at, error_message: e.message)
+      raise
     rescue RubyLLM::RateLimitError => e
       write_usage(ctx, outcome: :rate_limited, started_at: started_at, error_message: e.message)
       raised = RateLimited.new(e.message)

--- a/app/services/llm_client/adapter/moonshot.rb
+++ b/app/services/llm_client/adapter/moonshot.rb
@@ -9,7 +9,9 @@ class LlmClient
       FENCE = /\A```[a-z]*\n?(.*?)\n?```\z/m
 
       def apply_web(chat, _model)
-        chat.with_tool(LlmClient::Tools::WebSearch) if ::WebSearchProvider.configured?
+        if ::WebSearchProvider.configured?
+          chat.with_tool(LlmClient::Tools::WebSearch.new(provider: ::WebSearchProvider.default))
+        end
         chat.with_tool(LlmClient::Tools::WebFetch)
       end
 

--- a/app/services/llm_client/tools/web_search.rb
+++ b/app/services/llm_client/tools/web_search.rb
@@ -1,9 +1,11 @@
 class LlmClient
   module Tools
     # Client-side web search for providers without usable server-side web
-    # access. Backed by WebSearchProvider, so the vendor behind the tool
-    # (Serper, Brave, Tavily) is a deployment choice. An unconfigured
-    # deployment surfaces as an ordinary error result the model can read.
+    # access. Built around an injected, already-resolved WebSearchProvider,
+    # so the vendor and API key are the caller's choice. Transient failures
+    # surface as ordinary error results the model can read and work around;
+    # an auth failure escapes instead — a dead key is a run-level problem
+    # the model can't fix, and swallowing it would hide the failure forever.
     class WebSearch < RubyLLM::Tool
       description "Search the web. Returns result titles, URLs and snippets. " \
                   "Fetch a result URL with the web fetch tool to read the page."
@@ -11,11 +13,18 @@ class LlmClient
 
       MAX_RESULTS = 5
 
+      def initialize(provider:)
+        super()
+        @provider = provider
+      end
+
       def execute(query:)
         return { error: "Refused: query must not be blank." } if query.blank?
 
-        results = ::WebSearchProvider.default.search(query, max_results: MAX_RESULTS)
+        results = @provider.search(query, max_results: MAX_RESULTS)
         { results: results.map(&:to_h) }
+      rescue ::WebSearchProvider::AuthError
+        raise
       rescue ::WebSearchProvider::Error => e
         { error: e.message }
       end

--- a/app/services/web_search_provider.rb
+++ b/app/services/web_search_provider.rb
@@ -16,6 +16,10 @@ module WebSearchProvider
   Error = Class.new(StandardError)
   ConfigurationError = Class.new(Error)
   ProviderError = Class.new(Error)
+  # A rejected or exhausted API key (HTTP 401/402/403), as opposed to a
+  # transient ProviderError: retrying is pointless and the credential behind
+  # the key should be deactivated, so callers must be able to tell them apart.
+  AuthError = Class.new(Error)
 
   REGISTRY = {
     "serper" => "Serper",

--- a/app/services/web_search_provider/base.rb
+++ b/app/services/web_search_provider/base.rb
@@ -6,8 +6,6 @@ module WebSearchProvider
   class Base
     MAX_RESULTS = (1..10)
     TIMEOUT = 10
-    # 402 counts as an auth failure: an exhausted quota kills the key just as
-    # permanently as a rejected one until the owner intervenes.
     AUTH_STATUSES = [401, 402, 403].freeze
 
     def initialize(api_key:)

--- a/app/services/web_search_provider/base.rb
+++ b/app/services/web_search_provider/base.rb
@@ -6,6 +6,9 @@ module WebSearchProvider
   class Base
     MAX_RESULTS = (1..10)
     TIMEOUT = 10
+    # 402 counts as an auth failure: an exhausted quota kills the key just as
+    # permanently as a rejected one until the owner intervenes.
+    AUTH_STATUSES = [401, 402, 403].freeze
 
     def initialize(api_key:)
       @api_key = api_key
@@ -16,7 +19,11 @@ module WebSearchProvider
 
       count = max_results.to_i.clamp(MAX_RESULTS)
       response = request(query, count)
-      raise ProviderError, "#{provider_name}: HTTP #{response.status}" unless response.success?
+
+      unless response.success?
+        error = AUTH_STATUSES.include?(response.status) ? AuthError : ProviderError
+        raise error, "#{provider_name}: HTTP #{response.status}"
+      end
 
       parse(response.body).first(count)
     rescue HttpClient::Error => e

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -71,14 +71,20 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_equal [LlmClient::Tools::WebFetch], chat.tools
   end
 
-  test "moonshot #apply_web should also register the search tool when web search is configured" do
+  test "moonshot #apply_web should also register the search tool with the resolved provider when configured" do
     chat = fake_chat
+    provider = Object.new
 
     WebSearchProvider.stub(:configured?, true) do
-      LlmClient::Adapter::Moonshot.new.apply_web(chat, "kimi-k2.5")
+      WebSearchProvider.stub(:default, provider) do
+        LlmClient::Adapter::Moonshot.new.apply_web(chat, "kimi-k2.5")
+      end
     end
 
-    assert_equal [LlmClient::Tools::WebSearch, LlmClient::Tools::WebFetch], chat.tools
+    search_tool, fetch_tool = chat.tools
+    assert_instance_of LlmClient::Tools::WebSearch, search_tool
+    assert_same provider, search_tool.instance_variable_get(:@provider)
+    assert_equal LlmClient::Tools::WebFetch, fetch_tool
   end
 
   test "moonshot #unwrap_json should strip markdown fences and pass clean JSON through" do

--- a/test/services/llm_client/tools/web_search_test.rb
+++ b/test/services/llm_client/tools/web_search_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class LlmClient::Tools::WebSearchTest < ActiveSupport::TestCase
-  def tool = LlmClient::Tools::WebSearch.new
-
   def result(index)
     WebSearchProvider::Result.new(title: "T#{index}", url: "https://#{index}.example", snippet: "s#{index}")
   end
@@ -10,50 +8,61 @@ class LlmClient::Tools::WebSearchTest < ActiveSupport::TestCase
   # Stands in for a resolved WebSearchProvider: returns canned results or
   # raises, so the tool can be exercised without a real provider.
   class FakeProvider
+    attr_reader :queries
+
     def initialize(results: [], error: nil)
       @results = results
       @error = error
+      @queries = []
     end
 
-    def search(_query, **)
+    def search(query, **)
+      @queries << query
       raise @error if @error
 
       @results
     end
   end
 
+  def tool(provider)
+    LlmClient::Tools::WebSearch.new(provider: provider)
+  end
+
   test "#execute should return normalized results as plain hashes" do
     provider = FakeProvider.new(results: [result(1), result(2)])
 
-    WebSearchProvider.stub(:default, provider) do
-      payload = tool.execute(query: "ruby feeds")
+    payload = tool(provider).execute(query: "ruby feeds")
 
-      assert_equal [
-        { title: "T1", url: "https://1.example", snippet: "s1" },
-        { title: "T2", url: "https://2.example", snippet: "s2" }
-      ], payload[:results]
-    end
+    assert_equal [
+      { title: "T1", url: "https://1.example", snippet: "s1" },
+      { title: "T2", url: "https://2.example", snippet: "s2" }
+    ], payload[:results]
   end
 
-  test "#execute should refuse a blank query without resolving a provider" do
-    WebSearchProvider.stub(:default, ->(*) { flunk "default should not be resolved" }) do
-      assert_match(/Refused/, tool.execute(query: "  ")[:error])
-    end
+  test "#execute should refuse a blank query without hitting the provider" do
+    provider = FakeProvider.new
+
+    assert_match(/Refused/, tool(provider).execute(query: "  ")[:error])
+    assert_empty provider.queries
   end
 
-  test "#execute should report when no provider is configured" do
-    unconfigured = -> { raise WebSearchProvider::ConfigurationError, "no web search provider configured" }
+  test "#execute should surface configuration errors as an error result" do
+    provider = FakeProvider.new(error: WebSearchProvider::ConfigurationError.new("Serper API key missing"))
 
-    WebSearchProvider.stub(:default, unconfigured) do
-      assert_equal "no web search provider configured", tool.execute(query: "ruby feeds")[:error]
-    end
+    assert_equal "Serper API key missing", tool(provider).execute(query: "ruby feeds")[:error]
   end
 
   test "#execute should surface provider errors as an error result" do
     provider = FakeProvider.new(error: WebSearchProvider::ProviderError.new("Serper: HTTP 429"))
 
-    WebSearchProvider.stub(:default, provider) do
-      assert_equal "Serper: HTTP 429", tool.execute(query: "ruby feeds")[:error]
+    assert_equal "Serper: HTTP 429", tool(provider).execute(query: "ruby feeds")[:error]
+  end
+
+  test "#execute should let auth errors escape instead of returning them to the model" do
+    provider = FakeProvider.new(error: WebSearchProvider::AuthError.new("Serper: HTTP 401"))
+
+    assert_raises(WebSearchProvider::AuthError) do
+      tool(provider).execute(query: "ruby feeds")
     end
   end
 end

--- a/test/services/llm_client/web_search_auth_error_test.rb
+++ b/test/services/llm_client/web_search_auth_error_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class LlmClient::WebSearchAuthErrorTest < ActiveSupport::TestCase
+  test "#call records usage and preserves a search auth error" do
+    user = create(:user)
+    credential = create(:ai_credential, :active, user: user)
+    feed = create(
+      :feed,
+      user: user,
+      ai_credential: credential,
+      feed_profile_key: "rss",
+      params: { "url" => "http://example.com/feed.xml" }
+    )
+    client = LlmClient.new(credential)
+    error = WebSearchProvider::AuthError.new("Serper: HTTP 401")
+    client.define_singleton_method(:invoke_provider) { |**| raise error }
+    context = LlmClient::CallContext.new(
+      feed: feed,
+      profile_key: "llm",
+      stage: :loader,
+      model: "claude-sonnet-4-6"
+    )
+
+    raised = assert_raises(WebSearchProvider::AuthError) do
+      assert_difference("LlmUsage.count", 1) do
+        client.call(context, prompt: "Search", output_schema: nil, web: true)
+      end
+    end
+
+    assert_same error, raised
+    assert_equal "provider_error", LlmUsage.last.outcome
+    assert_equal "Serper: HTTP 401", LlmUsage.last.error_message
+  end
+end

--- a/test/services/llm_client/web_search_auth_error_test.rb
+++ b/test/services/llm_client/web_search_auth_error_test.rb
@@ -20,13 +20,13 @@ class LlmClient::WebSearchAuthErrorTest < ActiveSupport::TestCase
       stage: :loader,
       model: "claude-sonnet-4-6"
     )
+    usage_count = LlmUsage.count
 
     raised = assert_raises(WebSearchProvider::AuthError) do
-      assert_difference("LlmUsage.count", 1) do
-        client.call(context, prompt: "Search", output_schema: nil, web: true)
-      end
+      client.call(context, prompt: "Search", output_schema: nil, web: true)
     end
 
+    assert_equal usage_count + 1, LlmUsage.count
     assert_same error, raised
     assert_equal "provider_error", LlmUsage.last.outcome
     assert_equal "Serper: HTTP 401", LlmUsage.last.error_message

--- a/test/services/web_search_provider_test.rb
+++ b/test/services/web_search_provider_test.rb
@@ -173,6 +173,26 @@ class WebSearchProviderTest < ActiveSupport::TestCase
     end
   end
 
+  test "#search should raise AuthError on auth and quota HTTP statuses" do
+    [401, 402, 403].each do |status|
+      with_client(HttpClient::Response.new(status: status, body: "")) do
+        error = assert_raises(WebSearchProvider::AuthError) do
+          WebSearchProvider::Serper.new(api_key: "key").search("query")
+        end
+        assert_equal "Serper: HTTP #{status}", error.message
+      end
+    end
+  end
+
+  test "#search should not raise AuthError for a server error status" do
+    with_client(HttpClient::Response.new(status: 500, body: "")) do
+      error = assert_raises(WebSearchProvider::ProviderError) do
+        WebSearchProvider::Serper.new(api_key: "key").search("query")
+      end
+      assert_not_kind_of WebSearchProvider::AuthError, error
+    end
+  end
+
   test "#search should raise ProviderError on an unparseable response" do
     with_client(ok_response("<html>oops</html>")) do
       error = assert_raises(WebSearchProvider::ProviderError) do


### PR DESCRIPTION
Changes:

- `WebSearchProvider::AuthError` raised for HTTP 401/402/403 key rejections, distinct from transient `ProviderError`, so callers can tell a dead API key from a transient failure
- `LlmClient::Tools::WebSearch` takes an injected, already-resolved provider instance instead of resolving from ENV at execute time
- Auth errors escape the tool; transient errors stay in-band as `{ error: }` tool results the model can read
- `LlmClient#call` records a usage row (`provider_error`) for an escaping search auth failure and re-raises it with the class preserved, keeping the one-row-per-call accounting invariant

First step of the search-credentials plan (spec 006 §5, §8). Credential deactivation on auth errors arrives with the adapter-unification step.

References:

- Closes #992
- Related issue: #983