### PR TITLE
Shorten local UUID references in the UI

### DIFF
--- a/app/components/event_details_component.rb
+++ b/app/components/event_details_component.rb
@@ -23,10 +23,13 @@ class EventDetailsComponent < ViewComponent::Base
 
   def add_user_item(component)
     user_value = if @event.user_id.present?
-      helpers.link_to("User ##{@event.user_id}",
-                      helpers.admin_events_path(filter: { user_id: @event.user_id }),
-                      class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover",
-                      data: { key: "admin.event.user" })
+      helpers.uuid_reference(
+        @event.user_id,
+        path: (helpers.admin_user_path(@event.user) if @event.user),
+        title: [@event.user_id, @event.user&.email_address].compact_blank.join(" — "),
+        class: "font-mono font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover",
+        data: { key: "admin.event.user" }
+      )
     else
       helpers.tag.em("System", class: "text-muted", data: { key: "admin.event.user" })
     end

--- a/app/components/event_details_component.rb
+++ b/app/components/event_details_component.rb
@@ -27,7 +27,8 @@ class EventDetailsComponent < ViewComponent::Base
         @event.user_id,
         path: (helpers.admin_user_path(@event.user) if @event.user),
         title: [@event.user_id, @event.user&.email_address].compact_blank.join(" — "),
-        class: "font-mono font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover",
+        link_class: "font-mono font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover",
+        text_class: "font-mono font-medium text-body",
         data: { key: "admin.event.user" }
       )
     else

--- a/app/components/event_details_component.rb
+++ b/app/components/event_details_component.rb
@@ -23,14 +23,24 @@ class EventDetailsComponent < ViewComponent::Base
 
   def add_user_item(component)
     user_value = if @event.user_id.present?
-      helpers.uuid_reference(
-        @event.user_id,
-        path: (helpers.admin_user_path(@event.user) if @event.user),
-        title: [@event.user_id, @event.user&.email_address].compact_blank.join(" — "),
-        link_class: "font-mono font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover",
-        text_class: "font-mono font-medium text-body",
-        data: { key: "admin.event.user" }
-      )
+      title = [@event.user_id, @event.user&.email_address].compact_blank.join(" — ")
+
+      if @event.user
+        helpers.link_to(
+          helpers.short_ref(@event.user_id),
+          helpers.admin_user_path(@event.user),
+          title: title,
+          class: "font-mono font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover",
+          data: { key: "admin.event.user" }
+        )
+      else
+        helpers.tag.span(
+          helpers.short_ref(@event.user_id),
+          title: title,
+          class: "font-mono font-medium text-body",
+          data: { key: "admin.event.user" }
+        )
+      end
     else
       helpers.tag.em("System", class: "text-muted", data: { key: "admin.event.user" })
     end

--- a/app/components/event_list_item_component.rb
+++ b/app/components/event_list_item_component.rb
@@ -104,16 +104,18 @@ class EventListItemComponent < ListItemComponent
     safe_join(["Type: ", link])
   end
 
-  # Admins see who an event belongs to; the user links to a filtered log.
+  # Admins see who an event belongs to; existing users link to their detail page.
   def user_label
     label = if event.user_id.blank?
       helpers.tag.em("System", data: { key: "events.user" })
     else
-      helpers.link_to("##{event.user_id}",
-                      helpers.admin_events_path(filter: { user_id: event.user_id }),
-                      class: "underline underline-offset-2 transition hover:text-heading",
-                      title: event.user&.email_address,
-                      data: { key: "events.user" })
+      helpers.uuid_reference(
+        event.user_id,
+        path: helpers.admin_user_path(event.user) if event.user,
+        title: reference_title(event.user_id, event.user&.email_address),
+        class: "font-mono underline underline-offset-2 transition hover:text-heading",
+        data: { key: "events.user" }
+      )
     end
 
     safe_join(["User: ", label])
@@ -122,17 +124,39 @@ class EventListItemComponent < ListItemComponent
   def target_label
     return if event.subject_type.blank?
 
-    value = [event.subject_type, event.subject_id].compact.join("#")
-    filter_params = { subject_type: event.subject_type }
-    filter_params[:subject_id] = event.subject_id if event.subject_id.present?
+    label = if event.subject_id.present?
+      helpers.uuid_reference(
+        event.subject_id,
+        path: target_path,
+        prefix: event.subject_type,
+        title: reference_title(event.subject_id, target_title),
+        class: "font-mono underline underline-offset-2 transition hover:text-heading",
+        data: { key: "events.subject" }
+      )
+    else
+      helpers.tag.span(event.subject_type, data: { key: "events.subject" })
+    end
 
-    link = helpers.link_to(value,
-                           helpers.admin_events_path(filter: filter_params),
-                           class: "underline underline-offset-2 transition hover:text-heading",
-                           title: target_title,
-                           data: { key: "events.subject" })
+    safe_join(["Target: ", label])
+  end
 
-    safe_join(["Target: ", link])
+  # Only records with an operator-safe detail page are linked. Deleted records
+  # and owner-scoped records such as posts remain compact, titled plain text.
+  def target_path
+    case event.subject
+    when Feed
+      helpers.admin_feed_path(event.subject)
+    when User
+      helpers.admin_user_path(event.subject)
+    when Event
+      helpers.admin_event_path(event.subject)
+    when AccessToken
+      helpers.access_token_path(event.subject)
+    when AiCredential
+      helpers.ai_credential_path(event.subject)
+    when SearchCredential
+      helpers.search_credential_path(event.subject)
+    end
   end
 
   # Resolves the subject to its human name so admins don't have to memorize
