### PR TITLE
Trim redundant and low-signal tests

### DIFF
--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -59,76 +59,9 @@ class PostTest < ActiveSupport::TestCase
     assert post.valid?
   end
 
-  test "should belong to feed" do
-    post = valid_post
-    assert_respond_to post, :feed
-    assert_equal feed, post.feed
-  end
-
-  test "should belong to feed_entry" do
-    post = valid_post
-    assert_respond_to post, :feed_entry
-    assert_equal feed_entry, post.feed_entry
-  end
-
   test "should have draft status by default" do
     post = Post.new
     assert_equal "draft", post.status
-  end
-
-  test "should have valid enum statuses" do
-    post = valid_post
-
-    post.status = :draft
-    assert post.draft?
-    assert_equal "draft", post.status
-
-    post.status = :enqueued
-    assert post.enqueued?
-    assert_equal "enqueued", post.status
-
-    post.status = :rejected
-    assert post.rejected?
-    assert_equal "rejected", post.status
-
-    post.status = :published
-    assert post.published?
-    assert_equal "published", post.status
-
-    post.status = :failed
-    assert post.failed?
-    assert_equal "failed", post.status
-  end
-
-  test "should serialize attachment_urls as JSON array" do
-    urls = ["https://example.com/image1.jpg", "https://example.com/image2.png"]
-    post = create(:post, attachment_urls: urls)
-
-    saved_post = Post.find(post.id)
-    assert_equal urls, saved_post.attachment_urls
-  end
-
-  test "should serialize comments as JSON array" do
-    comments = ["First comment", "Second comment"]
-    post = create(:post, comments: comments)
-
-    saved_post = Post.find(post.id)
-    assert_equal comments, saved_post.comments
-  end
-
-  test "should serialize validation_errors as JSON array" do
-    errors = ["blank_text", "invalid_link"]
-    post = create(:post, validation_errors: errors)
-
-    saved_post = Post.find(post.id)
-    assert_equal errors, saved_post.validation_errors
-  end
-
-  test "should handle array fields" do
-    post = build(:post, attachment_urls: ["url1"], comments: ["comment1"], validation_errors: ["error1"])
-    assert_equal ["url1"], post.attachment_urls
-    assert_equal ["comment1"], post.comments
-    assert_equal ["error1"], post.validation_errors
   end
 
   test "#freefeed_url should return the full URL when all parts are present" do

--- a/test/services/feed_preview_workflow_test.rb
+++ b/test/services/feed_preview_workflow_test.rb
@@ -40,29 +40,23 @@ class FeedPreviewWorkflowTest < ActiveSupport::TestCase
       .to_return(status: 200, body: rss_body, headers: { "Content-Type" => "application/xml" })
   end
 
-  test "#initialize should assign feed_preview" do
+  test "#initialize should assign feed_preview and start with empty stats" do
     assert_equal feed_preview, workflow.feed_preview
     assert_equal({}, workflow.stats)
   end
 
-  test "#initialize should produce executable workflow" do
-    wf = FeedPreviewWorkflow.new(feed_preview, run_id: "run-1")
-    assert_equal feed_preview, wf.feed_preview
-    assert_equal({}, wf.stats)
-    assert_respond_to wf, :execute
+  test "#initialize should prefer the given run_id over the feed_preview's" do
+    wf = FeedPreviewWorkflow.new(feed_preview, run_id: "explicit-run")
+    assert_equal "explicit-run", wf.send(:run_id)
   end
 
   test "#initialize should fall back to feed_preview.run_id when run_id is omitted" do
     wf = FeedPreviewWorkflow.new(feed_preview)
-    assert_respond_to wf, :execute
+    assert_equal feed_preview.run_id, wf.send(:run_id)
   end
 
   test ".included should mix in Workflow module" do
     assert_includes FeedPreviewWorkflow.included_modules, Workflow
-  end
-
-  test "#execute should be defined as workflow step" do
-    assert_respond_to workflow, :execute
   end
 
   test "#load_feed_contents should run the loader with the preview purpose" do

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -113,62 +113,21 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_nil usage.error_message
   end
 
-  test "#call should populate error_message on provider error" do
+  test "#call should map a provider error to ProviderError and record the failure" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, RubyLLM::ServerError.new("downstream failure"))
 
-    assert_raises(LlmClient::ProviderError) { client.call(default_ctx, **call_opts) }
+    assert_difference("LlmUsage.count", 1) do
+      assert_raises(LlmClient::ProviderError) { client.call(default_ctx, **call_opts) }
+    end
 
     usage = LlmUsage.last
     assert_equal "provider_error", usage.outcome
-    assert_not_nil usage.error_message
     assert_includes usage.error_message, "downstream failure"
