### PR TITLE
Require admin for invite and email admin actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-17
+
+- Fixed a security hole where non-admins could grant themselves invites or change their email through admin-only actions.
+
 ## 2026-07-15
 
 - The Admin Panel now shows app-wide stats — users, feeds, imported and published posts — along with a publishing activity heatmap.

--- a/app/controllers/admin/available_invites_controller.rb
+++ b/app/controllers/admin/available_invites_controller.rb
@@ -1,7 +1,7 @@
 class Admin::AvailableInvitesController < ApplicationController
   def update
     user = User.find(params[:user_id])
-    authorize user
+    authorize user, :update_available_invites?
 
     if user.update(available_invites_params)
       flash.now[:success] = "Available invites updated successfully."

--- a/app/controllers/admin/email_updates_controller.rb
+++ b/app/controllers/admin/email_updates_controller.rb
@@ -1,12 +1,12 @@
 class Admin::EmailUpdatesController < ApplicationController
   def edit
     @user = User.find(params[:user_id])
-    authorize @user, :update?
+    authorize @user, :update_email?
   end
 
   def update
     user = User.find(params[:user_id])
-    authorize user, :update?
+    authorize user, :update_email?
 
     if new_email.blank?
       redirect_to edit_admin_user_email_update_path(user), alert: "Email address cannot be blank."

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -19,6 +19,14 @@ class UserPolicy < ApplicationPolicy
     admin?
   end
 
+  def update_email?
+    admin?
+  end
+
+  def update_available_invites?
+    admin?
+  end
+
   def suspend?
     admin? && record != user
   end

--- a/test/controllers/admin/available_invites_controller_test.rb
+++ b/test/controllers/admin/available_invites_controller_test.rb
@@ -68,29 +68,21 @@ class Admin::AvailableInvitesControllerTest < ActionDispatch::IntegrationTest
     patch admin_user_available_invites_url(target_user), params: {
       user: { available_invites: 10 }
     }
-    # Should get unauthorized since regular_user is trying to update target_user
-    # But due to UserPolicy#update? allowing self_or_admin?, this currently fails
-    # For now, expect success since regular_user can see the form but can't actually update another user
-    # In production, admins control who has available invites, regular users shouldn't access admin namespace
     assert_response :redirect
+
+    target_user.reload
+    assert_equal 3, target_user.available_invites
   end
 
-  test "should allow user to update own available invites if they navigate to their own admin page" do
+  test "should not allow user to update their own available invites" do
     sign_in_as target_user
     patch admin_user_available_invites_url(target_user), params: {
       user: { available_invites: 10 }
     }
-    assert_response :success
-    assert_equal "text/vnd.turbo-stream.html", response.media_type
-    assert_select "turbo-stream[action='replace'][target='available-invites-value']"
-    assert_select "turbo-stream[action='replace'][target='available-invites-input-wrapper-#{target_user.id}']"
-    assert_select "turbo-stream[action='replace'][target='flash-messages']" do
-      assert_select "div[id='flash-messages']"
-      assert_select ".bg-success-subtle", text: /Available invites updated successfully/
-    end
+    assert_response :redirect
 
     target_user.reload
-    assert_equal 10, target_user.available_invites
+    assert_equal 3, target_user.available_invites
   end
 
   test "should require authentication" do

--- a/test/controllers/admin/email_updates_controller_test.rb
+++ b/test/controllers/admin/email_updates_controller_test.rb
@@ -18,6 +18,15 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
+  test "should redirect non-admin users from updating their own email" do
+    login_as(regular_user)
+
+    patch admin_user_email_update_path(regular_user), params: { user: { email_address: "new@example.com" }, require_confirmation: "0" }
+
+    assert_redirected_to root_path
+    assert_not_equal "new@example.com", regular_user.reload.email_address
+  end
+
   test "should allow admin users to view email update form" do
     login_as(admin_user)
     user = create(:user, email_address: "test@example.com")

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -124,6 +124,36 @@ class UserPolicyTest < ActiveSupport::TestCase
     assert_not policy.suspend?
   end
 
+  test "#update_email? should allow admin users" do
+    policy = policy_for_user(admin_user, other_user)
+    assert policy.update_email?
+  end
+
+  test "#update_email? should deny self" do
+    policy = policy_for_user(user, user)
+    assert_not policy.update_email?
+  end
+
+  test "#update_email? should deny regular users" do
+    policy = policy_for_user(user, other_user)
+    assert_not policy.update_email?
+  end
+
+  test "#update_available_invites? should allow admin users" do
+    policy = policy_for_user(admin_user, other_user)
+    assert policy.update_available_invites?
+  end
+
+  test "#update_available_invites? should deny self" do
+    policy = policy_for_user(user, user)
+    assert_not policy.update_available_invites?
+  end
+
+  test "#update_available_invites? should deny regular users" do
+    policy = policy_for_user(user, other_user)
+    assert_not policy.update_available_invites?
+  end
+
   test "#confirm_email? should allow admin users" do
     policy = policy_for_user(admin_user, other_user)
     assert policy.confirm_email?


### PR DESCRIPTION
Changes:

- Add admin-only `update_email?` and `update_available_invites?` policy methods to `UserPolicy`
- Authorize `Admin::EmailUpdatesController` and `Admin::AvailableInvitesController` with these instead of the self-or-admin `update?`

Both admin endpoints authorized with `UserPolicy#update?`, which resolves to `self_or_admin?`. Because a user always passes that check for their own record, any authenticated user could hit the admin namespace and grant themselves invites (F-001) or change their own email while skipping the confirmation and cooldown flow (F-002). Gating these actions behind dedicated admin-only policy methods closes the privilege-escalation hole while leaving legitimate self-service profile updates untouched.

References:

- Related issue: #1010 (F-001, F-002)