@@ -142,5 +166,9 @@ class EventListItemComponent < ListItemComponent
     return unless subject
 
     subject.try(:display_name) || subject.try(:name) || subject.try(:email_address)
+  end
+
+  def reference_title(id, description)
+    [id, description].compact_blank.join(" — ")
   end
 end

--- a/app/components/event_list_item_component.rb
+++ b/app/components/event_list_item_component.rb
@@ -108,11 +108,19 @@ class EventListItemComponent < ListItemComponent
   def user_label
     label = if event.user_id.blank?
       helpers.tag.em("System", data: { key: "events.user" })
+    elsif event.user
+      helpers.link_to(
+        helpers.short_ref(event.user_id),
+        helpers.admin_user_path(event.user),
+        class: "font-mono underline underline-offset-2 transition hover:text-heading",
+        title: reference_title(event.user_id, event.user.email_address),
+        data: { key: "events.user" }
+      )
     else
-      helpers.uuid_reference(
-        event.user_id,
-        path: (helpers.admin_user_path(event.user) if event.user),
-        title: reference_title(event.user_id, event.user&.email_address),
+      helpers.tag.span(
+        helpers.short_ref(event.user_id),
+        class: "font-mono",
+        title: event.user_id,
         data: { key: "events.user" }
       )
     end
@@ -124,13 +132,26 @@ class EventListItemComponent < ListItemComponent
     return if event.subject_type.blank?
 
     label = if event.subject_id.present?
-      helpers.uuid_reference(
-        event.subject_id,
-        path: helpers.admin_event_subject_path(event.subject),
-        prefix: event.subject_type,
-        title: reference_title(event.subject_id, target_title),
-        data: { key: "events.subject" }
-      )
+      text = "#{event.subject_type} #{helpers.short_ref(event.subject_id)}"
+      title = reference_title(event.subject_id, target_title)
+      path = helpers.admin_event_subject_path(event.subject)
+
+      if path
+        helpers.link_to(
+          text,
+          path,
+          class: "font-mono underline underline-offset-2 transition hover:text-heading",
+          title: title,
+          data: { key: "events.subject" }
+        )
+      else
+        helpers.tag.span(
+          text,
+          class: "font-mono",
+          title: title,
+          data: { key: "events.subject" }
+        )
+      end
     else
       helpers.tag.span(event.subject_type, data: { key: "events.subject" })
     end

--- a/app/components/event_list_item_component.rb
+++ b/app/components/event_list_item_component.rb
@@ -127,7 +127,7 @@ class EventListItemComponent < ListItemComponent
     label = if event.subject_id.present?
       helpers.uuid_reference(
         event.subject_id,
-        path: target_path,
+        path: helpers.admin_event_subject_path(event.subject),
         prefix: event.subject_type,
         title: reference_title(event.subject_id, target_title),
         class: "font-mono underline underline-offset-2 transition hover:text-heading",
@@ -138,25 +138,6 @@ class EventListItemComponent < ListItemComponent
     end
 
     safe_join(["Target: ", label])
-  end
-
-  # Only records with an operator-safe detail page are linked. Deleted records
-  # and owner-scoped records such as posts remain compact, titled plain text.
-  def target_path
-    case event.subject
-    when Feed
-      helpers.admin_feed_path(event.subject)
-    when User
-      helpers.admin_user_path(event.subject)
-    when Event
-      helpers.admin_event_path(event.subject)
-    when AccessToken
-      helpers.access_token_path(event.subject)
-    when AiCredential
-      helpers.ai_credential_path(event.subject)
-    when SearchCredential
-      helpers.search_credential_path(event.subject)
-    end
   end
 
   # Resolves the subject to its human name so admins don't have to memorize

--- a/app/components/event_list_item_component.rb
+++ b/app/components/event_list_item_component.rb
@@ -113,7 +113,6 @@ class EventListItemComponent < ListItemComponent
         event.user_id,
         path: (helpers.admin_user_path(event.user) if event.user),
         title: reference_title(event.user_id, event.user&.email_address),
-        class: "font-mono underline underline-offset-2 transition hover:text-heading",
         data: { key: "events.user" }
       )
     end
@@ -130,7 +129,6 @@ class EventListItemComponent < ListItemComponent
         path: helpers.admin_event_subject_path(event.subject),
         prefix: event.subject_type,
         title: reference_title(event.subject_id, target_title),
-        class: "font-mono underline underline-offset-2 transition hover:text-heading",
         data: { key: "events.subject" }
       )
     else

