### PR TITLE
Describe event log filters as linked entity references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-20
 
+- Filtered event logs now describe the filter in plain words — "Filtering by Feed [ce23f]" — with a link to the feed, user, or other entity you're filtering by.
 - Draft feeds no longer show an empty Stats section — it appears once the feed is up and running.
 - Event pages now show refresh stats right in the details list at the top instead of a separate Stats section.
 - The admin Feeds page now explains that it lists feeds from all users.

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -30,6 +30,10 @@ class Admin::EventsController < ApplicationController
 
   private
 
+  def event_entity_paths
+    Admin::EventEntityPaths.new
+  end
+
   def events_log_path(**params)
     admin_events_path(filter: optional_filter.to_h.presence, **params)
   end

--- a/app/controllers/concerns/event_filtering.rb
+++ b/app/controllers/concerns/event_filtering.rb
@@ -1,7 +1,18 @@
 module EventFiltering
   extend ActiveSupport::Concern
 
+  included do
+    helper_method :event_entity_paths
+  end
+
   private
+
+  # Resolves filter references to the owner-facing entity pages. Admin
+  # controllers override this with Admin::EventEntityPaths so the same
+  # summary links to the operator pages instead.
+  def event_entity_paths
+    EventEntityPaths.new
+  end
 
   # Narrows an events relation by the permitted `filter` query params. Returns
   # the scope untouched when no filter is present.

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,6 +8,8 @@ class EventsController < ApplicationController
   MAX_RECENT_POSTS = 10
 
   def index
+    @filter = optional_filter
+
     respond_to do |format|
       format.html { render_events_page }
       format.turbo_stream { render_events_stream }

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -11,33 +11,28 @@ module EventsHelper
     end
   end
 
-  def admin_event_filter_summary(filter)
-    parts = filter.to_h.map do |key, value|
-      values = Array.wrap(value).map do |item|
-        admin_event_filter_value(key, item, filter:)
-      end
+  # Describes the active events filter as entity references — "Feed [ce23f]",
+  # with the id linked when `entity_paths` resolves a page for the entity —
+  # plus plain `key: value` parts for the remaining filter keys.
+  def event_filter_summary(filter, entity_paths:)
+    filter = filter.to_h.stringify_keys
+    parts = []
 
-      safe_join(["#{key}: ", safe_join(values, ", ")])
+    if filter.values_at("subject_type", "subject_id").any?(&:present?)
+      parts << event_entity_reference(filter["subject_type"], filter["subject_id"], entity_paths)
+    end
+
+    parts << event_entity_reference("User", filter["user_id"], entity_paths) if filter["user_id"].present?
+
+    filter.except("subject_type", "subject_id", "user_id").each do |key, value|
+      parts << "#{key}: #{Array.wrap(value).join(', ')}"
     end
 
     safe_join(parts, " • ")
   end
 
   def admin_event_subject_path(subject)
-    case subject
-    when Feed
-      admin_feed_path(subject)
-    when User
-      admin_user_path(subject)
-    when Event
-      admin_event_path(subject)
-    when AccessToken
-      access_token_path(subject)
-    when AiCredential
-      ai_credential_path(subject)
-    when SearchCredential
-      search_credential_path(subject)
-    end
+    subject && Admin::EventEntityPaths.new.path_for(subject.class.name, subject.id)
   end
 
   def format_stat_value(key, value)
@@ -75,43 +70,25 @@ module EventsHelper
 
   private
 
-  def admin_event_filter_value(key, value, filter:)
-    return value unless %w[user_id subject_id].include?(key.to_s)
+  # "Feed [ce23f]" — a humanized entity type with a short linked id. Either
+  # half may be missing: a type-only filter renders just the label, an id
+  # without a type gets a generic label and stays unlinked.
+  def event_entity_reference(type, id, entity_paths)
+    label = type.present? ? type.demodulize.underscore.humanize : "Subject"
+    return tag.strong(label) if id.blank?
 
