### PR TITLE
Fix deleted feed pluralization

### DIFF
--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -111,7 +111,7 @@ class EventDescriptionComponent < ViewComponent::Base
     deleted_feeds_count = disabled_feed_ids.size - disabled_feeds.size
 
     if deleted_feeds_count.positive?
-      deleted_feeds_note = helpers.pluralize(deleted_feeds_count, "deleted feeds")
+      deleted_feeds_note = helpers.pluralize(deleted_feeds_count, "deleted feed")
       helpers.safe_join([linked_feeds.presence, deleted_feeds_note].compact_blank, " and ")
     else
       linked_feeds


### PR DESCRIPTION
Changes:

- Pass the singular noun `deleted feed` to `pluralize`.

Why:

The previous plural noun produced `1 deleted feeds` when exactly one referenced feed had been removed.

References:

- Related issue: #1010 (F-059)

Checks:

- Existing `EventDescriptionComponentTest` coverage includes the singular deleted-feed case.
- Local tests were not available in this connector-only workflow; GitHub Actions will verify the branch.