### PR TITLE
Correct LlmUsage retention documentation

### DIFF
--- a/app/models/llm_usage.rb
+++ b/app/models/llm_usage.rb
@@ -2,9 +2,8 @@
 # regardless of outcome so users see the true cost of AI features
 # including failed calls.
 class LlmUsage < ApplicationRecord
-  # Usage rows are subject to retention pruning, so aggregate stats in the UI
-  # must cover a bounded window rather than all time — all-time totals would
-  # silently shrink as old rows expire.
+  # Aggregate stats use a bounded window so recent usage remains useful even if
+  # a retention policy is introduced later.
   STATS_PERIOD = 30.days
 
   belongs_to :user


### PR DESCRIPTION
Changes:

- Remove the unsupported claim that LLM usage rows are currently retention-pruned.
- Explain the bounded statistics window without promising a nonexistent purge process.

Why:

The model comment described behavior that the application does not implement.

References:

- Related issue: #1010 (F-028)

Checks:

- Executable behavior is unchanged.
- GitHub Actions will verify the branch.