### PR TITLE
Report unexpected group-fetch errors

### DIFF
--- a/app/controllers/access_tokens/groups_controller.rb
+++ b/app/controllers/access_tokens/groups_controller.rb
@@ -25,9 +25,10 @@ class AccessTokens::GroupsController < ApplicationController
     else
       error_locals(:inactive_token)
     end
-  rescue FreefeedClient::UnauthorizedError, FreefeedClient::ForbiddenError => e
+  rescue FreefeedClient::UnauthorizedError, FreefeedClient::ForbiddenError
     error_locals(:unauthorized)
   rescue StandardError => e
+    Rails.error.report(e, context: { access_token_id: access_token&.id, feed_id: feed&.id })
     error_locals(:api_error)
   end
 

--- a/test/controllers/access_tokens/groups_controller_test.rb
+++ b/test/controllers/access_tokens/groups_controller_test.rb
@@ -139,6 +139,21 @@ class AccessTokens::GroupsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Retry/, response.body)
   end
 
+  test "reports unexpected API errors" do
+    sign_in_as user
+
+    stub_request(:get, "#{active_token.host}/v4/managedGroups")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    reported = nil
+    Rails.error.stub(:report, ->(error, **) { reported = error }) do
+      get access_token_groups_path(active_token)
+    end
+
+    assert_response :success
+    assert_kind_of FreefeedClient::Error, reported
+  end
+
   test "handles unauthorized token without retry link" do
     sign_in_as user
 


### PR DESCRIPTION
Changes:

- Report unexpected errors through `Rails.error` in `AccessTokens::GroupsController` before falling back to the api_error state

The `rescue StandardError` swallowed genuine failures silently, so nothing surfaced in error tracking — against the project's error-reporting convention. Expected auth errors are still handled quietly.

References:

- Related issue: #1010 (F-010)