### PR TITLE
Remove redundant feeds join

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -60,7 +60,7 @@ class Admin::UsersController < ApplicationController
 
   def pagination_scope
     base_scope
-      .left_joins(:feeds, :access_tokens, :sessions)
+      .left_joins(:access_tokens, :sessions)
       .left_joins(feeds: :posts)
       .group("users.id")
       .select("users.*,


### PR DESCRIPTION
Changes:

- Remove the explicit `:feeds` entry from the admin users index join list.
- Keep `left_joins(feeds: :posts)`, which already joins both feeds and posts.

Why:

The separate feeds join is redundant and makes the query definition harder to read.

References:

- Related issue: #1010 (F-078)

Checks:

- Selected counts and ordering are unchanged.
- GitHub Actions will verify the branch.