### PR TITLE
Simplify access token memoization

### DIFF
--- a/app/controllers/access_tokens/groups_controller.rb
+++ b/app/controllers/access_tokens/groups_controller.rb
@@ -43,7 +43,7 @@ class AccessTokens::GroupsController < ApplicationController
     if defined?(@access_token)
       @access_token
     else
-      @access_token ||= current_user.access_tokens.find_by(id: params[:access_token_id])
+      @access_token = current_user.access_tokens.find_by(id: params[:access_token_id])
     end
   end
 


### PR DESCRIPTION
Changes:

- Replace the redundant `||=` assignment inside the `defined?` guard with a direct assignment.

Why:

The guard already distinguishes an uninitialized instance variable from a cached `nil`, so `||=` is misleading and unnecessary.

References:

- Related issue: #1010 (F-070)

Checks:

- Behavior is unchanged: missing tokens remain memoized as `nil`.
- Local tests were not available in this connector-only workflow; GitHub Actions will verify the branch.