### PR TITLE
Add webhook feed profile and endpoint plumbing

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -48,6 +48,7 @@ class FeedsController < ApplicationController
     authorize @feed
 
     if @feed.save
+      sync_webhook_endpoint(@feed)
       cleanup_feed_identification(@feed.source_input)
 
       if (gate_path = setup_gate_path(@feed))
@@ -103,6 +104,7 @@ class FeedsController < ApplicationController
     @feed.state = :disabled if @feed.enabled? && !enable_feed? && gate_path.nil?
 
     if @feed.save
+      sync_webhook_endpoint(@feed)
       # Capture interval-change signal from the first save before the
       # promotion attempt's save overwrites `saved_changes`.
       interval_changed = @feed.saved_change_to_cron_expression?
@@ -314,6 +316,21 @@ class FeedsController < ApplicationController
     return if input.blank?
 
     FeedIdentification.find_by(user: current_user, input: input)&.destroy
+  end
+
+  # A webhook feed's endpoint lives with the feed record (spec 006 §2): minted
+  # when the feed is created (drafts included) so the URL is pasteable
+  # immediately, destroyed when a draft moves off the profile so the old URL
+  # stops resolving. Kept here rather than in a model callback so the model
+  # stays decoupled from WebhookEndpoint.
+  def sync_webhook_endpoint(feed)
+    return unless feed.saved_change_to_feed_profile_key?
+
+    if feed.feed_profile_key == "webhook"
+      feed.create_webhook_endpoint! unless feed.webhook_endpoint
+    else
+      feed.webhook_endpoint&.destroy
+    end
   end
 
   def success_message_for(feed)

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -318,11 +318,9 @@ class FeedsController < ApplicationController
     FeedIdentification.find_by(user: current_user, input: input)&.destroy
   end
 
-  # A webhook feed's endpoint lives with the feed record (spec 006 §2): minted
-  # when the feed is created (drafts included) so the URL is pasteable
-  # immediately, destroyed when a draft moves off the profile so the old URL
-  # stops resolving. Kept here rather than in a model callback so the model
-  # stays decoupled from WebhookEndpoint.
+  # Minted with the feed so the URL is pasteable immediately, destroyed when
+  # a draft moves off the webhook profile so the old URL stops resolving
+  # (spec 006 §2).
   def sync_webhook_endpoint(feed)
     return unless feed.saved_change_to_feed_profile_key?
 

--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -9,10 +9,10 @@ class FeedRefreshJob < ApplicationJob
     feed = Feed.find_by(id: feed_id)
     return unless feed
 
-    # Push-ingested feeds have no loader; the scheduler never picks them up
+    # The webhook profile has no loader; the scheduler never picks it up
     # (spec 007), so a kick landing here is a stray manual refresh or a bug —
     # drop it (spec 006 §7).
-    return if feed.push_profile?
+    return if feed.feed_profile_key == "webhook"
 
     Feed.with_advisory_lock!("feed_refresh_#{feed.id}", timeout_seconds: 0) do
       FeedRefreshWorkflow.new(feed, manual: manual).execute

--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -9,9 +9,7 @@ class FeedRefreshJob < ApplicationJob
     feed = Feed.find_by(id: feed_id)
     return unless feed
 
-    # The webhook profile has no loader; the scheduler never picks it up
-    # (spec 007), so a kick landing here is a stray manual refresh or a bug —
-    # drop it (spec 006 §7).
+    # Webhook feeds have no loader to run; drop stray kicks (spec 006 §7).
     return if feed.feed_profile_key == "webhook"
 
     Feed.with_advisory_lock!("feed_refresh_#{feed.id}", timeout_seconds: 0) do

--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -9,6 +9,11 @@ class FeedRefreshJob < ApplicationJob
     feed = Feed.find_by(id: feed_id)
     return unless feed
 
+    # Push-ingested feeds have no loader; the scheduler never picks them up
+    # (spec 007), so a kick landing here is a stray manual refresh or a bug —
+    # drop it (spec 006 §7).
+    return if feed.push_profile?
+
     Feed.with_advisory_lock!("feed_refresh_#{feed.id}", timeout_seconds: 0) do
       FeedRefreshWorkflow.new(feed, manual: manual).execute
     end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -51,7 +51,6 @@ class Feed < ApplicationRecord
   attr_accessor :source_verified
 
   after_update :create_schedule_on_enable
-  after_save :ensure_webhook_endpoint
   before_validation :compose_import_after_from_parts
 
   validates :name, uniqueness: { scope: :user_id }, length: { maximum: NAME_MAX_LENGTH }
@@ -205,10 +204,6 @@ class Feed < ApplicationRecord
 
   def scheduled?
     FeedProfile.scheduled?(feed_profile_key)
-  end
-
-  def push_profile?
-    FeedProfile.push?(feed_profile_key)
   end
 
   def can_be_enabled?
@@ -547,14 +542,5 @@ class Feed < ApplicationRecord
     return if feed_schedule.present?
 
     defer_schedule!
-  end
-
-  def ensure_webhook_endpoint
-    if push_profile?
-      create_webhook_endpoint! unless webhook_endpoint
-    elsif saved_change_to_feed_profile_key?
-      webhook_endpoint&.destroy
-      association(:webhook_endpoint).reset
-    end
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -31,6 +31,7 @@ class Feed < ApplicationRecord
   belongs_to :search_credential, optional: true
 
   has_one :feed_schedule, dependent: :destroy
+  has_one :webhook_endpoint, dependent: :destroy
 
   has_many :events, as: :subject, dependent: :destroy
   has_many :feed_entries, dependent: :destroy
@@ -50,6 +51,7 @@ class Feed < ApplicationRecord
   attr_accessor :source_verified
 
   after_update :create_schedule_on_enable
+  after_save :ensure_webhook_endpoint
   before_validation :compose_import_after_from_parts
 
   validates :name, uniqueness: { scope: :user_id }, length: { maximum: NAME_MAX_LENGTH }
@@ -203,6 +205,10 @@ class Feed < ApplicationRecord
 
   def scheduled?
     FeedProfile.scheduled?(feed_profile_key)
+  end
+
+  def push_profile?
+    FeedProfile.push?(feed_profile_key)
   end
 
   def can_be_enabled?
@@ -541,5 +547,14 @@ class Feed < ApplicationRecord
     return if feed_schedule.present?
 
     defer_schedule!
+  end
+
+  def ensure_webhook_endpoint
+    if push_profile?
+      create_webhook_endpoint! unless webhook_endpoint
+    elsif saved_change_to_feed_profile_key?
+      webhook_endpoint&.destroy
+      association(:webhook_endpoint).reset
+    end
   end
 end

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -369,6 +369,27 @@ class FeedProfile
       processor: { class: "Processor::BlueskyProcessor", config: {} },
       normalizer: { class: "Normalizer::BlueskyNormalizer", config: {} },
       title_extractor: "TitleExtractor::BlueskyTitleExtractor"
