### PR TITLE
Remove unused invite statistic

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -45,8 +45,7 @@ class InvitesController < ApplicationController
   def invite_stats
     {
       remaining_invites_count: [0, available_invites_count - created_invites.count].max,
-      invited_users_count: created_invites.where.not(invited_user_id: nil).count,
-      unused_invites_count: created_invites.where(invited_user_id: nil).count
+      invited_users_count: created_invites.where.not(invited_user_id: nil).count
     }
   end
 

--- a/app/views/invites/_summary.html.erb
+++ b/app/views/invites/_summary.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (remaining_invites_count:, invited_users_count:, unused_invites_count:) %>
+<%# locals: (remaining_invites_count:, invited_users_count:) %>
 <% if remaining_invites_count.to_i > 0 %>
   You can send <strong><%= remaining_invites_count %></strong> <%= "invite".pluralize(remaining_invites_count) %>.
 <% else %>


### PR DESCRIPTION
Changes:

- Stop querying the count of unused invites in `InvitesController#invite_stats`.
- Remove the unused partial local declaration.

Why:

The summary partial never renders this value, so every summary refresh performs an unnecessary query.

References:

- Related issue: #1010 (F-141)

Checks:

- The partial still receives and renders its two used values.
- Local tests were not available in this connector-only workflow; GitHub Actions will verify the branch.