### PR TITLE
Use shared sign_in_as helper in controller tests

### DIFF
--- a/test/controllers/admin/email_reactivations_controller_test.rb
+++ b/test/controllers/admin/email_reactivations_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::EmailReactivationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should allow admin to reactivate user email" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
     user.deactivate_email!(reason: "bounced")
 
@@ -27,7 +27,7 @@ class Admin::EmailReactivationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should prevent non-admin from reactivating user email" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
     user = create(:user)
     user.deactivate_email!(reason: "bounced")
 
@@ -36,11 +36,5 @@ class Admin::EmailReactivationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     user.reload
     assert user.email_deactivated?
-  end
-
-  private
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/admin/email_updates_controller_test.rb
+++ b/test/controllers/admin/email_updates_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should redirect non-admin users from edit" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
     user = create(:user)
 
     get edit_admin_user_email_update_path(user)
@@ -19,7 +19,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should allow admin users to view email update form" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, email_address: "test@example.com")
 
     get edit_admin_user_email_update_path(user)
@@ -30,7 +30,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update email for user without confirmation" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, email_address: "old@example.com")
 
     patch admin_user_email_update_path(user), params: { user: { email_address: "new@example.com" }, require_confirmation: "0" }
@@ -41,7 +41,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should send confirmation email when checkbox is checked" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, email_address: "old@example.com")
 
     assert_enqueued_emails 1 do
@@ -54,7 +54,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should reject blank email" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, email_address: "test@example.com")
 
     patch admin_user_email_update_path(user), params: { user: { email_address: "" } }
@@ -65,7 +65,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should reject same email" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, email_address: "test@example.com")
 
     patch admin_user_email_update_path(user), params: { user: { email_address: "test@example.com" } }
@@ -75,7 +75,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should reject duplicate email" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     existing_user = create(:user, email_address: "existing@example.com")
     user = create(:user, email_address: "test@example.com")
 
@@ -84,11 +84,5 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_admin_user_email_update_path(user)
     assert_equal "Email address is already taken.", flash[:alert]
     assert_equal "test@example.com", user.reload.email_address
-  end
-
-  private
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should redirect non-admin users" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
 
     get admin_events_path
 
@@ -29,7 +29,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should allow admin users to view events index" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
     create(:event, type: "TestEvent", message: "Test message", user: user)
 
@@ -43,7 +43,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should allow admin users to view event details" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     event = create(:event, type: "TestEvent", message: "Test message", user: create(:user))
 
     get admin_event_path(event)
@@ -54,7 +54,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should describe the latest page with a zero offset" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     create(:event, user: create(:user))
 
     get admin_events_path
@@ -65,7 +65,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should describe the offset when paging into older events" do
     with_page_size(2) do
-      login_as(admin_user)
+      sign_in_as(admin_user)
       events = Array.new(5) { create(:event, user: create(:user)) }
 
       get admin_events_path, params: { before: events[3].id }
@@ -76,7 +76,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should list imported posts referenced by the event" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed)
     event = create(:event, type: "feed_refresh", subject: feed, user: feed.user)
     post = create(:post, feed: feed)
@@ -90,7 +90,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should link the event's feed to the admin feed page" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed)
     event = create(:event, type: "feed_refresh", subject: feed, user: feed.user)
 
@@ -101,7 +101,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should display stats from event metadata" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     event = create(:event, metadata: { "stats" => { "new_posts" => 3 } }, user: create(:user))
 
     get admin_event_path(event)
@@ -113,7 +113,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should render the most recent page of events" do
     with_page_size(2) do
-      login_as(admin_user)
+      sign_in_as(admin_user)
       3.times { |i| create(:event, type: "Event#{i}") }
 
       get admin_events_path
@@ -126,7 +126,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show empty state when no events exist" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
 
     get admin_events_path
 
@@ -138,7 +138,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should poll on the first page only" do
     with_page_size(2) do
-      login_as(admin_user)
+      sign_in_as(admin_user)
       3.times { |i| create(:event, type: "Event#{i}") }
 
       get admin_events_path
@@ -152,7 +152,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should browse older pages with a stable cursor" do
     with_page_size(2) do