-  end
-
-  test "#call should populate error_message and duration_ms on schema error" do
-    client = LlmClient.new(credential)
-    bad_response = LlmClient::ProviderResponse.new(
-      payload: { "wrong" => "shape" },
-      input_tokens: 10, output_tokens: 5,
-      cache_write_tokens: 0, cache_read_tokens: 0
-    )
-    stub_provider_response(client, bad_response)
-
-    assert_raises(LlmClient::SchemaError) { client.call(default_ctx, **call_opts) }
-
-    usage = LlmUsage.last
-    assert_equal "schema_error", usage.outcome
-    assert_not_nil usage.error_message
-    assert_not_nil usage.duration_ms
-    assert_equal 10, usage.input_tokens
-    assert_equal 5, usage.output_tokens
-  end
-
-  test "#call should populate error_message on rate limit" do
-    client = LlmClient.new(credential)
-    stub_provider_to_raise(client, RubyLLM::RateLimitError.new("rate limit exceeded"))
-
-    assert_raises(LlmClient::RateLimited) { client.call(default_ctx, **call_opts) }
-
-    usage = LlmUsage.last
-    assert_equal "rate_limited", usage.outcome
-    assert_not_nil usage.error_message
     assert_not_nil usage.duration_ms
   end
 
-  test "#call should populate error_message and duration_ms on timeout" do
-    client = LlmClient.new(credential)
-    stub_provider_to_raise(client, Net::ReadTimeout.new)
-
-    assert_raises(LlmClient::Timeout) { client.call(default_ctx, **call_opts) }
-
-    usage = LlmUsage.last
-    assert_equal "timeout", usage.outcome
-    assert_not_nil usage.error_message
-    assert_not_nil usage.duration_ms
-  end
-
-  test "#call should raise SchemaError and record a failed usage row when the response violates the schema" do
+  test "#call should map a schema violation to SchemaError and record the failure" do
     client = LlmClient.new(credential)
     bad_response = LlmClient::ProviderResponse.new(
       payload: { "wrong" => "shape" },
@@ -181,32 +140,29 @@ class LlmClientTest < ActiveSupport::TestCase
       assert_raises(LlmClient::SchemaError) { client.call(default_ctx, **call_opts) }
     end
 
-    assert_equal "schema_error", LlmUsage.last.outcome
+    usage = LlmUsage.last
+    assert_equal "schema_error", usage.outcome
+    assert_not_nil usage.error_message
+    assert_not_nil usage.duration_ms
+    assert_equal 10, usage.input_tokens
+    assert_equal 5, usage.output_tokens
   end
 
-  test "#call should raise RateLimited and record a usage row on RubyLLM::RateLimitError" do
+  test "#call should map a rate-limit error to RateLimited and record the failure" do
     client = LlmClient.new(credential)
-    stub_provider_to_raise(client, RubyLLM::RateLimitError.new("429"))
+    stub_provider_to_raise(client, RubyLLM::RateLimitError.new("rate limit exceeded"))
 
     assert_difference("LlmUsage.count", 1) do
       assert_raises(LlmClient::RateLimited) { client.call(default_ctx, **call_opts) }
     end
 
-    assert_equal "rate_limited", LlmUsage.last.outcome
+    usage = LlmUsage.last
+    assert_equal "rate_limited", usage.outcome
+    assert_not_nil usage.error_message
+    assert_not_nil usage.duration_ms
   end
 
-  test "#call should raise ProviderError on generic RubyLLM::Error and record the failure" do
-    client = LlmClient.new(credential)
-    stub_provider_to_raise(client, RubyLLM::ServerError.new("500"))
-
-    assert_difference("LlmUsage.count", 1) do
-      assert_raises(LlmClient::ProviderError) { client.call(default_ctx, **call_opts) }
-    end
-
-    assert_equal "provider_error", LlmUsage.last.outcome
-  end
-
-  test "#call should raise Timeout and record a usage row on Net::ReadTimeout" do
+  test "#call should map a timeout to Timeout and record the failure" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, Net::ReadTimeout.new)
 
@@ -214,7 +170,10 @@ class LlmClientTest < ActiveSupport::TestCase
       assert_raises(LlmClient::Timeout) { client.call(default_ctx, **call_opts) }
     end
 
-    assert_equal "timeout", LlmUsage.last.outcome
+    usage = LlmUsage.last
+    assert_equal "timeout", usage.outcome
+    assert_not_nil usage.error_message
+    assert_not_nil usage.duration_ms
   end
 
   test "#call should accept feed:nil for previews and skip the feed reference on the usage row" do


### PR DESCRIPTION
Changes:

- Consolidate the LLM client's error-mapping tests: each scenario (provider, schema, rate-limit, timeout) was covered by two tests with the same trigger and split assertions; merged into one test each
- Remove `Post` tests that only exercise Rails/Postgres (association readers, enum assignment, jsonb round-trips), keeping the app-specific default-status contract
- Replace `respond_to(:execute)`-only tests in `FeedPreviewWorkflow` with assertions on the actual `run_id` argument and fallback behavior the test names promised

Each change removes duplicated or vacuous coverage without losing signal — the consolidated LLM tests keep every assertion, and `execute` is still exercised by the workflow's integration tests.

References:

- Related issue: #1010 (F-051, F-052, F-053)
