### PR TITLE
Use an admin-only user policy

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,15 +35,14 @@ class Admin::UsersController < ApplicationController
     }
   }.freeze
 
-
   def index
-    authorize User
+    authorize [:admin, User]
     @users = paginate_scope
   end
 
   def show
     @user = User.includes(:feeds, :access_tokens, :sessions, :created_invites, :permissions).find(params[:id])
-    authorize @user
+    authorize [:admin, @user]
     @stats = UserStats.new(@user)
     @last_admin = @user.admin? && User.joins(:permissions).where(permissions: { name: Permission::ADMIN }).count == 1
   end
@@ -76,6 +75,6 @@ class Admin::UsersController < ApplicationController
   end
 
   def base_scope
-    policy_scope(User)
+    policy_scope([:admin, User])
   end
 end

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -1,0 +1,15 @@
+class Admin::UserPolicy < ApplicationPolicy
+  def index?
+    admin?
+  end
+
+  def show?
+    admin?
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      admin? ? scope.all : scope.none
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Add `Admin::UserPolicy` with an admin-only scope.
- Authorize and scope the admin users controller through the namespaced policy.

Why:

The admin namespace previously reused `UserPolicy`, whose self-or-admin rules allow a non-admin to resolve their own user record.

References:

- Related issue: #1010 (F-012)

Checks:

- Admin behavior is unchanged.
- Non-admin scopes now resolve no users.
- GitHub Actions will verify policy/controller coverage.