### PR TITLE
Add search credential management UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-14
+
+- You can now add, check, rename, choose a default, and remove search-provider API keys from a dedicated Search Credentials settings page.
+
 ## 2026-07-13
 
 - AI usage stats on feed pages now cover the last 30 days instead of all time, so the numbers reflect recent activity.

--- a/app/components/search_credential_details_component.rb
+++ b/app/components/search_credential_details_component.rb
@@ -1,0 +1,38 @@
+class SearchCredentialDetailsComponent < ViewComponent::Base
+  def initialize(search_credential:)
+    @search_credential = search_credential
+  end
+
+  def call
+    render(ListComponent.new) do |list|
+      items.each { list.with_item(StatListItemComponent.new(**_1)) }
+    end
+  end
+
+  private
+
+  def items
+    result = [
+      {
+        label: "Provider",
+        value: WebSearchProvider::REGISTRY.fetch(@search_credential.provider),
+        key: "search_credential.provider"
+      },
+      {
+        label: "Created",
+        value: helpers.datetime_with_duration_tag(@search_credential.created_at),
+        key: "search_credential.created"
+      }
+    ]
+
+    if @search_credential.last_validated_at
+      result << {
+        label: "Last checked",
+        value: helpers.datetime_with_duration_tag(@search_credential.last_validated_at),
+        key: "search_credential.last_checked"
+      }
+    end
+
+    result
+  end
+end

--- a/app/components/search_credential_list_item_component.rb
+++ b/app/components/search_credential_list_item_component.rb
@@ -1,0 +1,73 @@
+class SearchCredentialListItemComponent < ListItemComponent
+  DELETE_CONFIRM = "Delete this search credential?".freeze
+
+  def initialize(credential:)
+    super()
+    @credential = credential
+  end
+
+  def before_render
+    with_icon { icon_element }
+    with_primary { primary_element }
+    with_secondary { secondary_element }
+    with_trailing { menu }
+  end
+
+  private
+
+  attr_reader :credential
+
+  def li_id = helpers.dom_id(credential)
+  def li_data = { key: "search_credential.#{credential.id}" }
+  def row_css_class = HOVER_ROW_CSS_CLASS
+
+  def icon_element
+    helpers.tag.span(helpers.credential_status_icon(credential.state),
+                     class: "inline-flex shrink-0",
+                     data: { key: "search_credential.#{credential.id}.status_icon" })
+  end
+
+  def primary_element
+    helpers.tag.div(helpers.safe_join([title_link, default_badge].compact),
+                    class: "flex min-w-0 flex-1 items-center gap-2")
+  end
+
+  def title_link
+    helpers.link_to(credential.display_name, credential_url,
+                    class: "truncate text-base text-heading transition hover:text-heading rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-white")
+  end
+
+  def default_badge
+    return unless credential.default?
+
+    render(BadgeComponent.new(text: "Default", color: :info, key: "search_credential.default-badge"))
+  end
+
+  def secondary_element
+    helpers.tag.div(provider_name, class: "truncate text-sm text-muted")
+  end
+
+  def provider_name
+    WebSearchProvider::REGISTRY.fetch(credential.provider)
+  end
+
+  def menu
+    render(DropdownMenuComponent.new(menu_id: menu_id, items: menu_items, width: "w-40"))
+  end
+
+  def menu_items
+    items = [
+      { label: "Details", href: credential_url },
+      { label: "Edit", href: edit_url }
+    ]
+    items << { label: "Make default", href: default_url, data: { turbo_method: :patch } } unless credential.default?
+    items << { label: "Delete…", href: credential_url,
+               data: { turbo_method: :delete, turbo_confirm: DELETE_CONFIRM } }
+    items
+  end
+
+  def credential_url = helpers.search_credential_path(credential)
+  def edit_url = helpers.edit_search_credential_path(credential)
+  def default_url = helpers.search_credential_default_path(credential)
+  def menu_id = "search-credential-menu-#{credential.id}"
+end

--- a/app/components/search_credentials_list_component.rb
+++ b/app/components/search_credentials_list_component.rb
@@ -1,0 +1,12 @@
+class SearchCredentialsListComponent < ListComponent
+  def initialize(credentials:)
+    super()
+    @credentials = credentials
+  end
+
+  def before_render
+    @credentials.each do |credential|
+      with_item(SearchCredentialListItemComponent.new(credential: credential))
+    end
+  end
+end

