### PR TITLE
Stop feed factory writing to DB on build

### DIFF
--- a/test/factories/feeds.rb
+++ b/test/factories/feeds.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
     after(:build) do |feed|
       if feed.user && feed.access_token.nil?
-        feed.access_token = create(:access_token, :active, user: feed.user)
+        feed.access_token = build(:access_token, :active, user: feed.user)
       end
       if feed.feed_profile_key.nil?
         feed.feed_profile_key = "rss"

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -6,6 +6,12 @@ class FeedTest < ActiveSupport::TestCase
     assert feed.valid?
   end
 
+  test "build(:feed) should not write associated records to the database" do
+    assert_no_difference ["Feed.count", "AccessToken.count"] do
+      build(:feed)
+    end
+  end
+
   test "should require name when enabled" do
     feed = build(:feed, state: :enabled, name: nil)
     assert_not feed.valid?


### PR DESCRIPTION
Changes:

- Build the feed factory's access token with `build` instead of `create` in the `after(:build)` hook
- Add a regression test asserting `build(:feed)` writes nothing to the database

The `after(:build)` hook persisted an `AccessToken` via `create(...)`, so `build(:feed)` — which is meant to stay in memory — quietly wrote to the database. Since `Feed belongs_to :access_token`, Rails autosaves the built token when the feed itself is created, so `create(:feed)` is unaffected.

References:

- Related issue: #1010 (F-049)
