### PR TITLE
Centralize post counter recount on Feed

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -330,6 +330,17 @@ class Feed < ApplicationRecord
     posts.where(published_at: 1.week.ago.beginning_of_day..Time.current.end_of_day).count
   end
 
+  # Single source of truth for the cached post counters. Post's create/destroy
+  # callbacks keep these current on single-record writes; bulk paths that skip
+  # those callbacks (FeedRefreshWorkflow's insert_all) must call these to resync.
+  def recount_imported_posts!
+    update_column(:imported_posts_count, posts.count)
+  end
+
+  def recount_published_posts!
+    update_column(:published_posts_count, posts.published.count)
+  end
+
   # Makes the existing schedule due immediately (next_run_at = now). No-op for
   # a feed without one — the schedule is created when the feed is enabled.
   def reset_schedule!

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -89,13 +89,11 @@ class Post < ApplicationRecord
   end
 
   def recount_imported_posts
-    count = Post.where(feed_id: feed_id).count
-    Feed.where(id: feed_id).update_all(imported_posts_count: count)
+    feed.recount_imported_posts!
   end
 
   def recount_published_posts
-    count = Post.where(feed_id: feed_id).published.count
-    Feed.where(id: feed_id).update_all(published_posts_count: count)
+    feed.recount_published_posts!
   end
 
   def validate_enqueued_status

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -258,7 +258,7 @@ class FeedRefreshWorkflow
     end
 
     Post.insert_all(posts_data)
-    feed.update_column(:imported_posts_count, feed.posts.count)
+    feed.recount_imported_posts!
 
     new_uids = posts.map(&:uid)
     persisted_posts = feed.posts.where(uid: new_uids).order(:published_at)

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -1231,4 +1231,30 @@ class FeedTest < ActiveSupport::TestCase
       assert_not_nil schedule.last_run_at
     end
   end
+
+  test "#recount_imported_posts! should resync the counter after a callback-bypassing insert" do
+    feed = create(:feed)
+    feed_entry = create(:feed_entry, feed: feed)
+    now = Time.current
+    Post.insert_all([{
+      feed_id: feed.id, feed_entry_id: feed_entry.id, uid: "post-1",
+      published_at: now, source_url: "https://example.com/1", created_at: now, updated_at: now
+    }])
+    assert_equal 0, feed.reload.imported_posts_count
+
+    feed.recount_imported_posts!
+
+    assert_equal 1, feed.reload.imported_posts_count
+  end
+
+  test "#recount_published_posts! should count only published posts" do
+    feed = create(:feed)
+    create(:post, :published, feed: feed)
+    create(:post, feed: feed, status: :enqueued)
+    feed.update_column(:published_posts_count, 0)
+
+    feed.recount_published_posts!
+
+    assert_equal 1, feed.reload.published_posts_count
+  end
 end


### PR DESCRIPTION
Changes:

- Add `Feed#recount_imported_posts!` and `Feed#recount_published_posts!` as the single source of truth for the cached post counters
- Delegate `Post`'s create/destroy callbacks to these methods instead of duplicating the recount logic
- Call `Feed#recount_imported_posts!` from `FeedRefreshWorkflow`'s bulk `insert_all` path

The imported/published counter caches used to be recounted in two places with two different queries — `Post`'s callbacks and an inline `update_column` in the refresh workflow. That split is exactly what let the callback-bypassing bulk import path drift out of sync (F-005). Consolidating the recount onto `Feed` keeps every write path consistent without duplicated logic.

References:

- Addresses F-005 in #1010
