### PR TITLE
Use snake case normalizer errors

### DIFF
--- a/app/services/normalizer/llm_normalizer.rb
+++ b/app/services/normalizer/llm_normalizer.rb
@@ -34,8 +34,8 @@ module Normalizer
 
     def validate_content
       errors = []
-      errors << "missing source_url" if source_url.blank? && !digest?
-      errors << "missing content" if content.blank?
+      errors << "missing_source_url" if source_url.blank? && !digest?
+      errors << "missing_content" if content.blank?
       errors.concat(images_only_errors)
       errors
     end

--- a/test/services/normalizer/llm_normalizer_test.rb
+++ b/test/services/normalizer/llm_normalizer_test.rb
@@ -46,7 +46,7 @@ class Normalizer::LlmNormalizerTest < ActiveSupport::TestCase
     post = Normalizer::LlmNormalizer.new(feed_entry("source_url" => "")).normalize
 
     assert_equal "rejected", post.status
-    assert_includes post.validation_errors, "missing source_url"
+    assert_includes post.validation_errors, "missing_source_url"
   end
 
   test "#normalize should publish a digest post carrying a null source_url" do
@@ -55,14 +55,14 @@ class Normalizer::LlmNormalizerTest < ActiveSupport::TestCase
 
     assert_equal "enqueued", post.status
     assert_nil post.source_url
-    assert_not_includes post.validation_errors, "missing source_url"
+    assert_not_includes post.validation_errors, "missing_source_url"
   end
 
   test "#normalize should reject when content is missing" do
     post = Normalizer::LlmNormalizer.new(feed_entry("body" => "")).normalize
 
     assert_equal "rejected", post.status
-    assert_includes post.validation_errors, "missing content"
+    assert_includes post.validation_errors, "missing_content"
   end
 
   test "#normalize should reject image-less posts when the feed is images-only" do


### PR DESCRIPTION
Changes:

- Change the LLM normalizer error tokens to snake_case.

References:

- Related issue: #1010 (F-129)

Checks:

- GitHub Actions will verify normalizer coverage.