### PR TITLE
Remove unused sent email UUID assignment

### DIFF
--- a/app/controllers/development/sent_emails_controller.rb
+++ b/app/controllers/development/sent_emails_controller.rb
@@ -24,8 +24,6 @@ class Development::SentEmailsController < ApplicationController
       redirect_to development_sent_emails_path, alert: "Failed to load email"
       return
     end
-
-    @uuid = id
   end
 
   def purge

--- a/app/controllers/development/sent_emails_controller.rb
+++ b/app/controllers/development/sent_emails_controller.rb
@@ -22,7 +22,6 @@ class Development::SentEmailsController < ApplicationController
 
     unless @email
       redirect_to development_sent_emails_path, alert: "Failed to load email"
-      return
     end
   end
 


### PR DESCRIPTION
Changes:

- Remove the unused `@uuid` assignment from `Development::SentEmailsController#show`.

Why:

The view reads the loaded email and never references the UUID instance variable.

References:

- Related issue: #1010 (F-084)

Checks:

- Controller behavior and rendered data are unchanged.
- Local tests were not available in this connector-only workflow; GitHub Actions will verify the branch.