### PR TITLE
Fix workflow timing semantics

### DIFF
--- a/app/services/workflow.rb
+++ b/app/services/workflow.rb
@@ -48,10 +48,9 @@ module Workflow
 
   def execute(initial_input = nil)
     workflow_start_time = Time.current
-    steps = self.class.workflow_steps
     current_input = initial_input
 
-    steps.each do |step_name|
+    self.class.workflow_steps.each do |step_name|
       @current_step = step_name
       start_step_timer(step_name)
 
@@ -59,20 +58,23 @@ module Workflow
         logger.info "#{self.class.name}: Starting step: #{step_name}"
         before_step(current_input)
         current_input = send(step_name, current_input)
+        end_step_timer(step_name)
         after_step(current_input)
         logger.info "#{self.class.name}: Completed step: #{step_name}"
       rescue HaltExecution
+        end_step_timer(step_name)
+        record_total_duration(workflow_start_time)
         logger.info "#{self.class.name}: Halted at step: #{step_name}"
         return nil
       rescue => e
+        end_step_timer(step_name)
+        record_total_duration(workflow_start_time)
         on_error(e)
         raise
       end
-
-      end_step_timer(step_name)
     end
 
-    @total_duration = Time.current - workflow_start_time
+    record_total_duration(workflow_start_time)
     current_input
   end
 
@@ -114,6 +116,10 @@ module Workflow
     duration = Time.current - start_time
     step_durations[step_name] = duration
     duration
+  end
+
+  def record_total_duration(start_time)
+    @total_duration = Time.current - start_time
   end
 
   def step_timers

--- a/test/services/workflow_timing_test.rb
+++ b/test/services/workflow_timing_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class WorkflowTimingTest < ActiveSupport::TestCase
+  class SuccessfulWorkflow
+    include Workflow
+
+    step :complete
+
+    attr_reader :duration_seen_after_step
+
+    def run
+      execute
+    end
+
+    private
+
+    def complete(*)
+      :done
+    end
+
+    def after_step(*)
+      @duration_seen_after_step = step_durations.fetch(current_step)
+    end
+  end
+
+  class FailingWorkflow
+    include Workflow
+
+    step :fail_step
+
+    attr_reader :duration_seen_on_error, :total_duration_seen_on_error
+
+    def run
+      execute
+    end
+
+    private
+
+    def fail_step(*)
+      raise "boom"
+    end
+
+    def on_error(*)
+      @duration_seen_on_error = step_durations.fetch(current_step)
+      @total_duration_seen_on_error = total_duration
+    end
+  end
+
+  test "#execute should finalize the step timer before after_step" do
+    workflow = SuccessfulWorkflow.new
+
+    assert_equal :done, workflow.run
+    assert_kind_of Numeric, workflow.duration_seen_after_step
+    assert_operator workflow.duration_seen_after_step, :>=, 0
+  end
+
+  test "#execute should finalize timers before on_error" do
+    workflow = FailingWorkflow.new
+
+    assert_raises(RuntimeError) { workflow.run }
+    assert_kind_of Numeric, workflow.duration_seen_on_error
+    assert_operator workflow.total_duration_seen_on_error, :>=, workflow.duration_seen_on_error
+  end
+end


### PR DESCRIPTION
Changes:

- Finalize each step timer before `after_step` and `on_error` callbacks run.
- Preserve total workflow duration on halted and failed executions.
- Add contract-level tests for successful and failing callback paths.

This makes the workflow lifecycle internally consistent and fixes refresh step metrics that were recorded before their durations existed.

References:

- Related issue: #1010