### PR TITLE
Add global stats to admin panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-15
+
+- The Admin Panel now shows app-wide stats — users, feeds, imported and published posts — along with a publishing activity heatmap.
+
 ## 2026-07-14
 
 - Search credential and feed pages now show recent search-call counts and estimated search-provider spend.

--- a/app/components/global_stats_component.rb
+++ b/app/components/global_stats_component.rb
@@ -1,0 +1,92 @@
+class GlobalStatsComponent < ViewComponent::Base
+  def call
+    tag.div { safe_join([mobile_layout, desktop_layout]) }
+  end
+
+  private
+
+  def mobile_layout
+    render(DescriptionListComponent.new(css_class: class_names("md:hidden", DescriptionListComponent::DEFAULT_CSS_CLASSES))) do |list|
+      layout_items.each { |item| list.with_item(mobile_stat_cell(item)) }
+    end
+  end
+
+  def desktop_layout
+    render(StatsBarComponent.new(css_class: class_names("hidden", StatsBarComponent::DEFAULT_CSS_CLASSES))) do |bar|
+      layout_items.each { |item| bar.with_item(desktop_stat_cell(item)) }
+    end
+  end
+
+  def layout_items
+    @layout_items ||= [
+      {
+        key: "total_users",
+        label: "Total users",
+        label_short: "Users",
+        value: number_with_delimiter(total_users_count)
+      },
+      {
+        key: "total_feeds",
+        label: "Total feeds",
+        label_short: "Feeds",
+        value: number_with_delimiter(total_feeds_count)
+      },
+      {
+        key: "total_imported_posts",
+        label: "Total imported posts",
+        label_short: "Imported",
+        value: number_with_delimiter(total_imported_posts_count)
+      },
+      {
+        key: "total_published_posts",
+        label: "Total published posts",
+        label_short: "Published",
+        value: number_with_delimiter(total_published_posts_count)
+      },
+      {
+        key: "posts_last_week",
+        label: "Posts published last week",
+        label_short: "Last week",
+        value: number_with_delimiter(posts_published_last_week_count)
+      },
+      {
+        key: "most_recent_repost",
+        label: "Most recent repost",
+        label_short: "Recent",
+        value: most_recent_repost_at.present? ? helpers.short_time_ago(most_recent_repost_at) : "—"
+      }
+    ]
+  end
+
+  def mobile_stat_cell(item)
+    StatListItemComponent.new(label: item[:label], value: item[:value], key: "stats.#{item[:key]}")
+  end
+
+  def desktop_stat_cell(item)
+    StatBarItemComponent.new(label: item[:label_short], value: item[:value], key: "stats.#{item[:key]}")
+  end
+
+  def total_users_count
+    User.count
+  end
+
+  def total_feeds_count
+    Feed.count
+  end
+
+  def total_imported_posts_count
+    Post.count
+  end
+
+  def total_published_posts_count
+    Post.published.count
+  end
+
+  def posts_published_last_week_count
+    Post.where(published_at: 1.week.ago.beginning_of_day..Time.current.end_of_day).count
+  end
+
+  def most_recent_repost_at
+    @most_recent_repost_at ||= Post.published.maximum(:reposted_at)
+  end
+end

--- a/app/components/posts_heatmap_component.rb
+++ b/app/components/posts_heatmap_component.rb
@@ -48,6 +48,9 @@ class PostsHeatmapComponent < ViewComponent::Base
   end
 
   def base_scope
-    @feed ? @feed.feed_metrics : FeedMetric.for_user(@user)
+    return @feed.feed_metrics if @feed
+    return FeedMetric.for_user(@user) if @user
+
+    FeedMetric.all
   end
 end

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -34,4 +34,10 @@
       </div>
     <% end %>
   </div>
+
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold text-heading">Stats</h2>
+    <%= render GlobalStatsComponent.new %>
+    <%= render PostsHeatmapComponent.new %>
+  </section>
 </div>

