### PR TITLE
Remove unused Event.for_subject scope

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,7 +19,6 @@ class Event < ApplicationRecord
   validates :level, inclusion: { in: levels.keys }
 
   scope :recent, -> { order(created_at: :desc) }
-  scope :for_subject, ->(subject) { where(subject: subject) }
   # An event is expired once its explicit expiration has passed, or — when it
   # never set one — once it ages past DEFAULT_RETENTION. This is what the purge
   # job deletes.

--- a/test/jobs/llm_capability_probe_job_test.rb
+++ b/test/jobs/llm_capability_probe_job_test.rb
@@ -27,7 +27,7 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
       job.perform_now
     end
 
-    events = Event.for_subject(job_run).where(type: "job.llm_capability_probe.skipped")
+    events = Event.where(subject: job_run, type: "job.llm_capability_probe.skipped")
     assert_equal 1, events.count
     assert_predicate events.first, :warning?
   end
@@ -53,14 +53,14 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
       end
     end
 
-    checks = Event.for_subject(job_run).where(type: "job.llm_capability_probe.check").order(:id)
+    checks = Event.where(subject: job_run, type: "job.llm_capability_probe.check").order(:id)
     assert_equal 2, checks.count
     assert_equal "pong", checks.first.metadata["evidence"]
     assert_predicate checks.first, :info?
     assert_predicate checks.second, :warning?
     assert_includes checks.second.message, "schema: FAIL"
 
-    summary = Event.for_subject(job_run).find_by(type: "job.llm_capability_probe.completed")
+    summary = Event.find_by(subject: job_run, type: "job.llm_capability_probe.completed")
     assert_includes summary.message, "plain=PASS schema=FAIL"
     assert_equal false, summary.metadata["passed"]
     assert_predicate summary, :warning?

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -73,16 +73,6 @@ class EventTest < ActiveSupport::TestCase
     assert_equal [new_event, old_event], recent_events.to_a
   end
 
-  test "should scope events for subject" do
-    feed_event = Event.create!(type: "feed_event", subject: feed)
-    user_event = Event.create!(type: "user_event", subject: user)
-
-    feed_events = Event.for_subject(feed)
-
-    assert_includes feed_events, feed_event
-    assert_not_includes feed_events, user_event
-  end
-
   test "should identify expired events" do
     expired_event = Event.create!(type: "expired_event", expires_at: 1.hour.ago)
     active_event = Event.create!(type: "active_event", expires_at: 1.hour.from_now)


### PR DESCRIPTION
Changes:

- Remove the unused `Event.for_subject` scope.
- Remove the test that only exercised that scope.

Why:

The scope has no application callers and adds an unnecessary model API.

References:

- Related issue: #1010 (F-108)

Checks:

- Remaining event model coverage is unchanged.
- GitHub Actions will verify the branch.