### PR TITLE
Show recent user activity on admin user page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-20
 
+- Admin user pages now show the user's recent activity with a link to their full events log.
 - Draft feeds no longer show an empty Stats section — it appears once the feed is up and running.
 - Event pages now show refresh stats right in the details list at the top instead of a separate Stats section.
 - The admin Feeds page now explains that it lists feeds from all users.

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,6 +2,8 @@ class Admin::UsersController < ApplicationController
   include Pagination
   include Sortable
 
+  MAX_RECENT_EVENTS = 10
+
   SORTABLE_FIELDS = {
     email: {
       title: "Email",
@@ -45,6 +47,7 @@ class Admin::UsersController < ApplicationController
     authorize [:admin, @user]
     @stats = UserStats.new(@user)
     @last_admin = @user.admin? && User.joins(:permissions).where(permissions: { name: Permission::ADMIN }).count == 1
+    @recent_events = @user.events.recent.limit(MAX_RECENT_EVENTS)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   has_many :ai_credentials, dependent: :destroy
   has_many :search_credentials, dependent: :destroy
   has_many :llm_usages, dependent: :destroy
+  has_many :events, dependent: :nullify
   belongs_to :default_ai_credential, class_name: "AiCredential", optional: true
   belongs_to :default_search_credential, class_name: "SearchCredential", optional: true
   has_many :created_invites, class_name: "Invite", foreign_key: :created_by_user_id, dependent: :destroy

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -49,6 +49,16 @@
     <%= render Admin::UserStatisticsComponent.new(stats: @stats) %>
   </section>
 
+  <% if @recent_events.any? %>
+    <section class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
+        <%= link_to "View all", admin_events_path(filter: { user_id: @user.id }), class: "text-sm font-semibold text-brand hover:text-brand-hover", data: { key: "user.events.view_all" } %>
+      </div>
+      <%= render Admin::EventsListComponent.new(events: @recent_events) %>
+    </section>
+  <% end %>
+
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-heading">Invitations</h2>
     <%= render Admin::UserInvitationsComponent.new(user: @user, stats: @stats) %>
@@ -120,16 +130,6 @@
       <p class="text-muted">No active sessions</p>
     <% end %>
   </section>
-
-  <% if @recent_events.any? %>
-    <section class="space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
-        <%= link_to "View all", admin_events_path(filter: { user_id: @user.id }), class: "text-sm font-semibold text-brand hover:text-brand-hover", data: { key: "user.events.view_all" } %>
-      </div>
-      <%= render Admin::EventsListComponent.new(events: @recent_events) %>
-    </section>
-  <% end %>
 
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-heading">Actions</h2>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -121,6 +121,16 @@
     <% end %>
   </section>
 
+  <% if @recent_events.any? %>
+    <section class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
+        <%= link_to "View all", admin_events_path(filter: { user_id: @user.id }), class: "text-sm font-semibold text-brand hover:text-brand-hover", data: { key: "user.events.view_all" } %>
+      </div>
+      <%= render Admin::EventsListComponent.new(events: @recent_events) %>
+    </section>
+  <% end %>
+
   <section class="space-y-4">
     <h2 class="text-2xl font-semibold mb-3 text-heading">Actions</h2>
     <div class="flex gap-2">

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -99,6 +99,38 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "#confirm-email-modal-#{user.id}", count: 0
   end
 
+  test "#show should render a recent activity section with the user's events" do
+    sign_in_as(admin_user)
+    user = create(:user)
+    create(:event, user: user)
+
+    get admin_user_path(user)
+
+    assert_response :success
+    assert_select "h2", text: "Recent Activity", count: 1
+  end
+
+  test "#show should link recent activity to the events log filtered by user" do
+    sign_in_as(admin_user)
+    user = create(:user)
+    create(:event, user: user)
+
+    get admin_user_path(user)
+
+    assert_response :success
+    assert_select "[data-key='user.events.view_all'][href=?]", admin_events_path(filter: { user_id: user.id }), text: "View all"
+  end
+
+  test "#show should not render recent activity section when user has no events" do
+    sign_in_as(admin_user)
+    user = create(:user)
+
+    get admin_user_path(user)
+
+    assert_response :success
+    assert_select "h2", text: "Recent Activity", count: 0
+  end
+
   test "should redirect non-admin users from show" do
     sign_in_as(regular_user)
     user = create(:user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -169,6 +169,17 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test "should nullify associated events when user is destroyed" do
+    user = create(:user)
+    event = create(:event, user: user)
+
+    assert_no_difference("Event.count") do
+      user.destroy!
+    end
+
+    assert_nil event.reload.user_id
+  end
+
   test "#admin? returns true when user has admin permission" do
     user = create(:user, :admin)
 


### PR DESCRIPTION
Changes:

- Added a Recent Activity section to the admin user page, mirroring the one on the admin feed page but scoped to events attributed to the user
- The "View all" link opens the events log filtered by the selected user
- Added `User#events` association with `dependent: :nullify` so deleting a user no longer trips the events foreign key

Users aren't event subjects in this app, so the section is scoped by `events.user_id` — the same filter the events log already supports and uses elsewhere (e.g. the "View Email Events" link).