+    },
+    "webhook" => {
+      display_name: "Webhook",
+      description: "Posts sent in from your own scripts through a secret URL",
+      # Push-ingested (spec 006): content arrives via POST /hooks/:token, so
+      # there is nothing to fetch — no loader/processor and no matcher
+      # (structurally excluded from detection, like the AI profile). The
+      # normalizer is the one pipeline stage a push feed has. Scheduling is a
+      # pull-side feature, declared off via `scheduled` (spec 007); `push`
+      # marks ingest identity only (webhook endpoint minting, refresh guard).
+      input_shape: :none,
+      depends_on_ai: false,
+      scheduled: false,
+      push: true,
+      parameter_schema: {
+        "type" => "object",
+        "properties" => {},
+        "additionalProperties" => false
+      }.freeze,
+      normalizer: { class: "Normalizer::WebhookNormalizer", config: {} },
+      title_extractor: nil
     }
   }.freeze
 
@@ -413,6 +434,13 @@ class FeedProfile
       !!PROFILES.dig(key, :scheduled)
     end
 
+    # @param key [String] the profile key
+    # @return [Boolean] true if the profile is push-ingested: content arrives
+    #   through a webhook endpoint instead of being fetched by a loader
+    def push?(key)
+      !!PROFILES.dig(key, :push)
+    end
+
     # @return [Array<String>] keys of the AI-backed profiles
     def ai_profile_keys
       PROFILES.keys.select { |key| depends_on_ai?(key) }
@@ -428,10 +456,14 @@ class FeedProfile
     # The params key holding the feed's source input (e.g. "url", "prompt").
     # Derived from the profile's single required param, so the storage key is
     # independent of input_shape (which an `:any` profile can't double as).
-    # Unknown profiles fall back to "url".
+    # Unknown profiles fall back to "url". An input-less (:none) profile has
+    # no source key at all — returning nil here is what keeps source_input
+    # nil (and preview off) even if a stray key lands in the params jsonb.
     # @param key [String] the profile key
-    # @return [String] the source params key
+    # @return [String, nil] the source params key
     def source_key_for(key)
