### PR TITLE
Remove redundant authentication callbacks

### DIFF
--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -1,8 +1,6 @@
 class FeedIdentificationsController < ApplicationController
   include StatePolling
 
-  before_action :require_authentication
-
   rate_limit to: 10, within: 1.minute, by: -> { Current.user.id }, only: :create, with: -> {
     message = "Too many attempts in a row. Give it a minute, then try again."
     state = ai_mode? ? entry_form(mode: "ai", prompt: raw_prompt, error: message) : entry_form(error: message)

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -1,7 +1,6 @@
 class FeedPreviewsController < ApplicationController
   include StatePolling
 
-  before_action :require_authentication
   before_action :guard_preview, only: %i[show create]
 
   # Maps each FeedPreview status to the pane partial that renders it. `fetch`


### PR DESCRIPTION
Changes:

- Remove explicit `before_action :require_authentication` declarations from `FeedIdentificationsController` and `FeedPreviewsController`.

Why:

`ApplicationController` already includes `Authentication`, which registers the same callback for every controller. The duplicate declarations add no protection and make these controllers inconsistent with their peers.

References:

- Related issue: #1010 (F-085)

Checks:

- Authentication behavior is unchanged.
- GitHub Actions will verify the branch.