### PR TITLE
Remove redundant event reference deletion

### DIFF
--- a/app/jobs/purge_expired_events_job.rb
+++ b/app/jobs/purge_expired_events_job.rb
@@ -15,7 +15,6 @@ class PurgeExpiredEventsJob < ApplicationJob
     deleted_count = 0
 
     Event.expired.in_batches(of: BATCH_SIZE) do |events|
-      EventReference.where(event_id: events.select(:id)).delete_all
       # Events can also BE references (feed_refresh → web_search); delete_all
       # skips the incoming_event_references association cleanup, so inbound
       # rows must be cleared here or they dangle until the referrer purges.


### PR DESCRIPTION
Changes:

- Remove the explicit deletion of event-reference rows owned by expired events.
- Keep the separate cleanup for events referenced polymorphically by other events.

Why:

The `event_references.event_id` foreign key already uses `ON DELETE CASCADE`, so deleting those rows manually duplicates database behavior.

References:

- Related issue: #1010 (F-103)

Checks:

- Inbound polymorphic references are still deleted explicitly.
- GitHub Actions will verify the branch.