+      return nil if PROFILES.dig(key, :input_shape) == :none
+
       PROFILES.dig(key, :parameter_schema, "required")&.first || "url"
     end
 

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -373,11 +373,9 @@ class FeedProfile
     "webhook" => {
       display_name: "Webhook",
       description: "Posts sent in from your own scripts through a secret URL",
-      # Push-ingested (spec 006): content arrives via POST /hooks/:token, so
-      # there is nothing to fetch — no loader/processor and no matcher
-      # (structurally excluded from detection, like the AI profile). The
-      # normalizer is the one pipeline stage a push feed has. Scheduling is a
-      # pull-side feature, declared off via `scheduled` (spec 007).
+      # Push-ingested (spec 006): content arrives over HTTP, so there is
+      # nothing to fetch and nothing to detect — no loader/processor, no
+      # matcher, no schedule.
       input_shape: :none,
       depends_on_ai: false,
       scheduled: false,
@@ -447,9 +445,9 @@ class FeedProfile
     # The params key holding the feed's source input (e.g. "url", "prompt").
     # Derived from the profile's single required param, so the storage key is
     # independent of input_shape (which an `:any` profile can't double as).
-    # Unknown profiles fall back to "url". An input-less (:none) profile has
-    # no source key at all — returning nil here is what keeps source_input
-    # nil (and preview off) even if a stray key lands in the params jsonb.
+    # Unknown profiles fall back to "url". An input-less (:none) profile
+    # returns nil, which keeps source_input nil even if a stray key lands in
+    # the params jsonb.
     # @param key [String] the profile key
     # @return [String, nil] the source params key
     def source_key_for(key)

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -377,12 +377,10 @@ class FeedProfile
       # there is nothing to fetch — no loader/processor and no matcher
       # (structurally excluded from detection, like the AI profile). The
       # normalizer is the one pipeline stage a push feed has. Scheduling is a
-      # pull-side feature, declared off via `scheduled` (spec 007); `push`
-      # marks ingest identity only (webhook endpoint minting, refresh guard).
+      # pull-side feature, declared off via `scheduled` (spec 007).
       input_shape: :none,
       depends_on_ai: false,
       scheduled: false,
-      push: true,
       parameter_schema: {
         "type" => "object",
         "properties" => {},
@@ -432,13 +430,6 @@ class FeedProfile
     # @return [Boolean] true if the profile uses periodic scheduling
     def scheduled?(key)
       !!PROFILES.dig(key, :scheduled)
-    end
-
-    # @param key [String] the profile key
-    # @return [Boolean] true if the profile is push-ingested: content arrives
-    #   through a webhook endpoint instead of being fetched by a loader
-    def push?(key)
-      !!PROFILES.dig(key, :push)
     end
 
     # @return [Array<String>] keys of the AI-backed profiles

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -1,0 +1,27 @@
+# The ingress identity of a push feed: a secret capability-URL token
+# (spec 006 §2). Deterministic encryption keeps the token queryable through
+# the unique index and re-displayable on the feed page, while a separate
+# table keeps secret material out of feed.attributes (attached verbatim to
+# error-tracking context).
+class WebhookEndpoint < ApplicationRecord
+  TOKEN_BYTES = 32
+
+  belongs_to :feed
+
+  encrypts :encrypted_token, deterministic: true
+
+  validates :feed_id, uniqueness: true
+  validates :encrypted_token, presence: true, uniqueness: true
+
+  before_validation(on: :create) { self.encrypted_token ||= self.class.generate_token }
+
+  def self.generate_token
+    SecureRandom.urlsafe_base64(TOKEN_BYTES)
+  end
+
+  # Replaces the token in place — the remedy for a leaked URL. The old URL
+  # stops resolving the moment this commits.
+  def rotate!
+    update!(encrypted_token: self.class.generate_token)
+  end
+end

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -1,8 +1,6 @@
-# The ingress identity of a push feed: a secret capability-URL token
-# (spec 006 §2). Deterministic encryption keeps the token queryable through
-# the unique index and re-displayable on the feed page, while a separate
-# table keeps secret material out of feed.attributes (attached verbatim to
-# error-tracking context).
+# Secret capability-URL token of a webhook feed (spec 006 §2). Deterministic
+# encryption keeps the token queryable and re-displayable; a separate table
+# keeps it out of feed.attributes, which error reporting attaches verbatim.
 class WebhookEndpoint < ApplicationRecord
   TOKEN_BYTES = 32
 
@@ -19,8 +17,7 @@ class WebhookEndpoint < ApplicationRecord
     SecureRandom.urlsafe_base64(TOKEN_BYTES)
   end
 
-  # Replaces the token in place — the remedy for a leaked URL. The old URL
-  # stops resolving the moment this commits.
+  # The remedy for a leaked URL: the old one stops resolving immediately.
   def rotate!
     update!(encrypted_token: self.class.generate_token)
   end

--- a/app/services/normalizer/webhook_normalizer.rb
+++ b/app/services/normalizer/webhook_normalizer.rb
@@ -1,0 +1,38 @@
+module Normalizer
+  # Normalizer for push-ingested (webhook) feeds. The stored payload is the
+  # validated webhook request body (spec 006 §3), so this maps its fields
+  # straight onto Post, inheriting the Base choke-point guarantees: attachment
+  # SSRF filtering, comment clamping, images_only, and the
+  # no-content-no-images rule.
+  class WebhookNormalizer < Base
+    private
+
+    def normalize_source_url
+      raw_data["source_url"].presence
+    end
+
+    # House "link + commentary" shape: the source link folds into the body the
+    # same way pull feeds compose it.
+    def normalize_content
+      post_content_with_url(raw_data["content"].to_s, normalize_source_url)
+    end
+
+    def normalize_attachment_urls
+      Array(raw_data["images"]).map(&:to_s)
+    end
+
+    def normalize_comments
+      Array(raw_data["comments"]).map(&:to_s)
+    end
+
+    # Spec 006 §3: content is required unless images is non-empty. Base's
+    # default gate reads the composed content, where a bare source_url would
+    # masquerade as content — check the raw payload field instead.
+    def validate_content
+      errors = []
+      errors << "no_content_or_images" if raw_data["content"].to_s.blank? && attachment_urls.empty?
+      errors.concat(images_only_errors)
+      errors
+    end
+  end
+end

--- a/app/services/normalizer/webhook_normalizer.rb
+++ b/app/services/normalizer/webhook_normalizer.rb
@@ -1,9 +1,7 @@
 module Normalizer
-  # Normalizer for push-ingested (webhook) feeds. The stored payload is the
-  # validated webhook request body (spec 006 §3), so this maps its fields
-  # straight onto Post, inheriting the Base choke-point guarantees: attachment
-  # SSRF filtering, comment clamping, images_only, and the
-  # no-content-no-images rule.
+  # Maps a stored webhook payload (spec 006 §3) onto a Post through the Base
+  # choke-point guarantees: attachment SSRF filtering, comment clamping, and
+  # the content rules.
   class WebhookNormalizer < Base
     private
 
@@ -11,8 +9,7 @@ module Normalizer
       raw_data["source_url"].presence
     end
 
-    # House "link + commentary" shape: the source link folds into the body the
-    # same way pull feeds compose it.
+    # Folds the source link into the body, same shape as pull feeds.
     def normalize_content
       post_content_with_url(raw_data["content"].to_s, normalize_source_url)
     end
@@ -25,9 +22,9 @@ module Normalizer
       Array(raw_data["comments"]).map(&:to_s)
     end
 
-    # Spec 006 §3: content is required unless images is non-empty. Base's
-    # default gate reads the composed content, where a bare source_url would
-    # masquerade as content — check the raw payload field instead.
+    # Content is required unless images are present (spec 006 §3). Checked on
+    # the raw payload field: in the composed content a bare source_url would
+    # masquerade as content.
     def validate_content
       errors = []
       errors << "no_content_or_images" if raw_data["content"].to_s.blank? && attachment_urls.empty?

--- a/db/migrate/20260714120000_create_webhook_endpoints.rb
+++ b/db/migrate/20260714120000_create_webhook_endpoints.rb
@@ -1,0 +1,13 @@
+class CreateWebhookEndpoints < ActiveRecord::Migration[8.2]
+  def change
+    create_table :webhook_endpoints, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.references :feed, null: false, type: :uuid, foreign_key: true, index: { unique: true }
+      t.text :encrypted_token, null: false
+      t.datetime :last_received_at
+      t.integer :received_count, default: 0, null: false
+      t.timestamps
+
+      t.index :encrypted_token, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_14_010000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_14_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -457,6 +457,17 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_14_010000) do
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email", where: "(unconfirmed_email IS NOT NULL)"
   end
 
+  create_table "webhook_endpoints", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.uuid "feed_id", null: false
+    t.text "encrypted_token", null: false
+    t.datetime "last_received_at"
+    t.integer "received_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["encrypted_token"], name: "index_webhook_endpoints_on_encrypted_token", unique: true
+    t.index ["feed_id"], name: "index_webhook_endpoints_on_feed_id", unique: true
+  end
+
   add_foreign_key "access_token_details", "access_tokens"
   add_foreign_key "access_tokens", "users"
   add_foreign_key "ai_credentials", "users"
@@ -490,4 +501,5 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_14_010000) do
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "users", "ai_credentials", column: "default_ai_credential_id", on_delete: :nullify
   add_foreign_key "users", "search_credentials", column: "default_search_credential_id", on_delete: :nullify
+  add_foreign_key "webhook_endpoints", "feeds"
 end