-      login_as(admin_user)
+      sign_in_as(admin_user)
       events = Array.new(5) { |i| create(:event, type: "Event#{i}") }
       oldest_on_first_page = events[3]
 
@@ -169,7 +169,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should resume polling when newer navigation reaches the head" do
     with_page_size(2) do
-      login_as(admin_user)
+      sign_in_as(admin_user)
       events = Array.new(4) { |i| create(:event, type: "Event#{i}") }
 
       # after the 2nd-oldest id returns the newest two events (the head)
@@ -184,7 +184,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should redirect to the latest page when a cursor matches no events" do
     with_page_size(2) do
-      login_as(admin_user)
+      sign_in_as(admin_user)
       event = create(:event)
 
       get admin_events_path, params: { before: event.id }
@@ -195,7 +195,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should not drift older pages when new events arrive" do
     with_page_size(2) do
-      login_as(admin_user)
+      sign_in_as(admin_user)
       older = [create(:event, type: "Old0"), create(:event, type: "Old1")]
       boundary = create(:event, type: "Boundary")
       create(:event, type: "Newer0")
@@ -212,7 +212,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should render admin events turbo stream" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     cursor_event = create(:event, type: "OldAdminEvent")
     create(:event, type: "NewAdminEvent")
 
@@ -225,7 +225,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should return empty admin turbo stream when there are no new events" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     event = create(:event)
 
     get admin_events_path(format: :turbo_stream), params: { after_id: event.id }
@@ -236,7 +236,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should refresh only the first page when polling" do
     with_page_size(2) do
-      login_as(admin_user)
+      sign_in_as(admin_user)
       3.times { |i| create(:event, type: "admin_event_#{i}") }
 
       get admin_events_path(format: :turbo_stream), params: { after_id: 0 }
@@ -248,7 +248,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show recorded subject when subject missing" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     event = create(:event, type: "MissingSubjectEvent", subject: nil)
     missing_id = SecureRandom.uuid
     event.update!(subject_type: "Post", subject_id: missing_id)
@@ -261,7 +261,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should filter events by subject_type" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     test_user = create(:user, email_address: "test_user_#{SecureRandom.uuid}@example.com")
     feed = create(:feed, user: test_user)
 
@@ -278,7 +278,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should filter events by subject_id" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     test_user = create(:user, email_address: "test_user_#{SecureRandom.uuid}@example.com")
     feed1 = create(:feed, user: test_user, url: "https://example1.com/feed")
     feed2 = create(:feed, user: test_user, url: "https://example2.com/feed")
@@ -295,7 +295,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should handle invalid filter parameter gracefully" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     create(:event, type: "TestEvent")
 
     get admin_events_path, params: { filter: { invalid_field: "value" } }
@@ -305,7 +305,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should filter events by multiple types" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
 
     create(:event, type: "TypeA", message: "Event A")
     create(:event, type: "TypeB", message: "Event B")
@@ -322,7 +322,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should filter events by level" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
 
     create(:event, type: "InfoEvent", level: :info)
     create(:event, type: "WarningEvent", level: :warning)
@@ -335,7 +335,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should filter events by user_id" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
 
     user1 = create(:user)
     user2 = create(:user)
@@ -352,7 +352,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should filter events by user_id and multiple types" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
 
     user1 = create(:user)
     user2 = create(:user)
@@ -369,7 +369,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should include filter params in polling endpoint" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
 
     user1 = create(:user)
 
@@ -392,9 +392,5 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     yield
   ensure
     Admin::EventsController.events_page_size = original
-  end
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/admin/feeds_controller_test.rb
+++ b/test/controllers/admin/feeds_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should redirect non-admin users from index" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
 
     get admin_feeds_path
 
@@ -29,7 +29,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should list feeds from every user for admins" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))
 
     get admin_feeds_path
@@ -40,7 +40,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should let admins view another user's feed" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))
 
     get admin_feed_path(feed)
@@ -50,7 +50,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show another user's feed posts without owner-only links" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))
     post = create(:post, :published, feed: feed)
 
@@ -62,7 +62,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should render a recent activity section with the feed's events" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))
     create(:event, subject: feed, user: feed.user)
 
