### PR TITLE
Remove unused helper mixins

### DIFF
--- a/app/components/feed_filter_dropdown_component.html.erb
+++ b/app/components/feed_filter_dropdown_component.html.erb
@@ -9,7 +9,7 @@
     aria-haspopup="true"
     aria-expanded="false">
     <span><%= button_label %></span>
-    <%= icon("chevron-down", css_class: "size-4 text-muted") %>
+    <%= helpers.icon("chevron-down", css_class: "size-4 text-muted") %>
   </button>
   <div
     id="<%= menu_id %>"
@@ -22,7 +22,7 @@
       <label for="<%= menu_id %>-search" class="sr-only">Search feeds</label>
       <div class="relative">
         <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
-          <%= icon("search", css_class: "size-4 text-muted") %>
+          <%= helpers.icon("search", css_class: "size-4 text-muted") %>
         </div>
         <input
           type="text"

--- a/app/components/feed_filter_dropdown_component.rb
+++ b/app/components/feed_filter_dropdown_component.rb
@@ -1,6 +1,4 @@
 class FeedFilterDropdownComponent < ViewComponent::Base
-  include ApplicationHelper
-
   def initialize(feeds:, selected_feed:, sort_params:, menu_id:)
     @feeds = feeds
     @selected_feed = selected_feed

--- a/app/components/sort_dropdown_component.html.erb
+++ b/app/components/sort_dropdown_component.html.erb
@@ -7,12 +7,12 @@
     class="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 gap-2"
     aria-haspopup="true"
     aria-expanded="false">
-    <%= icon(direction_icon, css_class: "size-4 text-muted") %>
+    <%= helpers.icon(direction_icon, css_class: "size-4 text-muted") %>
     <span class="flex items-center gap-2">
       <span><%= presenter.current_title %></span>
       <span class="sr-only"><%= direction_label %></span>
     </span>
-    <%= icon("chevron-down", css_class: "size-4 text-muted") %>
+    <%= helpers.icon("chevron-down", css_class: "size-4 text-muted") %>
   </button>
   <div
     id="<%= menu_id %>"
@@ -26,7 +26,7 @@
             <span><%= option.title %></span>
             <% if option.icon_name.present? %>
               <span class="flex items-center text-muted">
-                <%= icon(option.icon_name, css_class: "size-4 text-muted") %>
+                <%= helpers.icon(option.icon_name, css_class: "size-4 text-muted") %>
                 <span class="sr-only"><%= option.active_direction == "asc" ? "Ascending" : "Descending" %></span>
               </span>
             <% end %>

--- a/app/components/sort_dropdown_component.rb
+++ b/app/components/sort_dropdown_component.rb
@@ -1,6 +1,4 @@
 class SortDropdownComponent < ViewComponent::Base
-  include ApplicationHelper
-
   def initialize(presenter:, menu_id:)
     @presenter = presenter
     @menu_id = menu_id


### PR DESCRIPTION
Changes:

- Remove unused helper-module mixins from the feed filter and sort dropdown components.

Why:

Both components already access view helpers through the component helper proxy.

References:

- Related issue: #1010 (F-063)

Checks:

- Executable behavior is unchanged.
- GitHub Actions will verify the branch.