### PR TITLE
Fix webhook feed form states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-19
 
+- Webhook feed setup now asks you to choose a name and uses clearer progress messages.
 - Webhook feeds now hide options that only apply to feeds checked on a schedule.
 - Menu items in the mobile navigation are now taller, making them easier to tap.
 

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -55,7 +55,7 @@
                                aria: { label: "Source link" },
                                data: { key: "form.entry-link" } %>
               <% if checking %>
-                <p class="text-sm text-muted" role="status" data-key="entry.checking-status">Checking this feed — usually takes a few seconds.</p>
+                <p class="text-sm text-muted" role="status" data-key="entry.checking-status">Checking this feed. This usually takes a few seconds.</p>
               <% elsif error && mode == "link" %>
                 <p class="text-sm text-danger" data-key="entry.error"><%= error %></p>
               <% else %>
@@ -92,7 +92,7 @@
               <% if error && mode == "ai" %>
                 <p class="text-sm text-danger" data-key="entry.error"><%= error %></p>
               <% else %>
-                <p class="text-sm text-muted">Describe a source or topic in your own words — a link, a few links, or what you're after. AI reads the web to keep up with it.</p>
+                <p class="text-sm text-muted">Describe a source or topic in your own words. Use a link, a few links, or explain what you're after. AI reads the web to keep up with it.</p>
               <% end %>
             </div>
           <% end %>
@@ -115,7 +115,7 @@
               <% if error && mode == "webhook" %>
                 <p class="text-sm text-danger" data-key="entry.error"><%= error %></p>
               <% else %>
-                <p class="text-sm text-muted">Nothing to follow — you send the posts to a webhook endpoint using a secret authorization token. A single curl command is enough.</p>
+                <p class="text-sm text-muted">There is nothing to follow. You send posts to a webhook endpoint using a secret authorization token. A single curl command is enough.</p>
               <% end %>
             </div>
           <% end %>
@@ -128,7 +128,7 @@
               data: { key: "entry.actions-link", mode: "link", mode_switch_target: "panel" } do %>
     <% if checking %>
       <%= submit_tag "Checking…", form: "entry-link-form", disabled: true,
-                     class: "#{primary_button_classes} disabled:opacity-60 disabled:cursor-not-allowed" %>
+                     class: "#{primary_button_classes} disabled:bg-brand disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-brand" %>
       <%= link_to "Cancel", feed_identifications_path(url: url), class: secondary_button_classes,
                   data: { turbo_method: :delete, key: "entry.cancel-check" } %>
     <% else %>
@@ -141,14 +141,14 @@
   <%= tag.div class: "mt-6 flex flex-wrap items-center justify-start gap-4 text-body", hidden: mode != "ai",
               data: { key: "entry.actions-ai", mode: "ai", mode_switch_target: "panel" } do %>
     <%= submit_tag "Continue", form: "entry-ai-form", class: primary_button_classes,
-                   data: { turbo_submits_with: "Setting up…" } %>
+                   data: { turbo_submits_with: "Preparing…" } %>
     <%= link_to "Cancel", feeds_path, class: secondary_button_classes %>
   <% end %>
 
   <%= tag.div class: "mt-6 flex flex-wrap items-center justify-start gap-4 text-body", hidden: mode != "webhook",
               data: { key: "entry.actions-webhook", mode: "webhook", mode_switch_target: "panel" } do %>
     <%= submit_tag "Continue", form: "entry-webhook-form", class: primary_button_classes,
-                   data: { turbo_submits_with: "Setting up…" } %>
+                   data: { turbo_submits_with: "Preparing…" } %>
     <%= link_to "Cancel", feeds_path, class: secondary_button_classes %>
   <% end %>
 <% end %>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -176,7 +176,7 @@
         <% elsif feed.name.present? %>
           <p class="text-sm text-muted">You can edit this name if you'd like.</p>
         <% elsif feed.sourceless? %>
-          <p class="text-sm text-muted">Choose a name for this webhook feed.</p>
+          <p class="text-sm text-muted">Choose a name for this feed.</p>
         <% else %>
           <p class="text-sm text-muted">We couldn't automatically detect a name. Please enter one.</p>
         <% end %>

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -60,8 +60,8 @@
             endpoint, so the whole source block collapses into a note. %>
         <div>
           <h2 class="text-xl font-semibold text-heading mb-4">Source</h2>
-          <%= render PanelComponent.new(variant: :info, data: { key: "form.webhook-note" }) do %>
-            <p class="text-sm">This feed doesn't follow anything on its own — it publishes whatever you send to its webhook endpoint with the authorization token. <%= feed.persisted? ? "You'll find both on the feed's page." : "Save the feed to get the endpoint and token." %></p>
+          <%= render AlertComponent.new(variant: :info, data: { key: "form.webhook-note" }) do %>
+            <p class="text-sm">This feed doesn't follow anything on its own. It publishes whatever you send to its webhook endpoint with the authorization token. <%= feed.persisted? ? "You'll find both on the feed's page." : "Save the feed to get the endpoint and token." %></p>
           <% end %>
           <%= f.hidden_field :feed_profile_key %>
         </div>
@@ -95,7 +95,7 @@
                                  class: input_field_classes(disabled: true),
                                  data: { preview_button_target: "source", action: "input->preview-button#refreshAvailability", key: "form.source-edit" } %>
               <% if checking %>
-                <p class="text-sm text-muted" role="status" data-key="form.source-checking">Checking this feed — usually takes a few seconds.</p>
+                <p class="text-sm text-muted" role="status" data-key="form.source-checking">Checking this feed. This usually takes a few seconds.</p>
               <% elsif source_error %>
                 <p class="text-sm text-danger" data-key="form.source-error"><%= source_error %></p>
               <% else %>
