### PR TITLE
Harden search usage accounting edge cases

### DIFF
--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -68,8 +68,15 @@ class EventDescriptionComponent < ViewComponent::Base
     when SearchCredential
       helpers.link_to(event.subject.display_name, helpers.search_credential_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
     else
-      ""
+      orphaned_subject_placeholder
     end
+  end
+
+  # A recorded subject_type with no loadable subject means the record was
+  # deleted (credentials outlive their events' subjects); descriptions that
+  # interpolate %{subject_link} need a stand-in, not a hole in the sentence.
+  def orphaned_subject_placeholder
+    event.subject.nil? && event.subject_type.present? ? "(removed)" : ""
   end
 
   # Feeds link to the owner-facing page. Admin::EventDescriptionComponent

--- a/app/jobs/purge_expired_events_job.rb
+++ b/app/jobs/purge_expired_events_job.rb
@@ -16,6 +16,10 @@ class PurgeExpiredEventsJob < ApplicationJob
 
     Event.expired.in_batches(of: BATCH_SIZE) do |events|
       EventReference.where(event_id: events.select(:id)).delete_all
+      # Events can also BE references (feed_refresh → web_search); delete_all
+      # skips the incoming_event_references association cleanup, so inbound
+      # rows must be cleared here or they dangle until the referrer purges.
+      EventReference.where(reference_type: "Event", reference_id: events.select(:id)).delete_all
       deleted_count += events.delete_all
       sleep BATCH_PAUSE
     end

--- a/app/jobs/search_credential_validation_job.rb
+++ b/app/jobs/search_credential_validation_job.rb
@@ -8,10 +8,21 @@ class SearchCredentialValidationJob < ApplicationJob
 
   def perform(credential)
     credential.validating!
-    WebSearchUsage.record!(credential: credential)
+    record_usage(credential)
     credential.web_search_provider.search(VALIDATION_QUERY, max_results: 1)
     credential.update!(state: :active, last_validated_at: Time.current, last_error: nil)
   rescue WebSearchProvider::Error => e
     credential.deactivate!(last_error: e.message)
+  end
+
+  private
+
+  # Best-effort: an accounting failure is not a WebSearchProvider::Error, so
+  # unguarded it would escape the rescue, strand the credential in
+  # "validating", and burn another billed query on every retry.
+  def record_usage(credential)
+    Rails.error.handle(StandardError, context: { search_credential_id: credential.id }) do
+      WebSearchUsage.record!(credential: credential)
+    end
   end
 end

--- a/app/services/llm_client/tools/web_search.rb
+++ b/app/services/llm_client/tools/web_search.rb
@@ -23,13 +23,24 @@ class LlmClient
       def execute(query:)
         return { error: "Refused: query must not be blank." } if query.blank?
 
-        WebSearchUsage.record!(credential: @credential, refresh_event: @refresh_event)
+        record_usage
         results = @provider.search(query, max_results: MAX_RESULTS)
         { results: results.map(&:to_h) }
       rescue ::WebSearchProvider::AuthError
         raise
       rescue ::WebSearchProvider::Error => e
         { error: e.message }
+      end
+
+      private
+
+      # Best-effort: a failed accounting write must not take down the search —
+      # or the whole run, since a non-search error escapes every rescue on the
+      # way up and would abort the LLM call over a bookkeeping hiccup.
+      def record_usage
+        Rails.error.handle(StandardError, context: { search_credential_id: @credential.id }) do
+          WebSearchUsage.record!(credential: @credential, refresh_event: @refresh_event)
+        end
       end
     end
   end

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -286,4 +286,22 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     # by normalizing resend.email.email_bounced -> resend_email_bounced
     assert_includes result.to_html, "Email bounced"
   end
+
+  test "#call should show a placeholder when the event's subject was deleted" do
+    credential = create(:ai_credential, :active, user: user)
+    event = Event.create!(
+      type: "ai_credential_deactivated",
+      level: :warning,
+      subject: credential,
+      user: user,
+      message: "",
+      metadata: {}
+    )
+    credential.destroy!
+
+    result = render_inline(EventDescriptionComponent.new(event: event.reload))
+
+    assert_includes result.to_html, "(removed)"
+    assert_not_includes result.to_html, "credential  stopped"
+  end
 end

--- a/test/jobs/purge_expired_events_job_test.rb
+++ b/test/jobs/purge_expired_events_job_test.rb
@@ -48,4 +48,16 @@ class PurgeExpiredEventsJobTest < ActiveJob::TestCase
     assert_not EventReference.exists?(expired_reference.id)
     assert EventReference.exists?(active_reference.id)
   end
+
+  test "#perform should delete references pointing at purged events" do
+    purged_target = create(:event, type: "web_search", expires_at: 1.hour.ago)
+    referrer = create(:event, expires_at: 1.hour.from_now)
+    inbound_reference = create(:event_reference, event: referrer, reference: purged_target)
+
+    PurgeExpiredEventsJob.perform_now
+
+    assert_not Event.exists?(purged_target.id)
+    assert Event.exists?(referrer.id)
+    assert_not EventReference.exists?(inbound_reference.id)
+  end
 end

--- a/test/jobs/search_credential_validation_job_test.rb
+++ b/test/jobs/search_credential_validation_job_test.rb
@@ -74,4 +74,17 @@ class SearchCredentialValidationJobTest < ActiveJob::TestCase
       assert_equal [{ query: SearchCredentialValidationJob::VALIDATION_QUERY, max_results: 1 }], provider.calls
     end
   end
+
+  test "#perform should still activate the credential when usage recording breaks" do
+    provider = FakeProvider.new
+    failing = ->(**) { raise ActiveRecord::RecordInvalid }
+
+    WebSearchUsage.stub(:record!, failing) do
+      WebSearchProvider.stub(:for, provider) do
+        SearchCredentialValidationJob.perform_now(credential)
+      end
+    end
+
+    assert credential.reload.active?
+  end
 end

--- a/test/services/llm_client/tools/web_search_test.rb
+++ b/test/services/llm_client/tools/web_search_test.rb
@@ -99,4 +99,15 @@ class LlmClient::Tools::WebSearchTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "#execute should not fail the search when usage recording breaks" do
+    provider = FakeProvider.new(results: [result(1)])
+    failing = ->(**) { raise ActiveRecord::RecordInvalid }
+
+    WebSearchUsage.stub(:record!, failing) do
+      payload = tool(provider).execute(query: "ruby feeds")
+
+      assert_equal 1, payload[:results].size
+    end
+  end
 end


### PR DESCRIPTION
Changes:

- Usage recording is best-effort in the `WebSearch` tool and the validation job: a failed `Event.create!` no longer aborts the LLM run (it isn't a `WebSearchProvider::Error`, so it would escape every rescue on the way up) or strand a credential in "validating" while retries burn extra billed queries
- The purge job clears `EventReference` rows pointing **at** purged events — `delete_all` skips the `incoming_event_references` cleanup, so feed_refresh → web_search rows dangled once the debug target purged first
- Event descriptions render a "(removed)" placeholder when the subject was deleted instead of a hole in the sentence (reachable today via AI credential deletion)

These are the review findings from the fresh-eye pass on the superseded #1025 that also apply to the implementation merged in #1024.

References:

- Related PR: #1024
- Related PR: #1025
- Related issue: #998
