### PR TITLE
Fix feed list and pagination scaling

### DIFF
--- a/app/components/feed_list_item_component.rb
+++ b/app/components/feed_list_item_component.rb
@@ -173,9 +173,7 @@ class FeedListItemComponent < ListItemComponent
   end
 
   def target_group_url
-    return unless feed.access_token && feed.target_group.present?
-
-    "#{feed.access_token.host}/#{feed.target_group}"
+    feed.target_group_url
   end
 
   def owner
@@ -187,15 +185,29 @@ class FeedListItemComponent < ListItemComponent
   end
 
   def last_refreshed_tag
-    return "Never" unless feed.last_refreshed_at
+    refreshed_at = listing_last_refreshed_at
+    return "Never" unless refreshed_at
 
-    helpers.short_time_ago_tag(feed.last_refreshed_at)
+    helpers.short_time_ago_tag(refreshed_at)
   end
 
   def most_recent_post_tag
-    return "None" unless feed.most_recent_post_date
+    published_at = listing_most_recent_post_date
+    return "None" unless published_at
 
-    helpers.short_time_ago_tag(feed.most_recent_post_date)
+    helpers.short_time_ago_tag(published_at)
+  end
+
+  def listing_last_refreshed_at
+    return feed[:listing_last_refreshed_at] if feed.has_attribute?(:listing_last_refreshed_at)
+
+    feed.last_refreshed_at
+  end
+
+  def listing_most_recent_post_date
+    return feed[:listing_most_recent_post_date] if feed.has_attribute?(:listing_most_recent_post_date)
+
+    feed.most_recent_post_date
   end
 
   def published_posts_count_tag

--- a/app/controllers/admin/feeds_controller.rb
+++ b/app/controllers/admin/feeds_controller.rb
@@ -28,8 +28,8 @@ class Admin::FeedsController < ApplicationController
   end
 
   def pagination_scope
-    policy_scope([:admin, Feed])
-      .includes(:user, :access_token, :feed_entries, :posts)
+    with_listing_stats(policy_scope([:admin, Feed]))
+      .includes(:user, :access_token)
       .order(sortable_order)
   end
 end

--- a/app/controllers/concerns/feed_listing.rb
+++ b/app/controllers/concerns/feed_listing.rb
@@ -1,12 +1,13 @@
 # Shared feed-list configuration for the user-facing and admin feed
-# controllers: the sort-field SQL and the show page's recent-posts query.
-# Keeping the raw order_by expressions in one place stops the two copies
-# from drifting.
+# controllers: sort expressions, listing stats, and recent-post queries.
 module FeedListing
   extend ActiveSupport::Concern
 
   MAX_RECENT_POSTS = 5
   MAX_RECENT_EVENTS = 10
+
+  LAST_REFRESH_SQL = "(SELECT MAX(created_at) FROM feed_entries WHERE feed_entries.feed_id = feeds.id)".freeze
+  MOST_RECENT_POST_SQL = "(SELECT MAX(published_at) FROM posts WHERE posts.feed_id = feeds.id)".freeze
 
   SORTABLE_FIELDS = {
     name: {
@@ -26,12 +27,12 @@ module FeedListing
     },
     last_refresh: {
       title: "Last Refresh",
-      order_by: "(SELECT MAX(created_at) FROM feed_entries WHERE feed_entries.feed_id = feeds.id)",
+      order_by: LAST_REFRESH_SQL,
       direction: :desc
     },
     recent_post: {
       title: "Recent Post",
-      order_by: "(SELECT MAX(published_at) FROM posts WHERE posts.feed_id = feeds.id)",
+      order_by: MOST_RECENT_POST_SQL,
       direction: :desc
     }
   }.freeze
@@ -40,6 +41,14 @@ module FeedListing
 
   def sortable_fields
     SORTABLE_FIELDS
+  end
+
+  def with_listing_stats(scope)
+    scope.select(
+      "feeds.*",
+      "#{LAST_REFRESH_SQL} AS listing_last_refreshed_at",
+      "#{MOST_RECENT_POST_SQL} AS listing_most_recent_post_date"
+    )
   end
 
   def recent_posts(feed)

--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -20,7 +20,7 @@ module Pagination
   end
 
   def pagination_total_count
-    @pagination_total_count ||= pagination_scope.count
+    @pagination_total_count ||= pagination_scope.unscope(:select, :order).count
   end
 
   def pagination_total_pages

