### PR TITLE
Remove redundant invite validation

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -2,8 +2,6 @@ class Invite < ApplicationRecord
   belongs_to :created_by_user, class_name: "User"
   belongs_to :invited_user, class_name: "User", optional: true
 
-  validates :created_by_user, presence: true
-
   def used?
     invited_user_id.present?
   end


### PR DESCRIPTION
Changes:

- Remove the explicit presence validation for `created_by_user` from `Invite`.

Why:

The required `belongs_to :created_by_user` already validates association presence, and the database column remains non-null.

References:

- Related issue: #1010 (F-114)

Checks:

- Validation behavior is unchanged.
- GitHub Actions will verify the branch.