--- a/app/components/event_list_item_component.rb
+++ b/app/components/event_list_item_component.rb
@@ -111,7 +111,7 @@ class EventListItemComponent < ListItemComponent
     else
       helpers.uuid_reference(
         event.user_id,
-        path: helpers.admin_user_path(event.user) if event.user,
+        path: (helpers.admin_user_path(event.user) if event.user),
         title: reference_title(event.user_id, event.user&.email_address),
         class: "font-mono underline underline-offset-2 transition hover:text-heading",
         data: { key: "events.user" }

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -9,6 +9,35 @@ module EventsHelper
     end
   end
 
+  def admin_event_filter_summary(filter)
+    parts = filter.to_h.map do |key, value|
+      values = Array.wrap(value).map do |item|
+        admin_event_filter_value(key, item, filter: filter)
+      end
+
+      safe_join(["#{key}: ", safe_join(values, ", ")])
+    end
+
+    safe_join(parts, " • ")
+  end
+
+  def admin_event_subject_path(subject)
+    case subject
+    when Feed
+      admin_feed_path(subject)
+    when User
+      admin_user_path(subject)
+    when Event
+      admin_event_path(subject)
+    when AccessToken
+      access_token_path(subject)
+    when AiCredential
+      ai_credential_path(subject)
+    when SearchCredential
+      search_credential_path(subject)
+    end
+  end
+
   def format_stat_value(key, value)
     key = key.to_s
 
@@ -40,5 +69,47 @@ module EventsHelper
       mail.profile_mailer.email_change_confirmation
       mail.passwords_mailer.reset
     ]
+  end
+
+  private
+
+  def admin_event_filter_value(key, value, filter:)
+    return value unless %w[user_id subject_id].include?(key.to_s)
+
+    path = admin_event_filter_reference_path(key, value, filter: filter)
+    text = short_ref(value)
+
+    if path
+      link_to(
+        text,
+        path,
+        title: value,
+        class: "font-mono underline underline-offset-2 transition hover:text-heading"
+      )
+    else
+      tag.span(text, title: value, class: "font-mono")
+    end
+  end
+
+  def admin_event_filter_reference_path(key, value, filter:)
+    case key.to_s
+    when "user_id"
+      admin_user_path(value)
+    when "subject_id"
+      case filter[:subject_type] || filter["subject_type"]
+      when "Feed"
+        admin_feed_path(value)
+      when "User"
+        admin_user_path(value)
+      when "Event"
+        admin_event_path(value)
+      when "AccessToken"
+        access_token_path(value)
+      when "AiCredential"
+        ai_credential_path(value)
+      when "SearchCredential"
+        search_credential_path(value)
+      end
+    end
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,4 +1,6 @@
 module EventsHelper
+  include IdentifierHelper
+
   # Explains where the current page sits in the log without leaning on page
   # numbers: the offset is how many newer events come before what's shown.
   def events_offset_summary(offset, system_wide: false)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -12,7 +12,7 @@ module EventsHelper
   def admin_event_filter_summary(filter)
     parts = filter.to_h.map do |key, value|
       values = Array.wrap(value).map do |item|
-        admin_event_filter_value(key, item, filter: filter)
+        admin_event_filter_value(key, item, filter:)
       end
 
       safe_join(["#{key}: ", safe_join(values, ", ")])
@@ -76,7 +76,7 @@ module EventsHelper
   def admin_event_filter_value(key, value, filter:)
     return value unless %w[user_id subject_id].include?(key.to_s)
 
-    path = admin_event_filter_reference_path(key, value, filter: filter)
+    path = admin_event_filter_reference_path(key, value, filter:)
     text = short_ref(value)
 
     if path

--- a/app/helpers/identifier_helper.rb
+++ b/app/helpers/identifier_helper.rb
@@ -1,46 +1,7 @@
 module IdentifierHelper
   UUID_SUFFIX_LENGTH = 5
 
-  EVENT_SUBJECT_MODELS = {
-    "Feed" => Feed,
-    "User" => User,
-    "Event" => Event,
-    "AccessToken" => AccessToken,
-    "AiCredential" => AiCredential,
-    "SearchCredential" => SearchCredential
-  }.freeze
-
   def short_ref(value)
     value.to_s.last(UUID_SUFFIX_LENGTH)
-  end
-
-  def admin_event_subject_path(subject)
-    case subject
-    when Feed
-      admin_feed_path(subject)
-    when User
-      admin_user_path(subject)
-    when Event
-      admin_event_path(subject)
-    when AccessToken
-      access_token_path(subject)
-    when AiCredential
-      ai_credential_path(subject)
-    when SearchCredential
-      search_credential_path(subject)
-    end
-  end
-
-  def admin_event_filter_reference_path(key, value, filter:)
-    case key.to_s
-    when "user_id"
-      user = User.find_by(id: value)
-      admin_user_path(user) if user
-    when "subject_id"
-      subject_type = filter[:subject_type] || filter["subject_type"]
-      model = EVENT_SUBJECT_MODELS[subject_type]
-      subject = model&.find_by(id: value)
-      admin_event_subject_path(subject) if subject
-    end
   end
 end

--- a/app/helpers/identifier_helper.rb
+++ b/app/helpers/identifier_helper.rb
@@ -1,0 +1,20 @@
+module IdentifierHelper
+  UUID_SUFFIX_LENGTH = 5
+  UUID_LINK_CLASSES = "font-mono underline underline-offset-2 transition hover:text-heading".freeze
+
+  def short_uuid(value)
+    value.to_s.last(UUID_SUFFIX_LENGTH)
+  end
+
+  def uuid_label(value, prefix: nil)
+    [prefix, short_uuid(value)].compact_blank.join(" ")
+  end
+
+  def uuid_reference(value, path: nil, prefix: nil, **html_options)
+    html_options[:title] ||= value.to_s
+    html_options[:class] ||= UUID_LINK_CLASSES
+    label = uuid_label(value, prefix: prefix)
+
+    path ? link_to(label, path, **html_options) : tag.span(label, **html_options)
+  end
+end