-    path = admin_event_filter_reference_path(key, value, filter:)
-    text = short_ref(value)
-
-    if path
+    path = type.present? ? entity_paths.path_for(type, id) : nil
+    ref = if path
       link_to(
-        text,
+        short_ref(id),
         path,
-        title: value,
+        title: id,
         class: "font-mono underline underline-offset-2 transition hover:text-heading"
       )
     else
-      tag.span(text, title: value, class: "font-mono")
+      tag.span(short_ref(id), title: id, class: "font-mono")
     end
-  end
 
-  def admin_event_filter_reference_path(key, value, filter:)
-    case key.to_s
-    when "user_id"
-      admin_user_path(value)
-    when "subject_id"
-      case filter[:subject_type] || filter["subject_type"]
-      when "Feed"
-        admin_feed_path(value)
-      when "User"
-        admin_user_path(value)
-      when "Event"
-        admin_event_path(value)
-      when "AccessToken"
-        access_token_path(value)
-      when "AiCredential"
-        ai_credential_path(value)
-      when "SearchCredential"
-        search_credential_path(value)
-      end
-    end
+    tag.strong(safe_join([label, " [", ref, "]"]))
   end
 end

--- a/app/services/admin/event_entity_paths.rb
+++ b/app/services/admin/event_entity_paths.rb
@@ -1,0 +1,15 @@
+module Admin
+  # Operator-facing variant of EventEntityPaths: entities with admin pages
+  # point there; the rest keep their owner-facing pages.
+  class EventEntityPaths < ::EventEntityPaths
+    private
+
+    def routes
+      super.merge(
+        "Feed" => :admin_feed_path,
+        "User" => :admin_user_path,
+        "Event" => :admin_event_path
+      )
+    end
+  end
+end

--- a/app/services/event_entity_paths.rb
+++ b/app/services/event_entity_paths.rb
@@ -1,0 +1,26 @@
+# Resolves the page that displays an entity referenced from the events log,
+# given its class name and id. This base resolver targets the owner-facing
+# pages; Admin::EventEntityPaths points entities with operator pages there
+# instead. To make a new entity type linkable, add its route to `routes`.
+class EventEntityPaths
+  include Rails.application.routes.url_helpers
+
+  # Returns the path for the entity, or nil when no page displays it.
+  def path_for(type, id)
+    route = routes[type.to_s]
+    route && public_send(route, id)
+  end
+
+  private
+
+  def routes
+    {
+      "Feed" => :feed_path,
+      "Event" => :event_path,
+      "Post" => :post_path,
+      "AccessToken" => :access_token_path,
+      "AiCredential" => :ai_credential_path,
+      "SearchCredential" => :search_credential_path
+    }
+  end
+end

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -6,7 +6,7 @@
     <% header.with_context_paragraph do %>
       <% if @filter.present? %>
         <span data-key="admin.events.filter-summary">
-          Filtering by <%= admin_event_filter_summary(@filter) %>.
+          Filtering by <%= event_filter_summary(@filter, entity_paths: event_entity_paths) %>.
         </span>
       <% end %>
       <span data-key="events.offset"><%= events_offset_summary(@offset, system_wide: @filter.blank?) %></span>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -5,6 +5,11 @@
     <% header.with_breadcrumb(label: "Status", url: status_path) %>
     <% header.with_context_paragraph "Everything Feeder has done on your feeds, newest first." %>
     <% header.with_context_paragraph do %>
