### PR TITLE
Add Beta badge to AI feed mode and simplify group list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-20
 
 - The "Follow with AI" option on the new feed page now carries a "Beta" badge, so it's clear the feature is still settling in.
+- The access token page now shows the groups you can post to right away, without a click to expand the list.
 
 ## 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-20
+
+- The "Follow with AI" option on the new feed page now carries a "Beta" badge, so it's clear the feature is still settling in.
+
 ## 2026-07-19
 
 - Webhook feed setup now asks you to choose a name and uses clearer progress messages.

--- a/app/components/beta_badge_component.rb
+++ b/app/components/beta_badge_component.rb
@@ -1,0 +1,9 @@
+class BetaBadgeComponent < ViewComponent::Base
+  def initialize(key: nil)
+    @key = key
+  end
+
+  def call
+    render BadgeComponent.new(text: "Beta", color: :info, key: @key)
+  end
+end

--- a/app/components/beta_badge_component.rb
+++ b/app/components/beta_badge_component.rb
@@ -1,9 +1,5 @@
-class BetaBadgeComponent < ViewComponent::Base
+class BetaBadgeComponent < BadgeComponent
   def initialize(key: nil)
-    @key = key
-  end
-
-  def call
-    render BadgeComponent.new(text: "Beta", color: :info, key: @key)
+    super(text: "Beta", color: :info, key: key)
   end
 end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -72,21 +72,15 @@
     <div class="space-y-4">
       <h2 class="text-2xl font-semibold mb-3 text-heading">Available Groups</h2>
       <p class="text-body">
-        This access token lets the authenticated FreeFeed user publish new posts to these groups.
+        This access token lets you create new posts in the following groups:
       </p>
       <% access_token.access_token_detail.managed_groups.tap do |groups| %>
         <% if groups.any? %>
-          <details class="group/groups">
-            <summary class="flex cursor-pointer list-none select-none items-center gap-2 font-medium text-heading hover:text-heading">
-              <%= icon("chevron-right", css_class: "size-4 shrink-0 transition-transform group-open/groups:rotate-90") %>
-              <%= pluralize(groups.count, "group") %> available for posting
-            </summary>
-            <ul class="mt-3 list-disc list-inside space-y-1 pl-6">
-              <% groups.sort_by { _1["username"] }.each do |group| %>
-                <li><%= link_to group["username"], "#{access_token.host}/#{group["username"]}", target: "_blank", rel: "noopener noreferrer", class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %></li>
-              <% end %>
-            </ul>
-          </details>
+          <ul class="list-disc list-inside space-y-1">
+            <% groups.sort_by { _1["username"] }.each do |group| %>
+              <li><%= link_to group["username"], "#{access_token.host}/#{group["username"]}", target: "_blank", rel: "noopener noreferrer", class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %></li>
+            <% end %>
+          </ul>
         <% else %>
           <%= render EmptyStateComponent.new("No groups available for posting") %>
         <% end %>

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -71,7 +71,10 @@
           <%= radio_button_tag "entry_mode", "ai", mode == "ai",
                                disabled: checking,
                                data: { mode_switch_target: "radio", action: "change->mode-switch#switch" } %>
-          Follow with AI
+          <span class="inline-flex items-center gap-2">
+            Follow with AI
+            <%= render BetaBadgeComponent.new(key: "entry.ai-beta-badge") %>
+          </span>
         </label>
 
         <%= tag.div class: "ps-7", hidden: mode != "ai",

--- a/test/components/beta_badge_component_test.rb
+++ b/test/components/beta_badge_component_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+require "view_component/test_case"
+
+class BetaBadgeComponentTest < ViewComponent::TestCase
+  test "#call should render Beta with info badge styling" do
+    result = render_inline(BetaBadgeComponent.new)
+
+    badge = result.at_css("span")
+    assert_equal "Beta", badge.text
+    assert_includes badge["class"], "bg-brand-subtle"
+    assert_includes badge["class"], "text-brand-strong"
+  end
+
+  test "#call should set data-key when key is given" do
+    result = render_inline(BetaBadgeComponent.new(key: "entry.ai-beta-badge"))
+
+    assert_not_nil result.at_css("[data-key='entry.ai-beta-badge']")
+  end
+
+  test "#call should omit data-key when key is missing" do
+    result = render_inline(BetaBadgeComponent.new)
+
+    assert_nil result.at_css("span")["data-key"]
+  end
+end

--- a/test/integration/smart_feed_creation_entry_test.rb
+++ b/test/integration/smart_feed_creation_entry_test.rb
@@ -16,6 +16,7 @@ class SmartFeedCreationEntryTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "[data-key='entry.mode-link'] input[type=radio][value=link][checked]"
     assert_select "[data-key='entry.mode-ai'] input[type=radio][value=ai]:not([checked])"
+    assert_select "[data-key='entry.ai-beta-badge']", text: "Beta"
     assert_select "[data-key='entry.mode-webhook'] input[type=radio][value=webhook]:not([checked])"
     assert_select "[data-key='entry.panel-link']:not([hidden])"
     assert_select "[data-key='entry.panel-ai'][hidden]"


### PR DESCRIPTION
Changes:

- Add `BetaBadgeComponent` and render a "Beta" badge next to the "Follow with AI" option on the new feed page
- Show the access token's groups as a plain list instead of a collapsed disclosure, with reworded intro copy

The badge signals that the AI mode is still settling in, and the groups list is now visible at a glance without an extra click.