### PR TITLE
Make feed scheduling optional by profile

### DIFF
--- a/app/jobs/feed_scheduler_job.rb
+++ b/app/jobs/feed_scheduler_job.rb
@@ -10,6 +10,8 @@ class FeedSchedulerJob < ApplicationJob
   private
 
   def refresh?(feed)
+    return false unless feed.scheduled?
+
     schedule = feed.feed_schedule
 
     if schedule

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -55,7 +55,7 @@ class Feed < ApplicationRecord
   validates :name, uniqueness: { scope: :user_id }, length: { maximum: NAME_MAX_LENGTH }
   validates :name, presence: true, if: :enabled?
 
-  validates :cron_expression, presence: true, if: :enabled?
+  validates :cron_expression, presence: true, if: -> { enabled? && scheduled? }
   validates :feed_profile_key, presence: true
   validates :feed_profile_key, inclusion: { in: ->(_) { FeedProfile.all } }, if: -> { feed_profile_key.present? }
 
@@ -85,8 +85,8 @@ class Feed < ApplicationRecord
             allow_blank: true
 
   scope :due, -> {
-    left_joins(:feed_schedule)
-      .where("feed_schedules.next_run_at <= ? OR feed_schedules.id IS NULL", Time.current)
+    joins(:feed_schedule)
+      .where("feed_schedules.next_run_at <= ?", Time.current)
       .where(state: :enabled)
   }
 
@@ -201,9 +201,13 @@ class Feed < ApplicationRecord
     FeedProfile.normalizer_class_for(feed_profile_key)
   end
 
+  def scheduled?
+    FeedProfile.scheduled?(feed_profile_key)
+  end
+
   def can_be_enabled?
     name.present? && access_token&.active? && target_group.present? && feed_profile_present? &&
-      cron_expression.present? && ai_enablement_requirements_met?
+      (!scheduled? || cron_expression.present?) && ai_enablement_requirements_met?
   end
 
   # Promote the feed to enabled, running the enabled-state validators. If
@@ -287,7 +291,7 @@ class Feed < ApplicationRecord
   end
 
   # Creates and returns a processor instance for this feed
-  # @param raw_data [String] raw feed data to process
+  # @param raw_data [String] loader data to process
   # @return [Processor::Base] processor instance
   def processor_instance(raw_data)
     processor_class.new(self, raw_data)
@@ -533,6 +537,7 @@ class Feed < ApplicationRecord
   def create_schedule_on_enable
     return unless saved_change_to_state?
     return unless enabled?
+    return unless scheduled?
     return if feed_schedule.present?
 
     defer_schedule!

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -318,7 +318,7 @@ class Feed < ApplicationRecord
 
   # Returns the time of the most recent repost (publication to FreeFeed),
   # regardless of the original source publication date.
-  # @return [Time, nil] last repost time or nil if no published posts
+  # @return [Time, nil] most recent repost time or nil if no published posts
   def most_recent_repost_at
     posts.published.maximum(:reposted_at)
   end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -291,7 +291,7 @@ class Feed < ApplicationRecord
   end
 
   # Creates and returns a processor instance for this feed
-  # @param raw_data [String] loader data to process
+  # @param raw_data [String] raw feed data to process
   # @return [Processor::Base] processor instance
   def processor_instance(raw_data)
     processor_class.new(self, raw_data)
@@ -318,7 +318,7 @@ class Feed < ApplicationRecord
 
   # Returns the time of the most recent repost (publication to FreeFeed),
   # regardless of the original source publication date.
-  # @return [Time, nil] most recent repost time or nil if no published posts
+  # @return [Time, nil] last repost time or nil if no published posts
   def most_recent_repost_at
     posts.published.maximum(:reposted_at)
   end

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -63,6 +63,7 @@ class FeedProfile
       description: "Posts from a site's RSS or Atom feed",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::RssProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -75,6 +76,7 @@ class FeedProfile
       description: "Posts from a site's JSON feed (jsonfeed.org)",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::JsonFeedProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -87,6 +89,7 @@ class FeedProfile
       description: "Posts from a subreddit or Reddit user page via RSS",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::RedditProfileMatcher",
       parameter_schema: LOOSE_URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::RedditLoader", config: {} },
