### PR TITLE
Render stat rows in semantic description lists

### DIFF
--- a/app/components/list_component.rb
+++ b/app/components/list_component.rb
@@ -7,6 +7,6 @@ class ListComponent < SlotListComponent
   private
 
   def container_tag
-    :ul
+    items.all? { _1.is_a?(StatItemComponent) } ? :dl : :ul
   end
 end


### PR DESCRIPTION
Changes:

- Make `ListComponent` render a `<dl>` when every item is a `StatItemComponent`.
- Keep ordinary list-item collections rendered as `<ul>`.

Why:

Detail components currently place `<dt>`/`<dd>` rows inside a `<ul>`, which is invalid HTML. The shared container can infer the correct semantic element without changing each credential/detail component separately.

References:

- Related issue: #1010 (F-008)

Checks:

- The change is limited to the container-tag selection.
- GitHub Actions will verify existing component coverage.