### PR TITLE
Limit posts on admin event pages

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -5,6 +5,8 @@ class Admin::EventsController < ApplicationController
   include EventReferencedLlmUsages
   include EventReferencedWebSearches
 
+  MAX_RECENT_POSTS = 10
+
   def index
     authorize Event
 
@@ -19,7 +21,7 @@ class Admin::EventsController < ApplicationController
   def show
     authorize Event
     @event = Event.find(params[:id])
-    @referenced_posts = referenced_posts(@event)
+    @referenced_posts = referenced_posts(@event).limit(MAX_RECENT_POSTS)
     @referenced_llm_usages = referenced_llm_usages(@event)
     @referenced_web_searches = referenced_web_searches(@event)
     @previous_event = previous_event(@event)


### PR DESCRIPTION
Changes:

- Apply the same ten-post cap used by the user event page to admin event details.

Why:

A single import event can reference a large number of posts; rendering all of them makes the admin page unbounded.

References:

- Related issue: #1010 (F-073)

Checks:

- Event metadata and usage sections are unchanged.
- GitHub Actions will verify controller coverage.