### PR TITLE
Scope posts feed filter to the current user

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -40,7 +40,7 @@ class PostsController < ApplicationController
     authorize Post
     @sortable_presenter = sortable_presenter
     @posts = paginate_scope
-    @feed = Feed.find(params[:feed_id]) if params[:feed_id].present?
+    @feed = policy_scope(Feed).find(params[:feed_id]) if params[:feed_id].present?
     @feeds = policy_scope(Feed).order(:name)
   end
 

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -37,6 +37,12 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Posts"
   end
 
+  test "#index should not load another user's feed via feed_id" do
+    sign_in_as(user)
+    get posts_url, params: { feed_id: other_feed.id }
+    assert_response :not_found
+  end
+
   test "#index should nudge users with no feeds toward adding one" do
     sign_in_as(user)
     get posts_url


### PR DESCRIPTION
Changes:

- Look up the posts index `feed_id` filter through `policy_scope(Feed)` instead of an unscoped `Feed.find`

The unscoped lookup let any signed-in user load another user's feed by passing its id; scoping it matches the feed list rendered on the same page.

References:

- Related issue: #1010 (F-015)