### PR TITLE
Reorder admin stats section

### DIFF
--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -3,6 +3,11 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Admin Panel") %>
 
+  <section class="space-y-4">
+    <%= render GlobalStatsComponent.new %>
+    <%= render PostsHeatmapComponent.new %>
+  </section>
+
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
     <%= render CardComponent.new(href: admin_users_path) do %>
       <div class="space-y-4">
@@ -34,10 +39,4 @@
       </div>
     <% end %>
   </div>
-
-  <section class="space-y-4">
-    <h2 class="text-2xl font-semibold text-heading">Stats</h2>
-    <%= render GlobalStatsComponent.new %>
-    <%= render PostsHeatmapComponent.new %>
-  </section>
 </div>


### PR DESCRIPTION
## What changed

- moved the admin stats section above the navigation cards
- removed the `Stats` heading

## Why

The stats should be the first content shown below the admin page header, while the navigation cards remain grouped in their existing responsive grid.

## Validation

- verified the branch differs from `main` by a single view-template change
- confirmed the resulting markup keeps the existing stats components and card grid intact