### PR TITLE
Merge event stats into details list, hide stats on draft feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-20
 
 - Draft feeds no longer show an empty Stats section — it appears once the feed is up and running.
+- Event pages now show refresh stats right in the details list at the top instead of a separate Stats section.
 
 ## 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-20
+
+- Draft feeds no longer show an empty Stats section — it appears once the feed is up and running.
+
 ## 2026-07-19
 
 - Webhook feed setup now asks you to choose a name and uses clearer progress messages.

--- a/app/components/event_details_component.rb
+++ b/app/components/event_details_component.rb
@@ -1,6 +1,13 @@
-# Renders the detail list shown at the top of an event page. Admin: true adds
-# operator-only rows (user, timestamps, expiry).
+# Renders the detail list shown at the top of an event page: base event
+# attributes followed by any stats captured in the event metadata. Admin: true
+# adds operator-only rows (user, timestamps, expiry). Subclasses can override
+# #items (or any individual row method) to reshape the list for specific
+# event presentations.
 class EventDetailsComponent < ViewComponent::Base
+  # Search calls are surfaced by the dedicated search usage section, so the
+  # details list skips them to avoid showing the same number twice.
+  HIDDEN_STATS = %w[search_calls].freeze
+
   def initialize(event:, admin: false)
     @event = event
     @admin = admin
@@ -8,16 +15,24 @@ class EventDetailsComponent < ViewComponent::Base
 
   def call
     render(ListComponent.new) do |list|
-      add_user_item(list) if @admin
-      add_created_item(list)
-      add_updated_item(list) if @admin
-      add_expires_item(list) if @admin && @event.expires_at.present?
+      items.each { |item| list.with_item(item) }
     end
   end
 
   private
 
-  def add_user_item(component)
+  # Ordered rows of the details list.
+  def items
+    [
+      (user_item if @admin),
+      created_item,
+      (updated_item if @admin),
+      (expires_item if @admin && @event.expires_at.present?),
+      *stat_items
+    ].compact
+  end
+
+  def user_item
     user_value = if @event.user_id.present?
       title = [@event.user_id, @event.user&.email_address].compact_blank.join(" — ")
 
@@ -41,37 +56,37 @@ class EventDetailsComponent < ViewComponent::Base
       helpers.tag.em("System", class: "text-muted", data: { key: "admin.event.user" })
     end
 
-    component.with_item(StatListItemComponent.new(
+    StatListItemComponent.new(
       label: "User",
       value: user_value
-    ))
+    )
   end
 
-  def add_created_item(component)
-    component.with_item(StatListItemComponent.new(
+  def created_item
+    StatListItemComponent.new(
       label: "Created",
       value: helpers.datetime_with_duration_tag(@event.created_at)
-    ))
+    )
   end
 
-  def add_updated_item(component)
-    component.with_item(StatListItemComponent.new(
+  def updated_item
+    StatListItemComponent.new(
       label: "Updated",
       value: helpers.datetime_with_duration_tag(@event.updated_at)
-    ))
+    )
   end
 
-  def add_expires_item(component)
+  def expires_item
     expires_value = helpers.safe_join([
       helpers.long_time_tag(@event.expires_at),
       " ",
       expires_status_badge
     ])
 
-    component.with_item(StatListItemComponent.new(
+    StatListItemComponent.new(
       label: "Expires",
       value: expires_value
-    ))
+    )
   end
 
   def expires_status_badge
@@ -80,5 +95,19 @@ class EventDetailsComponent < ViewComponent::Base
     else
       helpers.tag.span("(in #{helpers.short_time_ago(@event.expires_at)})", class: "text-muted")
     end
+  end
+
+  def stat_items
+    stats.map do |key, value|
+      StatListItemComponent.new(
+        label: helpers.t("events.metadata.stats.#{key}", default: key.humanize),
+        value: helpers.format_stat_value(key, value),
+        key: "events.stats.#{key}"
+      )
+    end
+  end
+
+  def stats
+    @event.metadata&.fetch("stats", nil).to_h.except(*HIDDEN_STATS)
   end
 end

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -56,18 +56,4 @@
       <% end %>
     </section>
   <% end %>
-
-  <% if (stats = @event.metadata&.fetch("stats", nil)).present? %>
-    <section class="space-y-4" data-key="events.stats">
-      <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.metadata.stats.section_title") %></h2>
-      <%= render ListComponent.new do |list| %>
-        <% stats.except("search_calls").each do |key, value| %>
-          <% list.with_item(StatListItemComponent.new(
-            label: t("events.metadata.stats.#{key}", default: key.humanize),
-            value: format_stat_value(key, value)
-          )) %>
-        <% end %>
-      <% end %>
-    </section>
-  <% end %>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -56,18 +56,4 @@
       <% end %>
     </section>
   <% end %>
-
-  <% if (stats = @event.metadata&.fetch("stats", nil)).present? %>
-    <section class="space-y-4" data-key="events.stats">
-      <h2 class="text-2xl font-semibold mb-3 text-heading"><%= t("events.metadata.stats.section_title") %></h2>
-      <%= render ListComponent.new do |list| %>
-        <% stats.except("search_calls").each do |key, value| %>
-          <% list.with_item(StatListItemComponent.new(
-            label: t("events.metadata.stats.#{key}", default: key.humanize),
-            value: format_stat_value(key, value)
-          )) %>
-        <% end %>
-      <% end %>
-    </section>
-  <% end %>
 </div>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -10,11 +10,13 @@
     </section>
   <% end %>
 