@@ -73,7 +73,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should not render recent activity section when feed has no events" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))
 
     get admin_feed_path(feed)
@@ -83,7 +83,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should render a recent posts section with the feed's posts" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))
     create(:post, feed: feed)
 
@@ -94,7 +94,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should not render recent posts section when feed has no posts" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))
 
     get admin_feed_path(feed)
@@ -104,7 +104,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should render AI usage section when feed has usages within the stats period" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))
     create(:llm_usage, feed: feed, user: feed.user)
 
@@ -115,7 +115,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should not render AI usage section when all usages are older than the stats period" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))
     create(:llm_usage, feed: feed, user: feed.user, created_at: LlmUsage::STATS_PERIOD.ago - 1.day)
 
@@ -126,7 +126,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should redirect non-admin users from show" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
     feed = create(:feed, user: create(:user))
 
     get admin_feed_path(feed)
@@ -135,7 +135,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should render the sort dropdown on index" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     create(:feed, user: create(:user))
 
     get admin_feeds_path
@@ -146,7 +146,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should sort feeds by name" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     create(:feed, user: create(:user), name: "Z Feed")
     create(:feed, user: create(:user), name: "A Feed")
 
@@ -158,7 +158,7 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should preserve sort parameters in pagination" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     3.times { |i| create(:feed, user: create(:user), name: "Feed #{i}") }
 
     get admin_feeds_path(sort: "name", direction: "desc", per_page: 2)
@@ -166,9 +166,5 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "nav a[href*='sort=name']"
     assert_select "nav a[href*='direction=desc']"
-  end
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/admin/password_resets_controller_test.rb
+++ b/test/controllers/admin/password_resets_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should redirect non-admin users from create" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
     user = create(:user)
 
     post admin_user_password_reset_path(user)
@@ -19,7 +19,7 @@ class Admin::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should send password reset email when email is active" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, email_address: "test@example.com")
 
     assert_difference -> { Event.where(type: "mail.passwords_mailer.reset", user: user).count }, 1 do
@@ -33,7 +33,7 @@ class Admin::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not send password reset email when email is deactivated" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, email_address: "test@example.com")
     user.deactivate_email!(reason: "bounced")
 
@@ -43,11 +43,5 @@ class Admin::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_user_path(user)
     assert_equal "Cannot send password reset email. Previous emails to this address were bounced by the mail server.", flash[:alert]
-  end
-
-  private
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should redirect non-admin users from index" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
 
     get admin_users_path
 
@@ -25,7 +25,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should allow admin users to view users index" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     other_user = create(:user, email_address: "other@example.com")
 
     get admin_users_path
@@ -36,7 +36,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should allow admin users to view user details" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, email_address: "test@example.com")
 
     get admin_user_path(user)
@@ -46,7 +46,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show active suspend button for other users" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     other_user = create(:user)
 
     get admin_user_path(other_user)
@@ -57,7 +57,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should disable suspend button for the current admin" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
 
     get admin_user_path(admin_user)
 
@@ -67,7 +67,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show confirm email button for a user with a pending email" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, :inactive)
 
     get admin_user_path(user)
@@ -77,7 +77,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should confirm email behind a confirmation dialog" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, :inactive)
 
     get admin_user_path(user)
@@ -88,7 +88,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should disable confirm email button once the email is confirmed" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user, state: :active)
 
     get admin_user_path(user)
@@ -100,7 +100,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should redirect non-admin users from show" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
     user = create(:user)
 
     get admin_user_path(user)
@@ -109,7 +109,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should paginate users" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
 
     4.times { create(:user) }
 
@@ -121,7 +121,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should display only total when feeds counts are zero" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
 
     get admin_user_path(user)
@@ -131,7 +131,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should hide zero enabled count" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
     create(:feed, user: user, state: :disabled)
 
@@ -143,7 +143,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should hide zero disabled count" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
     create(:feed, user: user, state: :enabled)
 
@@ -155,7 +155,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should display both enabled and disabled counts when non-zero" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
     create(:feed, user: user, state: :enabled)
     create(:feed, user: user, state: :disabled)
@@ -167,7 +167,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should display only total when access token counts are zero" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
 
     get admin_user_path(user)
