### PR TITLE
Record feed activity when credentials are removed

### DIFF
--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -12,7 +12,9 @@ class EventDescriptionComponent < ViewComponent::Base
   SUBCLASSES = {
     "feed_refresh" => "FeedRefreshDescriptionComponent",
     "feed_auto_disabled" => "FeedAutoDisabledDescriptionComponent",
-    "feed_target_group_unavailable" => "FeedTargetGroupUnavailableDescriptionComponent"
+    "feed_target_group_unavailable" => "FeedTargetGroupUnavailableDescriptionComponent",
+    "feed_ai_credential_removed" => "FeedCredentialRemovedDescriptionComponent",
+    "feed_search_credential_removed" => "FeedCredentialRemovedDescriptionComponent"
   }.freeze
 
   def self.for(event)

--- a/app/components/feed_credential_removed_description_component.rb
+++ b/app/components/feed_credential_removed_description_component.rb
@@ -1,0 +1,11 @@
+# Chooses wording based on whether credential removal also changed the feed's
+# state. Draft and already-disabled feeds still get an activity event, without
+# claiming they were disabled by the removal.
+class FeedCredentialRemovedDescriptionComponent < EventDescriptionComponent
+  private
+
+  def description_key
+    variant = event.metadata["disabled"] ? "disabled_description_html" : "description_html"
+    "events.#{event_type}.#{variant}"
+  end
+end

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -4,6 +4,7 @@
 # encrypted at rest.
 class AiCredential < ApplicationRecord
   DISPLAY_NAME_MAX_LENGTH = 80
+  REMOVED_EVENT_TYPE = "feed_ai_credential_removed"
 
   belongs_to :user
   # `dependent` is handled manually by `disable_dependent_feeds` so we can
@@ -103,15 +104,23 @@ class AiCredential < ApplicationRecord
     errors.add(:base, "Enter your API key") if credential_data.blank? || credential_data["api_key"].blank?
   end
 
-  # Mirrors AccessToken#disable_associated_feeds: drop the credential
-  # reference and pull any feed left without a usable credential out of
-  # the enabled state. The feeds.user_id is already set, so we don't
-  # have to touch other ownership fields.
+  # Detach this credential from every dependent feed. Enabled feeds are disabled;
+  # drafts and already-disabled feeds keep their state. Every feed gets its own
+  # user-visible event explaining the removal and whether it caused the disable.
   def disable_dependent_feeds
-    affected_feed_ids = feeds.pluck(:id)
-    return if affected_feed_ids.empty?
+    feeds.find_each do |feed|
+      disabled = feed.enabled?
+      attributes = { ai_credential_id: nil }
+      attributes[:state] = Feed.states[:disabled] if disabled
 
-    Feed.where(id: affected_feed_ids).update_all(ai_credential_id: nil)
-    Feed.where(id: affected_feed_ids, state: Feed.states[:enabled]).update_all(state: Feed.states[:disabled])
+      feed.update_columns(attributes)
+      Event.create!(
+        type: REMOVED_EVENT_TYPE,
+        level: :warning,
+        subject: feed,
+        user: user,
+        metadata: { disabled: disabled }
+      )
+    end
   end
 end

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -104,22 +104,20 @@ class AiCredential < ApplicationRecord
     errors.add(:base, "Enter your API key") if credential_data.blank? || credential_data["api_key"].blank?
   end
 
-  # Detach this credential from every dependent feed. Enabled feeds are disabled;
-  # drafts and already-disabled feeds keep their state. Every feed gets its own
-  # user-visible event explaining the removal and whether it caused the disable.
+  # Detach this credential from every dependent feed. Enabled feeds reuse the
+  # feed's generic disable-and-event transition; drafts and already-disabled
+  # feeds keep their state and receive a removal-only event.
   def disable_dependent_feeds
     feeds.find_each do |feed|
-      disabled = feed.enabled?
-      attributes = { ai_credential_id: nil }
-      attributes[:state] = Feed.states[:disabled] if disabled
+      feed.update_column(:ai_credential_id, nil)
+      next if feed.enabled? && feed.disable_with_event!(REMOVED_EVENT_TYPE, { disabled: true })
 
-      feed.update_columns(attributes)
       Event.create!(
         type: REMOVED_EVENT_TYPE,
         level: :warning,
         subject: feed,
         user: user,
-        metadata: { disabled: disabled }
+        metadata: { disabled: false }
       )
     end
   end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -300,7 +300,7 @@ class Feed < ApplicationRecord
 
   # Creates and returns a normalizer instance for the given feed entry
   # @param feed_entry [FeedEntry] the feed entry to normalize
