### PR TITLE
Remove static class_names wrappers

### DIFF
--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -3,19 +3,19 @@
   <% header.with_breadcrumb(label: "Access Tokens", url: access_tokens_path) %>
   <% if feed_id.present? %>
     <% header.with_action_button do %>
-      <%= link_to "Back to your feed", edit_feed_path(feed_id), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1") %>
+      <%= link_to "Back to your feed", edit_feed_path(feed_id), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1" %>
     <% end %>
   <% end %>
 
   <% unless access_token.pending? || access_token.validating? %>
     <% header.with_action_button do %>
-      <%= link_to "Edit", edit_access_token_path(access_token), class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1") %>
+      <%= link_to "Edit", edit_access_token_path(access_token), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1" %>
     <% end %>
 
     <% header.with_action_button do %>
       <%= link_to "Delete…",
                   "#",
-                  class: class_names("inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1"),
+                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",
                   data: { controller: "modal-trigger", modal_trigger_modal_id_value: "delete-token-modal", action: "click->modal-trigger#open" } %>
     <% end %>
   <% end %>


### PR DESCRIPTION
Changes:

- Pass the three static button class strings directly to `link_to`.
- Remove `class_names` calls that do not combine conditional classes.

Why:

Wrapping a single static string adds indirection without changing output.

References:

- Related issue: #1010 (F-135)

Checks:

- Rendered class attributes are unchanged.
- Local tests were not available in this connector-only workflow; GitHub Actions will verify the branch.