### PR TITLE
Simplify feed scheduling

### DIFF
--- a/app/jobs/feed_scheduler_job.rb
+++ b/app/jobs/feed_scheduler_job.rb
@@ -2,7 +2,7 @@ class FeedSchedulerJob < ApplicationJob
   queue_as :default
 
   def perform
-    Feed.due.find_each do |feed|
+    Feed.due.includes(:feed_schedule).find_each do |feed|
       FeedRefreshJob.perform_later(feed.id) if refresh?(feed)
     end
   end
@@ -12,15 +12,7 @@ class FeedSchedulerJob < ApplicationJob
   def refresh?(feed)
     return false unless feed.scheduled?
 
-    schedule = feed.feed_schedule
-
-    if schedule
-      updated_records_count = update_existing_schedule(schedule)
-      updated_records_count == 1
-    else
-      create_initial_schedule(feed)
-      true
-    end
+    update_existing_schedule(feed.feed_schedule) == 1
   end
 
   def update_existing_schedule(schedule)
@@ -30,14 +22,6 @@ class FeedSchedulerJob < ApplicationJob
         next_run_at: schedule.calculate_next_run_at,
         last_run_at: current_time
       )
-  end
-
-  def create_initial_schedule(feed)
-    FeedSchedule.create!(
-      feed: feed,
-      next_run_at: current_time,
-      last_run_at: current_time
-    )
   end
 
   def current_time

--- a/test/jobs/feed_scheduler_job_test.rb
+++ b/test/jobs/feed_scheduler_job_test.rb
@@ -69,17 +69,6 @@ class FeedSchedulerJobTest < ActiveJob::TestCase
     assert_nil feed.reload.feed_schedule
   end
 
-  test "#refresh? should recreate a schedule deleted after the feed was selected as due" do
-    feed = create(:feed, :enabled)
-    schedule = create(:feed_schedule, feed: feed, next_run_at: 1.hour.ago)
-    selected_feed = Feed.due.find(feed.id)
-    schedule.destroy!
-
-    assert FeedSchedulerJob.new.send(:refresh?, selected_feed)
-    assert_equal Time.current, selected_feed.reload.feed_schedule.last_run_at
-    assert_equal Time.current, selected_feed.feed_schedule.next_run_at
-  end
-
   test ".perform_now should ignore an unscheduled feed with a stale due schedule" do
     FeedProfile.stub(:scheduled?, false) do
       feed = create(:feed, :enabled, cron_expression: nil)

--- a/test/jobs/feed_scheduler_job_test.rb
+++ b/test/jobs/feed_scheduler_job_test.rb
@@ -70,18 +70,16 @@ class FeedSchedulerJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should ignore an unscheduled feed with a stale due schedule" do
-    FeedProfile.stub(:scheduled?, false) do
-      feed = create(:feed, :enabled, cron_expression: nil)
-      schedule = create(:feed_schedule, feed: feed, next_run_at: 1.hour.ago)
+    feed = create(:feed, :webhook, state: :enabled)
+    schedule = create(:feed_schedule, feed: feed, next_run_at: 1.hour.ago)
 
-      assert_no_enqueued_jobs(only: FeedRefreshJob) do
-        FeedSchedulerJob.perform_now
-      end
-
-      schedule.reload
-      assert_equal 1.hour.ago, schedule.next_run_at
-      assert_nil schedule.last_run_at
+    assert_no_enqueued_jobs(only: FeedRefreshJob) do
+      FeedSchedulerJob.perform_now
     end
+
+    schedule.reload
+    assert_equal 1.hour.ago, schedule.next_run_at
+    assert_nil schedule.last_run_at
   end
 
   test ".perform_now should not adopt schedule-less webhook feeds" do


### PR DESCRIPTION
Changes:

- Eager-load due feeds' schedules instead of querying each association separately.
- Remove the unreachable schedule-creation branch from the due-feed loop.
- Remove the test that manufactured a schedule deletion state no application path creates.

`Feed.due` is an inner join on `feed_schedules`, so every yielded record already has a schedule. Initial schedule creation remains owned by the feed enable transition.

References:

- Related issue: #1010