### PR TITLE
Measure preview content in bytes

### DIFF
--- a/app/services/feed_preview_workflow.rb
+++ b/app/services/feed_preview_workflow.rb
@@ -57,8 +57,13 @@ class FeedPreviewWorkflow
     loader = temp_feed.loader_instance(purpose: :preview)
     raw_data = loader.load
 
-    record_stats(content_size: raw_data.bytesize)
+    record_stats(content_size: content_bytesize(raw_data))
     { temp_feed: temp_feed, raw_data: raw_data }
+  end
+
+  # RSS/Atom loaders return a String body; AI loaders return an Array of items.
+  def content_bytesize(raw_data)
+    raw_data.respond_to?(:bytesize) ? raw_data.bytesize : raw_data.to_json.bytesize
   end
 
   def process_feed_contents(input)

--- a/app/services/feed_preview_workflow.rb
+++ b/app/services/feed_preview_workflow.rb
@@ -57,7 +57,7 @@ class FeedPreviewWorkflow
     loader = temp_feed.loader_instance(purpose: :preview)
     raw_data = loader.load
 
-    record_stats(content_size: raw_data.size)
+    record_stats(content_size: raw_data.bytesize)
     { temp_feed: temp_feed, raw_data: raw_data }
   end
 

--- a/test/services/feed_preview_workflow_test.rb
+++ b/test/services/feed_preview_workflow_test.rb
@@ -61,8 +61,9 @@ class FeedPreviewWorkflowTest < ActiveSupport::TestCase
 
   test "#load_feed_contents should run the loader with the preview purpose" do
     captured = nil
+    raw_data = "Привет"
     loader = Object.new
-    loader.define_singleton_method(:load) { [] }
+    loader.define_singleton_method(:load) { raw_data }
     temp_feed = Object.new
     temp_feed.define_singleton_method(:loader_instance) do |options = {}|
       captured = options
@@ -72,6 +73,7 @@ class FeedPreviewWorkflowTest < ActiveSupport::TestCase
     workflow.send(:load_feed_contents, temp_feed)
 
     assert_equal({ purpose: :preview }, captured)
+    assert_equal raw_data.bytesize, workflow.stats[:content_size]
   end
 
   test ".const_get should expose PREVIEW_POSTS_LIMIT constant" do


### PR DESCRIPTION
Changes:

- Use `bytesize` for preview content statistics.

References:

- Related issue: #1010 (F-120)

Checks:

- GitHub Actions will verify service coverage.