### PR TITLE
Fix admin email-change confirmation flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-17
 
+- Fixed admin-initiated email changes with confirmation: the confirmation email now actually gets sent, and the user's address only changes once they confirm.
 - If FreeFeed temporarily rate-limits a post comment, publishing now pauses and resumes from that comment later without duplicating the post or earlier comments. Other comment errors keep the post published, continue the feed, and appear in Recent Activity.
 
 ## 2026-07-15

--- a/app/controllers/admin/email_updates_controller.rb
+++ b/app/controllers/admin/email_updates_controller.rb
@@ -24,8 +24,12 @@ class Admin::EmailUpdatesController < ApplicationController
     end
 
     if require_confirmation?
-      ProfileMailer.email_change_confirmation(user, new_email).deliver_later
-      redirect_to admin_user_path(user), notice: "Confirmation email sent to #{new_email}. User must confirm before change takes effect."
+      if user.update(unconfirmed_email: new_email)
+        ProfileMailer.email_change_confirmation(user).deliver_later
+        redirect_to admin_user_path(user), notice: "Confirmation email sent to #{new_email}. User must confirm before change takes effect."
+      else
+        redirect_to edit_admin_user_email_update_path(user), alert: "Failed to update email address."
+      end
     elsif user.update(email_address: new_email)
       redirect_to admin_user_path(user), success: "Email address updated."
     else

--- a/test/controllers/admin/email_updates_controller_test.rb
+++ b/test/controllers/admin/email_updates_controller_test.rb
@@ -44,13 +44,20 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
     login_as(admin_user)
     user = create(:user, email_address: "old@example.com")
 
-    assert_enqueued_emails 1 do
+    perform_enqueued_jobs do
       patch admin_user_email_update_path(user), params: { user: { email_address: "new@example.com" }, require_confirmation: "1" }
     end
 
     assert_redirected_to admin_user_path(user)
     assert_equal "Confirmation email sent to new@example.com. User must confirm before change takes effect.", flash[:notice]
-    assert_equal "old@example.com", user.reload.email_address
+
+    user.reload
+    assert_equal "old@example.com", user.email_address, "email must not change until confirmed"
+    assert_equal "new@example.com", user.unconfirmed_email
+
+    delivery = ActionMailer::Base.deliveries.last
+    assert_not_nil delivery, "confirmation email should have been delivered"
+    assert_equal ["new@example.com"], delivery.to
   end
 
   test "should reject blank email" do


### PR DESCRIPTION
Changes:

- Set `unconfirmed_email` and call `ProfileMailer.email_change_confirmation` with a single argument in the admin confirmation path, matching the self-service settings flow
- Strengthen the controller test to perform the enqueued job and assert both the delivery and `unconfirmed_email`

The admin "require confirmation" path called the mailer with two arguments (it takes one) and never set `unconfirmed_email`, which the mailer reads. Because `deliver_later` defers execution, the mailer crashed only when the job ran — never at request time — and the existing test masked it by asserting the enqueue count alone. The corrected flow sends the confirmation and leaves the address unchanged until the user confirms via the same token path the settings flow uses.

References:

- Related issue: #1010 (F-003, F-047)