--- a/app/controllers/search_credentials/defaults_controller.rb
+++ b/app/controllers/search_credentials/defaults_controller.rb
@@ -1,0 +1,27 @@
+class SearchCredentials::DefaultsController < ApplicationController
+  def update
+    authorize credential, :update?
+    credential.make_default!
+
+    respond_to do |format|
+      format.turbo_stream do
+        flash.now[:success] = "'#{credential.display_name}' is now the default search credential."
+        @search_credentials = policy_scope(SearchCredential).order(created_at: :desc)
+      end
+      format.html do
+        redirect_to search_credentials_path,
+                    success: "'#{credential.display_name}' is now the default search credential."
+      end
+    end
+  end
+
+  private
+
+  def credential
+    @credential ||= scope.find(params[:search_credential_id])
+  end
+
+  def scope
+    policy_scope(SearchCredential)
+  end
+end

--- a/app/controllers/search_credentials/validations_controller.rb
+++ b/app/controllers/search_credentials/validations_controller.rb
@@ -1,0 +1,14 @@
+class SearchCredentials::ValidationsController < ApplicationController
+  def show
+    search_credential = policy_scope(SearchCredential).find(params[:search_credential_id])
+    authorize search_credential, :show?, policy_class: SearchCredentialPolicy
+
+    return head :no_content if search_credential.pending? || search_credential.validating?
+
+    render turbo_stream: turbo_stream.update(
+      "search-credential-show",
+      partial: "search_credentials/show_content",
+      locals: { search_credential: search_credential }
+    )
+  end
+end

--- a/app/controllers/search_credentials_controller.rb
+++ b/app/controllers/search_credentials_controller.rb
@@ -1,0 +1,94 @@
+class SearchCredentialsController < ApplicationController
+  include StatePolling
+
+  def index
+    authorize SearchCredential
+    @search_credentials = scope.order(created_at: :desc)
+  end
+
+  def show
+    @search_credential = find_credential
+    authorize @search_credential
+  end
+
+  def new
+    @search_credential = SearchCredential.new(provider: params[:provider] || WebSearchProvider::REGISTRY.keys.first)
+    authorize @search_credential
+  end
+
+  def create
+    @search_credential = build_credential
+    authorize @search_credential
+
+    if @search_credential.save
+      SearchCredentialValidationJob.perform_later(@search_credential)
+      redirect_to search_credential_path(@search_credential)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @search_credential = find_credential
+    authorize @search_credential
+  end
+
+  def update
+    @search_credential = find_credential
+    authorize @search_credential
+
+    key_changed = credential_data_from_params["api_key"].present?
+    if @search_credential.update(updated_credential_attrs(key_changed: key_changed))
+      SearchCredentialValidationJob.perform_later(@search_credential) if key_changed
+      redirect_to search_credential_path(@search_credential)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    credential = find_credential
+    authorize credential
+    credential.destroy!
+    redirect_to search_credentials_path, success: "Search credential '#{credential.display_name}' deleted."
+  end
+
+  private
+
+  def updated_credential_attrs(key_changed:)
+    attrs = { display_name: credential_params[:display_name] }
+    return attrs unless key_changed
+
+    attrs.merge(credential_data: credential_data_from_params, state: :pending)
+  end
+
+  def build_credential
+    Current.user.search_credentials.build(
+      provider: credential_params[:provider],
+      display_name: credential_params[:display_name],
+      credential_data: credential_data_from_params,
+      state: :pending
+    )
+  end
+
+  def find_credential
+    scope.find(params[:id])
+  end
+
+  def scope
+    policy_scope(SearchCredential)
+  end
+
+  def credential_params
+    params.require(:search_credential).permit(:provider, :display_name, credential_data: {})
+  end
+
+  def credential_data_from_params
+    raw = credential_params[:credential_data]
+    case raw
+    when ActionController::Parameters then raw.to_unsafe_h
+    when Hash then raw
+    else {}
+    end
+  end
+end

--- a/app/policies/search_credential_policy.rb
+++ b/app/policies/search_credential_policy.rb
@@ -1,0 +1,39 @@
+class SearchCredentialPolicy < ApplicationPolicy
+  def index?
+    authenticated?
+  end
+
+  def show?
+    owner_or_admin?
+  end
+
+  def create?
+    authenticated?
+  end
+
+  def destroy?
+    owner_or_admin?
+  end
+
+  def update?
+    owner_or_admin?
+  end
+
+  private
+
+  def owner_or_admin?
+    authenticated? && (user == record.user || admin?)
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      if admin?
+        scope.all
+      elsif user
+        scope.where(user: user)
+      else
+        scope.none
+      end
+    end
+  end
+end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -29,6 +29,9 @@
               <%= link_to "AI Credentials", ai_credentials_path, class: "block px-4 py-2 text-sm text-heading hover:bg-surface-sunken" %>
             </li>
             <li>