--- a/specs/001-smart-feed-creation/contracts/profile_registry.md
+++ b/specs/001-smart-feed-creation/contracts/profile_registry.md
@@ -11,13 +11,14 @@ Each entry in `FeedProfile::PROFILES` is a `Hash` matching the schema below. Sch
 {
   display_name:        String,           # required, ≤ 80 chars, shown in candidate chooser
   description:         String,           # required, ≤ 200 chars, shown in candidate chooser tooltip
-  input_shape:         Symbol,           # required, one of :url, :handle, :query, :any
+  input_shape:         Symbol,           # required, one of :url, :handle, :query, :any, :none
   depends_on_ai:       Boolean,          # required; true if any stage's class uses LlmClient
   scheduled:           Boolean,          # required; true when feeds use cron-backed periodic refresh
-  matcher:             String,           # required, fully-qualified class name (must subclass ProfileMatcher::Base)
+  push:                true?,            # present only on push-ingested profiles (content arrives via webhook, spec 006)
+  matcher:             String,           # required for pull non-AI profiles; AI and push profiles must omit it
   parameter_schema:    Hash,             # required, JSON Schema Draft 2020-12 describing the feed's `params` JSONB
-  loader:              StageEntry,       # required (see below)
-  processor:           StageEntry,       # required
+  loader:              StageEntry,       # required for pull profiles; push profiles must omit it
+  processor:           StageEntry,       # required for pull profiles; push profiles must omit it
   normalizer:          StageEntry,       # required
   title_extractor:     String?           # optional, fully-qualified class name (TitleExtractor::Base subclass) — used during detection to pre-fill the feed name
   output_schema:       Hash?             # required IFF any stage uses LlmClient; JSON Schema for the structured LLM response
@@ -52,6 +53,7 @@ For LLM-using stages, `StageEntry.config` carries the LLM-specific bits:
 4. `parameter_schema` MUST validate the `params` JSON the feed will store. Required fields surface as required form fields.
 5. `output_schema` MUST include the universal post fields (`title`, `body`, `supplementary?`, `images[]`, `source_url`, `published_at`, `uid`) — see [`../notes/profile-contracts.md`](../notes/profile-contracts.md).
 6. `scheduled` MUST be explicit. When false, the feed does not require a cron expression and must not acquire a `FeedSchedule` through enablement or scheduler recovery.
+7. A push-ingested profile (`push: true`, spec 006) has nothing to fetch: it MUST omit `matcher`, `loader`, and `processor`, and marks ingest identity only — scheduling stays governed by `scheduled` (spec 007).
 
 ## Adding a new profile
 

--- a/specs/001-smart-feed-creation/contracts/profile_registry.md
+++ b/specs/001-smart-feed-creation/contracts/profile_registry.md
@@ -53,7 +53,7 @@ For LLM-using stages, `StageEntry.config` carries the LLM-specific bits:
 4. `parameter_schema` MUST validate the `params` JSON the feed will store. Required fields surface as required form fields.
 5. `output_schema` MUST include the universal post fields (`title`, `body`, `supplementary?`, `images[]`, `source_url`, `published_at`, `uid`) — see [`../notes/profile-contracts.md`](../notes/profile-contracts.md).
 6. `scheduled` MUST be explicit. When false, the feed does not require a cron expression and must not acquire a `FeedSchedule` through enablement or scheduler recovery.
-7. A push-ingested profile (`push: true`, spec 006) has nothing to fetch: it MUST omit `matcher`, `loader`, and `processor`, and marks ingest identity only — scheduling stays governed by `scheduled` (spec 007).
+7. The push-ingested `webhook` profile (spec 006) has nothing to fetch: it MUST omit `matcher`, `loader`, and `processor`. Webhook-specific behavior keys on the profile name explicitly — scheduling stays governed by `scheduled` (spec 007).
 
 ## Adding a new profile
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -238,6 +238,49 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "#create should mint a webhook endpoint for a webhook feed" do
+    sign_in_as(user)
+
+    assert_difference("WebhookEndpoint.count", 1) do
+      post feeds_path, params: { feed: { feed_profile_key: "webhook" }, enable_feed: "0" }
+    end
+
+    feed = Feed.last
+    assert_predicate feed, :draft?
+    assert_not_nil feed.webhook_endpoint
+  end
+
+  test "#create should not mint a webhook endpoint for a pull feed" do
+    sign_in_as(user)
+    access_token
+
+    feed_params = {
+      params: { url: "http://example.com/feed.xml" },
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_no_difference("WebhookEndpoint.count") do
+      post feeds_path, params: { feed: feed_params, enable_feed: "0" }
+    end
+  end
+
+  test "#update should destroy the endpoint when a draft moves off the webhook profile" do
+    sign_in_as(user)
+    webhook_feed = create(:feed, :webhook, :draft, user: user)
+    endpoint = create(:webhook_endpoint, feed: webhook_feed)
+
+    patch feed_path(webhook_feed), params: {
+      feed: { feed_profile_key: "rss", params: { url: "https://example.com/feed.xml" } },
+      enable_feed: "0"
+    }
+
+    assert_nil webhook_feed.reload.webhook_endpoint
+    assert_nil WebhookEndpoint.find_by(id: endpoint.id)
+  end
+
   test "#create should enable a feed even when the only preview is for a different source" do
     sign_in_as(user)
     access_token

--- a/test/factories/feeds.rb
+++ b/test/factories/feeds.rb
@@ -39,6 +39,12 @@ FactoryBot.define do
       state { :enabled }
     end
 
+    trait :webhook do
+      feed_profile_key { "webhook" }
+      params { {} }
+      cron_expression { nil }
+    end
+
     trait :without_access_token do
       access_token { nil }
       target_group { nil }

--- a/test/factories/webhook_endpoints.rb
+++ b/test/factories/webhook_endpoints.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :webhook_endpoint do
+    association :feed
+  end
+end

--- a/test/jobs/feed_refresh_job_test.rb
+++ b/test/jobs/feed_refresh_job_test.rb
@@ -11,6 +11,16 @@ class FeedRefreshJobTest < ActiveJob::TestCase
     end
   end
 
+  test "#perform should no-op for a webhook feed instead of resolving its missing loader" do
+    push_feed = create(:feed, :webhook, state: :enabled)
+
+    assert_no_difference("Event.count") do
+      assert_nothing_raised do
+        FeedRefreshJob.perform_now(push_feed.id)
+      end
+    end
+  end
+
   test "handles unknown loader gracefully" do
     bad_feed = create(:feed, feed_profile_key: "rss")
 

--- a/test/jobs/feed_refresh_job_test.rb
+++ b/test/jobs/feed_refresh_job_test.rb
@@ -12,11 +12,11 @@ class FeedRefreshJobTest < ActiveJob::TestCase
   end
 
   test "#perform should no-op for a webhook feed instead of resolving its missing loader" do
-    push_feed = create(:feed, :webhook, state: :enabled)
+    webhook_feed = create(:feed, :webhook, state: :enabled)
 
     assert_no_difference("Event.count") do
       assert_nothing_raised do
-        FeedRefreshJob.perform_now(push_feed.id)
+        FeedRefreshJob.perform_now(webhook_feed.id)
       end
     end
   end

--- a/test/jobs/feed_scheduler_job_test.rb
+++ b/test/jobs/feed_scheduler_job_test.rb
@@ -94,4 +94,14 @@ class FeedSchedulerJobTest < ActiveJob::TestCase
       assert_nil schedule.last_run_at
     end
   end
+
+  test ".perform_now should not adopt schedule-less webhook feeds" do
+    feed = create(:feed, :webhook, state: :enabled)
+
+    assert_no_enqueued_jobs(only: FeedRefreshJob) do
+      FeedSchedulerJob.perform_now
+    end
+
+    assert_nil feed.reload.feed_schedule
+  end
 end

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -23,11 +23,42 @@ class FeedProfileTest < ActiveSupport::TestCase
       "theycantalk",
       "tomorrows",
       "twitter",
+      "webhook",
       "xkcd",
       "youtube"
     ]
 
     assert_equal expected, FeedProfile.all.sort
+  end
+
+  test ".push? should return true only for push-ingested profiles" do
+    assert FeedProfile.push?("webhook")
+    assert_not FeedProfile.push?("rss")
+    assert_not FeedProfile.push?("llm")
+    assert_not FeedProfile.push?(nil)
+  end
+
+  test "webhook profile resolves only its normalizer stage" do
+    assert_equal "Normalizer::WebhookNormalizer", FeedProfile.normalizer_class_for("webhook").name
+    assert_raises(ArgumentError) { FeedProfile.loader_class_for("webhook") }
+    assert_raises(ArgumentError) { FeedProfile.processor_class_for("webhook") }
+  end
+
+  test "webhook profile accepts only empty params" do
+    schema = FeedProfile.parameter_schema_for("webhook")
+
+    assert JSONSchemer.schema(schema).valid?({})
+    assert_not JSONSchemer.schema(schema).valid?({ "url" => "https://example.com" })
+  end
+
+  test ".source_key_for should return nil for an input-less profile" do
+    assert_nil FeedProfile.source_key_for("webhook")
+    assert_equal "url", FeedProfile.source_key_for("rss")
+    assert_equal "prompt", FeedProfile.source_key_for("llm")
+  end
+
+  test ".source_input_for should ignore a smuggled url key on an input-less profile" do
+    assert_nil FeedProfile.source_input_for("webhook", { "url" => "https://example.com" })
   end
 
   test ".exists? returns true for valid profile key" do
@@ -58,24 +89,31 @@ class FeedProfileTest < ActiveSupport::TestCase
     FeedProfile::PROFILES.each do |key, entry|
       assert_kind_of String, entry[:display_name], "#{key}: display_name"
       assert_kind_of String, entry[:description], "#{key}: description"
-      assert_includes %i[url query any], entry[:input_shape], "#{key}: input_shape"
+      assert_includes %i[url query any none], entry[:input_shape], "#{key}: input_shape"
       assert_includes [true, false], entry[:depends_on_ai], "#{key}: depends_on_ai"
       assert_includes [true, false], entry[:scheduled], "#{key}: scheduled"
-      if entry[:depends_on_ai]
-        # The AI profile is structurally excluded from detection (spec §7): no matcher.
-        assert_nil entry[:matcher], "#{key}: AI profile must not register a matcher"
+      if entry[:depends_on_ai] || entry[:push]
+        # AI and push profiles are structurally excluded from detection
+        # (spec 005 §7, spec 006 §1): no matcher.
+        assert_nil entry[:matcher], "#{key}: AI/push profile must not register a matcher"
       else
         assert_kind_of String, entry[:matcher], "#{key}: matcher"
       end
       assert_kind_of Hash, entry[:parameter_schema], "#{key}: parameter_schema"
 
-      assert_kind_of Hash, entry[:loader], "#{key}: loader entry must be a hash"
-      assert_kind_of String, entry[:loader][:class], "#{key}: loader.class"
-      assert_kind_of Hash, entry[:loader][:config], "#{key}: loader.config"
+      if entry[:push]
+        # Push profiles have nothing to fetch (spec 006 §1): no loader/processor.
+        assert_nil entry[:loader], "#{key}: push profile must not register a loader"
+        assert_nil entry[:processor], "#{key}: push profile must not register a processor"
+      else
+        assert_kind_of Hash, entry[:loader], "#{key}: loader entry must be a hash"
+        assert_kind_of String, entry[:loader][:class], "#{key}: loader.class"
+        assert_kind_of Hash, entry[:loader][:config], "#{key}: loader.config"
 
-      assert_kind_of Hash, entry[:processor], "#{key}: processor entry must be a hash"
-      assert_kind_of String, entry[:processor][:class], "#{key}: processor.class"
-      assert_kind_of Hash, entry[:processor][:config], "#{key}: processor.config"
+        assert_kind_of Hash, entry[:processor], "#{key}: processor entry must be a hash"
+        assert_kind_of String, entry[:processor][:class], "#{key}: processor.class"
+        assert_kind_of Hash, entry[:processor][:config], "#{key}: processor.config"
+      end
 
       assert_kind_of Hash, entry[:normalizer], "#{key}: normalizer entry must be a hash"
       assert_kind_of String, entry[:normalizer][:class], "#{key}: normalizer.class"
@@ -98,16 +136,20 @@ class FeedProfileTest < ActiveSupport::TestCase
     end
   end
 
-  test "all PROFILES have resolvable loader classes" do
+  test "all pull PROFILES have resolvable loader classes" do
     FeedProfile::PROFILES.each_key do |key|
+      next if FeedProfile.push?(key)
+
       loader_class = FeedProfile.loader_class_for(key)
       assert loader_class.present?, "Profile '#{key}' should have a resolvable loader class"
       assert loader_class < Loader::Base, "Profile '#{key}' loader should inherit from Loader::Base"
     end
   end
 
-  test "all PROFILES have resolvable processor classes" do
+  test "all pull PROFILES have resolvable processor classes" do
     FeedProfile::PROFILES.each_key do |key|
+      next if FeedProfile.push?(key)
+
       processor_class = FeedProfile.processor_class_for(key)
       assert processor_class.present?, "Profile '#{key}' should have a resolvable processor class"
       assert processor_class < Processor::Base, "Profile '#{key}' processor should inherit from Processor::Base"
@@ -122,11 +164,12 @@ class FeedProfileTest < ActiveSupport::TestCase
     end
   end
 
-  test "all non-AI PROFILES have resolvable title extractor classes" do
-    # AI-backed profiles emit the universal post shape directly, so they
-    # skip the title-extractor stage.
+  test "all non-AI pull PROFILES have resolvable title extractor classes" do
+    # AI-backed profiles emit the universal post shape directly, and push
+    # profiles never go through identification, so both skip the
+    # title-extractor stage.
     FeedProfile::PROFILES.each do |key, entry|
-      next if entry[:depends_on_ai]
+      next if entry[:depends_on_ai] || entry[:push]
 
       title_extractor_class = FeedProfile.title_extractor_class_for(key)
       assert title_extractor_class.present?, "Profile '#{key}' should have a resolvable title extractor class"

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -31,13 +31,6 @@ class FeedProfileTest < ActiveSupport::TestCase
     assert_equal expected, FeedProfile.all.sort
   end
 
-  test ".push? should return true only for push-ingested profiles" do
-    assert FeedProfile.push?("webhook")
-    assert_not FeedProfile.push?("rss")
-    assert_not FeedProfile.push?("llm")
-    assert_not FeedProfile.push?(nil)
-  end
-
   test "webhook profile resolves only its normalizer stage" do
     assert_equal "Normalizer::WebhookNormalizer", FeedProfile.normalizer_class_for("webhook").name
     assert_raises(ArgumentError) { FeedProfile.loader_class_for("webhook") }
@@ -92,19 +85,19 @@ class FeedProfileTest < ActiveSupport::TestCase
       assert_includes %i[url query any none], entry[:input_shape], "#{key}: input_shape"
       assert_includes [true, false], entry[:depends_on_ai], "#{key}: depends_on_ai"
       assert_includes [true, false], entry[:scheduled], "#{key}: scheduled"
-      if entry[:depends_on_ai] || entry[:push]
-        # AI and push profiles are structurally excluded from detection
+      if entry[:depends_on_ai] || key == "webhook"
+        # AI and webhook profiles are structurally excluded from detection
         # (spec 005 §7, spec 006 §1): no matcher.
-        assert_nil entry[:matcher], "#{key}: AI/push profile must not register a matcher"
+        assert_nil entry[:matcher], "#{key}: AI/webhook profile must not register a matcher"
       else
         assert_kind_of String, entry[:matcher], "#{key}: matcher"
       end
       assert_kind_of Hash, entry[:parameter_schema], "#{key}: parameter_schema"
 
-      if entry[:push]
-        # Push profiles have nothing to fetch (spec 006 §1): no loader/processor.
-        assert_nil entry[:loader], "#{key}: push profile must not register a loader"
-        assert_nil entry[:processor], "#{key}: push profile must not register a processor"
+      if key == "webhook"
+        # The webhook profile has nothing to fetch (spec 006 §1): no loader/processor.
+        assert_nil entry[:loader], "#{key}: webhook profile must not register a loader"
+        assert_nil entry[:processor], "#{key}: webhook profile must not register a processor"
       else
         assert_kind_of Hash, entry[:loader], "#{key}: loader entry must be a hash"
         assert_kind_of String, entry[:loader][:class], "#{key}: loader.class"
@@ -138,7 +131,7 @@ class FeedProfileTest < ActiveSupport::TestCase
 
   test "all pull PROFILES have resolvable loader classes" do
     FeedProfile::PROFILES.each_key do |key|
-      next if FeedProfile.push?(key)
+      next if key == "webhook"
 
       loader_class = FeedProfile.loader_class_for(key)
       assert loader_class.present?, "Profile '#{key}' should have a resolvable loader class"
@@ -148,7 +141,7 @@ class FeedProfileTest < ActiveSupport::TestCase
 
   test "all pull PROFILES have resolvable processor classes" do
     FeedProfile::PROFILES.each_key do |key|
-      next if FeedProfile.push?(key)
+      next if key == "webhook"
 
       processor_class = FeedProfile.processor_class_for(key)
       assert processor_class.present?, "Profile '#{key}' should have a resolvable processor class"
@@ -165,11 +158,11 @@ class FeedProfileTest < ActiveSupport::TestCase
   end
 
   test "all non-AI pull PROFILES have resolvable title extractor classes" do
-    # AI-backed profiles emit the universal post shape directly, and push
-    # profiles never go through identification, so both skip the
+    # AI-backed profiles emit the universal post shape directly, and the
+    # webhook profile never goes through identification, so both skip the
     # title-extractor stage.
     FeedProfile::PROFILES.each do |key, entry|
-      next if entry[:depends_on_ai] || entry[:push]
+      next if entry[:depends_on_ai] || key == "webhook"
 
       title_extractor_class = FeedProfile.title_extractor_class_for(key)
       assert title_extractor_class.present?, "Profile '#{key}' should have a resolvable title extractor class"

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -277,6 +277,73 @@ class FeedTest < ActiveSupport::TestCase
     end
   end
 
+  test "#due should exclude schedule-less webhook feeds" do
+    feed = create(:feed, :webhook, state: :enabled)
+
+    assert_nil feed.feed_schedule
+    assert_not_includes Feed.due, feed
+  end
+
+  test "#push_profile? should be true only for push profiles" do
+    assert build(:feed, :webhook).push_profile?
+    assert_not build(:feed).push_profile?
+  end
+
+  test "#can_be_enabled? should not require a schedule for a webhook feed" do
+    feed = create(:feed, :webhook)
+
+    assert_nil feed.cron_expression
+    assert feed.can_be_enabled?
+  end
+
+  test "should enable a webhook feed without cron and create no schedule" do
+    feed = create(:feed, :webhook, state: :disabled)
+
+    assert feed.enable
+    assert feed.reload.enabled?
+    assert_nil feed.feed_schedule
+  end
+
+  test "should mint a webhook endpoint when a webhook feed is created as a draft" do
+    feed = create(:feed, :webhook, :draft)
+
+    assert_not_nil feed.webhook_endpoint
+    assert feed.webhook_endpoint.persisted?
+  end
+
+  test "should not mint a webhook endpoint for a pull feed" do
+    feed = create(:feed)
+
+    assert_nil feed.webhook_endpoint
+  end
+
+  test "should destroy the webhook endpoint when the feed is destroyed" do
+    feed = create(:feed, :webhook)
+
+    assert_difference("WebhookEndpoint.count", -1) do
+      feed.destroy!
+    end
+  end
+
+  test "should destroy the webhook endpoint when a draft switches off the webhook profile" do
+    feed = create(:feed, :webhook, :draft)
+    old_token = feed.webhook_endpoint.encrypted_token
+
+    feed.update!(feed_profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
+
+    assert_nil feed.webhook_endpoint
+    assert_nil WebhookEndpoint.find_by(encrypted_token: old_token)
+  end
+
+  test "should mint a fresh endpoint when a draft switches back onto the webhook profile" do
+    feed = create(:feed, :webhook, :draft)
+    feed.update!(feed_profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
+
+    feed.update!(feed_profile_key: "webhook", params: {})
+
+    assert_not_nil feed.webhook_endpoint
+  end
+
   test "should require user" do
     feed = build(:feed, user: nil)
     assert_not feed.valid?

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -284,11 +284,6 @@ class FeedTest < ActiveSupport::TestCase
     assert_not_includes Feed.due, feed
   end
 
-  test "#push_profile? should be true only for push profiles" do
-    assert build(:feed, :webhook).push_profile?
-    assert_not build(:feed).push_profile?
-  end
-
   test "#can_be_enabled? should not require a schedule for a webhook feed" do
     feed = create(:feed, :webhook)
 
@@ -304,44 +299,13 @@ class FeedTest < ActiveSupport::TestCase
     assert_nil feed.feed_schedule
   end
 
-  test "should mint a webhook endpoint when a webhook feed is created as a draft" do
-    feed = create(:feed, :webhook, :draft)
-
-    assert_not_nil feed.webhook_endpoint
-    assert feed.webhook_endpoint.persisted?
-  end
-
-  test "should not mint a webhook endpoint for a pull feed" do
-    feed = create(:feed)
-
-    assert_nil feed.webhook_endpoint
-  end
-
   test "should destroy the webhook endpoint when the feed is destroyed" do
     feed = create(:feed, :webhook)
+    create(:webhook_endpoint, feed: feed)
 
     assert_difference("WebhookEndpoint.count", -1) do
       feed.destroy!
     end
-  end
-
-  test "should destroy the webhook endpoint when a draft switches off the webhook profile" do
-    feed = create(:feed, :webhook, :draft)
-    old_token = feed.webhook_endpoint.encrypted_token
-
-    feed.update!(feed_profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
-
-    assert_nil feed.webhook_endpoint
-    assert_nil WebhookEndpoint.find_by(encrypted_token: old_token)
-  end
-
-  test "should mint a fresh endpoint when a draft switches back onto the webhook profile" do
-    feed = create(:feed, :webhook, :draft)
-    feed.update!(feed_profile_key: "rss", params: { "url" => "https://example.com/feed.xml" })
-
-    feed.update!(feed_profile_key: "webhook", params: {})
-
-    assert_not_nil feed.webhook_endpoint
   end
 
   test "should require user" do

--- a/test/models/webhook_endpoint_test.rb
+++ b/test/models/webhook_endpoint_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class WebhookEndpointTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed)
+  end
+
+  test "should generate a token on create" do
+    endpoint = create(:webhook_endpoint, feed: feed)
+
+    assert_operator endpoint.encrypted_token.length, :>=, 43
+  end
+
+  test "should keep an explicitly assigned token" do
+    endpoint = create(:webhook_endpoint, feed: feed, encrypted_token: "explicit-token")
+
+    assert_equal "explicit-token", endpoint.encrypted_token
+  end
+
+  test "should require a unique token" do
+    create(:webhook_endpoint, feed: feed, encrypted_token: "taken")
+    duplicate = build(:webhook_endpoint, feed: create(:feed), encrypted_token: "taken")
+
+    assert_not duplicate.valid?
+    assert duplicate.errors.of_kind?(:encrypted_token, :taken)
+  end
+
+  test "should allow only one endpoint per feed" do
+    create(:webhook_endpoint, feed: feed)
+    duplicate = build(:webhook_endpoint, feed: feed)
+
+    assert_not duplicate.valid?
+    assert duplicate.errors.of_kind?(:feed_id, :taken)
+  end
+
+  test "should be findable by token through deterministic encryption" do
+    endpoint = create(:webhook_endpoint, feed: feed)
+
+    assert_equal endpoint, WebhookEndpoint.find_by(encrypted_token: endpoint.encrypted_token)
+  end
+
+  test "#rotate! should replace the token so the old one stops resolving" do
+    endpoint = create(:webhook_endpoint, feed: feed)
+    old_token = endpoint.encrypted_token
+
+    endpoint.rotate!
+
+    assert_not_equal old_token, endpoint.reload.encrypted_token
+    assert_nil WebhookEndpoint.find_by(encrypted_token: old_token)
+  end
+
+  test "should default received_count to zero" do
+    endpoint = create(:webhook_endpoint, feed: feed)
+
+    assert_equal 0, endpoint.received_count
+    assert_nil endpoint.last_received_at
+  end
+end

--- a/test/services/normalizer/webhook_normalizer_test.rb
+++ b/test/services/normalizer/webhook_normalizer_test.rb
@@ -1,0 +1,111 @@
+require "test_helper"
+
+class Normalizer::WebhookNormalizerTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, :webhook)
+  end
+
+  def feed_entry(overrides = {})
+    raw = {
+      "content" => "Look at this",
+      "source_url" => "https://example.com/article",
+      "images" => ["https://example.com/pic.jpg"],
+      "comments" => ["First comment"],
+      "uid" => "article-42"
+    }.merge(overrides)
+    FeedEntry.new(
+      feed: feed,
+      uid: raw["uid"],
+      published_at: Time.utc(2026, 7, 11, 12, 0),
+      raw_data: raw,
+      status: :pending
+    )
+  end
+
+  test "#normalize should map the payload onto a Post" do
+    post = Normalizer::WebhookNormalizer.new(feed_entry).normalize
+
+    assert_equal "Look at this - https://example.com/article", post.content
+    assert_equal "https://example.com/article", post.source_url
+    assert_equal ["https://example.com/pic.jpg"], post.attachment_urls
+    assert_equal ["First comment"], post.comments
+    assert_equal "article-42", post.uid
+    assert_equal Time.utc(2026, 7, 11, 12, 0), post.published_at
+    assert_equal "enqueued", post.status
+  end
+
+  test "#normalize should keep content bare without a source_url" do
+    post = Normalizer::WebhookNormalizer.new(feed_entry("source_url" => nil)).normalize
+
+    assert_equal "Look at this", post.content
+    assert_nil post.source_url
+    assert_equal "enqueued", post.status
+  end
+
+  test "#normalize should treat a blank source_url as absent" do
+    post = Normalizer::WebhookNormalizer.new(feed_entry("source_url" => "")).normalize
+
+    assert_nil post.source_url
+    assert_equal "enqueued", post.status
+  end
+
+  test "#normalize should accept images without content" do
+    post = Normalizer::WebhookNormalizer.new(
+      feed_entry("content" => nil, "source_url" => nil)
+    ).normalize
+
+    assert_equal "", post.content
+    assert_equal "enqueued", post.status
+  end
+
+  test "#normalize should reject a payload with no content and no images" do
+    post = Normalizer::WebhookNormalizer.new(
+      feed_entry("content" => nil, "source_url" => nil, "images" => [])
+    ).normalize
+
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "no_content_or_images"
+  end
+
+  test "#normalize should reject a URL-only payload despite the link folding into the body" do
+    post = Normalizer::WebhookNormalizer.new(
+      feed_entry("content" => nil, "images" => [])
+    ).normalize
+
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "no_content_or_images"
+  end
+
+  test "#normalize should drop non-public image URLs at the choke point" do
+    post = Normalizer::WebhookNormalizer.new(
+      feed_entry("images" => ["https://example.com/ok.png", "http://127.0.0.1/secret.png", "/etc/passwd"])
+    ).normalize
+
+    assert_equal ["https://example.com/ok.png"], post.attachment_urls
+  end
+
+  test "#normalize should clamp over-long comments" do
+    post = Normalizer::WebhookNormalizer.new(
+      feed_entry("comments" => ["a" * (Post::MAX_COMMENT_LENGTH + 100)])
+    ).normalize
+
+    assert_equal Post::MAX_COMMENT_LENGTH, post.comments.first.length
+  end
+
+  test "#normalize should truncate content folded with the source link to the FreeFeed limit" do
+    post = Normalizer::WebhookNormalizer.new(
+      feed_entry("content" => "a" * (Post::MAX_CONTENT_LENGTH + 100))
+    ).normalize
+
+    assert_operator post.content.length, :<=, Post::MAX_CONTENT_LENGTH
+    assert post.content.end_with?("https://example.com/article")
+  end
+
+  test "#normalize should reject an image-less payload on an images-only feed" do
+    feed.update!(images_only: true)
+    post = Normalizer::WebhookNormalizer.new(feed_entry("images" => [])).normalize
+
+    assert_equal "rejected", post.status
+    assert_includes post.validation_errors, "no_images"
+  end
+end

--- a/test/support/feed_profile_validator.rb
+++ b/test/support/feed_profile_validator.rb
@@ -15,16 +15,15 @@ module FeedProfileValidator
       depends_on_ai
       scheduled
       parameter_schema
-      loader
-      processor
       normalizer
     ],
     "properties" => {
       "display_name" => { "type" => "string", "minLength" => 1, "maxLength" => 80 },
       "description" => { "type" => "string", "minLength" => 1, "maxLength" => 200 },
-      "input_shape" => { "type" => "string", "enum" => %w[url query any] },
+      "input_shape" => { "type" => "string", "enum" => %w[url query any none] },
       "depends_on_ai" => { "type" => "boolean" },
       "scheduled" => { "type" => "boolean" },
+      "push" => { "const" => true },
       "matcher" => { "type" => "string", "minLength" => 1 },
       "parameter_schema" => { "type" => "object" },
       "loader" => { "$ref" => "#/$defs/stage_entry" },
@@ -32,6 +31,12 @@ module FeedProfileValidator
       "normalizer" => { "$ref" => "#/$defs/stage_entry" },
       "title_extractor" => { "type" => %w[string null] }
     },
+    # A push profile has nothing to fetch: no loader/processor (spec 006 §1).
+    # Pull profiles (the default) must declare both. A `false` property schema
+    # rejects the property's presence outright.
+    "if" => { "required" => %w[push] },
+    "then" => { "properties" => { "loader" => false, "processor" => false } },
+    "else" => { "required" => %w[loader processor] },
     "$defs" => {
       "stage_entry" => {
         "type" => "object",
@@ -60,10 +65,15 @@ module FeedProfileValidator
         failures << "FeedProfile #{key.inspect}: loader.config.output_schema is required when depends_on_ai is true"
       end
 
-      # The AI profile registers no matcher (structural detection exclusion,
-      # spec §7); every deterministic profile must declare one.
-      if !entry[:depends_on_ai] && entry[:matcher].to_s.empty?
+      # AI and push profiles register no matcher (structural detection
+      # exclusion, spec 005 §7 / spec 006 §1); every other profile must
+      # declare one.
+      if !entry[:depends_on_ai] && !entry[:push] && entry[:matcher].to_s.empty?
         failures << "FeedProfile #{key.inspect}: matcher is required for non-AI profiles"
+      end
+
+      if entry[:push] && !entry[:matcher].to_s.empty?
+        failures << "FeedProfile #{key.inspect}: push profiles must not register a matcher"
       end
     end
 

--- a/test/support/feed_profile_validator.rb
+++ b/test/support/feed_profile_validator.rb
@@ -23,7 +23,6 @@ module FeedProfileValidator
       "input_shape" => { "type" => "string", "enum" => %w[url query any none] },
       "depends_on_ai" => { "type" => "boolean" },
       "scheduled" => { "type" => "boolean" },
-      "push" => { "const" => true },
       "matcher" => { "type" => "string", "minLength" => 1 },
       "parameter_schema" => { "type" => "object" },
       "loader" => { "$ref" => "#/$defs/stage_entry" },
@@ -31,12 +30,6 @@ module FeedProfileValidator
       "normalizer" => { "$ref" => "#/$defs/stage_entry" },
       "title_extractor" => { "type" => %w[string null] }
     },
-    # A push profile has nothing to fetch: no loader/processor (spec 006 §1).
-    # Pull profiles (the default) must declare both. A `false` property schema
-    # rejects the property's presence outright.
-    "if" => { "required" => %w[push] },
-    "then" => { "properties" => { "loader" => false, "processor" => false } },
-    "else" => { "required" => %w[loader processor] },
     "$defs" => {
       "stage_entry" => {
         "type" => "object",
@@ -65,15 +58,20 @@ module FeedProfileValidator
         failures << "FeedProfile #{key.inspect}: loader.config.output_schema is required when depends_on_ai is true"
       end
 
-      # AI and push profiles register no matcher (structural detection
-      # exclusion, spec 005 §7 / spec 006 §1); every other profile must
-      # declare one.
-      if !entry[:depends_on_ai] && !entry[:push] && entry[:matcher].to_s.empty?
-        failures << "FeedProfile #{key.inspect}: matcher is required for non-AI profiles"
-      end
-
-      if entry[:push] && !entry[:matcher].to_s.empty?
-        failures << "FeedProfile #{key.inspect}: push profiles must not register a matcher"
+      # The webhook profile is push-ingested (spec 006 §1): nothing to fetch,
+      # so it alone omits matcher, loader, and processor. Every other profile
+      # must declare a loader/processor, and a matcher unless it's AI-backed
+      # (structural detection exclusion, spec 005 §7).
+      if key == "webhook"
+        %i[matcher loader processor].each do |stage|
+          failures << "FeedProfile #{key.inspect}: #{stage} must be absent for the webhook profile" if entry[stage]
+        end
+      else
+        failures << "FeedProfile #{key.inspect}: loader is required" if entry[:loader].nil?
+        failures << "FeedProfile #{key.inspect}: processor is required" if entry[:processor].nil?
+        if !entry[:depends_on_ai] && entry[:matcher].to_s.empty?
+          failures << "FeedProfile #{key.inspect}: matcher is required for non-AI profiles"
+        end
       end
     end
 

--- a/test/support/feed_profile_validator.rb
+++ b/test/support/feed_profile_validator.rb
@@ -58,10 +58,9 @@ module FeedProfileValidator
         failures << "FeedProfile #{key.inspect}: loader.config.output_schema is required when depends_on_ai is true"
       end
 
-      # The webhook profile is push-ingested (spec 006 §1): nothing to fetch,
-      # so it alone omits matcher, loader, and processor. Every other profile
-      # must declare a loader/processor, and a matcher unless it's AI-backed
-      # (structural detection exclusion, spec 005 §7).
+      # The webhook profile has nothing to fetch (spec 006 §1), so it alone
+      # omits matcher, loader, and processor. Every other profile declares a
+      # loader/processor, and a matcher unless it's AI-backed (spec 005 §7).
       if key == "webhook"
         %i[matcher loader processor].each do |stage|
           failures << "FeedProfile #{key.inspect}: #{stage} must be absent for the webhook profile" if entry[stage]


### PR DESCRIPTION
Changes:

- Add the `webhook` feed profile: no matcher, no loader/processor, `scheduled: false` — the normalizer is its only pipeline stage
- Add `WebhookEndpoint`: a per-feed secret URL token, deterministically encrypted so it stays queryable and re-displayable, with one-call rotation; created and destroyed by `FeedsController` alongside the feed
- Guard `FeedRefreshJob` against stray kicks for the loader-less webhook profile

Step 1 of the delivery plan in `specs/006-webhook-publication/spec.md` — plumbing only, no routes or UI. The ingress endpoint and the UX land in follow-up PRs.

References:

- Related PR: #978
- Related PR: #1028