-  <section class="space-y-4">
-    <h2 class="text-2xl font-semibold mb-3 text-heading">Stats</h2>
-    <%= render FeedStatsComponent.new(feed: @feed) %>
-    <%= render PostsHeatmapComponent.new(feed: @feed) %>
-  </section>
+  <% unless @feed.draft? %>
+    <section class="space-y-4">
+      <h2 class="text-2xl font-semibold mb-3 text-heading">Stats</h2>
+      <%= render FeedStatsComponent.new(feed: @feed) %>
+      <%= render PostsHeatmapComponent.new(feed: @feed) %>
+    </section>
+  <% end %>
 
   <% if @has_llm_usages %>
     <section class="space-y-4">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,7 +128,6 @@ en:
       description_html: "Email delivery failed"
     metadata:
       stats:
-        section_title: "Stats"
         started_at: "Started at"
         completed_at: "Completed at"
         total_duration: "Duration"

--- a/test/components/event_details_component_test.rb
+++ b/test/components/event_details_component_test.rb
@@ -29,4 +29,25 @@ class EventDetailsComponentTest < ViewComponent::TestCase
     assert_equal "/admin/users/#{event.user_id}", link["href"]
     assert_equal "#{event.user_id} — #{user.email_address}", link["title"]
   end
+
+  test "#call should merge metadata stats into the details list" do
+    event = create(:event, type: "owned_event", subject: feed,
+                   metadata: { "stats" => { "new_posts" => 1234, "llm_cost_cents" => 250 } })
+
+    result = render_inline(EventDetailsComponent.new(event: event))
+
+    assert_equal "New posts", result.css('[data-key="events.stats.new_posts.label"]').text
+    assert_equal "1,234", result.css('[data-key="events.stats.new_posts.value"]').text
+    assert_equal "Estimated AI spend", result.css('[data-key="events.stats.llm_cost_cents.label"]').text
+    assert_equal "$2.50", result.css('[data-key="events.stats.llm_cost_cents.value"]').text
+  end
+
+  test "#call should not render a search calls stat row" do
+    event = create(:event, type: "owned_event", subject: feed,
+                   metadata: { "stats" => { "search_calls" => 2 } })
+
+    result = render_inline(EventDetailsComponent.new(event: event))
+
+    assert_empty result.css('[data-key="events.stats.search_calls"]')
+  end
 end

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -100,15 +100,16 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", admin_feed_path(feed)
   end
 
-  test "should display stats from event metadata" do
+  test "should display stats from event metadata in the details list" do
     sign_in_as(admin_user)
     event = create(:event, metadata: { "stats" => { "new_posts" => 3 } }, user: create(:user))
 
     get admin_event_path(event)
 
     assert_response :success
-    assert_select "[data-key='events.stats']"
-    assert_select "h2", "Stats"
+    assert_select "[data-key='events.stats.new_posts.label']", text: "New posts"
+    assert_select "[data-key='events.stats.new_posts.value']", text: "3"
+    assert_select "h2", text: "Stats", count: 0
   end
 
   test "should render the most recent page of events" do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -250,6 +250,20 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Event #{event.id.to_s.last(5)}"
   end
 
+  test "#show should merge metadata stats into the details list" do
+    sign_in_as user
+    event = create(:event, type: "feed_refresh", user: user,
+                   metadata: { "stats" => { "new_posts" => 3, "search_calls" => 2 } })
+
+    get event_path(event)
+
+    assert_response :success
+    assert_select "[data-key='events.stats.new_posts.label']", text: "New posts"
+    assert_select "[data-key='events.stats.new_posts.value']", text: "3"
+    assert_select "[data-key='events.stats.search_calls']", count: 0
+    assert_select "h2", text: "Stats", count: 0
+  end
+
   test "#show should list imported posts referenced by the event" do
     sign_in_as user
     feed = create(:feed, user: user)

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -643,6 +643,16 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h2", text: "Stats", count: 1
   end
 
+  test "#show should not show stats section for a draft feed" do
+    sign_in_as(user)
+    draft = create(:feed, :draft, user: user)
+
+    get feed_url(draft)
+
+    assert_response :success
+    assert_select "h2", text: "Stats", count: 0
+  end
+
   test "#show should render AI usage section when feed has usages within the stats period" do
     create(:llm_usage, feed: feed, user: user)
     sign_in_as(user)


### PR DESCRIPTION
Changes:

- Hide the Stats section on the feed page while the feed is still a draft
- Show event metadata stats as extra rows of the details list at the top of event pages, replacing the separate Stats section on both the user-facing and admin views

`EventDetailsComponent` now builds the list from an overridable `#items` method, keeping event presentation flexible: subclasses can add, remove, or reorder rows. Search call counts stay in the dedicated search usage section to avoid duplication, and the imported posts / AI usage sections remain below the details list.