### PR TITLE
Remove unused time_ago_tag helper

### DIFF
--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -51,17 +51,6 @@ module TimeHelper
     time.strftime("%-d %b %Y, %H:%M")
   end
 
-  def time_ago_tag(time)
-    return nil unless time
-
-    content_tag(
-      :time,
-      "#{time_ago(time)} ago",
-      datetime: time.rfc3339,
-      title: long_time_format(time)
-    )
-  end
-
   def long_time_tag(time)
     return nil unless time
 

--- a/test/helpers/time_helper_test.rb
+++ b/test/helpers/time_helper_test.rb
@@ -70,20 +70,6 @@ class TimeHelperTest < ActiveSupport::TestCase
     end
   end
 
-  test "#time_ago_tag should return nil for nil input" do
-    assert_nil time_ago_tag(nil)
-  end
-
-  test "#time_ago_tag should generate HTML time element" do
-    time = Time.zone.parse("2025-01-15 15:45:30")
-
-    travel_to Time.zone.parse("2025-01-15 16:45:30") do
-      result = time_ago_tag(time)
-      expected = '<time datetime="2025-01-15T15:45:30Z" title="15 Jan 2025, 15:45">1 hour ago</time>'
-      assert_equal expected, result
-    end
-  end
-
   test "#long_time_tag should return nil for nil input" do
     assert_nil long_time_tag(nil)
   end


### PR DESCRIPTION
Changes:

- Remove the unused `time_ago_tag` helper.
- Remove its self-only tests.

Why:

No application code calls the helper; other time-tag helpers cover the active formats.

References:

- Related issue: #1010 (F-094)

Checks:

- Remaining time helper coverage is unchanged.
- GitHub Actions will verify the branch.