### PR TITLE
Remove no-op table header hover class

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -9,7 +9,7 @@
     <div class="overflow-x-auto rounded-lg border border-border">
       <table class="w-full text-left text-sm text-heading">
         <thead class="border-b border-border bg-surface-muted text-xs uppercase text-body">
-          <tr class="hover:bg-surface-muted">
+          <tr>
             <th scope="col" class="px-6 py-3">Email</th>
             <th scope="col" class="px-6 py-3">Name</th>
             <th scope="col" class="px-6 py-3 text-center">Feeds</th>


### PR DESCRIPTION
Changes:

- Remove `hover:bg-surface-muted` from the admin users table header row.

Why:

The row already has the same background through its `thead`, so the hover class has no visible effect.

References:

- Related issue: #1010 (F-137)

Checks:

- Rendered table content is unchanged.
- GitHub Actions will verify the branch.