### PR TITLE
Inline password reset user lookup

### DIFF
--- a/app/controllers/admin/password_resets_controller.rb
+++ b/app/controllers/admin/password_resets_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PasswordResetsController < ApplicationController
   def create
-    user = load_user
+    user = User.find(params[:user_id])
     authorize user, :update?
 
     if user.email_deactivated?
@@ -10,11 +10,5 @@ class Admin::PasswordResetsController < ApplicationController
       Event.create!(type: "mail.passwords_mailer.reset", user: user, subject: user, level: :info)
       redirect_to admin_user_path(user), notice: "Password reset email sent to #{user.email_address}."
     end
-  end
-
-  private
-
-  def load_user
-    User.find(params[:user_id])
   end
 end


### PR DESCRIPTION
Changes:

- Load the target user directly in `Admin::PasswordResetsController#create`.
- Remove the single-use private `load_user` method.

Why:

The indirection had one caller and its name differed from neighboring controller conventions.

References:

- Related issue: #1010 (F-075)

Checks:

- Behavior is unchanged.
- GitHub Actions will verify the branch.