### PR TITLE
Avoid loading users in PostPolicy ownership checks

### DIFF
--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -14,7 +14,7 @@ class PostPolicy < ApplicationPolicy
   private
 
   def owner?
-    authenticated? && record.feed.user == user
+    authenticated? && record.feed.user_id == user.id
   end
 
   class Scope < ApplicationPolicy::Scope


### PR DESCRIPTION
Changes:

- Compare `record.feed.user_id` with the current user's id in `PostPolicy#owner?`.

Why:

Authorization only needs the foreign key; loading the associated user adds an avoidable query when the feed is not preloaded.

References:

- Related issue: #1010 (F-118)

Checks:

- Authorization semantics are unchanged.
- GitHub Actions will verify policy coverage.