### PR TITLE
Remove stale access token TODO

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -140,7 +140,6 @@ class AccessToken < ApplicationRecord
     self.name = "Token #{next_available_token_number}"
   end
 
-  # TBD: Optimize this the token management flow is when stabilized
   def next_available_token_number
     counter = 1
 


### PR DESCRIPTION
Changes:

- Remove the garbled, stale TODO above `next_available_token_number`.

Why:

The comment does not describe an actionable task and no longer provides useful context.

References:

- Related issue: #1010 (F-106)

Checks:

- Executable code is unchanged.
- GitHub Actions will verify the branch.