### PR TITLE
Remove impossible refresh job tests

### DIFF
--- a/test/jobs/feed_refresh_job_test.rb
+++ b/test/jobs/feed_refresh_job_test.rb
@@ -21,58 +21,6 @@ class FeedRefreshJobTest < ActiveJob::TestCase
     end
   end
 
-  test "handles unknown loader gracefully" do
-    bad_feed = create(:feed, feed_profile_key: "rss")
-
-    # Mock the loader_class_for to raise ArgumentError for unknown loader
-    FeedProfile.stub(:loader_class_for, ->(_key) { raise ArgumentError, "Unknown loader: unknown" }) do
-      assert_raises(ArgumentError, "Unknown loader: unknown") do
-        FeedRefreshJob.perform_now(bad_feed.id)
-      end
-    end
-  end
-
-  test "handles unknown processor gracefully" do
-    bad_feed = create(:feed, feed_profile_key: "rss")
-
-    # Stub the HTTP request that will be made before hitting processor error
-    WebMock.stub_request(:get, bad_feed.url).to_return(body: "<rss></rss>", status: 200)
-
-    # Mock the processor_class_for to raise ArgumentError for unknown processor
-    FeedProfile.stub(:processor_class_for, ->(_key) { raise ArgumentError, "Unknown processor: unknown" }) do
-      assert_raises(ArgumentError, "Unknown processor: unknown") do
-        FeedRefreshJob.perform_now(bad_feed.id)
-      end
-    end
-  end
-
-  test "handles unknown normalizer gracefully" do
-    bad_feed = create(:feed, feed_profile_key: "rss")
-
-    # Stub with valid RSS content to reach normalizer step
-    sample_rss = <<~RSS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0">
-        <channel>
-          <item>
-            <guid>test-entry</guid>
-            <title>Test Entry</title>
-            <description>Test description</description>
-          </item>
-        </channel>
-      </rss>
-    RSS
-
-    WebMock.stub_request(:get, bad_feed.url).to_return(body: sample_rss, status: 200)
-
-    # Mock the normalizer_class_for to raise ArgumentError for unknown normalizer
-    FeedProfile.stub(:normalizer_class_for, ->(_key) { raise ArgumentError, "Unknown normalizer: unknown" }) do
-      assert_raises(ArgumentError, "Unknown normalizer: unknown") do
-        FeedRefreshJob.perform_now(bad_feed.id)
-      end
-    end
-  end
-
   test "does not raise when the loader raises Loader::Error" do
     WebMock.stub_request(:get, feed.url).to_return(status: 500)
 


### PR DESCRIPTION
Changes:

- Remove refresh-job tests that stub the profile registry into impossible loader, processor, and normalizer states.
- Keep job-level tests focused on behavior the job actually owns.

The removed cases duplicated the registry contract tests and exercised the entire refresh workflow while only asserting that synthetic `ArgumentError`s propagate.

References:

- Related issue: #1010