### PR TITLE
Preserve FileBuffer error messages

### DIFF
--- a/app/services/file_buffer.rb
+++ b/app/services/file_buffer.rb
@@ -30,6 +30,8 @@ class FileBuffer
     else
       url_to_io(url)
     end
+  rescue Error
+    raise
   rescue => e
     raise Error, "Failed to download attachment from #{url}: #{e.message}"
   end


### PR DESCRIPTION
Changes:

- Re-raise existing `FileBuffer::Error` values unchanged.
- Keep wrapping unexpected lower-level failures with source context.

References:

- Related issue: #1010 (F-123)

Checks:

- GitHub Actions will verify service coverage.