+      <% if @filter.present? %>
+        <span data-key="events.filter-summary">
+          Filtering by <%= event_filter_summary(@filter, entity_paths: event_entity_paths) %>.
+        </span>
+      <% end %>
       <span data-key="events.offset"><%= events_offset_summary(@offset) %></span>
     <% end %>
     <% if @log_endpoint %>

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -294,6 +294,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '[data-key="events.type"]', count: 2
+    assert_select '[data-key="admin.events.filter-summary"]', text: /Filtering by Feed \[#{feed1.id.to_s.last(5)}\]\./
     assert_select '[data-key="admin.events.filter-summary"] a[href=?]', admin_feed_path(feed1), text: feed1.id.to_s.last(5)
   end
 
@@ -351,6 +352,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '[data-key="events.type"]', count: 2
+    assert_select '[data-key="admin.events.filter-summary"]', text: /Filtering by User \[#{user1.id.to_s.last(5)}\]\./
     assert_select '[data-key="admin.events.filter-summary"] a[href=?]', admin_user_path(user1), text: user1.id.to_s.last(5)
   end
 

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -220,6 +220,28 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='events.entry']", count: 1
   end
 
+  test "#index should describe the active filter with a link to the owner feed page" do
+    sign_in_as user
+    feed = create(:feed, user: user)
+    create(:event, type: "feed_refresh", subject: feed, user: user)
+
+    get events_path, params: { filter: { subject_type: "Feed", subject_id: feed.id } }
+
+    assert_response :success
+    assert_select '[data-key="events.filter-summary"]', text: /Filtering by Feed \[#{feed.id.to_s.last(5)}\]\./
+    assert_select '[data-key="events.filter-summary"] a[href=?]', feed_path(feed), text: feed.id.to_s.last(5)
+  end
+
+  test "#index should not describe a filter when none is active" do
+    sign_in_as user
+    create(:event, user: user)
+
+    get events_path
+
+    assert_response :success
+    assert_select '[data-key="events.filter-summary"]', count: 0
+  end
+
   test "#index should not leak other users' events through filters" do
     sign_in_as user
     create(:event, type: "feed_refresh", user: other_user)

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -3,27 +3,77 @@ require "test_helper"
 class EventsHelperTest < ActionView::TestCase
   include TimeHelper
 
-  test "#admin_event_filter_summary renders a direct link for a known subject type" do
+  test "#event_filter_summary should render a bold linked subject reference" do
     subject_id = SecureRandom.uuid
 
-    result = admin_event_filter_summary({ subject_type: "Feed", subject_id: subject_id })
+    result = event_filter_summary({ subject_type: "Feed", subject_id: subject_id }, entity_paths: Admin::EventEntityPaths.new)
     fragment = Nokogiri::HTML.fragment(result)
-    link = fragment.at_css("a")
+    link = fragment.at_css("strong a")
 
-    assert_equal "subject_type: Feed • subject_id: #{subject_id.last(5)}", fragment.text
+    assert_equal "Feed [#{subject_id.last(5)}]", fragment.text
     assert_equal admin_feed_path(subject_id), link["href"]
     assert_equal subject_id, link["title"]
   end
 
-  test "#admin_event_filter_summary leaves an unknown subject type unlinked" do
+  test "#event_filter_summary should link subjects to owner pages with the base resolver" do
     subject_id = SecureRandom.uuid
 
-    result = admin_event_filter_summary({ subject_type: "Post", subject_id: subject_id })
+    result = event_filter_summary({ subject_type: "Feed", subject_id: subject_id }, entity_paths: EventEntityPaths.new)
     fragment = Nokogiri::HTML.fragment(result)
-    label = fragment.at_css("span")
 
-    assert_equal "subject_type: Post • subject_id: #{subject_id.last(5)}", fragment.text
+    assert_equal feed_path(subject_id), fragment.at_css("strong a")["href"]
+  end
+
+  test "#event_filter_summary should leave a subject type without a page unlinked" do
+    subject_id = SecureRandom.uuid
+
+    result = event_filter_summary({ subject_type: "JobRun", subject_id: subject_id }, entity_paths: Admin::EventEntityPaths.new)
+    fragment = Nokogiri::HTML.fragment(result)
+    label = fragment.at_css("strong span")
+
+    assert_equal "Job run [#{subject_id.last(5)}]", fragment.text
     assert_equal subject_id, label["title"]
+    assert_nil fragment.at_css("a")
+  end
+
+  test "#event_filter_summary should render user_id as a linked User reference" do
+    user_id = SecureRandom.uuid
+
+    result = event_filter_summary({ user_id: user_id }, entity_paths: Admin::EventEntityPaths.new)
+    fragment = Nokogiri::HTML.fragment(result)
+    link = fragment.at_css("strong a")
+
+    assert_equal "User [#{user_id.last(5)}]", fragment.text
+    assert_equal admin_user_path(user_id), link["href"]
+  end
+
+  test "#event_filter_summary should keep non-entity filter keys as plain parts" do
+    subject_id = SecureRandom.uuid
+
+    result = event_filter_summary(
+      { subject_type: "Feed", subject_id: subject_id, level: "error", type: %w[feed_refresh feed_auto_disabled] },
+      entity_paths: EventEntityPaths.new
+    )
+    fragment = Nokogiri::HTML.fragment(result)
+
+    assert_equal "Feed [#{subject_id.last(5)}] • level: error • type: feed_refresh, feed_auto_disabled", fragment.text
+  end
+
+  test "#event_filter_summary should render a type-only filter as a bare label" do
+    result = event_filter_summary({ subject_type: "Feed" }, entity_paths: EventEntityPaths.new)
+    fragment = Nokogiri::HTML.fragment(result)
+
+    assert_equal "Feed", fragment.text
+    assert_nil fragment.at_css("a")
+  end
+
+  test "#event_filter_summary should fall back to a generic label without a subject type" do
+    subject_id = SecureRandom.uuid
+
+    result = event_filter_summary({ subject_id: subject_id }, entity_paths: EventEntityPaths.new)
+    fragment = Nokogiri::HTML.fragment(result)
+
+    assert_equal "Subject [#{subject_id.last(5)}]", fragment.text
     assert_nil fragment.at_css("a")
   end
 

--- a/test/services/admin/event_entity_paths_test.rb
+++ b/test/services/admin/event_entity_paths_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Admin::EventEntityPathsTest < ActiveSupport::TestCase
+  def paths
+    @paths ||= Admin::EventEntityPaths.new
+  end
+
+  test "#path_for should resolve operator pages for admin-managed entities" do
+    assert_equal "/admin/feeds/abc", paths.path_for("Feed", "abc")
+    assert_equal "/admin/users/abc", paths.path_for("User", "abc")
+    assert_equal "/admin/events/abc", paths.path_for("Event", "abc")
+  end
+
+  test "#path_for should keep owner pages for entities without an admin page" do
+    assert_equal "/access_tokens/abc", paths.path_for("AccessToken", "abc")
+    assert_equal "/ai_credentials/abc", paths.path_for("AiCredential", "abc")
+  end
+
+  test "#path_for should return nil for unknown entity types" do
+    assert_nil paths.path_for("JobRun", "abc")
+  end
+end

--- a/test/services/event_entity_paths_test.rb
+++ b/test/services/event_entity_paths_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class EventEntityPathsTest < ActiveSupport::TestCase
+  def paths
+    @paths ||= EventEntityPaths.new
+  end
+
+  test "#path_for should resolve owner-facing entity pages" do
+    assert_equal "/feeds/abc", paths.path_for("Feed", "abc")
+    assert_equal "/events/abc", paths.path_for("Event", "abc")
+    assert_equal "/posts/abc", paths.path_for("Post", "abc")
+    assert_equal "/access_tokens/abc", paths.path_for("AccessToken", "abc")
+  end
+
+  test "#path_for should return nil for entities without a page" do
+    assert_nil paths.path_for("User", "abc")
+    assert_nil paths.path_for("JobRun", "abc")
+    assert_nil paths.path_for(nil, "abc")
+  end
+end


### PR DESCRIPTION
Changes:

- The events log filter summary now reads "Filtering by **Feed [ce23f]**" instead of raw `subject_type` / `subject_id` pairs, with the id linked to the entity's page.
- The personal events page now shows the active filter too, linking to owner pages (`/feeds/:id`), while the admin log links to operator pages (`/admin/feeds/:id`, `/admin/users/:id`).
- Entity-to-page resolution moved into small per-context resolvers (`EventEntityPaths`, `Admin::EventEntityPaths`), replacing the duplicated case statements in `EventsHelper`.

The summary degrades gracefully for any filter shape: entity types without a page render unlinked, type-only or id-only filters still read well, and non-entity keys keep the plain `level: error` form. Making a new entity type linkable is a one-line addition to a resolver's route map.