### PR TITLE
Fold registry-shape assertions into the validator

### DIFF
--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -78,47 +78,9 @@ class FeedProfileTest < ActiveSupport::TestCase
     assert_nil FeedProfile["nope"]
   end
 
-  test "every PROFILES entry conforms to the enriched shape" do
-    FeedProfile::PROFILES.each do |key, entry|
-      assert_kind_of String, entry[:display_name], "#{key}: display_name"
-      assert_kind_of String, entry[:description], "#{key}: description"
-      assert_includes %i[url query any none], entry[:input_shape], "#{key}: input_shape"
-      assert_includes [true, false], entry[:depends_on_ai], "#{key}: depends_on_ai"
-      assert_includes [true, false], entry[:scheduled], "#{key}: scheduled"
-      if entry[:depends_on_ai] || key == "webhook"
-        # AI and webhook profiles are structurally excluded from detection
-        # (spec 005 §7, spec 006 §1): no matcher.
-        assert_nil entry[:matcher], "#{key}: AI/webhook profile must not register a matcher"
-      else
-        assert_kind_of String, entry[:matcher], "#{key}: matcher"
-      end
-      assert_kind_of Hash, entry[:parameter_schema], "#{key}: parameter_schema"
-
-      if key == "webhook"
-        # The webhook profile has nothing to fetch (spec 006 §1): no loader/processor.
-        assert_nil entry[:loader], "#{key}: webhook profile must not register a loader"
-        assert_nil entry[:processor], "#{key}: webhook profile must not register a processor"
-      else
-        assert_kind_of Hash, entry[:loader], "#{key}: loader entry must be a hash"
-        assert_kind_of String, entry[:loader][:class], "#{key}: loader.class"
-        assert_kind_of Hash, entry[:loader][:config], "#{key}: loader.config"
-
-        assert_kind_of Hash, entry[:processor], "#{key}: processor entry must be a hash"
-        assert_kind_of String, entry[:processor][:class], "#{key}: processor.class"
-        assert_kind_of Hash, entry[:processor][:config], "#{key}: processor.config"
-      end
-
-      assert_kind_of Hash, entry[:normalizer], "#{key}: normalizer entry must be a hash"
-      assert_kind_of String, entry[:normalizer][:class], "#{key}: normalizer.class"
-      assert_kind_of Hash, entry[:normalizer][:config], "#{key}: normalizer.config"
-
-      if entry[:depends_on_ai]
-        # AI profiles declare the universal-post output_schema on the loader
-        # stage that calls the LLM.
-        assert_kind_of Hash, entry[:loader][:config][:output_schema], "#{key}: output_schema required for AI profile"
-      end
-    end
-  end
+  # Registry shape (required keys, types, matcher/loader/processor rules,
+  # AI output_schema) is validated in FeedProfileValidatorTest against
+  # FeedProfile::PROFILES; no need to re-assert it entry-by-entry here.
 
   test "every matcher-bearing PROFILES entry has a resolvable matcher class" do
     FeedProfile::PROFILES.each do |key, entry|

--- a/test/models/feed_profile_validator_test.rb
+++ b/test/models/feed_profile_validator_test.rb
@@ -109,7 +109,7 @@ class FeedProfileValidatorTest < ActiveSupport::TestCase
   end
 
   test "accepts AI profile with a loader output_schema" do
-    entry = valid_entry.merge(
+    entry = valid_entry.except(:matcher).merge(
       depends_on_ai: true,
       loader: { class: "Loader::LlmLoader", config: { output_schema: { "type" => "object" } } }
     )
@@ -137,5 +137,16 @@ class FeedProfileValidatorTest < ActiveSupport::TestCase
     assert_nothing_raised do
       FeedProfileValidator.validate!("sample" => entry)
     end
+  end
+
+  test "rejects an AI profile that registers a matcher" do
+    entry = valid_entry.merge(depends_on_ai: true,
+                              loader: { class: "Loader::LlmLoader", config: { output_schema: { "type" => "object" } } })
+
+    error = assert_raises(FeedProfileValidator::Error) do
+      FeedProfileValidator.validate!("sample" => entry)
+    end
+
+    assert_includes error.message, "matcher must be absent for AI profiles"
   end
 end

--- a/test/support/feed_profile_validator.rb
+++ b/test/support/feed_profile_validator.rb
@@ -68,7 +68,11 @@ module FeedProfileValidator
       else
         failures << "FeedProfile #{key.inspect}: loader is required" if entry[:loader].nil?
         failures << "FeedProfile #{key.inspect}: processor is required" if entry[:processor].nil?
-        if !entry[:depends_on_ai] && entry[:matcher].to_s.empty?
+        # AI profiles are excluded from detection (spec 005 §7), so they must
+        # not register a matcher; every other non-webhook profile requires one.
+        if entry[:depends_on_ai]
+          failures << "FeedProfile #{key.inspect}: matcher must be absent for AI profiles" if entry[:matcher]
+        elsif entry[:matcher].to_s.empty?
           failures << "FeedProfile #{key.inspect}: matcher is required for non-AI profiles"
         end
       end


### PR DESCRIPTION
Changes:

- Move the one shape rule the schema validator was missing — AI profiles must not register a matcher — into `FeedProfileValidator`, with a test for it
- Remove `FeedProfileTest`'s "every PROFILES entry conforms to the enriched shape" test, which duplicated the validator entry-by-entry

`FeedProfileValidator.validate!` already checks the whole registry against a JSON schema (required keys, types, matcher/loader/processor presence rules, AI `output_schema`) and runs against the live `PROFILES` in `FeedProfileValidatorTest`. The inline test re-asserted the same contract by hand; the only thing it added was the AI-has-no-matcher rule, now enforced in the validator itself.

References:

- Related issue: #1010 (F-050)