--- a/test/components/global_stats_component_test.rb
+++ b/test/components/global_stats_component_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+require "view_component/test_case"
+
+class GlobalStatsComponentTest < ViewComponent::TestCase
+  test "#render should include all metrics" do
+    result = render_inline(GlobalStatsComponent.new)
+
+    %w[
+      total_users
+      total_feeds
+      total_imported_posts
+      total_published_posts
+      posts_last_week
+      most_recent_repost
+    ].each do |key|
+      assert_not_nil result.css(%([data-key="stats.#{key}"])).first, "expected stats.#{key} to be rendered"
+    end
+  end
+
+  test "#render should include mobile layout with full labels" do
+    result = render_inline(GlobalStatsComponent.new)
+
+    mobile_layout = result.css(".md\\:hidden").first
+    assert_not_nil mobile_layout
+    assert_includes result.css(".md\\:hidden [data-key=\"stats.total_users.label\"]").first.text, "Total users"
+    assert_includes result.css(".md\\:hidden [data-key=\"stats.total_feeds.label\"]").first.text, "Total feeds"
+  end
+
+  test "#render should include desktop layout with short labels" do
+    result = render_inline(GlobalStatsComponent.new)
+
+    desktop_layout = result.css(".hidden.md\\:flex").first
+    assert_not_nil desktop_layout
+    assert_equal "Users", result.css(".hidden.md\\:flex [data-key=\"stats.total_users.label\"]").first.text
+    assert_equal "Feeds", result.css(".hidden.md\\:flex [data-key=\"stats.total_feeds.label\"]").first.text
+    assert_equal "Imported", result.css(".hidden.md\\:flex [data-key=\"stats.total_imported_posts.label\"]").first.text
+  end
+
+  test "#render should aggregate counts across all users" do
+    first_feed = create(:feed, user: create(:user))
+    second_feed = create(:feed, user: create(:user))
+    create(:post, :published, feed: first_feed)
+    create(:post, feed: second_feed)
+
+    result = render_inline(GlobalStatsComponent.new)
+
+    assert_equal User.count.to_s, result.css(".hidden.md\\:flex [data-key=\"stats.total_users.value\"]").first.text
+    assert_equal Feed.count.to_s, result.css(".hidden.md\\:flex [data-key=\"stats.total_feeds.value\"]").first.text
+    assert_equal "2", result.css(".hidden.md\\:flex [data-key=\"stats.total_imported_posts.value\"]").first.text
+    assert_equal "1", result.css(".hidden.md\\:flex [data-key=\"stats.total_published_posts.value\"]").first.text
+  end
+
+  test "#render should display fallback value when no published posts" do
+    result = render_inline(GlobalStatsComponent.new)
+
+    recent_value = result.css('[data-key="stats.most_recent_repost.value"]').first.text
+    assert_equal "—", recent_value
+  end
+end

--- a/test/components/posts_heatmap_component_test.rb
+++ b/test/components/posts_heatmap_component_test.rb
@@ -69,4 +69,22 @@ class PostsHeatmapComponentTest < ViewComponent::TestCase
     today_cell = result.css("[data-tippy-content='7']").first
     assert_not_nil today_cell
   end
+
+  test "#render? should return false when there are no metrics globally" do
+    component = PostsHeatmapComponent.new
+    render_inline(component)
+    assert_not component.render?
+  end
+
+  test "#call should aggregate published_posts_count across all users when no scope is given" do
+    other_user_feed = create(:feed, user: create(:user))
+    create(:feed_metric, feed: feed, date: Date.current, published_posts_count: 3)
+    create(:feed_metric, feed: other_user_feed, date: Date.current, published_posts_count: 4)
+
+    result = render_inline(PostsHeatmapComponent.new)
+    assert result.css("svg").any?
+
+    today_cell = result.css("[data-tippy-content='7']").first
+    assert_not_nil today_cell
+  end
 end

--- a/test/controllers/admins_controller_test.rb
+++ b/test/controllers/admins_controller_test.rb
@@ -38,6 +38,21 @@ class AdminsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{development_components_path}']", count: 0
   end
 
+  test "should show global stats on admin panel" do
+    create(:post, :published, feed: create(:feed, user: user))
+    create(:feed_metric, :with_published_posts, feed: create(:feed, user: admin_user))
+
+    sign_in_as(admin_user)
+    get admin_url
+
+    assert_response :success
+    assert_select "h2", "Stats"
+    assert_select "[data-key='stats.total_users.value']", text: User.count.to_s
+    assert_select "[data-key='stats.total_feeds.value']", text: Feed.count.to_s
+    assert_select "[data-key='stats.total_published_posts.value']", text: "1"
+    assert_select "[data-controller='heatmap']", count: 1
+  end
+
   test "should redirect when authenticated as regular user" do
     sign_in_as(user)
     get admin_url


### PR DESCRIPTION
Changes:

- Add a Stats section to the Admin Panel root page with app-wide totals: users, feeds, imported and published posts, posts published last week, and most recent repost
- New `GlobalStatsComponent` mirrors the `/status` page stats layout — description list on mobile, stats bar on desktop
- Extend `PostsHeatmapComponent` with a global scope (no user or feed given) for a publishing activity heatmap across all accounts

The section gives admins the same at-a-glance activity overview users get on their status page, but for the whole app.

References:

- Closes #1018