### PR TITLE
Refine admin event detail links

### DIFF
--- a/app/components/event_list_item_component.rb
+++ b/app/components/event_list_item_component.rb
@@ -13,7 +13,7 @@ class EventListItemComponent < ListItemComponent
   DEFAULT_TINT = "bg-surface hover:bg-surface-muted".freeze
 
   # Shows the severity, description and timestamp. Admin::EventListItemComponent
-  # adds a footer with the event type, user and target for the operator log.
+  # adds a footer with the event type, user and subject for the operator log.
   def initialize(event:, href:)
     super()
     @event = event
@@ -65,7 +65,7 @@ class EventListItemComponent < ListItemComponent
     EventDescriptionComponent
   end
 
-  # Whether to render the footer (type/user/target). Admin::EventListItemComponent
+  # Whether to render the footer (type/user/subject). Admin::EventListItemComponent
   # enables it for the operator log.
   def show_footer?
     false
@@ -92,16 +92,11 @@ class EventListItemComponent < ListItemComponent
   end
 
   def footer_items
-    [type_link, user_label, target_label].compact
+    [type_label, user_label, subject_label].compact
   end
 
-  def type_link
-    link = helpers.link_to(event.type,
-                           helpers.admin_events_path(filter: { type: [event.type] }),
-                           class: "transition hover:text-heading",
-                           data: { key: "events.type" })
-
-    safe_join(["Type: ", link])
+  def type_label
+    safe_join(["Type: ", helpers.tag.span(event.type, data: { key: "events.type" })])
   end
 
   # Admins see who an event belongs to; existing users link to their detail page.
@@ -112,7 +107,7 @@ class EventListItemComponent < ListItemComponent
       helpers.link_to(
         helpers.short_ref(event.user_id),
         helpers.admin_user_path(event.user),
-        class: "font-mono underline underline-offset-2 transition hover:text-heading",
+        class: "underline underline-offset-2 transition hover:text-heading",
         title: reference_title(event.user_id, event.user.email_address),
         data: { key: "events.user" }
       )
@@ -128,35 +123,30 @@ class EventListItemComponent < ListItemComponent
     safe_join(["User: ", label])
   end
 
-  def target_label
+  def subject_label
     return if event.subject_type.blank?
+    return helpers.tag.span(event.subject_type, data: { key: "events.subject" }) if event.subject_id.blank?
 
-    label = if event.subject_id.present?
-      text = "#{event.subject_type} #{helpers.short_ref(event.subject_id)}"
-      title = reference_title(event.subject_id, target_title)
-      path = helpers.admin_event_subject_path(event.subject)
-
-      if path
-        helpers.link_to(
-          text,
-          path,
-          class: "font-mono underline underline-offset-2 transition hover:text-heading",
-          title: title,
-          data: { key: "events.subject" }
-        )
-      else
-        helpers.tag.span(
-          text,
-          class: "font-mono",
-          title: title,
-          data: { key: "events.subject" }
-        )
-      end
+    title = reference_title(event.subject_id, target_title)
+    path = helpers.admin_event_subject_path(event.subject)
+    reference = if path
+      helpers.link_to(
+        helpers.short_ref(event.subject_id),
+        path,
+        class: "underline underline-offset-2 transition hover:text-heading",
+        title: title,
+        data: { key: "events.subject" }
+      )
     else
-      helpers.tag.span(event.subject_type, data: { key: "events.subject" })
+      helpers.tag.span(
+        helpers.short_ref(event.subject_id),
+        class: "font-mono",
+        title: title,
+        data: { key: "events.subject" }
+      )
     end
 
-    safe_join(["Target: ", label])
+    safe_join(["#{event.subject_type}: ", reference])
   end
 
   # Resolves the subject to its human name so admins don't have to memorize

--- a/app/components/event_list_item_component.rb
+++ b/app/components/event_list_item_component.rb
@@ -125,7 +125,9 @@ class EventListItemComponent < ListItemComponent
 
   def subject_label
     return if event.subject_type.blank?
-    return helpers.tag.span(event.subject_type, data: { key: "events.subject" }) if event.subject_id.blank?
+
+    subject_type = event.subject_type.demodulize.underscore.humanize
+    return helpers.tag.span(subject_type, data: { key: "events.subject" }) if event.subject_id.blank?
 
     title = reference_title(event.subject_id, target_title)
     path = helpers.admin_event_subject_path(event.subject)
@@ -146,7 +148,7 @@ class EventListItemComponent < ListItemComponent
       )
     end
 
-    safe_join(["#{event.subject_type}: ", reference])
+    safe_join(["#{subject_type}: ", reference])
   end
 
   # Resolves the subject to its human name so admins don't have to memorize

--- a/test/components/event_list_item_component_test.rb
+++ b/test/components/event_list_item_component_test.rb
@@ -141,7 +141,7 @@ class EventListItemComponentTest < ViewComponent::TestCase
     render_inline(Admin::EventListItemComponent.new(event: event, href: "/admin/events/#{event.id}"))
   end
 
