### PR TITLE
Warn when deleting search credentials

### DIFF
--- a/app/components/search_credential_list_item_component.rb
+++ b/app/components/search_credential_list_item_component.rb
@@ -1,5 +1,5 @@
 class SearchCredentialListItemComponent < ListItemComponent
-  DELETE_CONFIRM = "Delete this search credential?".freeze
+  DELETE_CONFIRM = "Delete this search credential? Feeds using it will be disabled.".freeze
 
   def initialize(credential:)
     super()


### PR DESCRIPTION
Changes:

- Expand the search-credential deletion confirmation to warn that dependent feeds will be disabled.

Why:

The confirmation now matches the actual destructive effect and the equivalent AI-credential warning.

References:

- Related issue: #1010 (F-068)

Checks:

- Only confirmation copy changes.
- GitHub Actions will verify the branch.