### PR TITLE
Include draft feeds in admin statistics

### DIFF
--- a/app/components/admin/user_statistics_component.rb
+++ b/app/components/admin/user_statistics_component.rb
@@ -18,6 +18,7 @@ class Admin::UserStatisticsComponent < ViewComponent::Base
     parts = ["#{@stats.feeds_count} total"]
     parts << "#{@stats.feeds_enabled_count} enabled" if @stats.feeds_enabled_count > 0
     parts << "#{@stats.feeds_disabled_count} disabled" if @stats.feeds_disabled_count > 0
+    parts << "#{@stats.feeds_draft_count} draft" if @stats.feeds_draft_count > 0
     summarize(parts)
   end
 

--- a/app/services/user_stats.rb
+++ b/app/services/user_stats.rb
@@ -25,6 +25,10 @@ class UserStats
     @feeds_disabled_count ||= user.feeds.count(&:disabled?)
   end
 
+  def feeds_draft_count
+    @feeds_draft_count ||= user.feeds.count(&:draft?)
+  end
+
   def access_tokens_count
     @access_tokens_count ||= user.access_tokens.size
   end

--- a/test/components/admin/user_statistics_component_test.rb
+++ b/test/components/admin/user_statistics_component_test.rb
@@ -25,12 +25,14 @@ class Admin::UserStatisticsComponentTest < ViewComponent::TestCase
 
   test "#call should summarize feed counts with a breakdown" do
     create(:feed, :enabled, user: user)
+    create(:feed, :draft, user: user)
     result = render_component
 
     feeds = result.css('[data-key="stats.feeds.value"]').first
     assert_not_nil feeds
     assert_includes feeds.text, "total"
     assert_includes feeds.text, "enabled"
+    assert_includes feeds.text, "draft"
   end
 
   test "#call should show No posts yet when there are none" do

--- a/test/services/user_stats_test.rb
+++ b/test/services/user_stats_test.rb
@@ -52,6 +52,14 @@ class UserStatsTest < ActiveSupport::TestCase
     assert_equal 2, UserStats.new(user).feeds_disabled_count
   end
 
+  test "#feeds_draft_count should return count of draft feeds" do
+    create(:feed, :draft, user: user)
+    create(:feed, :draft, user: user)
+    create(:feed, :disabled, user: user)
+
+    assert_equal 2, UserStats.new(user).feeds_draft_count
+  end
+
   test "#access_tokens_count should return total number of access tokens" do
     create(:access_token, user: user, status: :active)
     create(:access_token, user: user, status: :inactive)


### PR DESCRIPTION
Changes:

- Count draft feeds in `UserStats`.
- Include drafts in the admin feed-state breakdown.
- Add service and component coverage.

The total feed count already included drafts, so omitting them from the breakdown made the displayed numbers look inconsistent.

References:

- Related issue: #1010