### PR TITLE
Fix stray login_as in email updates test

### DIFF
--- a/test/controllers/admin/email_updates_controller_test.rb
+++ b/test/controllers/admin/email_updates_controller_test.rb
@@ -19,7 +19,7 @@ class Admin::EmailUpdatesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should redirect non-admin users from updating their own email" do
-    login_as(regular_user)
+    sign_in_as(regular_user)
 
     patch admin_user_email_update_path(regular_user), params: { user: { email_address: "new@example.com" }, require_confirmation: "0" }
 


### PR DESCRIPTION
Changes:

- Replace the leftover `login_as` call in `email_updates_controller_test` with `sign_in_as`

The shared-helper conversion (#1056) removed the per-file `login_as` definitions, but a test added around the same time (#1047) still called it, leaving `main`'s test suite red with `undefined method 'login_as'`.

References:

- Related PR: #1056
- Related PR: #1047