### PR TITLE
Authorize unsuspension on the user record

### DIFF
--- a/app/controllers/admin/suspensions_controller.rb
+++ b/app/controllers/admin/suspensions_controller.rb
@@ -7,8 +7,8 @@ class Admin::SuspensionsController < ApplicationController
   end
 
   def destroy
-    authorize User, :unsuspend?
     user = find_user
+    authorize user, :unsuspend?
     unsuspend_user_and_record_event(user)
     redirect_to admin_user_path(user), success: "User unsuspended."
   end


### PR DESCRIPTION
Changes:

- Load the target user before authorizing `unsuspend?`.
- Pass the record to the policy, matching the suspension path.

Why:

Class-level authorization cannot apply record-specific policy rules.

References:

- Related issue: #1010 (F-076)

Checks:

- Suspension and unsuspension behavior is otherwise unchanged.
- GitHub Actions will verify controller/policy coverage.