### PR TITLE
Track search usage and estimate its cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-14
 
+- You can now see what web search costs: each search credential page shows how many searches ran in the last day, week, and month with an estimated cost, feed pages count searches next to AI calls and fold them into the spend figure, and feed refresh entries show how many searches each run made.
 - AI feeds now use their selected managed search-provider key consistently across every AI provider.
 - AI feeds now let you choose a managed search-provider key alongside the AI provider and model; setup points directly to whichever credential type is still missing.
 - You can now add, check, rename, choose a default, and remove search-provider API keys from a dedicated Search Credentials settings page.

--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -65,6 +65,8 @@ class EventDescriptionComponent < ViewComponent::Base
       helpers.link_to("Post", helpers.post_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
     when AiCredential
       helpers.link_to(event.subject.display_name, helpers.ai_credential_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
+    when SearchCredential
+      helpers.link_to(event.subject.display_name, helpers.search_credential_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
     else
       ""
     end

--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -68,8 +68,15 @@ class EventDescriptionComponent < ViewComponent::Base
     when SearchCredential
       helpers.link_to(event.subject.display_name, helpers.search_credential_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
     else
-      ""
+      orphaned_subject_placeholder
     end
+  end
+
+  # A recorded subject_type with no loadable subject means the record was
+  # deleted (credentials outlive their events' subjects); descriptions that
+  # interpolate %{subject_link} need a stand-in, not a hole in the sentence.
+  def orphaned_subject_placeholder
+    event.subject.nil? && event.subject_type.present? ? "(removed)" : ""
   end
 
   # Feeds link to the owner-facing page. Admin::EventDescriptionComponent

--- a/app/components/feed_llm_stats_component.rb
+++ b/app/components/feed_llm_stats_component.rb
@@ -30,6 +30,12 @@ class FeedLlmStatsComponent < ViewComponent::Base
         value: helpers.number_with_delimiter(call_count)
       },
       {
+        key: "search_calls",
+        label: "Searches (last #{period_in_days} days)",
+        label_short: "Searches (#{period_in_days} days)",
+        value: helpers.number_with_delimiter(search_call_count)
+      },
+      {
         key: "estimated_spend",
         label: "Estimated spend (last #{period_in_days} days)",
         label_short: "Spend (#{period_in_days} days)",
@@ -66,11 +72,35 @@ class FeedLlmStatsComponent < ViewComponent::Base
     @feed.llm_usages.within_stats_period
   end
 
+  # Per-call "web_search" events carry the feed in metadata (their subject is
+  # the credential), so the feed scope goes through jsonb. Grouping by
+  # provider keeps the cost estimate right across credential switches.
+  def search_counts_by_provider
+    @search_counts_by_provider ||=
+      Event.where(type: "web_search")
+           .where("metadata->>'feed_id' = ?", @feed.id.to_s)
+           .where(created_at: LlmUsage::STATS_PERIOD.ago..)
+           .group(Arel.sql("metadata->>'provider'"))
+           .count
+  end
+
+  def search_call_count
+    search_counts_by_provider.values.sum
+  end
+
+  def search_cost_cents
+    search_counts_by_provider.sum do |provider, count|
+      WebSearchProvider.estimated_cost_cents(provider, count)
+    end
+  end
+
   def period_in_days
     LlmUsage::STATS_PERIOD.in_days.to_i
   end
 
+  # One spend figure for the whole run pipeline: LLM tokens plus estimated
+  # search fees — users think "what did this feed cost", not per-subsystem.
   def formatted_cost
-    helpers.number_to_currency(total_cost_cents / 100.0)
+    helpers.number_to_currency((total_cost_cents + search_cost_cents) / 100.0)
   end
 end

--- a/app/components/feed_llm_stats_component.rb
+++ b/app/components/feed_llm_stats_component.rb
@@ -77,8 +77,8 @@ class FeedLlmStatsComponent < ViewComponent::Base
   # provider keeps the cost estimate right across credential switches.
   def search_counts_by_provider
     @search_counts_by_provider ||=
-      Event.where(type: "web_search")
-           .where("metadata->>'feed_id' = ?", @feed.id.to_s)
+      Event.web_search
+           .attributed_to_feed(@feed)
            .where(created_at: LlmUsage::STATS_PERIOD.ago..)
            .group(Arel.sql("metadata->>'provider'"))
            .count

--- a/app/components/search_credential_usage_component.rb
+++ b/app/components/search_credential_usage_component.rb
@@ -1,0 +1,43 @@
+# Time-scoped search API call counts with estimated cost for one credential,
+# fed by the per-call "web_search" events. Windows stay inside event
+# retention (1 month), so the numbers can't silently shrink the way an
+# all-time total would (spec 006 §6).
+class SearchCredentialUsageComponent < ViewComponent::Base
+  WINDOWS = [
+    { label: "Last 24 hours", duration: 24.hours, key: "day" },
+    { label: "Last 7 days", duration: 7.days, key: "week" },
+    { label: "Last 30 days", duration: 30.days, key: "month" }
+  ].freeze
+
+  def initialize(search_credential:)
+    @search_credential = search_credential
+  end
+
+  def call
+    render(ListComponent.new) do |list|
+      WINDOWS.each do |window|
+        list.with_item(StatListItemComponent.new(
+          label: window[:label],
+          value: formatted_usage(call_count(window[:duration])),
+          key: "search_credential.usage.#{window[:key]}"
+        ))
+      end
+    end
+  end
+
+  private
+
+  def call_count(duration)
+    Event.for_subject(@search_credential)
+         .where(type: "web_search")
+         .where(created_at: duration.ago..)
+         .count
+  end
+
+  # Counts include failed calls, and the estimate bills them all — erring
+  # toward overstating an estimate rather than hiding spend.
+  def formatted_usage(count)
+    cents = WebSearchProvider.estimated_cost_cents(@search_credential.provider, count)
+    "#{helpers.pluralize(count, 'search')} · ~#{helpers.number_to_currency(cents / 100.0)}"
+  end
+end

--- a/app/components/search_credential_usage_component.rb
+++ b/app/components/search_credential_usage_component.rb
@@ -1,12 +1,12 @@
 # Time-scoped search API call counts with estimated cost for one credential,
-# fed by the per-call "web_search" events. Windows stay inside event
-# retention (1 month), so the numbers can't silently shrink the way an
-# all-time total would (spec 006 §6).
+# fed by the per-call "web_search" events. Windows track event retention
+# (1 month), so unlike an all-time total the figures stay honest — at worst
+# the month window undercounts by a day or two around short months.
 class SearchCredentialUsageComponent < ViewComponent::Base
   WINDOWS = [
     { label: "Last 24 hours", duration: 24.hours, key: "day" },
     { label: "Last 7 days", duration: 7.days, key: "week" },
-    { label: "Last 30 days", duration: 30.days, key: "month" }
+    { label: "Last #{LlmUsage::STATS_PERIOD.in_days.to_i} days", duration: LlmUsage::STATS_PERIOD, key: "month" }
   ].freeze
 
   def initialize(search_credential:)
@@ -28,8 +28,8 @@ class SearchCredentialUsageComponent < ViewComponent::Base
   private
 
   def call_count(duration)
-    Event.for_subject(@search_credential)
-         .where(type: "web_search")
+    Event.web_search
+         .for_subject(@search_credential)
          .where(created_at: duration.ago..)
          .count
   end

--- a/app/jobs/purge_expired_events_job.rb
+++ b/app/jobs/purge_expired_events_job.rb
@@ -16,6 +16,9 @@ class PurgeExpiredEventsJob < ApplicationJob
 
     Event.expired.in_batches(of: BATCH_SIZE) do |events|
       EventReference.where(event_id: events.select(:id)).delete_all
+      # Events can also BE references (feed_refresh → web_search); purging
+      # the target must clear those inbound rows too or they dangle.
+      EventReference.where(reference_type: "Event", reference_id: events.select(:id)).delete_all
       deleted_count += events.delete_all
       sleep BATCH_PAUSE
     end

--- a/app/jobs/search_credential_validation_job.rb
+++ b/app/jobs/search_credential_validation_job.rb
@@ -9,10 +9,20 @@ class SearchCredentialValidationJob < ApplicationJob
   def perform(credential)
     credential.validating!
     credential.web_search_provider.search(VALIDATION_QUERY, max_results: 1)
-    credential.record_search_call(purpose: :validation, outcome: :success)
     credential.update!(state: :active, last_validated_at: Time.current, last_error: nil)
+    record_call(credential, outcome: :success)
   rescue WebSearchProvider::Error => e
-    credential.record_search_call(purpose: :validation, outcome: :error, error: e.message)
     credential.deactivate!(last_error: e.message)
+    record_call(credential, outcome: :error, error: e.message)
+  end
+
+  private
+
+  # Best-effort, after the state transition: accounting must never leave a
+  # credential stuck in validating.
+  def record_call(credential, outcome:, error: nil)
+    Rails.error.handle(StandardError, context: { search_credential_id: credential.id }) do
+      credential.record_search_call(purpose: :validation, outcome: outcome, error: error)
+    end
   end
 end

--- a/app/jobs/search_credential_validation_job.rb
+++ b/app/jobs/search_credential_validation_job.rb
@@ -9,8 +9,10 @@ class SearchCredentialValidationJob < ApplicationJob
   def perform(credential)
     credential.validating!
     credential.web_search_provider.search(VALIDATION_QUERY, max_results: 1)
+    credential.record_search_call(purpose: :validation, outcome: :success)
     credential.update!(state: :active, last_validated_at: Time.current, last_error: nil)
   rescue WebSearchProvider::Error => e
+    credential.record_search_call(purpose: :validation, outcome: :error, error: e.message)
     credential.deactivate!(last_error: e.message)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,6 +16,10 @@ class Event < ApplicationRecord
 
   scope :recent, -> { order(created_at: :desc) }
   scope :for_subject, ->(subject) { where(subject: subject) }
+  scope :web_search, -> { where(type: "web_search") }
+  # web_search events hold the credential in the subject slot, so their feed
+  # attribution rides in metadata; jsonb text comparison needs the id string.
+  scope :attributed_to_feed, ->(feed) { where("metadata->>'feed_id' = ?", feed.id.to_s) }
   # An event is expired once its explicit expiration has passed, or — when it
   # never set one — once it ages past DEFAULT_RETENTION. This is what the purge
   # job deletes.

--- a/app/models/search_credential.rb
+++ b/app/models/search_credential.rb
@@ -33,6 +33,26 @@ class SearchCredential < ApplicationRecord
     WebSearchProvider.for(provider, api_key: credential_data["api_key"])
   end
 
+  # One debug event per search API call — the accounting record behind the
+  # per-credential usage stats and the refresh event's search-call count
+  # (spec 006 §6). feed_id lives in metadata rather than a reference so the
+  # refresh workflow can window this credential's calls to one feed's run.
+  def record_search_call(purpose:, outcome:, feed: nil, error: nil)
+    Event.create!(
+      type: "web_search",
+      level: :debug,
+      subject: self,
+      user: user,
+      metadata: {
+        provider: provider,
+        purpose: purpose.to_s,
+        outcome: outcome.to_s,
+        feed_id: feed&.id,
+        error: error
+      }.compact
+    )
+  end
+
   def deactivate!(last_error: nil)
     with_lock do
       update!(

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -80,7 +80,9 @@ class FeedRefreshWorkflow
   # since every later run's window starts after these rows. The event's own
   # started_at stat bounds them exactly.
   def interrupt_abandoned_event(event)
-    usage_rows = abandoned_llm_usage_rows(event)
+    run_started_at = abandoned_run_started_at(event)
+    usage_rows = abandoned_llm_usage_rows(run_started_at)
+    search_call_ids = search_call_event_ids(run_started_at)
     metadata = event.metadata.merge("status" => "interrupted")
 
     if usage_rows.any?
@@ -90,16 +92,22 @@ class FeedRefreshWorkflow
       )
     end
 
+    if search_call_ids.any?
+      metadata["stats"] = metadata.fetch("stats", {}).merge("search_calls" => search_call_ids.size)
+    end
+
     event.update!(level: :debug, metadata: metadata)
     reference_llm_usages(event, usage_rows)
+    reference_search_calls(event, search_call_ids)
   end
 
-  def abandoned_llm_usage_rows(event)
-    run_started_at = begin
-      Time.zone.parse(event.metadata.dig("stats", "started_at").to_s)
-    rescue ArgumentError
-      nil
-    end
+  def abandoned_run_started_at(event)
+    Time.zone.parse(event.metadata.dig("stats", "started_at").to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def abandoned_llm_usage_rows(run_started_at)
     return [] unless run_started_at
 
     feed.llm_usages.scheduled_run
@@ -312,7 +320,9 @@ class FeedRefreshWorkflow
   def complete_refresh_event(posts)
     @refresh_event.destroy!
     usage_rows = run_llm_usage_rows
+    search_call_ids = run_search_call_event_ids
     record_llm_usage_stats(usage_rows)
+    record_search_call_stats(search_call_ids)
 
     event = Event.create!(
       type: "feed_refresh",
@@ -325,6 +335,7 @@ class FeedRefreshWorkflow
     @refresh_completed = true
     reference_posts(event, posts)
     reference_llm_usages(event, usage_rows)
+    reference_search_calls(event, search_call_ids)
   end
 
   def reference_posts(event, posts)
@@ -354,6 +365,23 @@ class FeedRefreshWorkflow
         .pluck(:id, :cost_estimate_cents)
   end
 
+  # This run's per-call search events, windowed like run_llm_usage_rows. The
+  # feed_id lives in event metadata (the subject is the credential, which
+  # other feeds may share), so the filter goes through jsonb — bounded by the
+  # type+created_at index and event retention.
+  def search_call_event_ids(from_time)
+    return [] unless from_time
+
+    Event.where(type: "web_search", created_at: from_time..)
+         .where("metadata->>'feed_id' = ?", feed.id.to_s)
+         .where("metadata->>'purpose' = ?", "scheduled_run")
+         .pluck(:id)
+  end
+
+  def run_search_call_event_ids
+    search_call_event_ids(stats[:started_at])
+  end
+
   # No calls, no stat — keeps deterministic feeds' events free of a noisy $0.
   def record_llm_usage_stats(usage_rows)
     return if usage_rows.empty?
@@ -364,6 +392,12 @@ class FeedRefreshWorkflow
     )
   end
 
+  def record_search_call_stats(search_call_ids)
+    return if search_call_ids.empty?
+
+    record_stats(search_calls: search_call_ids.size)
+  end
+
   def reference_llm_usages(event, usage_rows)
     return if usage_rows.empty?
 
@@ -372,6 +406,22 @@ class FeedRefreshWorkflow
         event_id: event.id,
         reference_type: "LlmUsage",
         reference_id: usage_id,
+        created_at: event.created_at,
+        updated_at: event.created_at
+      }
+    end
+
+    EventReference.insert_all(references_data)
+  end
+
+  def reference_search_calls(event, search_call_ids)
+    return if search_call_ids.empty?
+
+    references_data = search_call_ids.map do |search_event_id|
+      {
+        event_id: event.id,
+        reference_type: "Event",
+        reference_id: search_event_id,
         created_at: event.created_at,
         updated_at: event.created_at
       }
@@ -397,7 +447,9 @@ class FeedRefreshWorkflow
 
     @refresh_event&.destroy!
     usage_rows = run_llm_usage_rows
+    search_call_ids = run_search_call_event_ids
     record_llm_usage_stats(usage_rows)
+    record_search_call_stats(search_call_ids)
 
     event = Event.create!(
       type: "feed_refresh",
@@ -418,6 +470,7 @@ class FeedRefreshWorkflow
     )
 
     reference_llm_usages(event, usage_rows)
+    reference_search_calls(event, search_call_ids)
   end
 
   # Persist this run's regime so the next scheduled run can skip a redundant

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -320,7 +320,7 @@ class FeedRefreshWorkflow
   def complete_refresh_event(posts)
     @refresh_event.destroy!
     usage_rows = run_llm_usage_rows
-    search_call_ids = run_search_call_event_ids
+    search_call_ids = search_call_event_ids(stats[:started_at])
     record_llm_usage_stats(usage_rows)
     record_search_call_stats(search_call_ids)
 
@@ -339,19 +339,7 @@ class FeedRefreshWorkflow
   end
 
   def reference_posts(event, posts)
-    return if posts.empty?
-
-    references_data = posts.map do |post|
-      {
-        event_id: event.id,
-        reference_type: "Post",
-        reference_id: post.id,
-        created_at: event.created_at,
-        updated_at: event.created_at
-      }
-    end
-
-    EventReference.insert_all(references_data)
+    insert_event_references(event, "Post", posts.map(&:id))
   end
 
   # This run's usage rows as [id, cost_cents] pairs. The started_at window is
@@ -368,18 +356,17 @@ class FeedRefreshWorkflow
   # This run's per-call search events, windowed like run_llm_usage_rows. The
   # feed_id lives in event metadata (the subject is the credential, which
   # other feeds may share), so the filter goes through jsonb — bounded by the
-  # type+created_at index and event retention.
+  # type+created_at index and event retention. Deterministic feeds skip the
+  # query outright: they can never emit search calls.
   def search_call_event_ids(from_time)
     return [] unless from_time
+    return [] unless FeedProfile.depends_on_ai?(feed.feed_profile_key)
 
-    Event.where(type: "web_search", created_at: from_time..)
-         .where("metadata->>'feed_id' = ?", feed.id.to_s)
+    Event.web_search
+         .attributed_to_feed(feed)
+         .where(created_at: from_time..)
          .where("metadata->>'purpose' = ?", "scheduled_run")
          .pluck(:id)
-  end
-
-  def run_search_call_event_ids
-    search_call_event_ids(stats[:started_at])
   end
 
   # No calls, no stat — keeps deterministic feeds' events free of a noisy $0.
@@ -399,29 +386,21 @@ class FeedRefreshWorkflow
   end
 
   def reference_llm_usages(event, usage_rows)
-    return if usage_rows.empty?
-
-    references_data = usage_rows.map do |usage_id, _cents|
-      {
-        event_id: event.id,
-        reference_type: "LlmUsage",
-        reference_id: usage_id,
-        created_at: event.created_at,
-        updated_at: event.created_at
-      }
-    end
-
-    EventReference.insert_all(references_data)
+    insert_event_references(event, "LlmUsage", usage_rows.map(&:first))
   end
 
   def reference_search_calls(event, search_call_ids)
-    return if search_call_ids.empty?
+    insert_event_references(event, "Event", search_call_ids)
+  end
 
-    references_data = search_call_ids.map do |search_event_id|
+  def insert_event_references(event, reference_type, reference_ids)
+    return if reference_ids.empty?
+
+    references_data = reference_ids.map do |reference_id|
       {
         event_id: event.id,
-        reference_type: "Event",
-        reference_id: search_event_id,
+        reference_type: reference_type,
+        reference_id: reference_id,
         created_at: event.created_at,
         updated_at: event.created_at
       }
@@ -447,7 +426,7 @@ class FeedRefreshWorkflow
 
     @refresh_event&.destroy!
     usage_rows = run_llm_usage_rows
-    search_call_ids = run_search_call_event_ids
+    search_call_ids = search_call_event_ids(stats[:started_at])
     record_llm_usage_stats(usage_rows)
     record_search_call_stats(search_call_ids)
 

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -154,7 +154,7 @@ class LlmClient
     # by #ask travels as a separate user-role message (spec §8).
     chat.with_instructions(system) if system.present?
     chat.with_schema(output_schema) if output_schema.present?
-    adapter.apply_web(chat, model, search_provider: search_provider_for(ctx)) if web
+    adapter.apply_web(chat, model, search_tool: search_tool_for(ctx)) if web
 
     response = chat.ask(prompt)
     ProviderResponse.new(
@@ -166,11 +166,19 @@ class LlmClient
     )
   end
 
-  def search_provider_for(ctx)
+  # The context-carrying tool instance: the credential supplies the provider
+  # key, and the feed/purpose let the tool attribute its per-call usage
+  # events (spec 006 §6).
+  def search_tool_for(ctx)
     search_credential = ctx.search_credential
     raise CredentialMissing, "no active search credential found" unless search_credential&.active?
 
-    search_credential.web_search_provider
+    Tools::WebSearch.new(
+      provider: search_credential.web_search_provider,
+      credential: search_credential,
+      feed: ctx.feed,
+      purpose: ctx.purpose
+    )
   end
 
   def adapter

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -10,11 +10,12 @@ class LlmClient
 
       # Every provider uses the same credential-backed search and fetch tools.
       # Adapters may still add provider-specific request params, but search never
-      # delegates to a provider-hosted implementation.
-      def apply_web(chat, model, search_provider:)
+      # delegates to a provider-hosted implementation. The search tool arrives
+      # prebuilt: LlmClient owns its credential/attribution context.
+      def apply_web(chat, model, search_tool:)
         params = web_params(model)
         chat.with_params(**params) if params.present?
-        chat.with_tool(LlmClient::Tools::WebSearch.new(provider: search_provider))
+        chat.with_tool(search_tool)
         chat.with_tool(LlmClient::Tools::WebFetch)
       end
 

--- a/app/services/llm_client/tools/web_search.rb
+++ b/app/services/llm_client/tools/web_search.rb
@@ -31,11 +31,10 @@ class LlmClient
         results = @provider.search(query, max_results: MAX_RESULTS)
         record_call(outcome: :success)
         { results: results.map(&:to_h) }
-      rescue ::WebSearchProvider::AuthError => e
-        record_call(outcome: :error, error: e.message)
-        raise
       rescue ::WebSearchProvider::Error => e
         record_call(outcome: :error, error: e.message)
+        raise if e.is_a?(::WebSearchProvider::AuthError)
+
         { error: e.message }
       end
 

--- a/app/services/llm_client/tools/web_search.rb
+++ b/app/services/llm_client/tools/web_search.rb
@@ -6,6 +6,10 @@ class LlmClient
     # surface as ordinary error results the model can read and work around;
     # an auth failure escapes instead — a dead key is a run-level problem
     # the model can't fix, and swallowing it would hide the failure forever.
+    #
+    # Each provider call is billed, so each one records a usage event on the
+    # credential (spec 006 §6). Recording is best-effort: accounting must
+    # never break a search that already succeeded.
     class WebSearch < RubyLLM::Tool
       description "Search the web. Returns result titles, URLs and snippets. " \
                   "Fetch a result URL with the web fetch tool to read the page."
@@ -13,20 +17,36 @@ class LlmClient
 
       MAX_RESULTS = 5
 
-      def initialize(provider:)
+      def initialize(provider:, credential: nil, feed: nil, purpose: :scheduled_run)
         super()
         @provider = provider
+        @credential = credential
+        @feed = feed
+        @purpose = purpose
       end
 
       def execute(query:)
         return { error: "Refused: query must not be blank." } if query.blank?
 
         results = @provider.search(query, max_results: MAX_RESULTS)
+        record_call(outcome: :success)
         { results: results.map(&:to_h) }
-      rescue ::WebSearchProvider::AuthError
+      rescue ::WebSearchProvider::AuthError => e
+        record_call(outcome: :error, error: e.message)
         raise
       rescue ::WebSearchProvider::Error => e
+        record_call(outcome: :error, error: e.message)
         { error: e.message }
+      end
+
+      private
+
+      def record_call(outcome:, error: nil)
+        return if @credential.nil?
+
+        Rails.error.handle(StandardError, context: { search_credential_id: @credential.id }) do
+          @credential.record_search_call(purpose: @purpose, outcome: outcome, feed: @feed, error: error)
+        end
       end
     end
   end

--- a/app/services/web_search_provider.rb
+++ b/app/services/web_search_provider.rb
@@ -22,10 +22,26 @@ module WebSearchProvider
     "tavily" => "Tavily"
   }.freeze
 
+  # Flat per-request pricing, in cents per 1000 requests, from each vendor's
+  # published entry-tier rates. Estimates only: real pricing is tiered, and
+  # cost is derived at display time as calls × rate — never stored per call,
+  # so sub-cent requests don't round away.
+  CENTS_PER_1K_REQUESTS = {
+    "serper" => 100,
+    "brave" => 500,
+    "tavily" => 800
+  }.freeze
+
   def self.for(name, api_key:)
     class_name = REGISTRY[name.to_s]
     raise ConfigurationError, "unknown web search provider: #{name}" unless class_name
 
     const_get(class_name).new(api_key: api_key)
+  end
+
+  # Estimated cost of `calls` requests in fractional cents. An unknown
+  # provider estimates to zero, mirroring RateTable's "0 = unknown, not free".
+  def self.estimated_cost_cents(name, calls)
+    calls * CENTS_PER_1K_REQUESTS.fetch(name.to_s, 0) / 1000.0
   end
 end

--- a/app/views/search_credentials/_show_content.html.erb
+++ b/app/views/search_credentials/_show_content.html.erb
@@ -45,6 +45,13 @@
     <%= render SearchCredentialDetailsComponent.new(search_credential: search_credential) %>
   <% end %>
 
+  <% if search_credential.active? || search_credential.inactive? %>
+    <section class="space-y-4" data-key="search_credential.usage">
+      <h2 class="text-2xl font-semibold mb-3 text-heading">Usage</h2>
+      <%= render SearchCredentialUsageComponent.new(search_credential: search_credential) %>
+    </section>
+  <% end %>
+
   <% if feed_id.present? || !search_credential.default? %>
     <div class="flex flex-wrap gap-3">
       <% if feed_id.present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,12 @@ en:
     ai_credential_deactivated:
       name: "AI credential deactivated"
       description_html: "AI credential %{subject_link} stopped working; update the key to resume its feeds."
+    search_credential_deactivated:
+      name: "Search credential deactivated"
+      description_html: "Search credential %{subject_link} stopped working; update the key to resume its feeds."
+    web_search:
+      name: "Web search"
+      description_html: "Web search via %{subject_link}"
     post_withdrawn:
       name: "Post withdrawn"
       description_html: "Post removed from FreeFeed"
@@ -121,6 +127,7 @@ en:
         new_posts: "New posts"
         llm_calls: "AI calls"
         llm_cost_cents: "Estimated AI spend"
+        search_calls: "Search API calls"
     llm_usage:
       section_title: "AI usage"
 

--- a/lib/tasks/ai_schema_verify.rake
+++ b/lib/tasks/ai_schema_verify.rake
@@ -76,7 +76,12 @@ namespace :ai do
       chat = LlmCapabilityProbe::Provider.build(provider_key).chat(model)
       chat.with_instructions(Loader::LlmPrompts::COMBINED_SYSTEM)
       chat.with_schema(schema)
-      adapter.apply_web(chat, model, search_provider: search_credential.web_search_provider)
+      search_tool = LlmClient::Tools::WebSearch.new(
+        provider: search_credential.web_search_provider,
+        credential: search_credential,
+        purpose: :validation
+      )
+      adapter.apply_web(chat, model, search_tool: search_tool)
 
       raw = chat.ask(user_prompt).content
       payload = raw.is_a?(Hash) ? raw : JSON.parse(adapter.unwrap_json(raw.to_s))

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -286,4 +286,41 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     # by normalizing resend.email.email_bounced -> resend_email_bounced
     assert_includes result.to_html, "Email bounced"
   end
+
+  def search_credential
+    @search_credential ||= create(:search_credential, :active, user: user, display_name: "My Serper Key")
+  end
+
+  test "#call should link the search credential on a deactivation event" do
+    event = Event.create!(
+      type: "search_credential_deactivated",
+      level: :warning,
+      subject: search_credential,
+      user: user,
+      message: "",
+      metadata: {}
+    )
+
+    result = render_inline(EventDescriptionComponent.new(event: event))
+
+    assert_includes result.to_html, "My Serper Key"
+    assert_includes result.to_html, "/search_credentials/#{search_credential.id}"
+    assert_includes result.to_html, "stopped working"
+  end
+
+  test "#call should link the search credential on a web search event" do
+    event = Event.create!(
+      type: "web_search",
+      level: :debug,
+      subject: search_credential,
+      user: user,
+      message: "",
+      metadata: { "provider" => "serper", "outcome" => "success" }
+    )
+
+    result = render_inline(EventDescriptionComponent.new(event: event))
+
+    assert_includes result.to_html, "Web search via"
+    assert_includes result.to_html, "/search_credentials/#{search_credential.id}"
+  end
 end

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -323,4 +323,20 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     assert_includes result.to_html, "Web search via"
     assert_includes result.to_html, "/search_credentials/#{search_credential.id}"
   end
+
+  test "#call should show a placeholder when the event's subject was deleted" do
+    event = Event.create!(
+      type: "search_credential_deactivated",
+      level: :warning,
+      subject: search_credential,
+      user: user,
+      message: "",
+      metadata: {}
+    )
+    search_credential.destroy!
+
+    result = render_inline(EventDescriptionComponent.new(event: event.reload))
+
+    assert_includes result.to_html, "Search credential (removed) stopped working"
+  end
 end

--- a/test/components/feed_llm_stats_component_test.rb
+++ b/test/components/feed_llm_stats_component_test.rb
@@ -63,5 +63,37 @@ class FeedLlmStatsComponentTest < ViewComponent::TestCase
 
     spend_value = result.css('[data-key="llm_stats.estimated_spend.value"]').first.text.strip
     assert_equal "$0.00", spend_value
+
+    searches_value = result.css('[data-key="llm_stats.search_calls.value"]').first.text.strip
+    assert_equal "0", searches_value
+  end
+
+  def record_search_calls(feed, count, at: 1.hour.ago, provider: "serper")
+    credential = create(:search_credential, :active, user: feed.user, provider: provider,
+                                                     display_name: "#{provider} #{feed.id}")
+    count.times do
+      create(:event, type: "web_search", level: :debug, subject: credential, user: feed.user,
+                     metadata: { "provider" => provider, "feed_id" => feed.id, "outcome" => "success" },
+                     created_at: at)
+    end
+  end
+
+  test "#render should count the feed's searches and fold their cost into spend" do
+    record_search_calls(feed_with_usages, 10)
+
+    result = render_inline(FeedLlmStatsComponent.new(feed: feed_with_usages))
+
+    assert_equal "10", result.css('[data-key="llm_stats.search_calls.value"]').first.text.strip
+    assert_equal "$0.41", result.css('[data-key="llm_stats.estimated_spend.value"]').first.text.strip
+  end
+
+  test "#render should exclude search calls outside the stats period and from other feeds" do
+    record_search_calls(feed_with_usages, 10, at: LlmUsage::STATS_PERIOD.ago - 1.day)
+    record_search_calls(feed, 3)
+
+    result = render_inline(FeedLlmStatsComponent.new(feed: feed_with_usages))
+
+    assert_equal "0", result.css('[data-key="llm_stats.search_calls.value"]').first.text.strip
+    assert_equal "$0.40", result.css('[data-key="llm_stats.estimated_spend.value"]').first.text.strip
   end
 end

--- a/test/components/search_credential_usage_component_test.rb
+++ b/test/components/search_credential_usage_component_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+require "view_component/test_case"
+
+class SearchCredentialUsageComponentTest < ViewComponent::TestCase
+  def credential
+    @credential ||= create(:search_credential, :active)
+  end
+
+  def record_calls(count, at:)
+    count.times do
+      create(:event, type: "web_search", level: :debug, subject: credential, user: credential.user,
+                     metadata: { "provider" => credential.provider, "outcome" => "success" }, created_at: at)
+    end
+  end
+
+  test "#render should show window-scoped call counts with estimated cost" do
+    record_calls(12, at: 1.hour.ago)
+    record_calls(8, at: 3.days.ago)
+    record_calls(10, at: 20.days.ago)
+    record_calls(5, at: 40.days.ago)
+
+    result = render_inline(SearchCredentialUsageComponent.new(search_credential: credential))
+
+    assert_equal "12 searches · ~$0.01", result.css('[data-key="search_credential.usage.day.value"]').first.text.strip
+    assert_equal "20 searches · ~$0.02", result.css('[data-key="search_credential.usage.week.value"]').first.text.strip
+    assert_equal "30 searches · ~$0.03", result.css('[data-key="search_credential.usage.month.value"]').first.text.strip
+  end
+
+  test "#render should show zeros for an unused credential" do
+    result = render_inline(SearchCredentialUsageComponent.new(search_credential: credential))
+
+    assert_equal "0 searches · ~$0.00", result.css('[data-key="search_credential.usage.day.value"]').first.text.strip
+  end
+
+  test "#render should not count another credential's calls" do
+    other = create(:search_credential, :active, user: credential.user, display_name: "Other")
+    create(:event, type: "web_search", level: :debug, subject: other, user: credential.user,
+                   metadata: { "provider" => other.provider }, created_at: 1.hour.ago)
+
+    result = render_inline(SearchCredentialUsageComponent.new(search_credential: credential))
+
+    assert_equal "0 searches · ~$0.00", result.css('[data-key="search_credential.usage.day.value"]').first.text.strip
+  end
+end

--- a/test/jobs/purge_expired_events_job_test.rb
+++ b/test/jobs/purge_expired_events_job_test.rb
@@ -48,4 +48,16 @@ class PurgeExpiredEventsJobTest < ActiveJob::TestCase
     assert_not EventReference.exists?(expired_reference.id)
     assert EventReference.exists?(active_reference.id)
   end
+
+  test "#perform should delete references pointing at purged events" do
+    purged_target = create(:event, type: "web_search", expires_at: 1.hour.ago)
+    referrer = create(:event, expires_at: 1.hour.from_now)
+    inbound_reference = create(:event_reference, event: referrer, reference: purged_target)
+
+    PurgeExpiredEventsJob.perform_now
+
+    assert_not Event.exists?(purged_target.id)
+    assert Event.exists?(referrer.id)
+    assert_not EventReference.exists?(inbound_reference.id)
+  end
 end

--- a/test/jobs/search_credential_validation_job_test.rb
+++ b/test/jobs/search_credential_validation_job_test.rb
@@ -39,6 +39,30 @@ class SearchCredentialValidationJobTest < ActiveJob::TestCase
     assert_equal [{ query: SearchCredentialValidationJob::VALIDATION_QUERY, max_results: 1 }], provider.calls
   end
 
+  test "#perform should record the validation search call" do
+    WebSearchProvider.stub(:for, FakeProvider.new) do
+      SearchCredentialValidationJob.perform_now(credential)
+    end
+
+    event = Event.find_by!(type: "web_search", subject: credential)
+    assert_equal "validation", event.metadata["purpose"]
+    assert_equal "success", event.metadata["outcome"]
+    assert_nil event.metadata["feed_id"]
+  end
+
+  test "#perform should record the validation search call when validation fails" do
+    provider = FakeProvider.new(error: WebSearchProvider::AuthError.new("Serper: HTTP 401"))
+
+    WebSearchProvider.stub(:for, provider) do
+      SearchCredentialValidationJob.perform_now(credential)
+    end
+
+    event = Event.find_by!(type: "web_search", subject: credential)
+    assert_equal "validation", event.metadata["purpose"]
+    assert_equal "error", event.metadata["outcome"]
+    assert_equal "Serper: HTTP 401", event.metadata["error"]
+  end
+
   test "#perform should deactivate and record every known provider error type" do
     error_classes = [
       WebSearchProvider::ConfigurationError,
@@ -51,7 +75,9 @@ class SearchCredentialValidationJobTest < ActiveJob::TestCase
                                            display_name: error_class.name.demodulize)
       provider = FakeProvider.new(error: error_class.new("validation failed"))
 
-      assert_difference("Event.count", 1) do
+      # Two events per failed validation: the per-call web_search record and
+      # the deactivation warning.
+      assert_difference("Event.count", 2) do
         WebSearchProvider.stub(:for, provider) do
           SearchCredentialValidationJob.perform_now(current)
         end

--- a/test/models/search_credential_test.rb
+++ b/test/models/search_credential_test.rb
@@ -148,4 +148,31 @@ class SearchCredentialTest < ActiveSupport::TestCase
 
     assert_includes user.search_credentials, credential
   end
+
+  test "#record_search_call should create a debug event with full attribution" do
+    credential = create(:search_credential, :active, user: user)
+    feed = create(:feed, user: user)
+
+    event = credential.record_search_call(
+      purpose: :scheduled_run, outcome: :success, feed: feed, error: nil
+    )
+
+    assert_equal "web_search", event.type
+    assert_equal "debug", event.level
+    assert_equal credential, event.subject
+    assert_equal user, event.user
+    assert_equal(
+      { "provider" => "serper", "purpose" => "scheduled_run", "outcome" => "success", "feed_id" => feed.id },
+      event.metadata
+    )
+  end
+
+  test "#record_search_call should omit blank feed and error from metadata" do
+    credential = create(:search_credential, :active, user: user)
+
+    event = credential.record_search_call(purpose: :validation, outcome: :error, error: "Serper: HTTP 401")
+
+    assert_not event.metadata.key?("feed_id")
+    assert_equal "Serper: HTTP 401", event.metadata["error"]
+  end
 end

--- a/test/services/feed_refresh_workflow_search_calls_test.rb
+++ b/test/services/feed_refresh_workflow_search_calls_test.rb
@@ -1,24 +1,36 @@
 require "test_helper"
 
 class FeedRefreshWorkflowSearchCallsTest < ActiveSupport::TestCase
-  def empty_rss
-    <<~RSS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0"><channel><title>Empty</title></channel></rss>
-    RSS
-  end
-
-  def refresh_feed
-    @refresh_feed ||= create(:feed, :enabled, feed_profile_key: "rss")
+  def user
+    @user ||= create(:user)
   end
 
   def credential
-    @credential ||= create(:search_credential, :active, user: refresh_feed.user)
+    @credential ||= create(:search_credential, :active, user: user)
+  end
+
+  def refresh_feed
+    @refresh_feed ||= begin
+      ai_credential = create(:ai_credential, :active, user: user,
+                                                      available_models: [{ "id" => "claude-sonnet-4-6" }])
+      create(:feed, :enabled, user: user,
+                              feed_profile_key: "llm",
+                              params: { "prompt" => "daily roundup" },
+                              ai_credential: ai_credential,
+                              ai_model: "claude-sonnet-4-6",
+                              search_credential: credential)
+    end
+  end
+
+  def plain_loader(items)
+    loader = Object.new
+    loader.define_singleton_method(:load) { items }
+    loader
   end
 
   # Stands in for a run whose gather step performed web searches: records the
   # per-call events mid-load, the way the WebSearch tool does.
-  def search_recording_loader(rss, purpose: :scheduled_run, error: nil)
+  def search_recording_loader(purpose: :scheduled_run, error: nil)
     recorded_credential = credential
     recorded_feed = refresh_feed
     loader = Object.new
@@ -26,7 +38,7 @@ class FeedRefreshWorkflowSearchCallsTest < ActiveSupport::TestCase
       recorded_credential.record_search_call(purpose: purpose, outcome: :success, feed: recorded_feed)
       raise error if error
 
-      rss
+      []
     end
     loader
   end
@@ -34,12 +46,12 @@ class FeedRefreshWorkflowSearchCallsTest < ActiveSupport::TestCase
   test "#execute should count and reference the run's search calls on the completed event" do
     prior_call = credential.record_search_call(purpose: :scheduled_run, outcome: :success, feed: refresh_feed)
 
-    refresh_feed.stub(:loader_instance, search_recording_loader(empty_rss)) do
+    refresh_feed.stub(:loader_instance, search_recording_loader) do
       FeedRefreshWorkflow.new(refresh_feed).execute
     end
 
     event = Event.find_by!(subject: refresh_feed, type: "feed_refresh")
-    run_call = Event.where(type: "web_search").where.not(id: prior_call.id).sole
+    run_call = Event.web_search.where.not(id: prior_call.id).sole
 
     assert_equal "completed", event.metadata["status"]
     assert_equal 1, event.metadata.dig("stats", "search_calls")
@@ -50,7 +62,7 @@ class FeedRefreshWorkflowSearchCallsTest < ActiveSupport::TestCase
   test "#execute should count and reference the run's search calls on the failed event" do
     error = LlmClient::ProviderError.new("server error")
 
-    refresh_feed.stub(:loader_instance, search_recording_loader(empty_rss, error: error)) do
+    refresh_feed.stub(:loader_instance, search_recording_loader(error: error)) do
       assert_raises(LlmClient::ProviderError) { FeedRefreshWorkflow.new(refresh_feed).execute }
     end
 
@@ -58,11 +70,11 @@ class FeedRefreshWorkflowSearchCallsTest < ActiveSupport::TestCase
 
     assert_equal "failed", event.metadata["status"]
     assert_equal 1, event.metadata.dig("stats", "search_calls")
-    assert_includes event.references, Event.where(type: "web_search").sole
+    assert_includes event.references, Event.web_search.sole
   end
 
   test "#execute should record no search stats for a run without searches" do
-    refresh_feed.stub(:loader_instance, Object.new.tap { |l| rss = empty_rss; l.define_singleton_method(:load) { rss } }) do
+    refresh_feed.stub(:loader_instance, plain_loader([])) do
       FeedRefreshWorkflow.new(refresh_feed).execute
     end
 
@@ -72,12 +84,29 @@ class FeedRefreshWorkflowSearchCallsTest < ActiveSupport::TestCase
   end
 
   test "#execute should not count another purpose's calls in the run window" do
-    refresh_feed.stub(:loader_instance, search_recording_loader(empty_rss, purpose: :preview)) do
+    refresh_feed.stub(:loader_instance, search_recording_loader(purpose: :preview)) do
       FeedRefreshWorkflow.new(refresh_feed).execute
     end
 
     event = Event.find_by!(subject: refresh_feed, type: "feed_refresh")
 
     assert_not event.metadata["stats"].key?("search_calls")
+  end
+
+  test "#execute should skip the search event query for deterministic feeds" do
+    rss_feed = create(:feed, :enabled, feed_profile_key: "rss")
+    rss = <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0"><channel><title>Empty</title></channel></rss>
+    RSS
+
+    assert_no_queries_match(/web_search/) do
+      rss_feed.stub(:loader_instance, plain_loader(rss)) do
+        FeedRefreshWorkflow.new(rss_feed).execute
+      end
+    end
+
+    event = Event.find_by!(subject: rss_feed, type: "feed_refresh")
+    assert_equal "completed", event.metadata["status"]
   end
 end

--- a/test/services/feed_refresh_workflow_search_calls_test.rb
+++ b/test/services/feed_refresh_workflow_search_calls_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class FeedRefreshWorkflowSearchCallsTest < ActiveSupport::TestCase
+  def empty_rss
+    <<~RSS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0"><channel><title>Empty</title></channel></rss>
+    RSS
+  end
+
+  def refresh_feed
+    @refresh_feed ||= create(:feed, :enabled, feed_profile_key: "rss")
+  end
+
+  def credential
+    @credential ||= create(:search_credential, :active, user: refresh_feed.user)
+  end
+
+  # Stands in for a run whose gather step performed web searches: records the
+  # per-call events mid-load, the way the WebSearch tool does.
+  def search_recording_loader(rss, purpose: :scheduled_run, error: nil)
+    recorded_credential = credential
+    recorded_feed = refresh_feed
+    loader = Object.new
+    loader.define_singleton_method(:load) do
+      recorded_credential.record_search_call(purpose: purpose, outcome: :success, feed: recorded_feed)
+      raise error if error
+
+      rss
+    end
+    loader
+  end
+
+  test "#execute should count and reference the run's search calls on the completed event" do
+    prior_call = credential.record_search_call(purpose: :scheduled_run, outcome: :success, feed: refresh_feed)
+
+    refresh_feed.stub(:loader_instance, search_recording_loader(empty_rss)) do
+      FeedRefreshWorkflow.new(refresh_feed).execute
+    end
+
+    event = Event.find_by!(subject: refresh_feed, type: "feed_refresh")
+    run_call = Event.where(type: "web_search").where.not(id: prior_call.id).sole
+
+    assert_equal "completed", event.metadata["status"]
+    assert_equal 1, event.metadata.dig("stats", "search_calls")
+    assert_includes event.references, run_call
+    assert_not_includes event.references, prior_call
+  end
+
+  test "#execute should count and reference the run's search calls on the failed event" do
+    error = LlmClient::ProviderError.new("server error")
+
+    refresh_feed.stub(:loader_instance, search_recording_loader(empty_rss, error: error)) do
+      assert_raises(LlmClient::ProviderError) { FeedRefreshWorkflow.new(refresh_feed).execute }
+    end
+
+    event = Event.find_by!(subject: refresh_feed, type: "feed_refresh")
+
+    assert_equal "failed", event.metadata["status"]
+    assert_equal 1, event.metadata.dig("stats", "search_calls")
+    assert_includes event.references, Event.where(type: "web_search").sole
+  end
+
+  test "#execute should record no search stats for a run without searches" do
+    refresh_feed.stub(:loader_instance, Object.new.tap { |l| rss = empty_rss; l.define_singleton_method(:load) { rss } }) do
+      FeedRefreshWorkflow.new(refresh_feed).execute
+    end
+
+    event = Event.find_by!(subject: refresh_feed, type: "feed_refresh")
+
+    assert_not event.metadata["stats"].key?("search_calls")
+  end
+
+  test "#execute should not count another purpose's calls in the run window" do
+    refresh_feed.stub(:loader_instance, search_recording_loader(empty_rss, purpose: :preview)) do
+      FeedRefreshWorkflow.new(refresh_feed).execute
+    end
+
+    event = Event.find_by!(subject: refresh_feed, type: "feed_refresh")
+
+    assert_not event.metadata["stats"].key?("search_calls")
+  end
+end

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -37,24 +37,25 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     end
   end
 
-  test "every adapter should attach the injected search provider and client-side fetch" do
-    provider = Object.new
+  def search_tool
+    @search_tool ||= LlmClient::Tools::WebSearch.new(provider: Object.new)
+  end
 
+  test "every adapter should attach the prebuilt search tool and client-side fetch" do
     LlmClient::Adapter::REGISTRY.each_key do |name|
       chat = fake_chat
-      LlmClient::Adapter.for(name).apply_web(chat, "model", search_provider: provider)
+      LlmClient::Adapter.for(name).apply_web(chat, "model", search_tool: search_tool)
 
-      search_tool, fetch_tool = chat.tools
-      assert_instance_of LlmClient::Tools::WebSearch, search_tool, name
-      assert_same provider, search_tool.instance_variable_get(:@provider), name
-      assert_equal LlmClient::Tools::WebFetch, fetch_tool, name
+      attached_search, attached_fetch = chat.tools
+      assert_same search_tool, attached_search, name
+      assert_equal LlmClient::Tools::WebFetch, attached_fetch, name
     end
   end
 
   test "Anthropic should not send provider-hosted web tools" do
     chat = fake_chat
 
-    LlmClient::Adapter::Anthropic.new.apply_web(chat, "claude-opus-4-8", search_provider: Object.new)
+    LlmClient::Adapter::Anthropic.new.apply_web(chat, "claude-opus-4-8", search_tool: search_tool)
 
     assert_equal({}, chat.params)
   end
@@ -62,7 +63,7 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
   test "OpenRouter should require structured parameters without enabling its web plugin" do
     chat = fake_chat
 
-    LlmClient::Adapter::OpenRouter.new.apply_web(chat, "openai/gpt-4o", search_provider: Object.new)
+    LlmClient::Adapter::OpenRouter.new.apply_web(chat, "openai/gpt-4o", search_tool: search_tool)
 
     assert_equal({ provider: { require_parameters: true } }, chat.params)
     assert_not chat.params.key?(:plugins)

--- a/test/services/llm_client/search_tool_injection_test.rb
+++ b/test/services/llm_client/search_tool_injection_test.rb
@@ -1,21 +1,29 @@
 require "test_helper"
 
-class LlmClient::SearchProviderInjectionTest < ActiveSupport::TestCase
-  test "web calls resolve the provider from the active search credential" do
+class LlmClient::SearchToolInjectionTest < ActiveSupport::TestCase
+  test "web calls build the search tool from the active search credential with attribution context" do
     user = create(:user)
     ai_credential = create(:ai_credential, :active, user: user)
     search_credential = create(:search_credential, :active, user: user)
+    feed = create(:feed, user: user)
     provider = Object.new
     context = LlmClient::CallContext.new(
-      feed: nil,
+      feed: feed,
       profile_key: "llm",
       stage: :loader,
       model: "claude-sonnet-4-6",
+      purpose: :preview,
       search_credential: search_credential
     )
 
     search_credential.stub(:web_search_provider, provider) do
-      assert_same provider, LlmClient.new(ai_credential).send(:search_provider_for, context)
+      tool = LlmClient.new(ai_credential).send(:search_tool_for, context)
+
+      assert_instance_of LlmClient::Tools::WebSearch, tool
+      assert_same provider, tool.instance_variable_get(:@provider)
+      assert_same search_credential, tool.instance_variable_get(:@credential)
+      assert_same feed, tool.instance_variable_get(:@feed)
+      assert_equal :preview, tool.instance_variable_get(:@purpose)
     end
   end
 
@@ -35,7 +43,7 @@ class LlmClient::SearchProviderInjectionTest < ActiveSupport::TestCase
       )
 
       assert_raises(LlmClient::CredentialMissing) do
-        client.send(:search_provider_for, context)
+        client.send(:search_tool_for, context)
       end
     end
   end

--- a/test/services/llm_client/tools/web_search_test.rb
+++ b/test/services/llm_client/tools/web_search_test.rb
@@ -65,4 +65,78 @@ class LlmClient::Tools::WebSearchTest < ActiveSupport::TestCase
       tool(provider).execute(query: "ruby feeds")
     end
   end
+
+  test "#execute should not record events without a credential" do
+    provider = FakeProvider.new(results: [result(1)])
+
+    assert_no_difference("Event.count") do
+      tool(provider).execute(query: "ruby feeds")
+    end
+  end
+
+  def credential
+    @credential ||= create(:search_credential, :active)
+  end
+
+  def feed
+    @feed ||= create(:feed, user: credential.user)
+  end
+
+  def recording_tool(provider)
+    LlmClient::Tools::WebSearch.new(provider: provider, credential: credential, feed: feed, purpose: :scheduled_run)
+  end
+
+  test "#execute should record a usage event on the credential for a successful call" do
+    provider = FakeProvider.new(results: [result(1)])
+
+    recording_tool(provider).execute(query: "ruby feeds")
+
+    event = Event.find_by!(type: "web_search", subject: credential)
+    assert_equal credential.user, event.user
+    assert_equal "debug", event.level
+    assert_equal "serper", event.metadata["provider"]
+    assert_equal "scheduled_run", event.metadata["purpose"]
+    assert_equal "success", event.metadata["outcome"]
+    assert_equal feed.id, event.metadata["feed_id"]
+  end
+
+  test "#execute should record an errored usage event when the provider fails in-band" do
+    provider = FakeProvider.new(error: WebSearchProvider::ProviderError.new("Serper: HTTP 429"))
+
+    recording_tool(provider).execute(query: "ruby feeds")
+
+    event = Event.find_by!(type: "web_search", subject: credential)
+    assert_equal "error", event.metadata["outcome"]
+    assert_equal "Serper: HTTP 429", event.metadata["error"]
+  end
+
+  test "#execute should record the call even when an auth error escapes" do
+    provider = FakeProvider.new(error: WebSearchProvider::AuthError.new("Serper: HTTP 401"))
+
+    assert_raises(WebSearchProvider::AuthError) do
+      recording_tool(provider).execute(query: "ruby feeds")
+    end
+
+    event = Event.find_by!(type: "web_search", subject: credential)
+    assert_equal "error", event.metadata["outcome"]
+    assert_equal "Serper: HTTP 401", event.metadata["error"]
+  end
+
+  test "#execute should not record an event for a refused blank query" do
+    provider = FakeProvider.new
+
+    assert_no_difference("Event.count") do
+      recording_tool(provider).execute(query: "  ")
+    end
+  end
+
+  test "#execute should not fail the search when event recording breaks" do
+    provider = FakeProvider.new(results: [result(1)])
+    failing = recording_tool(provider)
+    credential.stub(:record_search_call, ->(**) { raise ActiveRecord::RecordInvalid }) do
+      payload = failing.execute(query: "ruby feeds")
+
+      assert_equal 1, payload[:results].size
+    end
+  end
 end

--- a/test/services/web_search_provider_test.rb
+++ b/test/services/web_search_provider_test.rb
@@ -176,4 +176,18 @@ class WebSearchProviderTest < ActiveSupport::TestCase
       assert_empty WebSearchProvider::Serper.new(api_key: "key").search("query")
     end
   end
+
+  test ".estimated_cost_cents should derive fractional cents from the per-1K rate" do
+    assert_in_delta 0.1, WebSearchProvider.estimated_cost_cents("serper", 1)
+    assert_in_delta 500.0, WebSearchProvider.estimated_cost_cents("brave", 1000)
+    assert_in_delta 1.6, WebSearchProvider.estimated_cost_cents(:tavily, 2)
+  end
+
+  test ".estimated_cost_cents should estimate zero for an unknown provider" do
+    assert_equal 0, WebSearchProvider.estimated_cost_cents("nope", 50)
+  end
+
+  test "every registered provider should have a per-1K rate" do
+    assert_equal WebSearchProvider::REGISTRY.keys.sort, WebSearchProvider::CENTS_PER_1K_REQUESTS.keys.sort
+  end
 end


### PR DESCRIPTION
Superseded by #1024, which merged the same T7 scope (per-call `web_search` events, refresh-event counting and references, credential/feed usage surfaces, registry rates) while this branch was in review. #1024's design attaches per-call events to the in-flight refresh event, which is cleaner than the metadata-based feed attribution used here.

Three review findings from this branch's fresh-eye pass apply to the merged implementation as well and follow in a separate small PR: guarded best-effort usage recording (tool + validation job), purge cleanup for references pointing at purged events, and a placeholder for deleted event subjects.

References:

- Superseded by: #1024
- Related issue: #998