### PR TITLE
Remove redundant feed metric comment

### DIFF
--- a/app/models/feed_metric.rb
+++ b/app/models/feed_metric.rb
@@ -21,7 +21,6 @@ class FeedMetric < ApplicationRecord
   # @param posts_count [Integer] number of posts imported
   # @param invalid_posts_count [Integer] number of invalid posts
   def self.record(feed:, date:, posts_count: 0, invalid_posts_count: 0)
-    # Only record if there's actual activity
     return if posts_count.zero? && invalid_posts_count.zero?
 
     upsert(


### PR DESCRIPTION
Changes:

- Remove the inline comment above the zero-activity guard in `FeedMetric.record`.

Why:

The comment repeats both the method documentation and the guard clause immediately below it.

References:

- Related issue: #1010 (F-112)

Checks:

- Executable code is unchanged.
- GitHub Actions will verify the branch.