@@ -99,6 +102,7 @@ class FeedProfile
       description: "Posts from xkcd.com with the alt text included",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::XkcdProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -111,6 +115,7 @@ class FeedProfile
       description: "Wordless Buni comic strips from bunicomic.com",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::BuniProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -123,6 +128,7 @@ class FeedProfile
       description: "Science news from elementy.ru with cover images",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::ElementyProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -135,6 +141,7 @@ class FeedProfile
       description: "Posts from Melody Mae's plus-size fashion blog at melodymae.co.uk",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::MelodymaeProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -147,6 +154,7 @@ class FeedProfile
       description: "Technology news from nextbigfuture.com with cover images",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::NextbigfutureProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -159,6 +167,7 @@ class FeedProfile
       description: "MonkeyUser comics for developers",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::MonkeyuserProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -171,6 +180,7 @@ class FeedProfile
       description: "Stories from lobste.rs with a link to the discussion",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::LobstersProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -183,6 +193,7 @@ class FeedProfile
       description: "Family life comics from Litterbox Comics, bonus panels included",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::LitterboxProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -195,6 +206,7 @@ class FeedProfile
       description: "Comic strips from oglaf.com, multi-page stories included",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::OglafProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -207,6 +219,7 @@ class FeedProfile
       description: "Cory Doctorow's Pluralistic linkblog with cover images",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::PluralisticProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -219,6 +232,7 @@ class FeedProfile
       description: "Saturday Morning Breakfast Cereal comics with the hovertext and hidden panel",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::SmbcProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -231,6 +245,7 @@ class FeedProfile
       description: "Boris Grebenshchikov's Aerostat radio show episodes",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::AerostatProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -243,6 +258,7 @@ class FeedProfile
       description: "They Can Talk comics about what animals might say",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::TheycantalkProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -255,6 +271,7 @@ class FeedProfile
       description: "Daily flash science fiction from 365tomorrows.com",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::TomorrowsProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::HttpLoader", config: {} },
@@ -271,6 +288,7 @@ class FeedProfile
       # detection (spec §7) — Mode B selects it directly, detection never can.
       input_shape: :any,
       depends_on_ai: true,