--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -1,6 +1,9 @@
 module Pagination
   extend ActiveSupport::Concern
 
+  DEFAULT_PER_PAGE = 25
+  MAX_PER_PAGE = 100
+
   included do
     helper_method :pagination_total_pages, :pagination_current_page, :pagination_per_page, :pagination_total_count
   end
@@ -16,7 +19,7 @@ module Pagination
   end
 
   def pagination_current_page
-    @pagination_current_page ||= (params[:page] || 1).to_i
+    @pagination_current_page ||= [params[:page].to_i, 1].max
   end
 
   def pagination_total_count
@@ -28,7 +31,11 @@ module Pagination
   end
 
   def pagination_per_page
-    params[:per_page]&.to_i || 25
+    @pagination_per_page ||= begin
+      requested = params[:per_page].to_i
+      requested = DEFAULT_PER_PAGE unless requested.positive?
+      [requested, MAX_PER_PAGE].min
+    end
   end
 
   # Override this method in the including controller to provide the scope to paginate

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -278,7 +278,9 @@ class FeedsController < ApplicationController
   end
 
   def pagination_scope
-    policy_scope(Feed).includes(:feed_entries, :posts, :access_token).order(sortable_order)
+    with_listing_stats(policy_scope(Feed))
+      .includes(:access_token, :ai_credential, :search_credential)
+      .order(sortable_order)
   end
 
   def load_feed

--- a/test/controllers/concerns/feed_listing_test.rb
+++ b/test/controllers/concerns/feed_listing_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class FeedListingTest < ActiveSupport::TestCase
+  include FeedListing
+
+  test "#with_listing_stats should select aggregate activity timestamps" do
+    feed = create(:feed)
+    refreshed_at = 3.hours.ago
+    published_at = 2.hours.ago
+    entry = create(:feed_entry, feed: feed, created_at: refreshed_at)
+    create(:post, feed: feed, feed_entry: entry, published_at: published_at)
+
+    listed_feed = with_listing_stats(Feed.where(id: feed.id)).first
+
+    assert_in_delta refreshed_at.to_f, listed_feed[:listing_last_refreshed_at].to_f, 0.001
+    assert_in_delta published_at.to_f, listed_feed[:listing_most_recent_post_date].to_f, 0.001
+  end
+end

--- a/test/controllers/concerns/pagination_test.rb
+++ b/test/controllers/concerns/pagination_test.rb
@@ -5,7 +5,6 @@ class PaginationTest < ActionController::TestCase
     include Pagination
 
     def index
-      # Test action that would use pagination
     end
 
     private
@@ -38,10 +37,31 @@ class PaginationTest < ActionController::TestCase
     assert_equal 1, controller.send(:pagination_current_page)
   end
 
+  test "#pagination_current_page should reject non-positive pages" do
+    controller = TestController.new
+    controller.instance_variable_set(:@params, ActionController::Parameters.new(page: "0"))
+
+    assert_equal 1, controller.send(:pagination_current_page)
+  end
+
   test "#pagination_per_page should return default value" do
     controller = TestController.new
 
     assert_equal 25, controller.send(:pagination_per_page)
+  end
+
+  test "#pagination_per_page should reject non-positive values" do
+    controller = TestController.new
+    controller.instance_variable_set(:@params, ActionController::Parameters.new(per_page: "0"))
+
+    assert_equal 25, controller.send(:pagination_per_page)
+  end
+
+  test "#pagination_per_page should cap large values" do
+    controller = TestController.new
+    controller.instance_variable_set(:@params, ActionController::Parameters.new(per_page: "1000"))
+
+    assert_equal 100, controller.send(:pagination_per_page)
   end
 
   test "#paginate_scope should raise error when pagination_scope not implemented" do


### PR DESCRIPTION
Changes:

- Reuse the existing feed-list aggregate expressions as selected read-only values.
- Stop preloading every post and feed entry for each paginated feed.
- Preload only the credential associations the list actually reads.
- Keep pagination counts independent of custom projections and ordering.
- Reject invalid page sizes and cap requests at 100 rows.
- Add focused aggregate-selection and pagination tests.

This replaces the per-feed aggregate queries plus unbounded association preloads with a single readable feed query. The pagination guard also prevents malformed or unbounded query parameters without adding another pagination abstraction.

References:

- Related issue: #1010