### PR TITLE
Keep email on sign-in after failed attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- The sign-in page now keeps your email address in place after a wrong password, so you only need to retype the password.
 - "Back to sign in" links are now a bit taller, making them easier to tap.
 - The "Back to sign in" link on the password reset pages now lines up on the left on small screens, like on the other pages.
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,8 @@ class SessionsController < ApplicationController
     if user
       create_session_for(user)
     else
-      redirect_to new_session_path, alert: "Email address or password are not correct."
+      flash.now[:alert] = "Email address or password are not correct."
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -15,7 +15,16 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
   test "#create should reject invalid credentials" do
     post session_url, params: { email_address: "wrong@example.com", password: "wrong" }
-    assert_redirected_to new_session_path
+
+    assert_response :unprocessable_entity
+    assert_select "[role=\"alert\"]", text: /Email address or password are not correct./
+  end
+
+  test "#create should keep the email address after a failed attempt" do
+    post session_url, params: { email_address: "typed@example.com", password: "wrong" }
+
+    assert_response :unprocessable_entity
+    assert_select "input[name=?][value=?]", "email_address", "typed@example.com"
   end
 
   test "#destroy should clear session" do


### PR DESCRIPTION
Render the sign-in page with 422 instead of redirecting, so the submitted email address stays in the form when the password is wrong.
