### PR TITLE
Show password validation errors

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -17,7 +17,7 @@ class PasswordsController < ApplicationController
     if @user.update(params.permit(:password, :password_confirmation))
       redirect_to new_session_path, success: "Password reset."
     else
-      redirect_to edit_password_path(params[:token]), alert: "Passwords did not match."
+      redirect_to edit_password_path(params[:token]), alert: @user.errors.full_messages.to_sentence
     end
   end
 


### PR DESCRIPTION
Changes:

- Use the User model's validation messages when a password reset update fails.

Why:

The previous alert always claimed the passwords did not match, even when another validation caused the failure.

References:

- Related issue: #1010 (F-090)

Checks:

- Successful password reset behavior is unchanged.
- GitHub Actions will verify controller coverage.