### PR TITLE
Correct rate limit retry documentation

### DIFF
--- a/app/jobs/rate_limited.rb
+++ b/app/jobs/rate_limited.rb
@@ -7,7 +7,7 @@
 # `perform`, a deferral never reaches the error reporter — only a give-up does.
 #
 # Reschedules wait retry_after (plus jitter), up to MAX_ATTEMPTS, then report
-# once and stop. The recurring schedulers re-kick later, so giving up isn't final.
+# once and stop.
 module RateLimited
   MAX_ATTEMPTS = 10
   JITTER_SECONDS = 5


### PR DESCRIPTION
Changes:

- Remove the inaccurate claim that recurring schedulers always restart a job after rate-limit retry exhaustion.

Why:

The retry helper reports and stops after the attempt cap; not every including job has a recurring scheduler.

References:

- Related issue: #1010 (F-104)

Checks:

- Executable code is unchanged.
- GitHub Actions will verify the branch.