### PR TITLE
Report preview timestamp parse errors

### DIFF
--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -19,7 +19,7 @@ class PostPreviewComponent < ViewComponent::Base
       value = post_data["published_at"]
       value.present? ? Time.zone.parse(value) : nil
     rescue => error
-      Rails.logger.warn("Feed preview post published_at parse error for #{value.inspect}: #{error.message}")
+      Rails.error.report(error, context: { component: self.class.name, published_at: value })
       nil
     end
   end


### PR DESCRIPTION
Changes:

- Report malformed preview timestamps through `Rails.error` instead of writing an isolated warning log.
- Keep returning `nil` so an invalid timestamp does not break preview rendering.

Why:

Handled exceptions should still reach the application's error-reporting pipeline.

References:

- Related issue: #1010 (F-066)

Checks:

- User-facing fallback behavior is unchanged.
- GitHub Actions will verify the branch.