### PR TITLE
Decode HTML character references in Reddit post titles

### DIFF
--- a/.database_consistency.todo.yml
+++ b/.database_consistency.todo.yml
@@ -82,6 +82,11 @@ RateLimit::Bucket:
     NullConstraintChecker:
       enabled: false
 User:
+  events:
+    # wontfix: dependent: :nullify covers the Rails destroy flow; the plain FK
+    # deliberately blocks raw-SQL user deletes instead of orphaning events.
+    ForeignKeyCascadeChecker:
+      enabled: false
   index_users_on_email_address:
     # wontfix: covered by the custom both_emails_are_globally_unique
     # validator, which checks email_address and unconfirmed_email together.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-20
 
+- Reddit posts no longer show raw character codes like `&#8217;` in titles — they come through as the intended characters.
 - Admin user pages now show the user's recent activity with a link to their full events log.
 - Filtered event logs now describe the filter in plain words — "Filtering by Feed [ce23f]" — with a link to the feed, user, or other entity you're filtering by.
 - Draft feeds no longer show an empty Stats section — it appears once the feed is up and running.

--- a/app/services/normalizer/reddit_normalizer.rb
+++ b/app/services/normalizer/reddit_normalizer.rb
@@ -5,8 +5,10 @@ module Normalizer
   class RedditNormalizer < RssNormalizer
     private
 
+    # Reddit HTML-escapes titles inside the feed XML, so character references
+    # like &#8217; survive the XML parse and need one more decode pass.
     def normalize_content
-      title = raw_data.dig("title").to_s.strip
+      title = strip_html(raw_data.dig("title"))
       body = extract_post_body
       body.present? ? "#{title}\n\n#{body}" : title
     end

--- a/test/fixtures/files/feeds/reddit/feed.xml
+++ b/test/fixtures/files/feeds/reddit/feed.xml
@@ -32,5 +32,14 @@
       <dc:creator>newsbot</dc:creator>
     </item>
 
+    <item>
+      <title>It&amp;#8217;s a &amp;#8220;quoted&amp;#8221; title &amp;amp; more</title>
+      <link>https://www.reddit.com/r/programming/comments/ghi789/its_a_quoted_title/</link>
+      <guid isPermaLink="true">https://www.reddit.com/r/programming/comments/ghi789/its_a_quoted_title/</guid>
+      <pubDate>Fri, 12 Jun 2026 09:00:00 +0000</pubDate>
+      <description>&lt;!-- SC_OFF --&gt;&lt;div class="md"&gt;&lt;p&gt;Here&amp;#8217;s the body text.&lt;/p&gt;&lt;/div&gt;&lt;!-- SC_ON --&gt; &amp;#32; submitted by &amp;#32; &lt;a href="https://www.reddit.com/user/quoter"&gt; /u/quoter &lt;/a&gt;</description>
+      <dc:creator>quoter</dc:creator>
+    </item>
+
   </channel>
 </rss>

--- a/test/services/normalizer/reddit_normalizer_test.rb
+++ b/test/services/normalizer/reddit_normalizer_test.rb
@@ -52,6 +52,15 @@ class Normalizer::RedditNormalizerTest < ActiveSupport::TestCase
     assert_equal [], post.attachment_urls
   end
 
+  test "#normalize should decode HTML character references in the title" do
+    entry = feed_entry(3)
+
+    normalizer = Normalizer::RedditNormalizer.new(entry)
+    post = normalizer.normalize
+
+    assert post.content.start_with?("It’s a “quoted” title & more\n\nHere’s the body text.")
+  end
+
   test "#normalize should include Reddit permalink as source URL" do
     entry = feed_entry(0)
 


### PR DESCRIPTION
Changes:

- Decode HTML character references in Reddit post titles during normalization
- Add a Reddit fixture item and test covering entity decoding in titles
- Baseline the `ForeignKeyCascadeChecker` finding for `User#events` inherited from #1137, which was failing CI on main and on every branch cut from it

Reddit double-escapes post titles in its feed XML, so numeric character references survived the XML parse and showed up raw in published posts (a curly apostrophe arriving as its `#8217` code, for example). The title now goes through the same `strip_html` decode pass the post body already uses.

References:

- Related PR: #1137