@@ -153,7 +153,7 @@
         <% if source_changed && profile_changed %>
           <%= render AlertComponent.new(variant: :warning, class: "mt-4", data: { key: "form.dup-risk-warning" }) do %>
             <p class="font-semibold">This changes how posts are identified</p>
-            <p class="text-sm">Reading this source a different way can bring some recent posts back through. We've switched on “Skip older posts” below to hold them back — pick a start date that suits you. It can't promise zero repeats.</p>
+            <p class="text-sm">Reading this source a different way can bring some recent posts back through. We've switched on “Skip older posts” below to hold them back. Pick a start date that suits you. It can't promise zero repeats.</p>
           <% end %>
         <% elsif source_changed %>
           <%= render AlertComponent.new(variant: :info, class: "mt-4", data: { key: "form.dup-risk-warning" }) do %>
@@ -175,6 +175,8 @@
           <p class="text-sm text-danger"><%= f.object.errors[:name].to_sentence.capitalize %></p>
         <% elsif feed.name.present? %>
           <p class="text-sm text-muted">You can edit this name if you'd like.</p>
+        <% elsif feed.sourceless? %>
+          <p class="text-sm text-muted">Choose a name for this webhook feed.</p>
         <% else %>
           <p class="text-sm text-muted">We couldn't automatically detect a name. Please enter one.</p>
         <% end %>
@@ -382,7 +384,7 @@
     <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-body">
       <%= f.submit checking ? "Checking…" : "Save feed",
                    disabled: checking,
-                   class: "#{primary_button_classes} disabled:opacity-60 disabled:cursor-not-allowed",
+                   class: "#{primary_button_classes} disabled:bg-brand disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-brand",
                    data: { turbo_submits_with: "Saving…" } %>
       <%= link_to "Cancel", feeds_path, class: secondary_button_classes %>
     </div>

--- a/test/controllers/admins_controller_test.rb
+++ b/test/controllers/admins_controller_test.rb
@@ -46,7 +46,6 @@ class AdminsControllerTest < ActionDispatch::IntegrationTest
     get admin_url
 
     assert_response :success
-    assert_select "section > h2", "Stats"
     assert_select "[data-key='stats.total_users.value']", text: User.count.to_s
     assert_select "[data-key='stats.total_feeds.value']", text: Feed.count.to_s
     assert_select "[data-key='stats.total_published_posts.value']", text: "1"

--- a/test/controllers/admins_controller_test.rb
+++ b/test/controllers/admins_controller_test.rb
@@ -46,7 +46,7 @@ class AdminsControllerTest < ActionDispatch::IntegrationTest
     get admin_url
 
     assert_response :success
-    assert_select "h2", "Stats"
+    assert_select "section > h2", "Stats"
     assert_select "[data-key='stats.total_users.value']", text: User.count.to_s
     assert_select "[data-key='stats.total_feeds.value']", text: Feed.count.to_s
     assert_select "[data-key='stats.total_published_posts.value']", text: "1"

--- a/test/controllers/feed_identifications_form_test.rb
+++ b/test/controllers/feed_identifications_form_test.rb
@@ -22,7 +22,7 @@ class FeedIdentificationsFormTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-key='form.webhook-note'][role='alert']", count: 1
-    assert_select "input[data-key='form.name'] + p", text: "Choose a name for this webhook feed."
+    assert_select "input[data-key='form.name'] + p", text: "Choose a name for this feed."
     assert_not_includes response.body, "We couldn't automatically detect a name"
   end
 

--- a/test/controllers/feed_identifications_form_test.rb
+++ b/test/controllers/feed_identifications_form_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class FeedIdentificationsFormTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup do
+    clear_enqueued_jobs
+  end
+
+  def user
+    @user ||= create(:user)
+  end
+
+  test "#create should open the webhook form without detection copy" do
+    sign_in_as(user)
+
+    assert_no_enqueued_jobs(only: FeedIdentificationJob) do
+      post feed_identifications_path,
+           params: { webhook: "1" },
+           headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_select "[data-key='form.webhook-note'][role='alert']", count: 1
+    assert_select "input[data-key='form.name'] + p", text: "Choose a name for this webhook feed."
+    assert_not_includes response.body, "We couldn't automatically detect a name"
+  end
+
+  test "#new should use state labels that match each feed type" do
+    sign_in_as(user)
+    get new_feed_path
+
+    assert_response :success
+    assert_select "[data-key='entry.actions-link'] input[data-turbo-submits-with='Checking…']", count: 1
+    assert_select "[data-key='entry.actions-ai'] input[data-turbo-submits-with='Preparing…']", count: 1
+    assert_select "[data-key='entry.actions-webhook'] input[data-turbo-submits-with='Preparing…']", count: 1
+  end
+
+  test "#create should disable and visibly dim the checking submit button" do
+    sign_in_as(user)
+
+    post feed_identifications_path,
+         params: { url: "http://example.com/feed.xml" },
+         headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    button = css_select("input[type=submit][value='Checking…'][disabled]").first
+    assert button
+    assert_includes button["class"], "disabled:opacity-60"
+    assert_includes button["class"], "disabled:cursor-not-allowed"
+    assert_includes button["class"], "disabled:hover:bg-brand"
+  end
+end


### PR DESCRIPTION
Changes:

- Ask users to name webhook feeds directly instead of showing detection-oriented copy, and present the webhook explanation as an info alert.
- Keep “Checking…” for link detection while using “Preparing…” for AI and webhook setup, with visibly disabled checking buttons.
- Remove em dashes from feed form help text and cover the behavior with focused integration tests.