-  # @return [Normalizer::Base] normalizer instance
+  # @return [Normalizer::Base]
   def normalizer_instance(feed_entry)
     normalizer_class.new(feed_entry)
   end
@@ -368,6 +368,20 @@ class Feed < ApplicationRecord
     disable_with_event!("feed_target_group_unavailable", metadata)
   end
 
+  # Disables the feed and records why in one transaction. Already-disabled feeds
+  # are left untouched so callers can safely race or retry without duplicate events.
+  # update_columns flips the state and zeroes the counter in one write, skipping
+  # validations neither needs; metadata is evaluated first, so it can read
+  # pre-disable values like the failure streak.
+  def disable_with_event!(type, metadata)
+    return false if disabled?
+
+    transaction do
+      update_columns(state: self.class.states[:disabled], consecutive_failures: 0)
+      Event.create!(type: type, level: :warning, subject: self, user: user, metadata: metadata)
+    end
+  end
+
   # Clears the streak after a successful refresh.
   def reset_refresh_failures!
     return if consecutive_failures.zero?
@@ -395,17 +409,6 @@ class Feed < ApplicationRecord
   # activity log shows how many failures it took.
   def disable_after_repeated_failures!
     disable_with_event!("feed_auto_disabled", { error_count: consecutive_failures })
-  end
-
-  # Disables the feed and records why in one transaction. update_columns flips
-  # the state and zeroes the counter in one write, skipping validations neither
-  # needs; the metadata is evaluated first, so it can read pre-disable values
-  # like the failure streak.
-  def disable_with_event!(type, metadata)
-    transaction do
-      update_columns(state: self.class.states[:disabled], consecutive_failures: 0)
-      Event.create!(type: type, level: :warning, subject: self, user: user, metadata: metadata)
-    end
   end
 
   # Only touches import_after when the form parts were assigned, so saves that

--- a/app/models/search_credential.rb
+++ b/app/models/search_credential.rb
@@ -1,6 +1,7 @@
 # Stores a user's API credential for a web search provider.
 class SearchCredential < ApplicationRecord
   DISPLAY_NAME_MAX_LENGTH = 80
+  REMOVED_EVENT_TYPE = "feed_search_credential_removed"
 
   belongs_to :user
   has_many :feeds
@@ -80,11 +81,23 @@ class SearchCredential < ApplicationRecord
     errors.add(:base, "Enter your API key") if credential_data.blank? || credential_data["api_key"].blank?
   end
 
+  # Detach this credential from every dependent feed. Enabled feeds are disabled;
+  # drafts and already-disabled feeds keep their state. Every feed gets its own
+  # user-visible event explaining the removal and whether it caused the disable.
   def disable_dependent_feeds
-    affected_feed_ids = feeds.pluck(:id)
-    return if affected_feed_ids.empty?
+    feeds.find_each do |feed|
+      disabled = feed.enabled?
+      attributes = { search_credential_id: nil }
+      attributes[:state] = Feed.states[:disabled] if disabled
 
-    Feed.where(id: affected_feed_ids).update_all(search_credential_id: nil)
-    Feed.where(id: affected_feed_ids, state: Feed.states[:enabled]).update_all(state: Feed.states[:disabled])
+      feed.update_columns(attributes)
+      Event.create!(
+        type: REMOVED_EVENT_TYPE,
+        level: :warning,
+        subject: feed,
+        user: user,
+        metadata: { disabled: disabled }
+      )
+    end
   end
 end

--- a/app/models/search_credential.rb
+++ b/app/models/search_credential.rb
@@ -81,22 +81,20 @@ class SearchCredential < ApplicationRecord
     errors.add(:base, "Enter your API key") if credential_data.blank? || credential_data["api_key"].blank?
   end
 
-  # Detach this credential from every dependent feed. Enabled feeds are disabled;
-  # drafts and already-disabled feeds keep their state. Every feed gets its own
-  # user-visible event explaining the removal and whether it caused the disable.
+  # Detach this credential from every dependent feed. Enabled feeds reuse the
+  # feed's generic disable-and-event transition; drafts and already-disabled
+  # feeds keep their state and receive a removal-only event.
   def disable_dependent_feeds
     feeds.find_each do |feed|
-      disabled = feed.enabled?
-      attributes = { search_credential_id: nil }
-      attributes[:state] = Feed.states[:disabled] if disabled
+      feed.update_column(:search_credential_id, nil)
+      next if feed.enabled? && feed.disable_with_event!(REMOVED_EVENT_TYPE, { disabled: true })
 
