### PR TITLE
Use native submit behavior in invites modal

### DIFF
--- a/app/components/edit_available_invites_modal_component.html.erb
+++ b/app/components/edit_available_invites_modal_component.html.erb
@@ -10,11 +10,10 @@
 
   <% modal.with_footer do %>
     <%= tag.button "Update",
-                   type: "button",
+                   type: "submit",
                    form: "available-invites-form-#{@user.id}",
                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",
-                   data: { action: "click->modal#confirm" },
-                   onclick: "this.form.requestSubmit()" %>
+                   data: { action: "modal#confirm" } %>
     <%= tag.button "Cancel",
                    type: "button",
                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",


### PR DESCRIPTION
Changes:

- Change the modal's Update button to a native submit button associated with the form.
- Remove the inline `onclick` call to `requestSubmit()`.

Why:

Native form submission is simpler, works without inline JavaScript, and preserves keyboard/form semantics.

References:

- Related issue: #1010 (F-057)

Checks:

- The existing modal confirm action still closes the modal.
- GitHub Actions will verify the template.