### PR TITLE
Preserve the invites input replacement target

### DIFF
--- a/app/views/admin/users/_available_invites_input.html.erb
+++ b/app/views/admin/users/_available_invites_input.html.erb
@@ -1,1 +1,3 @@
-<%= number_field(:user, :available_invites, value: user.available_invites, min: 0, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2") %>
+<span id="available-invites-input-wrapper-<%= user.id %>">
+  <%= number_field(:user, :available_invites, value: user.available_invites, min: 0, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2") %>
+</span>


### PR DESCRIPTION
Changes:

- Render the Turbo replacement wrapper inside the available-invites input partial.

Why:

After the first successful replacement, the target element disappeared, so subsequent updates could not replace it again.

References:

- Related issue: #1010 (F-044)

Checks:

- The wrapper id matches `Admin::AvailableInvitesController`.
- GitHub Actions will verify the template.