### PR TITLE
Add description to admin feeds index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-20
+
+- The admin Feeds page now explains that it lists feeds from all users.
+
 ## 2026-07-19
 
 - Webhook feed setup now asks you to choose a name and uses clearer progress messages.

--- a/app/views/admin/feeds/index.html.erb
+++ b/app/views/admin/feeds/index.html.erb
@@ -3,6 +3,9 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Feeds") do |header| %>
     <% header.with_breadcrumb(label: "Admin Panel", url: admin_path) %>
+    <% header.with_context_paragraph do %>
+      <span data-key="admin.feeds.description">All the feeds created by every user on Feeder, in one place.</span>
+    <% end %>
     <% if @feeds.any? %>
       <% header.with_action_button do %>
         <%= render SortDropdownComponent.new(presenter: @sortable_presenter, menu_id: "admin-feed-sort-menu") %>

--- a/test/controllers/admin/feeds_controller_test.rb
+++ b/test/controllers/admin/feeds_controller_test.rb
@@ -39,6 +39,15 @@ class Admin::FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", admin_feed_path(feed), text: feed.display_name
   end
 
+  test "should explain that index lists feeds from all users" do
+    sign_in_as(admin_user)
+
+    get admin_feeds_path
+
+    assert_response :success
+    assert_select "[data-key='admin.feeds.description']", text: "All the feeds created by every user on Feeder, in one place."
+  end
+
   test "should let admins view another user's feed" do
     sign_in_as(admin_user)
     feed = create(:feed, user: create(:user))


### PR DESCRIPTION
Changes:

- Added a short explanatory paragraph to the admin Feeds page header, noting that it lists feeds created by all users
- Added a controller test asserting the paragraph renders
- Added a changelog entry

The admin Feeds page looks just like the personal Feeds page, so a one-line description in the header makes its wider scope obvious at a glance.