+              <%= link_to "Search Credentials", search_credentials_path, class: "block px-4 py-2 text-sm text-heading hover:bg-surface-sunken" %>
+            </li>
+            <li>
               <%= link_to "Invites", invites_path, class: "block px-4 py-2 text-sm text-heading hover:bg-surface-sunken" %>
             </li>
             <li>
@@ -124,6 +127,15 @@
                 }
               ),
               aria: (current_page?(ai_credentials_path) ? { current: "page" } : nil) %>
+          <%= link_to "Search Credentials", search_credentials_path,
+              class: class_names(
+                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
+                {
+                  "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => current_page?(search_credentials_path),
+                  "text-heading" => !current_page?(search_credentials_path)
+                }
+              ),
+              aria: (current_page?(search_credentials_path) ? { current: "page" } : nil) %>
           <%= link_to "Invites", invites_path,
               class: class_names(
                 "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",

--- a/app/views/search_credentials/_show_content.html.erb
+++ b/app/views/search_credentials/_show_content.html.erb
@@ -1,0 +1,54 @@
+<%# locals: (search_credential:) %>
+<div class="space-y-6" data-key="search_credential.show">
+  <%= render PageHeaderComponent.new(title: search_credential.display_name) do |header| %>
+    <% header.with_breadcrumb(label: "Search credentials", url: search_credentials_path) %>
+    <% header.with_action_button do %>
+      <%= link_to "Edit",
+                  edit_search_credential_path(search_credential),
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted",
+                  data: { key: "search_credential.edit" } %>
+    <% end %>
+    <% header.with_action_button do %>
+      <%= button_to "Delete…",
+                    search_credential_path(search_credential),
+                    method: :delete,
+                    form: { data: { turbo_confirm: "Delete this search credential?" } },
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
+    <% end %>
+  <% end %>
+
+  <% case search_credential.state %>
+  <% when "pending", "validating" %>
+    <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-xs"
+         data-key="search_credential.validating">
+      <div class="flex-shrink-0"><%= render SpinnerComponent.new %></div>
+      <div class="space-y-1">
+        <p class="font-semibold text-heading">Checking your credential…</p>
+        <p class="text-body">This makes one small search request and usually takes a few seconds.</p>
+      </div>
+    </div>
+  <% when "active" %>
+    <%= render AlertComponent.new(variant: :success, icon: "circle-check",
+                                  data: { credential_state: "active", key: "search_credential.active" }) do %>
+      <span>Credential is active</span>
+    <% end %>
+    <%= render SearchCredentialDetailsComponent.new(search_credential: search_credential) %>
+  <% when "inactive" %>
+    <%= render AlertComponent.new(variant: :error, icon: "circle-x",
+                                  data: { credential_state: "inactive", key: "search_credential.inactive" }) do %>
+      <% if search_credential.last_error.present? %>
+        <span><%= search_credential.last_error %></span>
+      <% else %>
+        <span>This key didn't work. Get a fresh key from your search provider and replace it.</span>
+      <% end %>
+    <% end %>
+    <%= render SearchCredentialDetailsComponent.new(search_credential: search_credential) %>
+  <% end %>
+
+  <% unless search_credential.default? %>
+    <%= button_to "Make default",
+                  search_credential_default_path(search_credential),
+                  method: :patch,
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
+  <% end %>
+</div>

--- a/app/views/search_credentials/defaults/update.turbo_stream.erb
+++ b/app/views/search_credentials/defaults/update.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.replace "search_credentials_list" do %>
+  <div id="search_credentials_list">
+    <% if @search_credentials.any? %>
+      <%= render SearchCredentialsListComponent.new(credentials: @search_credentials) %>
+    <% else %>
+      <%= render EmptyStateComponent.new("No search credentials yet") %>
+    <% end %>
+  </div>
+<% end %>
+
+<%= turbo_stream.replace "flash-messages", partial: "layouts/flash" %>

--- a/app/views/search_credentials/edit.html.erb
+++ b/app/views/search_credentials/edit.html.erb
@@ -1,0 +1,57 @@
+<% content_for :title, "Edit Search Credential" %>
+
+<div class="space-y-8" data-key="search_credentials.edit">
+  <%= render PageHeaderComponent.new(title: "Edit credential") do |header| %>
+    <% header.with_context_paragraph("Update the name or replace the API key. Only a new key triggers another check.") %>
+  <% end %>
+
+  <div class="max-w-2xl">
+    <%= form_with model: @search_credential do |f| %>
+      <% if @search_credential.errors.any? %>
+        <%= render AlertComponent.new(variant: :warning) do %>
+          <ul class="list-disc list-inside text-sm">
+            <% @search_credential.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+
+      <div class="space-y-10">
+        <div class="space-y-2">
+          <%= label_tag "search_credential_provider", "Search Provider", class: "block font-semibold text-heading" %>
+          <%= text_field_tag "search_credential_provider",
+                             WebSearchProvider::REGISTRY.fetch(@search_credential.provider),
+                             disabled: true,
+                             class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2 disabled:bg-surface-sunken disabled:text-muted disabled:border-border disabled:cursor-not-allowed" %>
+        </div>
+
+        <div class="space-y-2">
+          <%= f.label :display_name, "Name", class: "block font-semibold text-heading" %>
+          <%= f.text_field :display_name,
+                           class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
+                           required: true,
+                           data: { key: "search_credentials.display-name" } %>
+        </div>
+
+        <div class="space-y-2">
+          <%= label_tag "search_credential_credential_data_api_key", "API key", class: "block font-semibold text-heading" %>
+          <%= password_field_tag "search_credential[credential_data][api_key]",
+                                 nil,
+                                 id: "search_credential_credential_data_api_key",
+                                 class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
+                                 autocomplete: "off",
+                                 data: { key: "search_credentials.credential-data.api_key" } %>
+          <p class="text-sm text-muted">Leave blank to keep the current key and validation state.</p>
+        </div>
+      </div>
+
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4">
+        <%= f.submit "Update Credential",
+                     class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring",
+                     data: { turbo_submits_with: "Saving…" } %>
+        <%= link_to "Cancel", search_credential_path(@search_credential), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-6 py-3 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/search_credentials/index.html.erb
+++ b/app/views/search_credentials/index.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Search Credentials" %>
+
+<div class="space-y-8" data-key="search_credentials.index">
+  <%= render PageHeaderComponent.new(title: "Search Credentials") do |header| %>
+    <% header.with_breadcrumb(label: "Settings", url: settings_path) %>
+    <% header.with_context_paragraph("AI feeds need a search key to find grounded web content. Non-AI feeds do not use search credentials.") %>
+    <% header.with_action_button do %>
+      <%= link_to "New Credential",
+                  new_search_credential_path,
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",
+                  data: { key: "search_credentials.new-button" } %>
+    <% end %>
+  <% end %>
+
+  <div id="search_credentials_list">
+    <% if @search_credentials.any? %>
+      <%= render SearchCredentialsListComponent.new(credentials: @search_credentials) %>
+    <% else %>
+      <%= render EmptyStateComponent.new("No search credentials yet") do %>
+        <p>AI feeds need a search-provider API key to search the web. Non-AI feeds never need one.</p>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/search_credentials/new.html.erb
+++ b/app/views/search_credentials/new.html.erb
@@ -1,0 +1,59 @@
+<% content_for :title, "New Search Credential" %>
+
+<div class="space-y-8" data-key="search_credentials.new">
+  <%= render PageHeaderComponent.new(title: "Add a Search Credential") do |header| %>
+    <% header.with_context_paragraph("Add a search-provider API key for AI feeds that need web search.") %>
+  <% end %>
+
+  <div class="max-w-2xl">
+    <%= form_with model: @search_credential do |f| %>
+      <% if @search_credential.errors.any? %>
+        <%= render AlertComponent.new(variant: :warning) do %>
+          <ul class="list-disc list-inside text-sm">
+            <% @search_credential.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+
+      <div class="space-y-10">
+        <div class="space-y-2">
+          <%= f.label :provider, "Search Provider", class: "block font-semibold text-heading" %>
+          <%= f.select :provider,
+                       WebSearchProvider::REGISTRY.map { |name, label| [label, name] },
+                       {},
+                       class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
+                       data: { key: "search_credentials.provider" } %>
+        </div>
+
+        <div class="space-y-2">
+          <%= f.label :display_name, "Name", class: "block font-semibold text-heading" %>
+          <%= f.text_field :display_name,
+                           placeholder: "Personal Serper key",
+                           class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
+                           data: { key: "search_credentials.display-name" } %>
+          <p class="text-sm text-muted">A label so you can tell credentials apart. Leave blank to get one automatically.</p>
+        </div>
+
+        <div class="space-y-2">
+          <%= label_tag "search_credential_credential_data_api_key", "API key", class: "block font-semibold text-heading" %>
+          <%= password_field_tag "search_credential[credential_data][api_key]",
+                                 @search_credential.credential_data&.dig("api_key"),
+                                 id: "search_credential_credential_data_api_key",
+                                 class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
+                                 required: true,
+                                 autocomplete: "off",
+                                 data: { key: "search_credentials.credential-data.api_key" } %>
+        </div>
+      </div>
+
+      <div class="mt-6 flex flex-wrap items-center justify-start gap-4">
+        <%= f.submit "Save Credential",
+                     class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring",
+                     data: { turbo_submits_with: "Saving…" } %>
+        <%= link_to "Cancel", search_credentials_path, class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-6 py-3 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/search_credentials/show.html.erb
+++ b/app/views/search_credentials/show.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, "Search Credential" %>
+
+<% if @search_credential.pending? || @search_credential.validating? %>
+  <div
+    data-controller="polling"
+    data-polling-endpoint-value="<%= search_credential_validation_path(@search_credential) %>"
+    data-polling-interval-value="<%= polling_interval_ms %>"
+    data-polling-max-polls-value="<%= polling_max_polls %>"
+    data-polling-stop-condition-value="[data-credential-state]"
+    aria-busy="true">
+    <div id="search-credential-show" class="space-y-8">
+      <%= render "search_credentials/show_content", search_credential: @search_credential %>
+    </div>
+    <div data-polling-target="timeoutMessage" hidden class="mt-4">
+      <%= render AlertComponent.new(variant: :warning) do %>
+        <p class="font-semibold">The credential check is taking longer than expected.</p>
+        <p><%= link_to "Refresh the page", request.path, data: { turbo: false }, class: "underline underline-offset-2" %> to check the current status.</p>
+      <% end %>
+    </div>
+  </div>
+<% else %>
+  <div id="search-credential-show" class="space-y-8">
+    <%= render "search_credentials/show_content", search_credential: @search_credential %>
+  </div>
+<% end %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -53,6 +53,16 @@
       </div>
     <% end %>
 
+    <%= render CardComponent.new(href: search_credentials_path) do %>
+      <div class="space-y-4">
+        <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
+          <%= icon("search", css_class: "size-5") %>
+          <span>Search Credentials</span>
+        </h2>
+        <p class="text-body">Connect search-provider keys for AI feeds that search the web</p>
+      </div>
+    <% end %>
+
     <%= render CardComponent.new(href: invites_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,13 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :search_credentials do
+    scope module: :search_credentials do
+      resource :validation, only: :show
+      resource :default, only: :update
+    end
+  end
+
   get "up" => "rails/health#show", as: :rails_health_check
 
   resource :resend_webhooks, only: :create, path: "resend"

--- a/test/components/search_credential_details_component_test.rb
+++ b/test/components/search_credential_details_component_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "view_component/test_case"
+
+class SearchCredentialDetailsComponentTest < ViewComponent::TestCase
+  test "#render should show provider display name" do
+    credential = create(:search_credential, provider: "brave")
+
+    result = render_inline(SearchCredentialDetailsComponent.new(search_credential: credential))
+
+    assert_includes result.css('[data-key="search_credential.provider.value"]').first.text, "Brave"
+  end
+
+  test "#render should show created date" do
+    credential = create(:search_credential)
+
+    result = render_inline(SearchCredentialDetailsComponent.new(search_credential: credential))
+
+    assert_not_nil result.css('[data-key="search_credential.created.value"]').first
+  end
+
+  test "#render should show last checked when last_validated_at is present" do
+    credential = create(:search_credential, :active)
+
+    result = render_inline(SearchCredentialDetailsComponent.new(search_credential: credential))
+
+    assert_not_nil result.css('[data-key="search_credential.last_checked.value"]').first
+  end
+
+  test "#render should not show last checked when last_validated_at is absent" do
+    credential = create(:search_credential, state: :pending)
+
+    result = render_inline(SearchCredentialDetailsComponent.new(search_credential: credential))
+
+    assert_nil result.css('[data-key="search_credential.last_checked.value"]').first
+  end
+end

--- a/test/components/search_credentials_list_component_test.rb
+++ b/test/components/search_credentials_list_component_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+require "view_component/test_case"
+
+class SearchCredentialsListComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def credential
+    @credential ||= create(:search_credential, :active, user: user)
+  end
+
+  test "#call should render each credential as a list item" do
+    result = render_inline(SearchCredentialsListComponent.new(credentials: [credential]))
+
+    assert_not_nil result.css("[data-key='search_credential.#{credential.id}']").first
+  end
+
+  test "#call should link to the credential show page" do
+    result = render_inline(SearchCredentialsListComponent.new(credentials: [credential]))
+    link = result.css("a").first
+
+    assert_not_nil link
+    assert_includes link["href"], "/search_credentials/#{credential.id}"
+  end
+
+  test "#call should show the provider display name" do
+    result = render_inline(SearchCredentialsListComponent.new(credentials: [credential]))
+
+    assert_includes result.text, "Serper"
+  end
+
+  test "#call should show default badge for the default credential" do
+    user.update!(default_search_credential: credential)
+
+    result = render_inline(SearchCredentialsListComponent.new(credentials: [credential]))
+
+    assert_not_nil result.css("[data-key='search_credential.default-badge']").first
+  end
+
+  test "#call should not show default badge for a non-default credential" do
+    result = render_inline(SearchCredentialsListComponent.new(credentials: [credential]))
+
+    assert_empty result.css("[data-key='search_credential.default-badge']")
+  end
+
+  test "#call should show inactive status icon for inactive credentials" do
+    inactive = create(:search_credential, :inactive, user: user)
+
+    result = render_inline(SearchCredentialsListComponent.new(credentials: [inactive]))
+
+    icon = result.at_css("[data-key='search_credential.#{inactive.id}.status_icon'] svg")
+    assert_not_nil icon
+    assert_equal "Inactive", icon["aria-label"]
+  end
+
+  test "#call should render management menu items" do
+    result = render_inline(SearchCredentialsListComponent.new(credentials: [credential]))
+    items = result.css("a[role='menuitem']").to_h { |item| [item.text.strip, item] }
+
+    assert_includes items.fetch("Details")["href"], "/search_credentials/#{credential.id}"
+    assert_includes items.fetch("Edit")["href"], "/search_credentials/#{credential.id}/edit"
+    assert_not_nil items["Make default"]
+    assert_not_nil items["Delete…"]
+  end
+end

--- a/test/controllers/search_credentials/defaults_controller_test.rb
+++ b/test/controllers/search_credentials/defaults_controller_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class SearchCredentials::DefaultsControllerTest < ActionDispatch::IntegrationTest
+  def user
+    @user ||= create(:user)
+  end
+
+  def other_user
+    @other_user ||= create(:user)
+  end
+
+  test "#update should set the credential as the user's default" do
+    sign_in_as(user)
+    create(:search_credential, :default, user: user, display_name: "First")
+    second = create(:search_credential, user: user, display_name: "Second")
+
+    patch search_credential_default_url(second)
+
+    assert_redirected_to search_credentials_path
+    assert_equal second.id, user.reload.default_search_credential_id
+  end
+
+  test "#update should set default when no other default exists" do
+    sign_in_as(user)
+    credential = create(:search_credential, user: user)
+
+    patch search_credential_default_url(credential)
+
+    assert_equal credential.id, user.reload.default_search_credential_id
+  end
+
+  test "#update should 404 for another user's credential" do
+    sign_in_as(user)
+    other = create(:search_credential, user: other_user)
+
+    patch search_credential_default_url(other)
+
+    assert_response :not_found
+    assert_nil other_user.reload.default_search_credential_id
+  end
+
+  test "#update should respond with turbo stream when requested" do
+    sign_in_as(user)
+    credential = create(:search_credential, user: user)
+
+    patch search_credential_default_url(credential), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :ok
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_equal credential.id, user.reload.default_search_credential_id
+  end
+
+  test "#update should require authentication" do
+    credential = create(:search_credential, user: user)
+
+    patch search_credential_default_url(credential)
+
+    assert_redirected_to new_session_path
+  end
+end

--- a/test/controllers/search_credentials/validations_controller_test.rb
+++ b/test/controllers/search_credentials/validations_controller_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class SearchCredentials::ValidationsControllerTest < ActionDispatch::IntegrationTest
+  def user
+    @user ||= create(:user)
+  end
+
+  def other_user
+    @other_user ||= create(:user)
+  end
+
+  def credential
+    @credential ||= create(:search_credential, user: user, state: :pending)
+  end
+
+  test "#show should require authentication" do
+    get search_credential_validation_url(credential)
+
+    assert_redirected_to new_session_path
+  end
+
+  test "#show should return no content while still pending" do
+    sign_in_as(user)
+
+    get search_credential_validation_url(credential),
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :no_content
+    assert_empty response.body
+  end
+
+  test "#show should return no content while still validating" do
+    sign_in_as(user)
+    validating = create(:search_credential, user: user, state: :validating)
+
+    get search_credential_validation_url(validating),
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :no_content
+    assert_empty response.body
+  end
+
+  test "#show should render the turbo stream once validation resolves" do
+    sign_in_as(user)
+    active = create(:search_credential, :active, user: user)
+
+    get search_credential_validation_url(active),
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html; charset=utf-8", response.content_type
+    assert_includes response.body, "search-credential-show"
+    assert_includes response.body, "search_credential.active"
+  end
+
+  test "#show should 404 for another user's credential" do
+    sign_in_as(user)
+    other = create(:search_credential, user: other_user)
+
+    get search_credential_validation_url(other),
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/search_credentials_controller_test.rb
+++ b/test/controllers/search_credentials_controller_test.rb
@@ -1,0 +1,299 @@
+require "test_helper"
+
+class SearchCredentialsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup { clear_enqueued_jobs }
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def other_user
+    @other_user ||= create(:user)
+  end
+
+  def credential
+    @credential ||= create(:search_credential, user: user)
+  end
+
+  test "#index should require authentication" do
+    get search_credentials_url
+    assert_redirected_to new_session_path
+  end
+
+  test "#index should render only the user's credentials" do
+    sign_in_as(user)
+    credential
+    hidden = create(:search_credential, user: other_user)
+
+    get search_credentials_url
+
+    assert_response :success
+    assert_select "[data-key='search_credentials.index']"
+    assert_select "[data-key='search_credential.#{credential.id}']"
+    assert_select "[data-key='search_credential.#{hidden.id}']", count: 0
+    assert_select "nav[aria-label='Breadcrumb'] a[href=?]", settings_path, text: "Settings"
+  end
+
+  test "#index should explain when no search credentials exist" do
+    sign_in_as(user)
+
+    get search_credentials_url
+
+    assert_response :success
+    assert_select "[data-key='empty-state']", text: /AI feeds need a search-provider API key to search the web/
+    assert_select "[data-key='empty-state']", text: /Non-AI feeds never need one/
+  end
+
+  test "#new should render the provider and API key fields" do
+    sign_in_as(user)
+
+    get new_search_credential_url
+
+    assert_response :success
+    assert_select "[data-key='search_credentials.new']"
+    assert_select "[data-key='search_credentials.provider']"
+    assert_select "[data-key='search_credentials.credential-data.api_key']"
+  end
+
+  test "#create should save and enqueue validation when params are valid" do
+    sign_in_as(user)
+
+    assert_difference("SearchCredential.count", 1) do
+      assert_enqueued_with(job: SearchCredentialValidationJob) do
+        post search_credentials_url, params: {
+          search_credential: {
+            provider: "serper",
+            display_name: "My Search Key",
+            credential_data: { api_key: "serper-#{SecureRandom.hex(16)}" }
+          }
+        }
+      end
+    end
+
+    saved = SearchCredential.last
+    assert_redirected_to search_credential_path(saved)
+    assert_equal "pending", saved.state
+    assert_equal user, saved.user
+  end
+
+  test "#create should generate a name when display_name is blank" do
+    sign_in_as(user)
+
+    post search_credentials_url, params: {
+      search_credential: {
+        provider: "serper",
+        display_name: "",
+        credential_data: { api_key: "serper-#{SecureRandom.hex(16)}" }
+      }
+    }
+
+    saved = SearchCredential.last
+    assert saved.display_name.start_with?("Serper ")
+    assert_equal 3, saved.display_name.split.count
+  end
+
+  test "#create should render new with errors on invalid input" do
+    sign_in_as(user)
+
+    assert_no_difference("SearchCredential.count") do
+      post search_credentials_url, params: {
+        search_credential: {
+          provider: "serper",
+          display_name: "My Search Key",
+          credential_data: { api_key: "" }
+        }
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_select "[data-key='search_credentials.new']"
+  end
+
+  test "#show should render own credential" do
+    sign_in_as(user)
+
+    get search_credential_url(credential)
+
+    assert_response :success
+    assert_select "[data-key='search_credential.show']"
+  end
+
+  test "#show should place edit and delete actions in the header" do
+    sign_in_as(user)
+
+    get search_credential_url(credential)
+
+    assert_response :success
+    assert_select "header [data-key='search_credential.edit']"
+    assert_select "header form[action=?]", search_credential_path(credential) do
+      assert_select "button", text: /Delete/
+    end
+  end
+
+  test "#show should render the pending state with polling" do
+    sign_in_as(user)
+    pending = create(:search_credential, user: user, state: :pending)
+
+    get search_credential_url(pending)
+
+    assert_response :success
+    assert_select "[data-controller='polling']"
+    assert_select "[data-key='search_credential.validating']"
+  end
+
+  test "#show should render the validating state with polling" do
+    sign_in_as(user)
+    validating = create(:search_credential, user: user, state: :validating)
+
+    get search_credential_url(validating)
+
+    assert_response :success
+    assert_select "[data-controller='polling']"
+    assert_select "[data-key='search_credential.validating']"
+  end
+
+  test "#show should render the active state without polling" do
+    sign_in_as(user)
+    active = create(:search_credential, :active, user: user)
+
+    get search_credential_url(active)
+
+    assert_response :success
+    assert_select "[data-controller='polling']", count: 0
+    assert_select "[data-key='search_credential.active']"
+  end
+
+  test "#show should render the inactive state without polling" do
+    sign_in_as(user)
+    inactive = create(:search_credential, :inactive, user: user, last_error: "Invalid key")
+
+    get search_credential_url(inactive)
+
+    assert_response :success
+    assert_select "[data-controller='polling']", count: 0
+    assert_select "[data-key='search_credential.inactive']", text: /Invalid key/
+  end
+
+  test "#show should 404 for another user's credential" do
+    sign_in_as(user)
+    other = create(:search_credential, user: other_user)
+
+    get search_credential_url(other)
+
+    assert_response :not_found
+  end
+
+  test "#edit should render the form and key-change copy" do
+    sign_in_as(user)
+
+    get edit_search_credential_url(credential)
+
+    assert_response :success
+    assert_select "[data-key='search_credentials.edit']"
+    assert_select "[data-key='search_credentials.display-name']"
+    assert_select "[data-key='search_credentials.credential-data.api_key']"
+    assert_select "p", text: /Leave blank to keep the current key and validation state/
+  end
+
+  test "#edit should 404 for another user's credential" do
+    sign_in_as(user)
+    other = create(:search_credential, user: other_user)
+
+    get edit_search_credential_url(other)
+
+    assert_response :not_found
+  end
+
+  test "#update should rename without resetting state or enqueuing validation" do
+    sign_in_as(user)
+    active = create(:search_credential, :active, user: user)
+    original_key = active.credential_data["api_key"]
+
+    assert_no_enqueued_jobs only: SearchCredentialValidationJob do
+      patch search_credential_url(active), params: {
+        search_credential: {
+          display_name: "Renamed Search Key",
+          credential_data: { api_key: "" }
+        }
+      }
+    end
+
+    active.reload
+    assert_redirected_to search_credential_path(active)
+    assert_equal "Renamed Search Key", active.display_name
+    assert_equal "active", active.state
+    assert_equal original_key, active.credential_data["api_key"]
+  end
+
+  test "#update should replace a new key, reset state, and enqueue validation" do
+    sign_in_as(user)
+    active = create(:search_credential, :active, user: user)
+    new_key = "serper-#{SecureRandom.hex(16)}"
+
+    assert_enqueued_with(job: SearchCredentialValidationJob) do
+      patch search_credential_url(active), params: {
+        search_credential: {
+          display_name: active.display_name,
+          credential_data: { api_key: new_key }
+        }
+      }
+    end
+
+    active.reload
+    assert_redirected_to search_credential_path(active)
+    assert_equal new_key, active.credential_data["api_key"]
+    assert_equal "pending", active.state
+  end
+
+  test "#update should render edit with errors on invalid input" do
+    sign_in_as(user)
+
+    patch search_credential_url(credential), params: {
+      search_credential: {
+        display_name: "",
+        credential_data: { api_key: "" }
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "[data-key='search_credentials.edit']"
+  end
+
+  test "#update should 404 for another user's credential" do
+    sign_in_as(user)
+    other = create(:search_credential, user: other_user)
+
+    patch search_credential_url(other), params: {
+      search_credential: {
+        display_name: "Hacked",
+        credential_data: { api_key: "" }
+      }
+    }
+
+    assert_response :not_found
+  end
+
+  test "#destroy should delete own credential" do
+    sign_in_as(user)
+    credential
+
+    assert_difference("SearchCredential.count", -1) do
+      delete search_credential_url(credential)
+    end
+
+    assert_redirected_to search_credentials_path
+  end
+
+  test "#destroy should 404 for another user's credential" do
+    sign_in_as(user)
+    other = create(:search_credential, user: other_user)
+
+    assert_no_difference("SearchCredential.count") do
+      delete search_credential_url(other)
+    end
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -35,6 +35,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", edit_settings_password_update_path
     assert_select "a[href=?]", access_tokens_path
     assert_select "a[href=?]", ai_credentials_path
+    assert_select "a[href=?]", search_credentials_path
     assert_select "a[href=?]", invites_path
   end
 


### PR DESCRIPTION
## Summary

- add Search Credentials routes, CRUD controllers, ownership policy, default selection, and validation polling
- add list, form, and state-aware detail pages matching the AI credential management experience
- preserve validation state for name-only edits and revalidate only when a replacement API key is submitted
- add Settings/navbar entry points and a user-facing changelog entry
- add controller and component coverage for authentication, ownership, CRUD, defaults, polling, all four states, and key-change-only revalidation

## Context

This is T3 of the managed search credentials plan and builds on the model and validation lifecycle merged in #1000.

Closes #994
Related to #983

## Validation

- full Rails test suite and model/schema consistency
- RuboCop, ERB, Herb, and GitHub Actions linters
- Ruby/JavaScript dependency and static security scans
- CodeQL for Ruby and JavaScript
