### PR TITLE
Replace ERB tap with a local variable

### DIFF
--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -71,22 +71,21 @@
 
     <div class="space-y-4">
       <h2 class="text-2xl font-semibold mb-3 text-heading">FreeFeed Groups</h2>
-      <% access_token.access_token_detail.managed_groups.tap do |groups| %>
-        <% if groups.any? %>
-          <details class="group/groups">
-            <summary class="flex cursor-pointer list-none select-none items-center gap-2 font-medium text-heading hover:text-heading">
-              <%= icon("chevron-right", css_class: "size-4 shrink-0 transition-transform group-open/groups:rotate-90") %>
-              <%= pluralize(groups.count, "group") %> available for posting
-            </summary>
-            <ul class="mt-3 list-disc list-inside space-y-1 pl-6">
-              <% groups.sort_by { _1["username"] }.each do |group| %>
-                <li><%= link_to group["username"], "#{access_token.host}/#{group["username"]}", target: "_blank", rel: "noopener noreferrer", class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %></li>
-              <% end %>
-            </ul>
-          </details>
-        <% else %>
-          <%= render EmptyStateComponent.new("No groups available for posting") %>
-        <% end %>
+      <% groups = access_token.access_token_detail.managed_groups %>
+      <% if groups.any? %>
+        <details class="group/groups">
+          <summary class="flex cursor-pointer list-none select-none items-center gap-2 font-medium text-heading hover:text-heading">
+            <%= icon("chevron-right", css_class: "size-4 shrink-0 transition-transform group-open/groups:rotate-90") %>
+            <%= pluralize(groups.count, "group") %> available for posting
+          </summary>
+          <ul class="mt-3 list-disc list-inside space-y-1 pl-6">
+            <% groups.sort_by { _1["username"] }.each do |group| %>
+              <li><%= link_to group["username"], "#{access_token.host}/#{group["username"]}", target: "_blank", rel: "noopener noreferrer", class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %></li>
+            <% end %>
+          </ul>
+        </details>
+      <% else %>
+        <%= render EmptyStateComponent.new("No groups available for posting") %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
Changes:

- Assign managed groups to an explicit ERB local before rendering the groups section.
- Remove the `tap` block used only to introduce that local.

Why:

A direct assignment expresses the template flow more clearly without changing output.

References:

- Related issue: #1010 (F-136)

Checks:

- Rendered branches and content are unchanged.
- GitHub Actions will verify the branch.