--- a/app/helpers/identifier_helper.rb
+++ b/app/helpers/identifier_helper.rb
@@ -2,6 +2,15 @@ module IdentifierHelper
   UUID_SUFFIX_LENGTH = 5
   UUID_LINK_CLASSES = "font-mono underline underline-offset-2 transition hover:text-heading".freeze
 
+  EVENT_SUBJECT_MODELS = {
+    "Feed" => Feed,
+    "User" => User,
+    "Event" => Event,
+    "AccessToken" => AccessToken,
+    "AiCredential" => AiCredential,
+    "SearchCredential" => SearchCredential
+  }.freeze
+
   def short_uuid(value)
     value.to_s.last(UUID_SUFFIX_LENGTH)
   end
@@ -16,5 +25,35 @@ module IdentifierHelper
     label = uuid_label(value, prefix: prefix)
 
     path ? link_to(label, path, **html_options) : tag.span(label, **html_options)
+  end
+
+  def admin_event_subject_path(subject)
+    case subject
+    when Feed
+      admin_feed_path(subject)
+    when User
+      admin_user_path(subject)
+    when Event
+      admin_event_path(subject)
+    when AccessToken
+      access_token_path(subject)
+    when AiCredential
+      ai_credential_path(subject)
+    when SearchCredential
+      search_credential_path(subject)
+    end
+  end
+
+  def admin_event_filter_reference_path(key, value, filter:)
+    case key.to_s
+    when "user_id"
+      user = User.find_by(id: value)
+      admin_user_path(user) if user
+    when "subject_id"
+      subject_type = filter[:subject_type] || filter["subject_type"]
+      model = EVENT_SUBJECT_MODELS[subject_type]
+      subject = model&.find_by(id: value)
+      admin_event_subject_path(subject) if subject
+    end
   end
 end

--- a/app/helpers/identifier_helper.rb
+++ b/app/helpers/identifier_helper.rb
@@ -1,7 +1,5 @@
 module IdentifierHelper
   UUID_SUFFIX_LENGTH = 5
-  UUID_LINK_CLASSES = "font-mono underline underline-offset-2 transition hover:text-heading".freeze
-  UUID_TEXT_CLASSES = "font-mono".freeze
 
   EVENT_SUBJECT_MODELS = {
     "Feed" => Feed,
@@ -12,20 +10,8 @@ module IdentifierHelper
     "SearchCredential" => SearchCredential
   }.freeze
 
-  def short_uuid(value)
+  def short_ref(value)
     value.to_s.last(UUID_SUFFIX_LENGTH)
-  end
-
-  def uuid_label(value, prefix: nil)
-    [prefix, short_uuid(value)].compact_blank.join(" ")
-  end
-
-  def uuid_reference(value, path: nil, prefix: nil, link_class: UUID_LINK_CLASSES, text_class: UUID_TEXT_CLASSES, **html_options)
-    html_options[:title] ||= value.to_s
-    html_options[:class] ||= path ? link_class : text_class
-    label = uuid_label(value, prefix: prefix)
-
-    path ? link_to(label, path, **html_options) : tag.span(label, **html_options)
   end
 
   def admin_event_subject_path(subject)

--- a/app/helpers/identifier_helper.rb
+++ b/app/helpers/identifier_helper.rb
@@ -1,6 +1,7 @@
 module IdentifierHelper
   UUID_SUFFIX_LENGTH = 5
   UUID_LINK_CLASSES = "font-mono underline underline-offset-2 transition hover:text-heading".freeze
