### PR TITLE
Fix admin email-change confirmation flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-17
+
+- Admins changing a user's email with confirmation required now correctly send the confirmation link to the new address.
+
 ## 2026-07-15
 
 - The Admin Panel now shows app-wide stats — users, feeds, imported and published posts — along with a publishing activity heatmap.

--- a/app/controllers/admin/email_updates_controller.rb
+++ b/app/controllers/admin/email_updates_controller.rb
@@ -24,8 +24,13 @@ class Admin::EmailUpdatesController < ApplicationController
     end
 
     if require_confirmation?
-      ProfileMailer.email_change_confirmation(user, new_email).deliver_later
-      redirect_to admin_user_path(user), notice: "Confirmation email sent to #{new_email}. User must confirm before change takes effect."
+      if user.update(unconfirmed_email: new_email)
+        ProfileMailer.email_change_confirmation(user).deliver_later
+        Event.create!(type: "mail.profile_mailer.email_change_confirmation", user: user, subject: user, level: :info)
+        redirect_to admin_user_path(user), notice: "Confirmation email sent to #{new_email}. User must confirm before change takes effect."
+      else
+        redirect_to edit_admin_user_email_update_path(user), alert: "Failed to update email address."
+      end
     elsif user.update(email_address: new_email)
       redirect_to admin_user_path(user), success: "Email address updated."
     else

--- a/test/controllers/admin/email_updates_controller_test.rb
+++ b/test/controllers/admin/email_updates_controller_test.rb
@@ -44,13 +44,21 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
     login_as(admin_user)
     user = create(:user, email_address: "old@example.com")
 
-    assert_enqueued_emails 1 do
-      patch admin_user_email_update_path(user), params: { user: { email_address: "new@example.com" }, require_confirmation: "1" }
+    assert_emails 1 do
+      perform_enqueued_jobs do
+        patch admin_user_email_update_path(user), params: { user: { email_address: "new@example.com" }, require_confirmation: "1" }
+      end
     end
 
     assert_redirected_to admin_user_path(user)
     assert_equal "Confirmation email sent to new@example.com. User must confirm before change takes effect.", flash[:notice]
-    assert_equal "old@example.com", user.reload.email_address
+
+    user.reload
+    assert_equal "old@example.com", user.email_address
+    assert_equal "new@example.com", user.unconfirmed_email
+
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ["new@example.com"], email.to
   end
 
   test "should reject blank email" do


### PR DESCRIPTION
Changes:

- Persist `unconfirmed_email` before sending the admin confirmation email, and call `ProfileMailer.email_change_confirmation` with a single argument, mirroring `Settings::EmailUpdatesController`.
- Strengthen the confirmation-email test to actually deliver the mail and assert the recipient and persisted `unconfirmed_email`, instead of only counting enqueues.

The admin confirmation branch called the mailer with two arguments, but it takes only the user and reads the target address from `unconfirmed_email`. The job raised on delivery, and `unconfirmed_email` was never persisted, so the confirmation token and link had nothing to work with. The existing test hid this because it only asserted the enqueue count and never executed the mailer.

References:

- Part of #1010 (F-003, F-047)
