### PR TITLE
Remove modal element listeners on disconnect

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -3,7 +3,8 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     // Add backdrop click handler
-    this.element.addEventListener('click', this.handleBackdropClick.bind(this))
+    this.backdropClickHandler = this.handleBackdropClick.bind(this)
+    this.element.addEventListener('click', this.backdropClickHandler)
 
     // Add escape key handler
     this.escapeHandler = this.handleEscape.bind(this)
@@ -17,10 +18,13 @@ export default class extends Controller {
     this.previouslyFocusedElement = null
 
     // Listen for custom show event from trigger
-    this.element.addEventListener('modal:show', this.show.bind(this))
+    this.showHandler = this.show.bind(this)
+    this.element.addEventListener('modal:show', this.showHandler)
   }
 
   disconnect() {
+    this.element.removeEventListener('click', this.backdropClickHandler)
+    this.element.removeEventListener('modal:show', this.showHandler)
     document.removeEventListener('keydown', this.escapeHandler)
     document.removeEventListener('keydown', this.focusTrapHandler)
   }


### PR DESCRIPTION
Changes:

- Store the bound backdrop and show handlers.
- Remove both element-level listeners when the Stimulus controller disconnects.

Why:

Reconnects previously accumulated anonymous bound handlers on the same modal element.

References:

- Related issue: #1010 (F-098)

Checks:

- Document-level listener cleanup remains unchanged.
- GitHub Actions will verify JavaScript checks.