-      feed.update_columns(attributes)
       Event.create!(
         type: REMOVED_EVENT_TYPE,
         level: :warning,
         subject: feed,
         user: user,
-        metadata: { disabled: disabled }
+        metadata: { disabled: false }
       )
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,14 @@ en:
     feed_ai_model_unavailable:
       name: "AI model unavailable"
       description_html: "%{subject_link}'s AI model is no longer available, so it's running on a fallback for now — pick a new model to keep it accurate."
+    feed_ai_credential_removed:
+      name: "AI credentials removed"
+      description_html: "%{subject_link}'s AI credentials were removed"
+      disabled_description_html: "%{subject_link} was disabled because its AI credentials were removed"
+    feed_search_credential_removed:
+      name: "Search credentials removed"
+      description_html: "%{subject_link}'s search credentials were removed"
+      disabled_description_html: "%{subject_link} was disabled because its search credentials were removed"
     feed_refresh:
       name: "Feed refreshed"
       description_html: "%{subject_link} refreshed"

--- a/test/components/feed_credential_removed_description_component_test.rb
+++ b/test/components/feed_credential_removed_description_component_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+require "view_component/test_case"
+
+class FeedCredentialRemovedDescriptionComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed
+    @feed ||= create(:feed, user: user, name: "Test Feed")
+  end
+
+  test "renders AI credential removal as the reason an enabled feed was disabled" do
+    event = Event.create!(
+      type: AiCredential::REMOVED_EVENT_TYPE,
+      level: :warning,
+      subject: feed,
+      user: user,
+      metadata: { disabled: true }
+    )
+
+    result = render_inline(EventDescriptionComponent.for(event)).to_html
+
+    assert_includes result, "Test Feed"
+    assert_includes result, "/feeds/#{feed.id}"
+    assert_includes result, "was disabled because its AI credentials were removed"
+  end
+
+  test "does not claim an already-inactive feed was disabled by search credential removal" do
+    event = Event.create!(
+      type: SearchCredential::REMOVED_EVENT_TYPE,
+      level: :warning,
+      subject: feed,
+      user: user,
+      metadata: { disabled: false }
+    )
+
+    result = render_inline(EventDescriptionComponent.for(event)).to_html
+
+    assert_includes result, "Test Feed"
+    assert_includes result, "search credentials were removed"
+    assert_not_includes result, "was disabled"
+  end
+end

--- a/test/integration/credential_removal_activity_test.rb
+++ b/test/integration/credential_removal_activity_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class CredentialRemovalActivityTest < ActionDispatch::IntegrationTest
+  def user
+    @user ||= create(:user)
+  end
+
+  def ai_credential
+    @ai_credential ||= create(:ai_credential, :active, user: user)
+  end
+
+  def search_credential
+    @search_credential ||= create(:search_credential, :active, user: user)
+  end
+
+  def enabled_ai_feed
+    @enabled_ai_feed ||= create(
+      :feed,
+      :disabled,
+      user: user,
+      name: "AI news",
+      feed_profile_key: "llm",
+      params: { "prompt" => "Ruby news" },
+      ai_credential: ai_credential,
+      search_credential: search_credential,
+      ai_model: "claude-sonnet-4-6"
+    ).tap { |feed| feed.update_columns(state: Feed.states[:enabled]) }
+  end
+
+  test "AI credential removal is explained in the feed's Recent Activity" do
+    feed = enabled_ai_feed
+    sign_in_as(user)
+
+    ai_credential.destroy!
+    get feed_path(feed)
+
+    assert_response :success
+    assert_predicate feed.reload, :disabled?
+    assert_nil feed.ai_credential_id
+    assert_select "h2", text: "Recent Activity"
+    assert_select "[data-key='events.entry'][data-event-type='#{AiCredential::REMOVED_EVENT_TYPE}']" do
+      assert_select "[data-key='events.description']", text: /was disabled because its AI credentials were removed/
+    end
+  end
+
+  test "search credential removal is explained in the feed's Recent Activity" do
+    feed = enabled_ai_feed
+    sign_in_as(user)
+
+    search_credential.destroy!
+    get feed_path(feed)
+
+    assert_response :success
+    assert_predicate feed.reload, :disabled?
+    assert_nil feed.search_credential_id
+    assert_select "h2", text: "Recent Activity"
+    assert_select "[data-key='events.entry'][data-event-type='#{SearchCredential::REMOVED_EVENT_TYPE}']" do
+      assert_select "[data-key='events.description']", text: /was disabled because its search credentials were removed/
+    end
+  end
+end

