### PR TITLE
Enforce one schedule per feed

### DIFF
--- a/app/models/feed_schedule.rb
+++ b/app/models/feed_schedule.rb
@@ -1,6 +1,8 @@
 class FeedSchedule < ApplicationRecord
   belongs_to :feed
 
+  validates :feed_id, uniqueness: true
+
   def calculate_next_run_at
     Fugit.parse(feed.cron_expression).next_time.to_t
   end

--- a/db/migrate/20260718234500_enforce_single_feed_schedule.rb
+++ b/db/migrate/20260718234500_enforce_single_feed_schedule.rb
@@ -1,0 +1,6 @@
+class EnforceSingleFeedSchedule < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :feed_schedules, :feed_id
+    add_index :feed_schedules, :feed_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_17_130000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_18_234500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -151,7 +151,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_17_130000) do
     t.datetime "next_run_at"
     t.datetime "updated_at", null: false
     t.date "last_digest_period"
-    t.index ["feed_id"], name: "index_feed_schedules_on_feed_id"
+    t.index ["feed_id"], name: "index_feed_schedules_on_feed_id", unique: true
   end
 
   create_table "feeds", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|


### PR DESCRIPTION
Changes:

- Replace the ordinary `feed_schedules.feed_id` index with a unique index.

Why:

The model is `has_one`/`belongs_to`, but the database currently permits multiple schedules for one feed.

References:

- Related issue: #1010 (F-046)

Checks:

- Existing valid rows are unaffected.
- GitHub Actions will run the migration checks.