### PR TITLE
Remove Sortable comment noise

### DIFF
--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -3,10 +3,6 @@ module Sortable
 
   private
 
-  # Builds the presenter that encapsulates available sort fields configuration
-  # and current options.
-  #
-  # @return [SortablePresenter]
   def sortable_presenter
     SortablePresenter.new(
       params: params,
@@ -15,10 +11,6 @@ module Sortable
     )
   end
 
-  # Resolves the requested sort field, falling back to the default when the
-  # param is missing or invalid.
-  #
-  # @return [String]
   def sortable_field
     field = params[:sort]
 
@@ -29,17 +21,10 @@ module Sortable
     end
   end
 
-  # The default sort field configured by the controller, which is the first one
-  # in the sortable_fields hash.
-  #
-  # @return [String]
   def sortable_default_field
     sortable_fields.keys.first.to_s
   end
 
-  # Resolves the sort direction, sanitising unexpected values.
-  #
-  # @return [String] either "asc" or "desc"
   def sortable_direction
     direction = params[:direction]
 
@@ -51,20 +36,11 @@ module Sortable
     end
   end
 
-  # The configured default direction for a specific field.
-  #
-  # @param field [String, Symbol]
-  # @return [String] either "asc" or "desc"
   def default_direction_for(field)
     config = sortable_fields[field.to_sym]
     config ? config.fetch(:direction, "desc").to_s : "desc"
   end
 
-  # The Arel ordering for the current sort field and direction. A field may
-  # request `nulls: :last` to keep rows with a NULL value out of the way.
-  # Intended for use in the "index" action that outputs the ordered records.
-  #
-  # @return [Arel::Nodes::Ordering]
   def sortable_order
     field_name = sortable_field.to_sym
     config = sortable_fields.fetch(field_name, {})
@@ -79,19 +55,10 @@ module Sortable
     config[:nulls] == :last ? ordering.nulls_last : ordering
   end
 
-  # Returns the configuration hash describing available sort fields.
-  # Controllers including this concern must override this method.
-  #
-  # @return [Hash{Symbol=>Hash}]
   def sortable_fields
     raise NotImplementedError, "Include Sortable and override #sortable_fields in the controller"
   end
 
-  # Builds the path for a specific sort configuration.
-  # Controllers including this concern must override this method.
-  #
-  # @param params [Hash] additional query params to apply to the generated path
-  # @return [String]
   def sortable_path(_params)
     raise NotImplementedError, "Include Sortable and override #sortable_path(params) in the controller"
   end


### PR DESCRIPTION
Changes:

- Remove YARD-style comments that restate the private method implementations in `Sortable`.

Why:

The comments duplicate the code and add maintenance overhead without documenting non-obvious behavior.

References:

- Related issue: #1010 (F-082)

Checks:

- Executable code is unchanged.
- GitHub Actions will verify the branch.