+  UUID_TEXT_CLASSES = "font-mono".freeze
 
   EVENT_SUBJECT_MODELS = {
     "Feed" => Feed,
@@ -19,9 +20,9 @@ module IdentifierHelper
     [prefix, short_uuid(value)].compact_blank.join(" ")
   end
 
-  def uuid_reference(value, path: nil, prefix: nil, **html_options)
+  def uuid_reference(value, path: nil, prefix: nil, link_class: UUID_LINK_CLASSES, text_class: UUID_TEXT_CLASSES, **html_options)
     html_options[:title] ||= value.to_s
-    html_options[:class] ||= UUID_LINK_CLASSES
+    html_options[:class] ||= path ? link_class : text_class
     label = uuid_label(value, prefix: prefix)
 
     path ? link_to(label, path, **html_options) : tag.span(label, **html_options)

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -6,11 +6,18 @@
     <% header.with_context_paragraph do %>
       <% if @filter.present? %>
         <span data-key="admin.events.filter-summary">
-          <% filter_parts = [] %>
-          <% @filter.to_h.each do |key, value| %>
-            <% filter_parts << (value.is_a?(Array) ? "#{key}: #{value.join(', ')}" : "#{key}: #{value}") %>
+          <% filter_parts = @filter.to_h.map do |key, value| %>
+            <% values = value.is_a?(Array) ? value : [value] %>
+            <% rendered_values = values.map do |item| %>
+              <% if %w[user_id subject_id].include?(key.to_s) %>
+                <% uuid_reference(item, path: admin_event_filter_reference_path(key, item, filter: @filter)) %>
+              <% else %>
+                <% item %>
+              <% end %>
+            <% end %>
+            <% safe_join(["#{key}: ", safe_join(rendered_values, ", ")]) %>
           <% end %>
-          Filtering by <%= filter_parts.join(" • ") %>.
+          Filtering by <%= safe_join(filter_parts, " • ") %>.
         </span>
       <% end %>
       <span data-key="events.offset"><%= events_offset_summary(@offset, system_wide: @filter.blank?) %></span>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -6,25 +6,7 @@
     <% header.with_context_paragraph do %>
       <% if @filter.present? %>
         <span data-key="admin.events.filter-summary">
-          <% filter_parts = @filter.to_h.map do |key, value| %>
-            <% values = value.is_a?(Array) ? value : [value] %>
-            <% rendered_values = values.map do |item| %>
-              <% if %w[user_id subject_id].include?(key.to_s) %>
-                <% path = admin_event_filter_reference_path(key, item, filter: @filter) %>
-                <% if path %>
-                  <% link_to short_ref(item), path,
-                             title: item,
-                             class: "font-mono underline underline-offset-2 transition hover:text-heading" %>
-                <% else %>
-                  <% tag.span short_ref(item), title: item, class: "font-mono" %>
-                <% end %>
-              <% else %>
-                <% item %>
-              <% end %>
-            <% end %>
-            <% safe_join(["#{key}: ", safe_join(rendered_values, ", ")]) %>
-          <% end %>
-          Filtering by <%= safe_join(filter_parts, " • ") %>.
+          Filtering by <%= admin_event_filter_summary(@filter) %>.
         </span>
       <% end %>
       <span data-key="events.offset"><%= events_offset_summary(@offset, system_wide: @filter.blank?) %></span>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -10,7 +10,14 @@
             <% values = value.is_a?(Array) ? value : [value] %>
             <% rendered_values = values.map do |item| %>
               <% if %w[user_id subject_id].include?(key.to_s) %>
-                <% uuid_reference(item, path: admin_event_filter_reference_path(key, item, filter: @filter)) %>
+                <% path = admin_event_filter_reference_path(key, item, filter: @filter) %>
+                <% if path %>
+                  <% link_to short_ref(item), path,
+                             title: item,
+                             class: "font-mono underline underline-offset-2 transition hover:text-heading" %>
+                <% else %>
+                  <% tag.span short_ref(item), title: item, class: "font-mono" %>
+                <% end %>
               <% else %>
                 <% item %>
               <% end %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -1,4 +1,4 @@
-<% event_title = uuid_label(@event.id, prefix: "Event") %>
+<% event_title = "Event #{short_ref(@event.id)}" %>
 <% content_for :title, event_title %>
 
 <div class="space-y-8">

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -1,7 +1,8 @@
-<% content_for :title, "Event ##{@event.id}" %>
+<% event_title = uuid_label(@event.id, prefix: "Event") %>
+<% content_for :title, event_title %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Event ##{@event.id}") do |header| %>
+  <%= render PageHeaderComponent.new(title: event_title) do |header| %>
     <% header.with_breadcrumb(label: "Events Log", url: admin_events_path) %>
     <% if @previous_event %>
       <% header.with_action_button do %>

--- a/app/views/development/job_runs/show.html.erb
+++ b/app/views/development/job_runs/show.html.erb
@@ -1,7 +1,8 @@
-<% content_for :title, "#{@job_class.name} run ##{@run.id}" %>
+<% run_title = uuid_label(@run.id, prefix: "Run") %>
+<% content_for :title, "#{@job_class.name} #{run_title.downcase}" %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Run ##{@run.id}") do |header| %>
+  <%= render PageHeaderComponent.new(title: run_title) do |header| %>
     <% header.with_breadcrumb(label: @job_class.name, url: development_job_job_runs_path(@job_class.name)) %>
   <% end %>
 

--- a/app/views/development/job_runs/show.html.erb
+++ b/app/views/development/job_runs/show.html.erb
@@ -1,4 +1,4 @@
-<% run_title = uuid_label(@run.id, prefix: "Run") %>
+<% run_title = "Run #{short_ref(@run.id)}" %>
 <% content_for :title, "#{@job_class.name} #{run_title.downcase}" %>
 
 <div class="space-y-8">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,7 +1,8 @@
-<% content_for :title, "Event ##{@event.id}" %>
+<% event_title = uuid_label(@event.id, prefix: "Event") %>
+<% content_for :title, event_title %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Event ##{@event.id}") do |header| %>
+  <%= render PageHeaderComponent.new(title: event_title) do |header| %>
     <% header.with_breadcrumb(label: "Events Log", url: events_path) %>
     <% if @previous_event %>
       <% header.with_action_button do %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,4 @@
-<% event_title = uuid_label(@event.id, prefix: "Event") %>
+<% event_title = "Event #{short_ref(@event.id)}" %>
 <% content_for :title, event_title %>
 
 <div class="space-y-8">

--- a/app/views/feed_entries/show.html.erb
+++ b/app/views/feed_entries/show.html.erb
@@ -1,4 +1,4 @@
-<% feed_entry_title = uuid_label(@feed_entry.id, prefix: "Feed Entry") %>
+<% feed_entry_title = "Feed Entry #{short_ref(@feed_entry.id)}" %>
 <% content_for :title, feed_entry_title %>
 
 <div class="space-y-8">

--- a/app/views/feed_entries/show.html.erb
+++ b/app/views/feed_entries/show.html.erb
@@ -1,7 +1,8 @@
-<% content_for :title, "Feed Entry #{@feed_entry.id}" %>
+<% feed_entry_title = uuid_label(@feed_entry.id, prefix: "Feed Entry") %>
+<% content_for :title, feed_entry_title %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Feed Entry #{@feed_entry.id}") do |header| %>
+  <%= render PageHeaderComponent.new(title: feed_entry_title) do |header| %>
     <% header.with_context_paragraph do %>
       <%= render BadgeComponent.new(
         text: @feed_entry.status.capitalize,

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,4 @@
-<% post_title = uuid_label(@post.id, prefix: "Post") %>
+<% post_title = "Post #{short_ref(@post.id)}" %>
 <% content_for :title, post_title %>
 
 <div class="space-y-8">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,8 @@
-<% content_for :title, "Post #{@post.id}" %>
+<% post_title = uuid_label(@post.id, prefix: "Post") %>
+<% content_for :title, post_title %>
 
 <div class="space-y-8">
-  <%= render PageHeaderComponent.new(title: "Post #{@post.id}") do |header| %>
+  <%= render PageHeaderComponent.new(title: post_title) do |header| %>
     <% header.with_breadcrumb(label: "Posts", url: posts_path) %>
     <% header.with_context_paragraph do %>
       <%= render BadgeComponent.new(

--- a/test/components/event_details_component_test.rb
+++ b/test/components/event_details_component_test.rb
@@ -25,11 +25,14 @@ class EventDetailsComponentTest < ViewComponent::TestCase
     assert_empty result.css('[data-key="admin.event.user"]')
   end
 
-  test "#call should render admin rows and links when admin" do
+  test "#call should render a compact user link when admin" do
     event = create(:event, type: "owned_event", user: user, subject: feed)
 
     result = render_inline(EventDetailsComponent.for(event, admin: true))
+    link = result.css("a[data-key='admin.event.user']").first
 
-    assert_equal "User ##{event.user_id}", result.css("a[data-key='admin.event.user']").text
+    assert_equal event.user_id.to_s.last(5), link.text
+    assert_equal "/admin/users/#{event.user_id}", link["href"]
+    assert_equal "#{event.user_id} — #{user.email_address}", link["title"]
   end
 end

--- a/test/components/event_list_item_component_test.rb
+++ b/test/components/event_list_item_component_test.rb
@@ -188,15 +188,16 @@ class EventListItemComponentTest < ViewComponent::TestCase
     assert_includes result.css("[data-key='events.footer']").text, "Type: custom_event"
   end
 
-  test "#call should link the user to the admin filter and reveal the email on hover" do
+  test "#call should link the compact user id to the admin user page" do
     event = create(:event, user: user)
 
     result = render_admin_item(event)
 
     link = result.css("a[data-key='events.user']").first
-    assert_equal "##{user.id}", link.text
-    assert_includes link["href"], "filter%5Buser_id%5D=#{user.id}"
-    assert_equal user.email_address, link["title"]
+    assert_equal user.id.to_s.last(5), link.text
+    assert_equal "/admin/users/#{user.id}", link["href"]
+    assert_equal "#{user.id} — #{user.email_address}", link["title"]
+    assert_not_includes link.text, "#"
   end
 
   test "#call should show System for events without a user in extended mode" do
@@ -208,28 +209,31 @@ class EventListItemComponentTest < ViewComponent::TestCase
     assert_equal "System", label.text
   end
 
-  test "#call should link the subject to the admin filter and reveal its name on hover" do
+  test "#call should link the compact subject id to its application page" do
     feed = create(:feed, user: user)
     event = create(:event, type: "feed_refresh", subject: feed, user: user)
 
     result = render_admin_item(event)
 
     link = result.css("a[data-key='events.subject']").first
-    assert_equal "Feed##{feed.id}", link.text
-    assert_includes link["href"], "filter%5Bsubject_type%5D=Feed"
-    assert_includes link["href"], "filter%5Bsubject_id%5D=#{feed.id}"
-    assert_equal feed.display_name, link["title"]
+    assert_equal "Feed #{feed.id.to_s.last(5)}", link.text
+    assert_equal "/admin/feeds/#{feed.id}", link["href"]
+    assert_equal "#{feed.id} — #{feed.display_name}", link["title"]
+    assert_not_includes link.text, "#"
   end
 
-  test "#call should omit the subject hover title when the subject is gone" do
+  test "#call should render an orphaned subject as compact plain text" do
     event = create(:event, user: user)
-    event.update!(subject_type: "Feed", subject_id: SecureRandom.uuid)
+    missing_id = SecureRandom.uuid
+    event.update!(subject_type: "Feed", subject_id: missing_id)
 
     result = render_admin_item(event)
 
-    link = result.css("a[data-key='events.subject']").first
-    assert_not_nil link
-    assert_nil link["title"]
+    label = result.css("span[data-key='events.subject']").first
+    assert_not_nil label
+    assert_equal "Feed #{missing_id.last(5)}", label.text
+    assert_equal missing_id, label["title"]
+    assert_empty result.css("a[data-key='events.subject']")
   end
 
   test "#call should omit the target for events without a subject" do

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -38,7 +38,8 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Events Log"
     assert_select '[data-key="events.type"]', "TestEvent"
-    assert_select 'a[data-key="events.user"]', "##{user.id}"
+    assert_select 'a[data-key="events.user"]', user.id.to_s.last(5)
+    assert_select 'a[data-key="events.user"][href=?]', admin_user_path(user)
   end
 
   test "should allow admin users to view event details" do
@@ -48,8 +49,8 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     get admin_event_path(event)
 
     assert_response :success
-    assert_select "h1", "Event ##{event.id}"
-    assert_select "a[data-key='admin.event.user']", "User ##{event.user_id}"
+    assert_select "h1", "Event #{event.id.to_s.last(5)}"
+    assert_select "a[data-key='admin.event.user']", event.user_id.to_s.last(5)
   end
 
   test "should describe the latest page with a zero offset" do
@@ -87,7 +88,6 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='events.imported_posts']"
     assert_select "##{ActionView::RecordIdentifier.dom_id(post)}"
   end
-
 
   test "should link the event's feed to the admin feed page" do
     login_as(admin_user)
@@ -256,7 +256,8 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     get admin_events_path
 
     assert_response :success
-    assert_select '[data-key="events.subject"]', text: "Post##{missing_id}"
+    assert_select '[data-key="events.subject"]', text: "Post #{missing_id.last(5)}"
+    assert_select 'a[data-key="events.subject"]', count: 0
   end
 
   test "should filter events by subject_type" do
@@ -272,8 +273,8 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '[data-key="events.type"]', count: 2
-    assert_select '[data-key="events.subject"]', text: /User#/, count: 2
-    assert_select '[data-key="events.subject"]', text: /Feed#/, count: 0
+    assert_select '[data-key="events.subject"]', text: /User [0-9a-f]{5}/, count: 2
+    assert_select '[data-key="events.subject"]', text: /Feed [0-9a-f]{5}/, count: 0
   end
 
   test "should filter events by subject_id" do
@@ -290,6 +291,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '[data-key="events.type"]', count: 2
+    assert_select '[data-key="admin.events.filter-summary"] a[href=?]', admin_feed_path(feed1), text: feed1.id.to_s.last(5)
   end
 
   test "should handle invalid filter parameter gracefully" do
@@ -346,6 +348,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '[data-key="events.type"]', count: 2
+    assert_select '[data-key="admin.events.filter-summary"] a[href=?]', admin_user_path(user1), text: user1.id.to_s.last(5)
   end
 
   test "should filter events by user_id and multiple types" do

--- a/test/controllers/development/job_runs_controller_test.rb
+++ b/test/controllers/development/job_runs_controller_test.rb
@@ -77,13 +77,13 @@ class Development::JobRunsControllerTest < ActionDispatch::IntegrationTest
     assert_select %([data-key="development.job_runs.#{run.id}.event.#{event.id}"]), text: /Purged 3 expired events/
   end
 
-  test "#show should title the page with the run id" do
+  test "#show should title the page with the compact run id" do
     run = create(:job_run, job_class: "PurgeExpiredEventsJob", status: :succeeded)
     sign_in_as(dev_user)
     get development_job_job_run_path("PurgeExpiredEventsJob", run)
 
     assert_response :success
-    assert_select "h1", text: "Run ##{run.id}"
+    assert_select "h1", text: "Run #{run.id.to_s.last(5)}"
   end
 
   test "#show should render event metadata as formatted JSON" do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -247,7 +247,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     get event_path(event)
 
     assert_response :success
-    assert_select "h1", "Event ##{event.id}"
+    assert_select "h1", "Event #{event.id.to_s.last(5)}"
   end
 
   test "#show should list imported posts referenced by the event" do
@@ -338,7 +338,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     get event_path(event), params: { filter: { type: ["something_else"] } }
 
     assert_response :success
-    assert_select "h1", "Event ##{event.id}"
+    assert_select "h1", "Event #{event.id.to_s.last(5)}"
   end
 
   test "#show should not render another user's event" do

--- a/test/controllers/feed_entries_controller_test.rb
+++ b/test/controllers/feed_entries_controller_test.rb
@@ -34,7 +34,7 @@ class FeedEntriesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     get feed_entry_url(feed_entry)
     assert_response :success
-    assert_select "h1", text: /Feed Entry \d+/
+    assert_select "h1", "Feed Entry #{feed_entry.id.to_s.last(5)}"
   end
 
   test "#show should reject access to other user's feed entry" do

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -82,7 +82,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     get post_url(user_post)
     assert_response :success
-    assert_select "h1", text: /Post \d+/
+    assert_select "h1", "Post #{user_post.id.to_s.last(5)}"
   end
 
   test "#show should reject access to other user's post" do

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -3,6 +3,30 @@ require "test_helper"
 class EventsHelperTest < ActionView::TestCase
   include TimeHelper
 
+  test "#admin_event_filter_summary renders a direct link for a known subject type" do
+    subject_id = SecureRandom.uuid
+
+    result = admin_event_filter_summary({ subject_type: "Feed", subject_id: subject_id })
+    fragment = Nokogiri::HTML.fragment(result)
+    link = fragment.at_css("a")
+
+    assert_equal "subject_type: Feed • subject_id: #{subject_id.last(5)}", fragment.text
+    assert_equal admin_feed_path(subject_id), link["href"]
+    assert_equal subject_id, link["title"]
+  end
+
+  test "#admin_event_filter_summary leaves an unknown subject type unlinked" do
+    subject_id = SecureRandom.uuid
+
+    result = admin_event_filter_summary({ subject_type: "Post", subject_id: subject_id })
+    fragment = Nokogiri::HTML.fragment(result)
+    label = fragment.at_css("span")
+
+    assert_equal "subject_type: Post • subject_id: #{subject_id.last(5)}", fragment.text
+    assert_equal subject_id, label["title"]
+    assert_nil fragment.at_css("a")
+  end
+
   test "#format_event_duration should format seconds under a minute" do
     assert_equal "3.2s", format_event_duration(3.2)
     assert_equal "59.0s", format_event_duration(59.0)

--- a/test/helpers/identifier_helper_test.rb
+++ b/test/helpers/identifier_helper_test.rb
@@ -1,25 +1,7 @@
 require "test_helper"
 
 class IdentifierHelperTest < ActionView::TestCase
-  test "#short_uuid returns the final five characters" do
-    assert_equal "1674a", short_uuid("019f5bd6-d55f-7ac2-9d75-15be0cf1674a")
-  end
-
-  test "#uuid_label adds a prefix without an integer-style hash" do
-    assert_equal "Feed ec464", uuid_label("019f5bd6-d5b7-79e3-a943-8bdbb0fec464", prefix: "Feed")
-  end
-
-  test "#uuid_reference links the compact label while preserving the full UUID" do
-    uuid = "019f5bd6-d55f-7ac2-9d75-15be0cf1674a"
-    result = uuid_reference(uuid, path: "/admin/users/#{uuid}", prefix: "User")
-
-    assert_dom_equal %(<a title="#{uuid}" class="#{IdentifierHelper::UUID_LINK_CLASSES}" href="/admin/users/#{uuid}">User 1674a</a>), result
-  end
-
-  test "#uuid_reference renders plain text when no target page is available" do
-    uuid = "019f5bd6-d5b7-79e3-a943-8bdbb0fec464"
-    result = uuid_reference(uuid, prefix: "Feed")
-
-    assert_dom_equal %(<span title="#{uuid}" class="#{IdentifierHelper::UUID_TEXT_CLASSES}">Feed ec464</span>), result
+  test "#short_ref returns the final five characters" do
+    assert_equal "1674a", short_ref("019f5bd6-d55f-7ac2-9d75-15be0cf1674a")
   end
 end

--- a/test/helpers/identifier_helper_test.rb
+++ b/test/helpers/identifier_helper_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class IdentifierHelperTest < ActionView::TestCase
+  test "#short_uuid returns the final five characters" do
+    assert_equal "1674a", short_uuid("019f5bd6-d55f-7ac2-9d75-15be0cf1674a")
+  end
+
+  test "#uuid_label adds a prefix without an integer-style hash" do
+    assert_equal "Feed ec464", uuid_label("019f5bd6-d5b7-79e3-a943-8bdbb0fec464", prefix: "Feed")
+  end
+
+  test "#uuid_reference links the compact label while preserving the full UUID" do
+    uuid = "019f5bd6-d55f-7ac2-9d75-15be0cf1674a"
+    result = uuid_reference(uuid, path: "/admin/users/#{uuid}", prefix: "User")
+
+    assert_dom_equal %(<a title="#{uuid}" class="#{IdentifierHelper::UUID_LINK_CLASSES}" href="/admin/users/#{uuid}">User 1674a</a>), result
+  end
+
+  test "#uuid_reference renders plain text when no target page is available" do
+    uuid = "019f5bd6-d5b7-79e3-a943-8bdbb0fec464"
+    result = uuid_reference(uuid, prefix: "Feed")
+
+    assert_dom_equal %(<span title="#{uuid}" class="#{IdentifierHelper::UUID_LINK_CLASSES}">Feed ec464</span>), result
+  end
+end

--- a/test/helpers/identifier_helper_test.rb
+++ b/test/helpers/identifier_helper_test.rb
@@ -20,6 +20,6 @@ class IdentifierHelperTest < ActionView::TestCase
     uuid = "019f5bd6-d5b7-79e3-a943-8bdbb0fec464"
     result = uuid_reference(uuid, prefix: "Feed")
 
-    assert_dom_equal %(<span title="#{uuid}" class="#{IdentifierHelper::UUID_LINK_CLASSES}">Feed ec464</span>), result
+    assert_dom_equal %(<span title="#{uuid}" class="#{IdentifierHelper::UUID_TEXT_CLASSES}">Feed ec464</span>), result
   end
 end


### PR DESCRIPTION
## What changed

- added a focused `short_ref` helper for five-character UUID suffixes
- extracted admin event filter-summary rendering into `EventsHelper`
- generate filter-summary links directly from UUIDs and known subject-type strings, without record lookups or constantization
- linked compact event user and subject references to safe application detail pages
- shortened local UUIDs in event, post, feed-entry, and maintenance-run headings
- kept FreeFeed post IDs, raw diagnostic JSON, URL parameters, DOM identifiers, and data attributes unchanged
- retained visually plain compact text where no route is known

## Why

Full UUIDs and obsolete integer-style `#` prefixes create unnecessary visual noise. The full UUID remains in each URL and tooltip while the visible label reads like a short Git reference.

Filter rendering should not query the database or imply that a render-time existence check guarantees the link target will still exist when clicked.

## Validation

- full test suite passed
- model/schema consistency passed
- Ruby, ERB, and Herb linting passed
- dependency, security, secret, and CodeQL scans passed