--- a/test/models/credential_removal_test.rb
+++ b/test/models/credential_removal_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class CredentialRemovalTest < ActiveSupport::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  test "destroying an AI credential detaches every feed, disables enabled feeds, and records per-feed events" do
+    credential = create(:ai_credential, user: user)
+    draft_feed = create(:feed, :draft, user: user, ai_credential: credential)
+    disabled_feed = create(:feed, :disabled, user: user, ai_credential: credential)
+    enabled_feed = create(:feed, :disabled, user: user, ai_credential: credential)
+    enabled_feed.update_columns(state: Feed.states[:enabled])
+
+    assert_difference("Event.count", 3) do
+      credential.destroy!
+    end
+
+    assert_nil draft_feed.reload.ai_credential_id
+    assert_predicate draft_feed, :draft?
+    assert_nil disabled_feed.reload.ai_credential_id
+    assert_predicate disabled_feed, :disabled?
+    assert_nil enabled_feed.reload.ai_credential_id
+    assert_predicate enabled_feed, :disabled?
+
+    assert_removal_event(draft_feed, AiCredential::REMOVED_EVENT_TYPE, disabled: false)
+    assert_removal_event(disabled_feed, AiCredential::REMOVED_EVENT_TYPE, disabled: false)
+    assert_removal_event(enabled_feed, AiCredential::REMOVED_EVENT_TYPE, disabled: true)
+  end
+
+  test "destroying a search credential detaches every feed, disables enabled feeds, and records per-feed events" do
+    credential = create(:search_credential, user: user)
+    draft_feed = create(:feed, :draft, user: user, search_credential: credential)
+    disabled_feed = create(:feed, :disabled, user: user, search_credential: credential)
+    enabled_feed = create(:feed, :disabled, user: user, search_credential: credential)
+    enabled_feed.update_columns(state: Feed.states[:enabled])
+
+    assert_difference("Event.count", 3) do
+      credential.destroy!
+    end
+
+    assert_nil draft_feed.reload.search_credential_id
+    assert_predicate draft_feed, :draft?
+    assert_nil disabled_feed.reload.search_credential_id
+    assert_predicate disabled_feed, :disabled?
+    assert_nil enabled_feed.reload.search_credential_id
+    assert_predicate enabled_feed, :disabled?
+
+    assert_removal_event(draft_feed, SearchCredential::REMOVED_EVENT_TYPE, disabled: false)
+    assert_removal_event(disabled_feed, SearchCredential::REMOVED_EVENT_TYPE, disabled: false)
+    assert_removal_event(enabled_feed, SearchCredential::REMOVED_EVENT_TYPE, disabled: true)
+  end
+
+  private
+
+  def assert_removal_event(feed, type, disabled:)
+    event = feed.events.find_by!(type: type)
+
+    assert_equal "warning", event.level
+    assert_equal user, event.user
+    assert_equal disabled, event.metadata["disabled"]
+  end
+end

--- a/test/models/credential_removal_test.rb
+++ b/test/models/credential_removal_test.rb
@@ -5,6 +5,15 @@ class CredentialRemovalTest < ActiveSupport::TestCase
     @user ||= create(:user)
   end
 
+  test "#disable_with_event! is public and short-circuits for disabled feeds" do
+    feed = create(:feed, :disabled, user: user)
+
+    assert_respond_to feed, :disable_with_event!
+    assert_no_difference("Event.count") do
+      assert_equal false, feed.disable_with_event!("test_disable", {})
+    end
+  end
+
   test "destroying an AI credential detaches every feed, disables enabled feeds, and records per-feed events" do
     credential = create(:ai_credential, user: user)
     draft_feed = create(:feed, :draft, user: user, ai_credential: credential)


### PR DESCRIPTION
## Summary

Deleting an AI or search credential now detaches it from every associated feed. Feeds that were enabled are disabled, while drafts and already-disabled feeds keep their existing state.

Each affected feed receives its own warning-level activity event. On the feed page, Recent Activity explains whether the credential was simply removed or whether its removal also disabled the feed. No separate notice is shown on the edit form.

## Implementation

- handle AI and search credential deletion symmetrically
- detach the deleted credential from every associated feed
- disable feeds that were enabled at deletion time
- create one feed-subject warning event per affected feed
- render state-accurate Recent Activity descriptions
- remove the previous form-only marker approach

## Validation

- Ruby syntax checks passed for all changed Ruby files
- locale YAML parses successfully
- added model coverage for draft, disabled, and enabled feeds
- added component coverage for both activity wording variants
- added integration coverage for AI and search credential removal appearing in Recent Activity
- full Rails test execution is delegated to CI because this environment cannot clone the repository

Closes #875