### PR TITLE
Actually assert raised error messages

### DIFF
--- a/test/lib/freefeed_client_publisher_test.rb
+++ b/test/lib/freefeed_client_publisher_test.rb
@@ -232,9 +232,10 @@ class FreefeedClientPublisherTest < ActiveSupport::TestCase
     stub_request(:post, "#{@host}/v4/posts")
       .to_return(status: 201, body: "invalid json")
 
-    assert_raises(FreefeedClient::Error, /Invalid JSON response/) do
+    error = assert_raises(FreefeedClient::Error) do
       @client.create_post(body: "Test", feeds: ["testgroup"])
     end
+    assert_match(/Invalid JSON response/, error.message)
   end
 
   test "handles missing required fields in response" do

--- a/test/services/freefeed_publisher_test.rb
+++ b/test/services/freefeed_publisher_test.rb
@@ -453,9 +453,10 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
 
     service = FreefeedPublisher.new(post)
 
-    assert_raises(FreefeedPublisher::PublishError, /Failed to publish to FreeFeed/) do
+    error = assert_raises(FreefeedPublisher::PublishError) do
       service.publish
     end
+    assert_match(/Failed to create FreeFeed post: HTTP 500/, error.message)
   end
 
   test "#publish should raise error when attachment upload fails" do
@@ -463,9 +464,10 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
 
     service = FreefeedPublisher.new(post)
 
-    assert_raises(FreefeedPublisher::PublishError, /Failed to upload attachments/) do
+    error = assert_raises(FreefeedPublisher::PublishError) do
       service.publish
     end
+    assert_match(/Failed to upload attachments/, error.message)
   end
 
   test "#publish should truncate an over-long comment before sending it to FreeFeed" do
@@ -514,9 +516,10 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
 
     service = FreefeedPublisher.new(post)
 
-    assert_raises(FreefeedPublisher::PublishError, /Failed to create comments/) do
+    error = assert_raises(FreefeedPublisher::PublishError) do
       service.publish
     end
+    assert_match(/Failed to create comments/, error.message)
   end
 
   test "#publish should download remote image attachment to memory" do
@@ -577,9 +580,10 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
 
     service = FreefeedPublisher.new(post)
 
-    assert_raises(FreefeedPublisher::PublishError, /Failed to download attachment from #{Regexp.escape(image_url)}/) do
+    error = assert_raises(FreefeedPublisher::PublishError) do
       service.publish
     end
+    assert_match(/Failed to download attachment from #{Regexp.escape(image_url)}/, error.message)
   end
 
   test "#publish should skip an attachment rejected as too large and publish with the rest" do
@@ -714,8 +718,9 @@ class FreefeedPublisherTest < ActiveSupport::TestCase
 
     service = FreefeedPublisher.new(post)
 
-    assert_raises(FreefeedPublisher::PublishError, /Failed to download attachment from #{Regexp.escape(image_url)}: Request timed out/) do
+    error = assert_raises(FreefeedPublisher::PublishError) do
       service.publish
     end
+    assert_match(/Failed to download attachment from #{Regexp.escape(image_url)}: Request timed out/, error.message)
   end
 end


### PR DESCRIPTION
Changes:

- Capture the raised error and `assert_match` its message across the publisher tests, instead of passing a regex as `assert_raises`' second argument
- Fix a stale expectation this exposed: a 500 on post creation raises "Failed to create FreeFeed post: HTTP 500…", not "Failed to publish to FreeFeed"

`assert_raises`' second positional argument is the failure message shown when no error is raised — not a matcher. Every regex passed there was silently ignored, so the message assertions never ran. Once the messages are actually checked, one turned out to have drifted from the real error text.

References:

- Related issue: #1010 (F-007)