-  test "#call should render a footer with type, user and target in extended mode" do
+  test "#call should render a footer with type, user and subject in extended mode" do
     feed = create(:feed, user: user)
     event = create(:event, type: "feed_refresh", subject: feed, user: user)
 
@@ -150,7 +150,7 @@ class EventListItemComponentTest < ViewComponent::TestCase
     assert_not_nil result.css("[data-key='events.footer']").first
     assert_not_nil result.css("[data-key='events.type']").first
     assert_includes result.text, "User:"
-    assert_includes result.text, "Target:"
+    assert_includes result.text, "Feed:"
   end
 
   test "#call should link the severity icon to the level filter in extended mode" do
@@ -177,14 +177,14 @@ class EventListItemComponentTest < ViewComponent::TestCase
     assert_not_includes link.parent["class"].to_s, "border-t"
   end
 
-  test "#call should link the type to the admin filter" do
+  test "#call should render the type as plain text" do
     event = create(:event, type: "custom_event", user: user)
 
     result = render_admin_item(event)
 
-    link = result.css("a[data-key='events.type']").first
-    assert_equal "custom_event", link.text
-    assert_includes link["href"], "filter%5Btype%5D%5B%5D=custom_event"
+    label = result.css("span[data-key='events.type']").first
+    assert_equal "custom_event", label.text
+    assert_empty result.css("a[data-key='events.type']")
     assert_includes result.css("[data-key='events.footer']").text, "Type: custom_event"
   end
 
@@ -197,6 +197,7 @@ class EventListItemComponentTest < ViewComponent::TestCase
     assert_equal user.id.to_s.last(5), link.text
     assert_equal "/admin/users/#{user.id}", link["href"]
     assert_equal "#{user.id} — #{user.email_address}", link["title"]
+    assert_not_includes link["class"], "font-mono"
     assert_not_includes link.text, "#"
   end
 
@@ -209,17 +210,19 @@ class EventListItemComponentTest < ViewComponent::TestCase
     assert_equal "System", label.text
   end
 
-  test "#call should link the compact subject id to its application page" do
+  test "#call should link only the compact subject id to its application page" do
     feed = create(:feed, user: user)
     event = create(:event, type: "feed_refresh", subject: feed, user: user)
 
     result = render_admin_item(event)
 
     link = result.css("a[data-key='events.subject']").first
-    assert_equal "Feed #{feed.id.to_s.last(5)}", link.text
+    assert_equal feed.id.to_s.last(5), link.text
     assert_equal "/admin/feeds/#{feed.id}", link["href"]
     assert_equal "#{feed.id} — #{feed.display_name}", link["title"]
+    assert_not_includes link["class"], "font-mono"
     assert_not_includes link.text, "#"
+    assert_includes result.css("[data-key='events.footer']").text, "Feed: #{feed.id.to_s.last(5)}"
   end
 
   test "#call should render an orphaned subject as compact plain text" do
@@ -231,12 +234,13 @@ class EventListItemComponentTest < ViewComponent::TestCase
 
     label = result.css("span[data-key='events.subject']").first
     assert_not_nil label
-    assert_equal "Feed #{missing_id.last(5)}", label.text
+    assert_equal missing_id.last(5), label.text
     assert_equal missing_id, label["title"]
     assert_empty result.css("a[data-key='events.subject']")
+    assert_includes result.css("[data-key='events.footer']").text, "Feed: #{missing_id.last(5)}"
   end
 
-  test "#call should omit the target for events without a subject" do
+  test "#call should omit the subject for events without one" do
     event = create(:event, user: user)
 
     result = render_admin_item(event)

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -256,7 +256,8 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     get admin_events_path
 
     assert_response :success
-    assert_select '[data-key="events.subject"]', text: "Post #{missing_id.last(5)}"
+    assert_select '[data-key="events.subject"]', text: missing_id.last(5)
+    assert_select '[data-key="events.footer"]', text: /Post: #{missing_id.last(5)}/
     assert_select 'a[data-key="events.subject"]', count: 0
   end
 
@@ -273,8 +274,9 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '[data-key="events.type"]', count: 2
-    assert_select '[data-key="events.subject"]', text: /User [0-9a-f]{5}/, count: 2
-    assert_select '[data-key="events.subject"]', text: /Feed [0-9a-f]{5}/, count: 0
+    assert_select '[data-key="events.subject"]', text: test_user.id.to_s.last(5), count: 2
+    assert_select '[data-key="events.footer"]', text: /User: #{test_user.id.to_s.last(5)}/, count: 2
+    assert_select '[data-key="events.footer"]', text: /Feed:/, count: 0
   end
 
   test "should filter events by subject_id" do


### PR DESCRIPTION
## What changed

- rendered the event type as plain text instead of a filter link
- replaced the generic `Target` label with the event subject type, such as `Feed`
- linked only compact user and subject IDs
- removed `font-mono` from linked IDs
- updated component tests for the new markup

## Result

Event footers now read like:

`Type: feed_refresh · User: 1674a · Feed: ea6a2`

Only the user and subject IDs are linked.

## Validation

- confirmed the branch contains only the event list component and its tests
- added assertions for plain event type text, subject-type labels, link scope, and non-monospace linked IDs