### PR TITLE
Stabilize repeated clipboard feedback

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -5,12 +5,17 @@ export default class extends Controller {
     text: String
   }
 
+  disconnect() {
+    clearTimeout(this.resetTimer)
+  }
+
   copy(event) {
     event.preventDefault()
 
     const button = event.currentTarget
-    const originalHTML = button.innerHTML
-    const originalTitle = button.title
+    this.originalHTML ??= button.innerHTML
+    this.originalTitle ??= button.title
+    clearTimeout(this.resetTimer)
 
     navigator.clipboard.writeText(this.textValue).then(() => {
       button.innerHTML = '✓'
@@ -18,11 +23,12 @@ export default class extends Controller {
       button.classList.add('text-success')
       button.classList.remove('text-muted')
 
-      setTimeout(() => {
-        button.innerHTML = originalHTML
-        button.title = originalTitle
+      this.resetTimer = setTimeout(() => {
+        button.innerHTML = this.originalHTML
+        button.title = this.originalTitle
         button.classList.remove('text-success')
         button.classList.add('text-muted')
+        this.resetTimer = null
       }, 2000)
     }).catch(err => {
       console.error('Failed to copy text: ', err)


### PR DESCRIPTION
Changes:

- Preserve the button's original content only once.
- Cancel the previous reset timer before starting a new one.
- Clear the timer when the controller disconnects.

Why:

A second click during the feedback interval could save the checkmark as the original content and overlapping timers could restore stale state.

References:

- Related issue: #1010 (F-096)

Checks:

- Clipboard write behavior is unchanged.
- GitHub Actions will verify JavaScript checks.