### PR TITLE
Remove EventDetailsComponent factory alias

### DIFF
--- a/app/components/event_details_component.rb
+++ b/app/components/event_details_component.rb
@@ -1,10 +1,6 @@
 # Renders the detail list shown at the top of an event page. Admin: true adds
 # operator-only rows (user, timestamps, expiry).
 class EventDetailsComponent < ViewComponent::Base
-  def self.for(event, admin: false)
-    new(event: event, admin: admin)
-  end
-
   def initialize(event:, admin: false)
     @event = event
     @admin = admin

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -28,7 +28,7 @@
     <%= render Admin::EventDescriptionComponent.for(@event) %>
   <% end %>
 
-  <%= render EventDetailsComponent.for(@event, admin: true) %>
+  <%= render EventDetailsComponent.new(event: @event, admin: true) %>
 
   <% if @referenced_posts.any? %>
     <section class="space-y-4" data-key="events.imported_posts">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -28,7 +28,7 @@
     <%= render EventDescriptionComponent.for(@event) %>
   <% end %>
 
-  <%= render EventDetailsComponent.for(@event) %>
+  <%= render EventDetailsComponent.new(event: @event) %>
 
   <% if @referenced_posts.any? %>
     <section class="space-y-4" data-key="events.imported_posts">
@@ -59,7 +59,7 @@
 
   <% if (stats = @event.metadata&.fetch("stats", nil)).present? %>
     <section class="space-y-4" data-key="events.stats">
-      <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.metadata.stats.section_title") %></h2>
+      <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.metadata.stats.section_title", default: "Stats") %></h2>
       <%= render ListComponent.new do |list| %>
         <% stats.except("search_calls").each do |key, value| %>
           <% list.with_item(StatListItemComponent.new(

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -59,7 +59,7 @@
 
   <% if (stats = @event.metadata&.fetch("stats", nil)).present? %>
     <section class="space-y-4" data-key="events.stats">
-      <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.metadata.stats.section_title", default: "Stats") %></h2>
+      <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.metadata.stats.section_title") %></h2>
       <%= render ListComponent.new do |list| %>
         <% stats.except("search_calls").each do |key, value| %>
           <% list.with_item(StatListItemComponent.new(

--- a/test/components/event_details_component_test.rb
+++ b/test/components/event_details_component_test.rb
@@ -10,16 +10,10 @@ class EventDetailsComponentTest < ViewComponent::TestCase
     @feed ||= create(:feed, user: user, name: "Test Feed")
   end
 
-  test ".for should return the base component" do
-    event = create(:event, type: "generic_event")
-
-    assert_instance_of EventDetailsComponent, EventDetailsComponent.for(event)
-  end
-
   test "#call should render the created timestamp without admin extras" do
     event = create(:event, type: "owned_event", level: :warning, subject: feed)
 
-    result = render_inline(EventDetailsComponent.for(event))
+    result = render_inline(EventDetailsComponent.new(event: event))
 
     assert_includes result.to_html, "Created"
     assert_empty result.css('[data-key="admin.event.user"]')
@@ -28,7 +22,7 @@ class EventDetailsComponentTest < ViewComponent::TestCase
   test "#call should render a compact user link when admin" do
     event = create(:event, type: "owned_event", user: user, subject: feed)
 
-    result = render_inline(EventDetailsComponent.for(event, admin: true))
+    result = render_inline(EventDetailsComponent.new(event: event, admin: true))
     link = result.css("a[data-key='admin.event.user']").first
 
     assert_equal event.user_id.to_s.last(5), link.text


### PR DESCRIPTION
Changes:

- Remove the `EventDetailsComponent.for` alias.
- Instantiate the component directly at both call sites.
- Remove the alias-only test and update rendering tests.

Why:

The factory method only forwarded to `.new` and performed no dispatch or configuration.

References:

- Related issue: #1010 (F-060)

Checks:

- Existing component tests continue to cover normal and admin rendering.
- GitHub Actions will verify the branch.