@@ -177,7 +177,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should hide zero active token count" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
     create(:access_token, :inactive, user: user)
 
@@ -188,7 +188,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should hide zero inactive token count" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
     create(:access_token, :active, user: user)
 
@@ -200,7 +200,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should display both active and inactive token counts when non-zero" do
-    login_as(admin_user)
+    sign_in_as(admin_user)
     user = create(:user)
     create(:access_token, :active, user: user)
     create(:access_token, :inactive, user: user)
@@ -209,11 +209,5 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-key='stats.access_tokens.value']", text: "2 total (1 active, 1 not active)"
-  end
-
-  private
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class AuthenticationTest < ActionDispatch::IntegrationTest
   test "#authenticated? should return true when user is signed in" do
     user = create(:user)
-    login_as(user)
+    sign_in_as(user)
     follow_redirect!
 
     get feeds_path
@@ -17,7 +17,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
 
   test "#update_session_activity should touch session after 10 minutes" do
     user = create(:user)
-    login_as(user)
+    sign_in_as(user)
     session = user.sessions.last
 
     session.update_column(:updated_at, 11.minutes.ago)
@@ -30,7 +30,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
 
   test "#update_session_activity should not touch recent session" do
     user = create(:user)
-    login_as(user)
+    sign_in_as(user)
     session = user.sessions.last
 
     session.update_column(:updated_at, 5.minutes.ago)
@@ -40,11 +40,5 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_equal old_timestamp.to_i, session.reload.updated_at.to_i
-  end
-
-  private
-
-  def login_as(user)
-    post session_url, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/development/components_controller_test.rb
+++ b/test/controllers/development/components_controller_test.rb
@@ -10,7 +10,7 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should render the UI elements reference" do
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     get development_components_path
 
@@ -34,7 +34,7 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should require dev permission" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
 
     get development_components_path
 
@@ -43,7 +43,7 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should associate checkbox and radio labels with their controls" do
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     get development_components_path
 
@@ -60,7 +60,7 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should render the feed profile chooser states" do
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     get development_components_path
 
@@ -71,11 +71,5 @@ class Development::ComponentsControllerTest < ActionDispatch::IntegrationTest
     assert_select '[data-key="section.feed-profile-chooser"] input[type=radio][disabled]', count: 0
     assert_select '[data-key="section.feed-profile-chooser"] input[type=radio][checked]'
     assert_select '[data-key="section.feed-profile-chooser"] [data-key="candidate.suggested-badge"]'
-  end
-
-  private
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/development/email_previews_controller_test.rb
+++ b/test/controllers/development/email_previews_controller_test.rb
@@ -16,7 +16,7 @@ class Development::EmailPreviewsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#index should deny users without dev permission" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
 
     get development_email_previews_path
 
@@ -24,7 +24,7 @@ class Development::EmailPreviewsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#index should show email list for dev users" do
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     get development_email_previews_path
 
@@ -39,7 +39,7 @@ class Development::EmailPreviewsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should deny users without dev permission" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
 
     get development_email_preview_path("passwords_mailer-reset")
 
@@ -47,7 +47,7 @@ class Development::EmailPreviewsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should redirect for unknown email type" do
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     get development_email_preview_path("unknown-mailer")
 
@@ -61,17 +61,11 @@ class Development::EmailPreviewsControllerTest < ActionDispatch::IntegrationTest
     test_mailer-ping
   ].each do |id|
     test "#show should render preview for #{id}" do
-      login_as(dev_user)
+      sign_in_as(dev_user)
 
       get development_email_preview_path(id)
 
       assert_response :success
     end
-  end
-
-  private
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/development/sent_emails_controller_test.rb
+++ b/test/controllers/development/sent_emails_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Development::SentEmailsControllerTest < ActionDispatch::IntegrationTest
   setup do
     email_storage.purge
-    login_as(dev_user)
+    sign_in_as(dev_user)
   end
 
   def dev_user
@@ -26,7 +26,7 @@ class Development::SentEmailsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#index should require dev permission" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
     get development_sent_emails_path
 
     assert_redirected_to root_path
@@ -138,9 +138,6 @@ class Development::SentEmailsControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
-  end
 
   def create_test_email(uuid, subject, body)
     multipart = body.is_a?(Hash)

