### PR TITLE
Left-align back link on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- "Back to sign in" links are now a bit taller, making them easier to tap.
 - The "Back to sign in" link on the password reset pages now lines up on the left on small screens, like on the other pages.
 
 ## 2026-07-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-21
+
+- The "Back to sign in" link on the password reset pages now lines up on the left on small screens, like on the other pages.
+
 ## 2026-07-20
 
 - Timestamps in event details, like "Started at" and "Completed at", now show how long ago they happened — "20 Jul 2026, 20:00 (48m)" — matching the rest of the page.

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -35,7 +35,7 @@
         </div>
       </div>
 
-      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-body flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="mt-6 flex flex-col items-start justify-start gap-4 text-body sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Save password", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
         <%= link_to "Back to sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
       </div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -37,7 +37,7 @@
 
       <div class="mt-6 flex flex-col items-start justify-start gap-4 text-body sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Save password", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
-        <%= link_to "Back to sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
+        <p><%= link_to "Back to sign in", new_session_path, class: "inline-block font-medium leading-loose text-brand underline underline-offset-4 transition hover:text-brand-hover" %></p>
       </div>
     <% end %>
   </div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -19,7 +19,7 @@
         </div>
       </div>
 
-      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-body flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="mt-6 flex flex-col items-start justify-start gap-4 text-body sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Email reset instructions", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
         <%= link_to "Back to sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
       </div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -21,7 +21,7 @@
 
       <div class="mt-6 flex flex-col items-start justify-start gap-4 text-body sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Email reset instructions", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
-        <%= link_to "Back to sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
+        <p><%= link_to "Back to sign in", new_session_path, class: "inline-block font-medium leading-loose text-brand underline underline-offset-4 transition hover:text-brand-hover" %></p>
       </div>
     <% end %>
   </div>

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -15,7 +15,7 @@
 
       <div class="mt-6 flex flex-col items-start justify-start gap-4 text-body sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Send confirmation email", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
-        <%= link_to "Back to sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
+        <p><%= link_to "Back to sign in", new_session_path, class: "inline-block font-medium leading-loose text-brand underline underline-offset-4 transition hover:text-brand-hover" %></p>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
The stacked mobile layout on the password reset pages centered the
Back to sign in link; use items-start like the resend-confirmation
page so it lines up with the rest of the content.
