### PR TITLE
Use semantic disk usage color

### DIFF
--- a/app/views/development/system_status/show.html.erb
+++ b/app/views/development/system_status/show.html.erb
@@ -57,7 +57,7 @@
         <% if other_used_percentage > 0 %>
           <div class="bg-muted" style="width: <%= other_used_percentage %>%" title="Other Used Space"></div>
         <% end %>
-        <div class="bg-blue-500" style="width: <%= postgres_percentage %>%" title="Postgres DB"></div>
+        <div class="bg-info" style="width: <%= postgres_percentage %>%" title="Postgres DB"></div>
         <div class="bg-surface-sunken" style="width: <%= free_percentage %>%" title="Free Space"></div>
       </div>
 
@@ -70,7 +70,7 @@
           </div>
         <% end %>
         <div class="flex items-center gap-2">
-          <div class="h-3 w-3 rounded-sm bg-blue-500"></div>
+          <div class="h-3 w-3 rounded-sm bg-info"></div>
           <span class="text-body">Postgres DB (<%= postgres_percentage %>%, <%= number_to_human_size(postgres_size) %>)</span>
         </div>
         <div class="flex items-center gap-2">


### PR DESCRIPTION
Changes:

- Replace the raw `bg-blue-500` utility in the disk-usage bar and legend with the semantic `bg-info` token.

Why:

The development status view should follow the same themeable color-token system as the rest of the UI.

References:

- Related issue: #1010 (F-139)

Checks:

- Both the bar segment and matching legend swatch use the same token.
- GitHub Actions will verify the template.