### PR TITLE
Remove redundant candidate badge guard

### DIFF
--- a/app/components/candidate_option_component.html.erb
+++ b/app/components/candidate_option_component.html.erb
@@ -4,9 +4,7 @@
   <span class="flex flex-col gap-1">
     <span class="flex flex-wrap items-center gap-2">
       <span class="font-semibold text-heading"><%= display_name %></span>
-      <% if badge_text %>
-        <%= render BadgeComponent.new(text: badge_text, color: :success, key: "candidate.#{profile_key}.status") %>
-      <% end %>
+      <%= render BadgeComponent.new(text: badge_text, color: :success, key: "candidate.#{profile_key}.status") %>
       <% if selected? %>
         <%= render BadgeComponent.new(text: "Suggested", color: :info, key: "candidate.suggested-badge") %>
       <% end %>


### PR DESCRIPTION
Changes:

- Render the candidate status badge directly.
- Remove the condition that can never be false because `badge_text` always returns a string.

Why:

This removes dead template branching without changing rendered output.

References:

- Related issue: #1010 (F-056)

Checks:

- Existing `CandidateOptionComponentTest` coverage exercises badge rendering.
- Local tests were not available in this connector-only workflow; GitHub Actions will verify the branch.