### PR TITLE
Measure feed refresh queue health

### DIFF
--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -10,12 +10,23 @@ Rails.application.config.after_initialize do
   # would run identical queries every flush and overwrite the same series.
   # Counters are per-process and register/push everywhere regardless.
   if ENV["METRICS_GAUGES"].present?
+    feed_refresh_jobs_ready = lambda do
+      SolidQueue::ReadyExecution.where(
+        job_id: SolidQueue::Job.where(class_name: FeedRefreshJob.name)
+      )
+    end
+
     Metrics.gauge_set("posts_count") do
       counts = Post.group(:status).count
       Post.statuses.keys.to_h { |status| [{ status: status }, counts.fetch(status, 0)] }
     end
     Metrics.gauge("jobs_ready") { SolidQueue::ReadyExecution.count }
     Metrics.gauge("jobs_failed") { SolidQueue::FailedExecution.count }
+    Metrics.gauge("feed_refresh_jobs_ready") { feed_refresh_jobs_ready.call.count }
+    Metrics.gauge("feed_refresh_oldest_ready_age_seconds") do
+      ready_since = feed_refresh_jobs_ready.call.minimum(:created_at)
+      ready_since ? [Time.current - ready_since, 0].max.to_i : 0
+    end
     Metrics.gauge("pg_database_size_bytes") { PostgresMetrics.database_size }
     Metrics.gauge_set("pg_table_size_bytes") { PostgresMetrics.table_sizes }
   end

--- a/config/victoriametrics/dashboards/node-overview.json
+++ b/config/victoriametrics/dashboards/node-overview.json
@@ -104,12 +104,24 @@
           "expr": [
             "feeder_posts_count{status=\"enqueued\"}",
             "feeder_jobs_ready",
+            "feeder_feed_refresh_jobs_ready",
             "feeder_jobs_failed"
           ],
           "alias": [
             "enqueued posts",
             "ready jobs",
+            "ready feed refreshes",
             "failed jobs"
+          ]
+        },
+        {
+          "title": "Oldest feed refresh wait",
+          "unit": "s",
+          "expr": [
+            "feeder_feed_refresh_oldest_ready_age_seconds"
+          ],
+          "alias": [
+            "queue age"
           ]
         },
         {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,23 @@
+# Application metrics
+
+## Feed refresh queue
+
+### `feeder_feed_refresh_jobs_ready`
+
+Number of `FeedRefreshJob` executions currently waiting in Solid Queue's ready queue.
+
+A brief increase is expected when several feeds become due at the same schedule boundary. This metric shows the size of that burst, but not whether it is causing a practical delay.
+
+### `feeder_feed_refresh_oldest_ready_age_seconds`
+
+Age, in seconds, of the oldest `FeedRefreshJob` waiting in the ready queue. The value is `0` when no feed refresh is waiting.
+
+This is the primary signal for deciding whether synchronized feed schedules need to be staggered:
+
+- A high ready count with a low age means workers are draining the burst quickly.
+- A growing age means feed refreshes are waiting and may delay other jobs in the shared queue.
+- Repeated multi-minute peaks around schedule boundaries are evidence that staggering may be worth implementing.
+
+Compare these metrics with `feeder_jobs_ready`, which includes every job type. If the global queue grows while the feed-refresh queue does not, feed scheduling is not the cause.
+
+Both metrics are global gauges without feed or user labels. They are sampled by the process configured with `METRICS_GAUGES` and appear after the next metrics flush.

--- a/docs/victoriametrics.md
+++ b/docs/victoriametrics.md
@@ -5,6 +5,8 @@ Staging runs VictoriaMetrics as a Kamal accessory (`config/deploy.staging.yml`) 
 - **Scrape:** VM pulls host OS metrics (CPU, memory, disk, network) from the `node-exporter` accessory, per `config/victoriametrics/scrape.yml`.
 - **Push:** the app sends its own `feeder_*` metrics (counters and gauges, including PostgreSQL sizes) to VM's import endpoint on the configured flush interval — 60 seconds on staging. See `app/services/metrics.rb` and `config/initializers/metrics.rb`.
 
+Metric definitions and guidance for interpreting them are in [Application metrics](metrics.md).
+
 VM is bound to localhost on the server, so view the UI through an SSH tunnel:
 
 ```


### PR DESCRIPTION
## Summary

- add gauges for the number of ready feed refresh jobs and the age of the oldest one
- chart both signals in the existing VictoriaMetrics dashboard
- document what the metrics mean and when feed staggering would be justified

## Why

Feeds with the same interval can become due together, but at the current expected scale the important question is whether the resulting queue burst creates meaningful delay. These metrics measure that impact without adding scheduling state or changing feed behavior prematurely.

Refs #1019

## Checks

- `ruby -c config/initializers/metrics.rb`
- `python -m json.tool config/victoriametrics/dashboards/node-overview.json`

The Rails test suite was not run because this environment has GitHub API access but no repository checkout or GitHub CLI.