--- a/test/controllers/development/sent_emails_file_system_test.rb
+++ b/test/controllers/development/sent_emails_file_system_test.rb
@@ -6,7 +6,7 @@ require "test_helper"
 class Development::SentEmailsFileSystemTest < ActionDispatch::IntegrationTest
   setup do
     FileUtils.mkdir_p(storage_dir)
-    login_as(dev_user)
+    sign_in_as(dev_user)
   end
 
   teardown do
@@ -90,9 +90,5 @@ class Development::SentEmailsFileSystemTest < ActionDispatch::IntegrationTest
       },
       text_content: body
     )
-  end
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end

--- a/test/controllers/development/system_status_controller_test.rb
+++ b/test/controllers/development/system_status_controller_test.rb
@@ -10,7 +10,7 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should redirect non-dev users" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
 
     get development_system_status_path
 
@@ -25,7 +25,7 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show system status for dev users" do
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     get development_system_status_path
 
@@ -33,7 +33,7 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show configuration checklist" do
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     get development_system_status_path
 
@@ -50,7 +50,7 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
 
   test "should flag metrics push as healthy when METRICS_URL is set" do
     Metrics.stub(:enabled?, true) do
-      login_as(dev_user)
+      sign_in_as(dev_user)
 
       get development_system_status_path
     end
@@ -61,7 +61,7 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
 
   test "should flag metrics push as neutral when METRICS_URL is unset" do
     Metrics.stub(:enabled?, false) do
-      login_as(dev_user)
+      sign_in_as(dev_user)
 
       get development_system_status_path
     end
@@ -72,7 +72,7 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
 
   test "should flag background jobs as healthy when a process is heartbeating" do
     SolidQueue::Process.create!(kind: "Worker", name: "worker-test", pid: 999, last_heartbeat_at: Time.current)
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     get development_system_status_path
 
@@ -82,7 +82,7 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
 
   test "should flag background jobs as a problem when no process is heartbeating" do
     SolidQueue::Process.delete_all
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     get development_system_status_path
 
@@ -96,7 +96,7 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
       "APP_REVISION_SHORT" => "0123456",
       "APP_DEPLOYED_AT" => "2026-05-09T12:34:56Z"
     ) do
-      login_as(dev_user)
+      sign_in_as(dev_user)
 
       get development_system_status_path
     end
@@ -109,9 +109,6 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
-  end
 
   def with_release_env(values)
     previous_values = values.keys.index_with { |key| ENV.fetch(key, nil) }

--- a/test/controllers/development/test_emails_controller_test.rb
+++ b/test/controllers/development/test_emails_controller_test.rb
@@ -16,7 +16,7 @@ class Development::TestEmailsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#create should deny users without dev permission" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
 
     post development_email_preview_test_email_path("passwords_mailer-reset")
 
@@ -24,7 +24,7 @@ class Development::TestEmailsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#create should enqueue a test email to the current user and confirm" do
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     assert_enqueued_with(job: EmailPreviewTestJob, args: ["passwords_mailer-reset", dev_user.email_address]) do
       post development_email_preview_test_email_path("passwords_mailer-reset")
@@ -35,7 +35,7 @@ class Development::TestEmailsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#create should redirect for an unknown email type" do
-    login_as(dev_user)
+    sign_in_as(dev_user)
 
     assert_no_enqueued_jobs do
       post development_email_preview_test_email_path("unknown-mailer")
@@ -43,11 +43,5 @@ class Development::TestEmailsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to development_email_previews_path
     assert_equal "Unknown email type.", flash[:alert]
-  end
-
-  private
-
-  def login_as(user)
-    post session_path, params: { email_address: user.email_address, password: "password123" }
   end
 end


### PR DESCRIPTION
Changes:

- Remove the private `login_as` helper duplicated across 13 integration tests and call the shared `sign_in_as` helper instead

`IntegrationTestHelpers#sign_in_as` is already mixed into every `ActionDispatch::IntegrationTest`, but 13 test files each re-defined a byte-identical `login_as` under their own name. Dropping the copies removes ~160 lines of duplication with no behavior change.

References:

- Related issue: #1010 (F-048)