+      scheduled: true,
       parameter_schema: {
         "type" => "object",
         "properties" => {
@@ -305,6 +323,7 @@ class FeedProfile
       description: "Videos from a YouTube channel",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::YoutubeProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::YoutubeLoader", config: {} },
@@ -317,6 +336,7 @@ class FeedProfile
       description: "Posts from a public Telegram channel, images included",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::TelegramProfileMatcher",
       parameter_schema: LOOSE_URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::TelegramLoader", config: {} },
@@ -329,6 +349,7 @@ class FeedProfile
       description: "Posts from a public X (Twitter) account",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::TwitterProfileMatcher",
       parameter_schema: LOOSE_URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::TwitterLoader", config: {} },
@@ -341,6 +362,7 @@ class FeedProfile
       description: "Posts from a public Bluesky account, images included",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::BlueskyProfileMatcher",
       parameter_schema: URL_PARAMETER_SCHEMA,
       loader: { class: "Loader::BlueskyLoader", config: {} },
@@ -383,6 +405,12 @@ class FeedProfile
     # @return [Boolean] true if any of the profile's stages calls an LLM
     def depends_on_ai?(key)
       !!PROFILES.dig(key, :depends_on_ai)
+    end
+
+    # @param key [String] the profile key
+    # @return [Boolean] true if the profile uses periodic scheduling
+    def scheduled?(key)
+      !!PROFILES.dig(key, :scheduled)
     end
 
     # @return [Array<String>] keys of the AI-backed profiles

--- a/specs/001-smart-feed-creation/contracts/profile_registry.md
+++ b/specs/001-smart-feed-creation/contracts/profile_registry.md
@@ -13,6 +13,7 @@ Each entry in `FeedProfile::PROFILES` is a `Hash` matching the schema below. Sch
   description:         String,           # required, ≤ 200 chars, shown in candidate chooser tooltip
   input_shape:         Symbol,           # required, one of :url, :handle, :query, :any
   depends_on_ai:       Boolean,          # required; true if any stage's class uses LlmClient
+  scheduled:           Boolean,          # required; true when feeds use cron-backed periodic refresh
   matcher:             String,           # required, fully-qualified class name (must subclass ProfileMatcher::Base)
   parameter_schema:    Hash,             # required, JSON Schema Draft 2020-12 describing the feed's `params` JSONB
   loader:              StageEntry,       # required (see below)
@@ -50,12 +51,13 @@ For LLM-using stages, `StageEntry.config` carries the LLM-specific bits:
    - **AI penalty**: profiles with `depends_on_ai: true` rank lower than any non-AI profile that matched the same input.
 4. `parameter_schema` MUST validate the `params` JSON the feed will store. Required fields surface as required form fields.
 5. `output_schema` MUST include the universal post fields (`title`, `body`, `supplementary?`, `images[]`, `source_url`, `published_at`, `uid`) — see [`../notes/profile-contracts.md`](../notes/profile-contracts.md).
+6. `scheduled` MUST be explicit. When false, the feed does not require a cron expression and must not acquire a `FeedSchedule` through enablement or scheduler recovery.
 
 ## Adding a new profile
 
 1. Write the matcher class (subclass `ProfileMatcher::Base`, declare `input_shape`, declare `match_specificity`, implement `match?(input)`).
 2. Write or reuse loader / processor / normalizer classes.
-3. Add the entry to `FeedProfile::PROFILES`.
+3. Add the entry to `FeedProfile::PROFILES` and explicitly set `scheduled`.
 4. Add a profile fixture in `test/fixtures/profiles/` and a profile-level test exercising `parameter_schema` validity, end-to-end `FeedRefreshWorkflow` for one sample item, and (if AI-backed) an `LlmClient` stub.
 5. CI fails if `FeedProfileValidator.validate!` rejects the new entry.
 

--- a/specs/007-optional-feed-scheduling/spec.md
+++ b/specs/007-optional-feed-scheduling/spec.md
@@ -1,0 +1,27 @@
+# Optional feed scheduling
+
+**Status**: Implemented
+
+Scheduling is a capability of a feed profile, not an implicit property of every feed.
+
+Each `FeedProfile::PROFILES` entry declares `scheduled: true` or `scheduled: false` explicitly.
+The registry flag is the single predicate used by feed validation and automatic schedule creation.
+It supersedes feature-specific flags such as the proposed webhook `push: true` flag for deciding
+whether a feed participates in periodic refreshes.
+
+## Behavior
+
+- A scheduled profile requires a cron expression when the feed is enabled.
+- Enabling a scheduled feed creates its initial `FeedSchedule`.
+- An unscheduled profile does not require a cron expression and automatic lifecycle paths do not
+  create a `FeedSchedule` for it.
+- `Feed.due` includes only enabled feeds with an existing schedule whose `next_run_at` is due.
+  A missing schedule is not an implicit due date.
+- `FeedSchedulerJob#refresh?` checks the profile capability before its schedule recovery branch,
+  so an unscheduled feed never acquires a schedule there.
+- If a scheduled feed's row disappears after it was selected as due, the existing recovery branch
+  may recreate it; this is a race recovery path, not schedule-less discovery.
+
+All profiles present when this contract was introduced are explicitly scheduled. A future webhook
+profile should declare `scheduled: false`; its separate ingestion behavior does not need a generic
+`push` registry flag for scheduling decisions.

--- a/specs/007-optional-feed-scheduling/spec.md
+++ b/specs/007-optional-feed-scheduling/spec.md
@@ -9,16 +9,21 @@ The registry flag is the single predicate used by feed validation and automatic 
 It supersedes feature-specific flags such as the proposed webhook `push: true` flag for deciding
 whether a feed participates in periodic refreshes.
 
+This contract supersedes the scheduling-specific parts of the webhook design in
+[`006-webhook-publication`](../006-webhook-publication/spec.md), especially its proposed
+`push: true` scheduling predicate and schedule-less self-healing workaround. The webhook profile
+should instead declare `scheduled: false` when that branch is rebased.
+
 ## Behavior
 
 - A scheduled profile requires a cron expression when the feed is enabled.
 - Enabling a scheduled feed creates its initial `FeedSchedule`.
 - An unscheduled profile does not require a cron expression and automatic lifecycle paths do not
   create a `FeedSchedule` for it.
-- `Feed.due` includes only enabled feeds with an existing schedule whose `next_run_at` is due.
-  A missing schedule is not an implicit due date.
-- `FeedSchedulerJob#refresh?` checks the profile capability before its schedule recovery branch,
-  so an unscheduled feed never acquires a schedule there.
+- `Feed.due` includes only enabled feeds with an existing, non-null `next_run_at` that is due.
+  A missing schedule or a schedule without a date is not an implicit due date.
+- `FeedSchedulerJob#refresh?` checks the profile capability before reading or updating its schedule.
+  An unscheduled feed is ignored even if a stale due schedule exists.
 - If a scheduled feed's row disappears after it was selected as due, the existing recovery branch
   may recreate it; this is a race recovery path, not schedule-less discovery.
 

--- a/test/jobs/feed_scheduler_job_test.rb
+++ b/test/jobs/feed_scheduler_job_test.rb
@@ -36,6 +36,17 @@ class FeedSchedulerJobTest < ActiveJob::TestCase
     end
   end
 
+  test ".perform_now should skip schedules without an explicit next run date" do
+    feed = create(:feed, :enabled)
+    schedule = create(:feed_schedule, feed: feed, next_run_at: nil)
+
+    assert_no_enqueued_jobs(only: FeedRefreshJob) do
+      FeedSchedulerJob.perform_now
+    end
+
+    assert_nil schedule.reload.last_run_at
+  end
+
   test ".perform_now should handle concurrent updates with optimistic locking" do
     feed = create(:feed, :enabled)
     schedule = create(:feed_schedule, feed: feed, next_run_at: 1.hour.ago)
@@ -58,20 +69,29 @@ class FeedSchedulerJobTest < ActiveJob::TestCase
     assert_nil feed.reload.feed_schedule
   end
 
-  test "#refresh? should recreate a missing schedule for a scheduled feed selected before deletion" do
+  test "#refresh? should recreate a schedule deleted after the feed was selected as due" do
     feed = create(:feed, :enabled)
+    schedule = create(:feed_schedule, feed: feed, next_run_at: 1.hour.ago)
+    selected_feed = Feed.due.find(feed.id)
+    schedule.destroy!
 
-    assert FeedSchedulerJob.new.send(:refresh?, feed)
-    assert_equal Time.current, feed.reload.feed_schedule.last_run_at
-    assert_equal Time.current, feed.feed_schedule.next_run_at
+    assert FeedSchedulerJob.new.send(:refresh?, selected_feed)
+    assert_equal Time.current, selected_feed.reload.feed_schedule.last_run_at
+    assert_equal Time.current, selected_feed.feed_schedule.next_run_at
   end
 
-  test "#refresh? should not create a schedule for an unscheduled profile" do
+  test ".perform_now should ignore an unscheduled feed with a stale due schedule" do
     FeedProfile.stub(:scheduled?, false) do
       feed = create(:feed, :enabled, cron_expression: nil)
+      schedule = create(:feed_schedule, feed: feed, next_run_at: 1.hour.ago)
 
-      assert_not FeedSchedulerJob.new.send(:refresh?, feed)
-      assert_nil feed.reload.feed_schedule
+      assert_no_enqueued_jobs(only: FeedRefreshJob) do
+        FeedSchedulerJob.perform_now
+      end
+
+      schedule.reload
+      assert_equal 1.hour.ago, schedule.next_run_at
+      assert_nil schedule.last_run_at
     end
   end
 end

--- a/test/jobs/feed_scheduler_job_test.rb
+++ b/test/jobs/feed_scheduler_job_test.rb
@@ -67,12 +67,11 @@ class FeedSchedulerJobTest < ActiveJob::TestCase
   end
 
   test "#refresh? should not create a schedule for an unscheduled profile" do
-    feed = create(:feed, :enabled, cron_expression: nil)
-
     FeedProfile.stub(:scheduled?, false) do
-      assert_not FeedSchedulerJob.new.send(:refresh?, feed)
-    end
+      feed = create(:feed, :enabled, cron_expression: nil)
 
-    assert_nil feed.reload.feed_schedule
+      assert_not FeedSchedulerJob.new.send(:refresh?, feed)
+      assert_nil feed.reload.feed_schedule
+    end
   end
 end

--- a/test/jobs/feed_scheduler_job_test.rb
+++ b/test/jobs/feed_scheduler_job_test.rb
@@ -48,16 +48,31 @@ class FeedSchedulerJobTest < ActiveJob::TestCase
     end
   end
 
-  test ".perform_now should create schedule for feeds without one" do
+  test ".perform_now should ignore feeds without an explicit schedule" do
     feed = create(:feed, :enabled)
 
-    assert_enqueued_with(job: FeedRefreshJob, args: [feed.id]) do
+    assert_no_enqueued_jobs(only: FeedRefreshJob) do
       FeedSchedulerJob.perform_now
     end
 
-    feed.reload
-    assert feed.feed_schedule.present?
-    assert_equal Time.current, feed.feed_schedule.last_run_at
+    assert_nil feed.reload.feed_schedule
+  end
+
+  test "#refresh? should recreate a missing schedule for a scheduled feed selected before deletion" do
+    feed = create(:feed, :enabled)
+
+    assert FeedSchedulerJob.new.send(:refresh?, feed)
+    assert_equal Time.current, feed.reload.feed_schedule.last_run_at
     assert_equal Time.current, feed.feed_schedule.next_run_at
+  end
+
+  test "#refresh? should not create a schedule for an unscheduled profile" do
+    feed = create(:feed, :enabled, cron_expression: nil)
+
+    FeedProfile.stub(:scheduled?, false) do
+      assert_not FeedSchedulerJob.new.send(:refresh?, feed)
+    end
+
+    assert_nil feed.reload.feed_schedule
   end
 end

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -60,6 +60,7 @@ class FeedProfileTest < ActiveSupport::TestCase
       assert_kind_of String, entry[:description], "#{key}: description"
       assert_includes %i[url query any], entry[:input_shape], "#{key}: input_shape"
       assert_includes [true, false], entry[:depends_on_ai], "#{key}: depends_on_ai"
+      assert_includes [true, false], entry[:scheduled], "#{key}: scheduled"
       if entry[:depends_on_ai]
         # The AI profile is structurally excluded from detection (spec §7): no matcher.
         assert_nil entry[:matcher], "#{key}: AI profile must not register a matcher"
@@ -176,6 +177,13 @@ class FeedProfileTest < ActiveSupport::TestCase
     assert_not FeedProfile.depends_on_ai?("rss")
     assert_not FeedProfile.depends_on_ai?("xkcd")
     assert_not FeedProfile.depends_on_ai?("nonexistent")
+  end
+
+  test ".scheduled? returns the explicit scheduling capability" do
+    assert FeedProfile.scheduled?("rss")
+    assert FeedProfile.scheduled?("llm")
+    assert_not FeedProfile.scheduled?("nonexistent")
+    assert_not FeedProfile.scheduled?(nil)
   end
 
   test ".parameter_schema_for returns the schema for a profile" do

--- a/test/models/feed_profile_validator_test.rb
+++ b/test/models/feed_profile_validator_test.rb
@@ -7,6 +7,7 @@ class FeedProfileValidatorTest < ActiveSupport::TestCase
       description: "Sample profile for testing",
       input_shape: :url,
       depends_on_ai: false,
+      scheduled: true,
       matcher: "ProfileMatcher::RssProfileMatcher",
       parameter_schema: {
         "type" => "object",
@@ -38,6 +39,16 @@ class FeedProfileValidatorTest < ActiveSupport::TestCase
     end
 
     assert_includes error.message, "display_name"
+  end
+
+  test "requires the scheduling capability to be explicit" do
+    entry = valid_entry.except(:scheduled)
+
+    error = assert_raises(FeedProfileValidator::Error) do
+      FeedProfileValidator.validate!("sample" => entry)
+    end
+
+    assert_includes error.message, "scheduled"
   end
 
   test "rejects entry with unknown input_shape" do

--- a/test/models/feed_profile_validator_test.rb
+++ b/test/models/feed_profile_validator_test.rb
@@ -31,6 +31,12 @@ class FeedProfileValidatorTest < ActiveSupport::TestCase
     end
   end
 
+  test "accepts an explicitly unscheduled profile" do
+    assert_nothing_raised do
+      FeedProfileValidator.validate!("sample" => valid_entry.merge(scheduled: false))
+    end
+  end
+
   test "rejects entry missing required key" do
     entry = valid_entry.except(:display_name)
 

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -124,6 +124,14 @@ class FeedTest < ActiveSupport::TestCase
     assert feed.errors.of_kind?(:cron_expression, :blank)
   end
 
+  test "should not require cron_expression for an unscheduled profile" do
+    FeedProfile.stub(:scheduled?, false) do
+      feed = build(:feed, state: :enabled, cron_expression: nil)
+
+      assert feed.valid?, feed.errors.full_messages.inspect
+    end
+  end
+
   test "should not require cron_expression for disabled feeds" do
     feed = build(:feed, cron_expression: nil, state: :disabled)
     feed.valid?
@@ -192,6 +200,15 @@ class FeedTest < ActiveSupport::TestCase
     end
   end
 
+  test "should not create feed_schedule when enabling an unscheduled profile" do
+    FeedProfile.stub(:scheduled?, false) do
+      feed = create(:feed, state: :disabled, cron_expression: nil)
+
+      assert feed.enable
+      assert_nil feed.reload.feed_schedule
+    end
+  end
+
   test "should not create duplicate feed_schedule when already exists" do
     user = create(:user)
     access_token = create(:access_token, :active, user: user)
@@ -217,11 +234,11 @@ class FeedTest < ActiveSupport::TestCase
     end
   end
 
-  test "#due should include feeds without schedule" do
+  test "#due should exclude feeds without schedule" do
     freeze_time do
       feed = create(:feed, state: :enabled)
 
-      assert_includes Feed.due, feed
+      assert_not_includes Feed.due, feed
     end
   end
 
@@ -248,6 +265,9 @@ class FeedTest < ActiveSupport::TestCase
       draft_feed = create(:feed, state: :draft)
       disabled_feed = create(:feed, state: :disabled)
       enabled_feed = create(:feed, state: :enabled)
+      create(:feed_schedule, feed: draft_feed, next_run_at: 1.hour.ago)
+      create(:feed_schedule, feed: disabled_feed, next_run_at: 1.hour.ago)
+      create(:feed_schedule, feed: enabled_feed, next_run_at: 1.hour.ago)
 
       due_feeds = Feed.due
 
@@ -325,12 +345,26 @@ class FeedTest < ActiveSupport::TestCase
     assert_equal "enabled", reloaded_feed.state
   end
 
+  test "#scheduled? delegates to the feed profile" do
+    feed = build(:feed, feed_profile_key: "rss")
+
+    assert feed.scheduled?
+  end
+
   test "#can_be_enabled? returns true when feed has active access token and target group" do
     user = create(:user)
     access_token = create(:access_token, :active, user: user)
     feed = create(:feed, user: user, access_token: access_token, target_group: "test_group")
 
     assert feed.can_be_enabled?
+  end
+
+  test "#can_be_enabled? does not require a cron expression for an unscheduled profile" do
+    FeedProfile.stub(:scheduled?, false) do
+      feed = build(:feed, cron_expression: nil)
+
+      assert feed.can_be_enabled?
+    end
   end
 
   test "#can_be_enabled? returns false when feed has a blank name" do

--- a/test/support/feed_profile_validator.rb
+++ b/test/support/feed_profile_validator.rb
@@ -13,6 +13,7 @@ module FeedProfileValidator
       description
       input_shape
       depends_on_ai
+      scheduled
       parameter_schema
       loader
       processor
@@ -23,6 +24,7 @@ module FeedProfileValidator
       "description" => { "type" => "string", "minLength" => 1, "maxLength" => 200 },
       "input_shape" => { "type" => "string", "enum" => %w[url query any] },
       "depends_on_ai" => { "type" => "boolean" },
+      "scheduled" => { "type" => "boolean" },
       "matcher" => { "type" => "string", "minLength" => 1 },
       "parameter_schema" => { "type" => "object" },
       "loader" => { "$ref" => "#/$defs/stage_entry" },


### PR DESCRIPTION
## Summary

- add an explicit `scheduled` boolean to every feed profile and expose it through `FeedProfile.scheduled?` / `Feed#scheduled?`
- remove schedule-less feeds from `Feed.due`; a feed is due only when it has an explicit, non-null `FeedSchedule#next_run_at` that has passed
- require cron configuration and create schedules on enable only for scheduled profiles
- make `FeedSchedulerJob#refresh?` return early for unscheduled profiles before reading or updating a schedule
- validate the registry contract and cover scheduled/unscheduled lifecycle behavior with model and job tests
- add a short optional-scheduling specification that explicitly supersedes the scheduling-specific `push: true` design in the webhook spec

## Behavior contract

- `scheduled: true`: an enabled feed requires a cron expression and gains a deferred `FeedSchedule` when enabled
- `scheduled: false`: no cron expression is required and automatic lifecycle paths do not create a `FeedSchedule`
- `Feed.due` contains only enabled feeds with an existing due date; a missing schedule or null date is not an implicit due date
- the scheduler ignores an unscheduled feed even if a stale due schedule exists
- the scheduler may recreate a missing row only for a scheduled feed selected as due before the row disappeared

## Relationship to #1027

This PR is intentionally based on `main` and contains no webhook implementation. It is a precursor to #1027. After this merges, #1027 should be rebased and its webhook profile should declare `scheduled: false` instead of introducing `push: true` for scheduling decisions.

## Validation

Fresh review added explicit coverage for:

- schedules with a null `next_run_at`
- a schedule deleted after its feed was selected as due
- an unscheduled feed carrying a stale due schedule
- acceptance of an explicit `scheduled: false` registry entry

GitHub Actions CI run 3673 passed in full:

- application tests
- model/schema consistency
- Ruby, ERB, Herb, and Actions linting
- gem, JavaScript, Rails, and secret scans
- Ruby and JavaScript CodeQL
