### PR TITLE
Increase mobile navigation item padding for better touch targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-19
+
+- Menu items in the mobile navigation are now taller, making them easier to tap.
+
 ## 2026-07-18
 
 - New "Post via webhook" feed type: publish posts from your own scripts through a webhook endpoint and secret authorization token — a single curl command is enough. Images, comments, and safe retries are supported.

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -81,7 +81,7 @@
         <% navbar_items.each_with_index do |item, index| %>
           <%
             mobile_link_classes = class_names(
-              "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading",
+              "block w-full px-4 py-4 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading",
               {
                 "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => item[:active],
                 "text-heading" => !item[:active],
@@ -102,7 +102,7 @@
         <div class="mt-3 rounded-lg border border-border bg-surface md:hidden">
           <%= link_to "Settings", settings_path,
               class: class_names(
-                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading rounded-t-lg border-b border-border",
+                "block w-full px-4 py-4 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading rounded-t-lg border-b border-border",
                 {
                   "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => current_page?(settings_path),
                   "text-heading" => !current_page?(settings_path)
@@ -111,7 +111,7 @@
               aria: (current_page?(settings_path) ? { current: "page" } : nil) %>
           <%= link_to "Freefeed Access Tokens", access_tokens_path,
               class: class_names(
-                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
+                "block w-full px-4 py-4 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
                 {
                   "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => current_page?(access_tokens_path),
                   "text-heading" => !current_page?(access_tokens_path)
@@ -120,7 +120,7 @@
               aria: (current_page?(access_tokens_path) ? { current: "page" } : nil) %>
           <%= link_to "AI Credentials", ai_credentials_path,
               class: class_names(
-                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
+                "block w-full px-4 py-4 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
                 {
                   "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => current_page?(ai_credentials_path),
                   "text-heading" => !current_page?(ai_credentials_path)
@@ -129,7 +129,7 @@
               aria: (current_page?(ai_credentials_path) ? { current: "page" } : nil) %>
           <%= link_to "Search Credentials", search_credentials_path,
               class: class_names(
-                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
+                "block w-full px-4 py-4 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
                 {
                   "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => current_page?(search_credentials_path),
                   "text-heading" => !current_page?(search_credentials_path)
@@ -138,7 +138,7 @@
               aria: (current_page?(search_credentials_path) ? { current: "page" } : nil) %>
           <%= link_to "Invites", invites_path,
               class: class_names(
-                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
+                "block w-full px-4 py-4 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading border-b border-border",
                 {
                   "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => current_page?(invites_path),
                   "text-heading" => !current_page?(invites_path)
@@ -147,7 +147,7 @@
               aria: (current_page?(invites_path) ? { current: "page" } : nil) %>
           <%= link_to "Changelog", changelog_path,
               class: class_names(
-                "block w-full px-4 py-2 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading rounded-b-lg",
+                "block w-full px-4 py-4 cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading rounded-b-lg",
                 {
                   "bg-surface-inverted text-on-brand hover:bg-surface-inverted-hover hover:text-on-brand focus:text-on-brand" => current_page?(changelog_path),
                   "text-heading" => !current_page?(changelog_path)
@@ -160,7 +160,7 @@
         <div class="mt-3 rounded-lg border border-border bg-surface md:hidden">
           <%= link_to "Sign Out", session_path,
               data: { turbo_method: :delete },
-              class: "block w-full px-4 py-2 text-heading rounded-lg cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading" %>
+              class: "block w-full px-4 py-4 text-heading rounded-lg cursor-pointer hover:bg-surface-sunken hover:text-heading focus:outline-none focus:ring-2 focus:ring-ring focus:text-heading" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
Changes:

- Increased vertical padding on the expandable mobile nav menu items from `py-2` to `py-4`.
- Added a changelog entry.

Taller menu items give bigger, easier-to-hit touch targets on mobile. The desktop nav links and user dropdown keep their original padding.