### PR TITLE
Remove unused service option constants

### DIFF
--- a/app/services/loader.rb
+++ b/app/services/loader.rb
@@ -1,3 +1,2 @@
 module Loader
-  AVAILABLE_OPTIONS = %w[http].freeze
 end

--- a/app/services/normalizer.rb
+++ b/app/services/normalizer.rb
@@ -1,3 +1,2 @@
 module Normalizer
-  AVAILABLE_OPTIONS = %w[rss xkcd].freeze
 end

--- a/app/services/processor.rb
+++ b/app/services/processor.rb
@@ -1,3 +1,2 @@
 module Processor
-  AVAILABLE_OPTIONS = %w[rss].freeze
 end


### PR DESCRIPTION
Changes:

- Remove the unused `AVAILABLE_OPTIONS` constants from the Loader, Normalizer, and Processor namespaces.

Why:

The constants have no callers and duplicate information already owned by the profile registry.

References:

- Related issue: #1010 (F-126)

Checks:

- Namespace modules remain defined.
- GitHub Actions will verify the branch.