### PR TITLE
Guard normalize_published_at against nil

### DIFF
--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -119,7 +119,7 @@ module Normalizer
     end
 
     def normalize_published_at(published_at)
-      return Time.current if published_at > Time.current
+      return Time.current if published_at.nil? || published_at > Time.current
       published_at
     end
 

--- a/test/services/normalizer/base_test.rb
+++ b/test/services/normalizer/base_test.rb
@@ -29,6 +29,23 @@ class Normalizer::BaseTest < ActiveSupport::TestCase
     assert_equal "Subclasses must implement #normalize_content", error.message
   end
 
+  test "#normalize_published_at should fall back to now for an undated entry" do
+    freeze_time do
+      assert_equal Time.current, normalizer.send(:normalize_published_at, nil)
+    end
+  end
+
+  test "#normalize_published_at should clamp future timestamps to now" do
+    freeze_time do
+      assert_equal Time.current, normalizer.send(:normalize_published_at, 1.hour.from_now)
+    end
+  end
+
+  test "#normalize_published_at should keep a past timestamp" do
+    past = 3.days.ago
+    assert_equal past, normalizer.send(:normalize_published_at, past)
+  end
+
   test "#normalize_attachment_urls should return empty array by default" do
     result = normalizer.send(:normalize_attachment_urls)
     assert_equal [], result


### PR DESCRIPTION
Changes:

- Treat a nil `published_at` as the current time in `Normalizer::Base#normalize_published_at`, alongside the existing future-date clamp

An undated RSS item passed `nil` into the `published_at > Time.current` comparison, which raised and failed the entire feed refresh. Falling back to now keeps the item importable.

References:

- Related issue: #1010 (F-006)