### PR TITLE
Limit table usage to ten largest tables

### DIFF
--- a/app/controllers/development/system_status_controller.rb
+++ b/app/controllers/development/system_status_controller.rb
@@ -3,7 +3,7 @@ class Development::SystemStatusController < ApplicationController
     authorize :access, :dev?
     @config_checks = config_checks
     @release_info = release_info
-    @disk_usage = Rails.cache.fetch("development/system_status/v4", expires_in: 5.minutes) do
+    @disk_usage = Rails.cache.fetch("development/system_status/v5", expires_in: 5.minutes) do
       DiskUsageService.new.call
     end
   end

--- a/app/services/disk_usage_service.rb
+++ b/app/services/disk_usage_service.rb
@@ -1,6 +1,8 @@
 require "open3"
 
 class DiskUsageService
+  TOP_TABLES_COUNT = 10
+
   def initialize(df_command: method(:execute_df_command))
     @df_command = df_command
   end
@@ -15,7 +17,9 @@ class DiskUsageService
       postgres_percentage: postgres_percentage,
       other_used_percentage: other_used_percentage,
       free_percentage: free_percentage,
-      table_usage: table_usage
+      table_usage: table_usage,
+      other_tables_size: other_tables_size,
+      other_tables_count: other_tables_count
     }
   end
 
@@ -86,7 +90,23 @@ class DiskUsageService
   end
 
   def table_usage
-    execute_query(<<-SQL
+    all_tables.first(TOP_TABLES_COUNT)
+  end
+
+  def other_tables_size
+    remaining_tables.sum { |row| row["total_size"] }
+  end
+
+  def other_tables_count
+    remaining_tables.size
+  end
+
+  def remaining_tables
+    all_tables.drop(TOP_TABLES_COUNT)
+  end
+
+  def all_tables
+    @all_tables ||= execute_query(<<-SQL
       SELECT
         relname AS table_name,
         pg_total_relation_size(pg_class.oid) AS total_size

--- a/app/views/development/system_status/show.html.erb
+++ b/app/views/development/system_status/show.html.erb
@@ -90,6 +90,14 @@
           value: number_to_human_size(row["total_size"])
         )) %>
       <% end %>
+      <% if @disk_usage[:other_tables_count] > 0 %>
+        <% list.with_item(StatListItemComponent.new(
+          label: "Other",
+          value: number_to_human_size(@disk_usage[:other_tables_size]),
+          key: "table_usage.other",
+          muted: true
+        )) %>
+      <% end %>
     <% end %>
   </section>
 </div>

--- a/test/controllers/development/system_status_controller_test.rb
+++ b/test/controllers/development/system_status_controller_test.rb
@@ -90,6 +90,16 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='config.background_jobs'][data-status='error']"
   end
 
+  test "should show other tables total in table usage" do
+    sign_in_as(dev_user)
+
+    get development_system_status_path
+
+    assert_response :success
+    assert_select "[data-key='table_usage.other.label']", text: "Other"
+    assert_select "[data-key='table_usage.other.value']"
+  end
+
   test "should show deployed version details" do
     with_release_env(
       "APP_REVISION" => "0123456789abcdef",

--- a/test/services/disk_usage_service_test.rb
+++ b/test/services/disk_usage_service_test.rb
@@ -51,6 +51,29 @@ class DiskUsageServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "#call should limit table usage to the largest tables" do
+    service = DiskUsageService.new(df_command: stub_df_command)
+    result = service.call
+
+    assert_equal DiskUsageService::TOP_TABLES_COUNT, result[:table_usage].size
+
+    sizes = result[:table_usage].map { |row| row["total_size"] }
+    assert_equal sizes.sort.reverse, sizes
+  end
+
+  test "#call should aggregate remaining tables into other tables size" do
+    service = DiskUsageService.new(df_command: stub_df_command)
+    result = service.call
+
+    assert result[:other_tables_count].positive?, "expected more than #{DiskUsageService::TOP_TABLES_COUNT} tables in the test database"
+    assert_instance_of Integer, result[:other_tables_size]
+    assert result[:other_tables_size] >= 0
+
+    smallest_listed = result[:table_usage].last["total_size"]
+    average_other = result[:other_tables_size].to_f / result[:other_tables_count]
+    assert average_other <= smallest_listed, "aggregated tables should not be larger than the listed ones"
+  end
+
   test "#call should return other used space as integer" do
     service = DiskUsageService.new(df_command: stub_df_command)
     result = service.call


### PR DESCRIPTION
Changes:

- Show only the 10 largest tables in the Postgres Table Usage section of the system status page
- Aggregate the remaining tables into a single "Other" row showing their total size

Keeps the section readable as the schema grows, while still accounting for all database disk usage.