### PR TITLE
Lock Enable checkbox off while setup is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- The "Enable feed" option now stays off with a note about what's missing — like a FreeFeed token or AI credentials — instead of failing with an error that didn't point anywhere.
 - The Invites page now shows only your own invitations. Admins previously saw everyone's invites there, including the one they signed up with.
 - Empty state placeholders now look the same on phones as on larger screens — rounded corners, comfortable spacing, and softer gray text.
 - The default userpic no longer flickers between white and gray backgrounds on token and post pages.

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -182,7 +182,8 @@
         <% end %>
       </div>
 
-      <%= render FeedAiSettingsComponent.new(feed: feed, form: f) %>
+      <% ai_settings = FeedAiSettingsComponent.new(feed: feed, form: f) %>
+      <%= render ai_settings %>
 
       <% unless feed.sourceless? %>
       <div class="mt-2" data-key="form.preview">
@@ -360,17 +361,34 @@
         </div>
       <% end %>
 
+      <%# When a setup gate replaced the token or credential fields, enabling
+          can only fail — and the failure's errors would render inside the
+          missing fields, i.e. nowhere. Lock the checkbox off and say what's
+          missing instead. A (legacy) still-enabled feed keeps an interactive
+          checkbox so unchecking-to-pause stays available. %>
+      <%
+        enable_missing = []
+        enable_missing << "a FreeFeed access token" if active_tokens.empty?
+        if ai_settings.section_visible?
+          enable_missing << "AI credentials" unless ai_settings.credentials?
+          enable_missing << "search credentials" unless ai_settings.search_credentials?
+        end
+        enable_blocked = enable_missing.any? && !feed.enabled?
+      %>
       <div class="mt-6">
         <div class="flex items-start">
           <div class="flex items-center h-6">
             <%= check_box_tag "enable_feed",
                               "1",
-                              params[:enable_feed] == "1" || feed.enabled?,
-                              id: "enable_feed" %>
+                              !enable_blocked && (params[:enable_feed] == "1" || feed.enabled?),
+                              id: "enable_feed",
+                              disabled: enable_blocked %>
           </div>
           <div class="ml-3">
-            <%= label_tag "enable_feed", "Enable feed", class: "block font-semibold text-heading mb-0" %>
-            <% if feed.scheduled? %>
+            <%= label_tag "enable_feed", "Enable feed", class: "block font-semibold #{enable_blocked ? 'text-muted' : 'text-heading'} mb-0" %>
+            <% if enable_blocked %>
+              <p class="text-sm text-muted" data-key="form.enable-blocked-note">Add <%= enable_missing.to_sentence %> first, then you can enable this feed.</p>
+            <% elsif feed.scheduled? %>
               <p class="text-sm text-muted">Start checking for new posts and publish them to FreeFeed.</p>
             <% else %>
               <p class="text-sm text-muted">Enable this feed so its webhook endpoint can publish to FreeFeed.</p>

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -798,6 +798,64 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type=checkbox][name='enable_feed'][checked]:not([disabled])"
   end
 
+  test "#edit should lock the Enable checkbox off when the user has no active tokens" do
+    sign_in_as(user)
+    draft = create(:feed, :draft, :without_access_token, user: user)
+
+    get edit_feed_url(draft)
+
+    assert_response :success
+    assert_select "[data-key='token.gate']", count: 1
+    assert_select "input[type=checkbox][name='enable_feed'][disabled]", count: 1
+    assert_select "input[type=checkbox][name='enable_feed'][checked]", false,
+                  "Enable checkbox should be unchecked while enabling is unavailable"
+    assert_select "[data-key='form.enable-blocked-note']", text: /FreeFeed access token/
+  end
+
+  test "#edit should lock the Enable checkbox off when all tokens are inactive" do
+    sign_in_as(user)
+    create(:access_token, :inactive, user: user)
+    draft = create(:feed, :draft, :without_access_token, user: user)
+
+    get edit_feed_url(draft)
+
+    assert_response :success
+    assert_select "input[type=checkbox][name='enable_feed'][disabled]", count: 1
+    assert_select "[data-key='form.enable-blocked-note']", text: /FreeFeed access token/
+  end
+
+  test "#edit should keep the Enable checkbox interactive for an enabled feed without active tokens" do
+    sign_in_as(user)
+    enabled = create(:feed, :enabled, user: user, access_token: access_token)
+    access_token.update!(status: :inactive)
+
+    get edit_feed_url(enabled)
+
+    assert_response :success
+    assert_select "[data-key='token.gate']", count: 1
+    assert_select "input[type=checkbox][name='enable_feed'][checked]:not([disabled])"
+  end
+
+  test "#new re-render should lock the Enable checkbox off when the user has no active tokens" do
+    sign_in_as(user)
+
+    create(:feed, :draft, :without_access_token, user: user, name: "Taken")
+
+    feed_params = {
+      params: { url: "http://example.com/feed.xml" },
+      feed_profile_key: "rss",
+      # Duplicate name fails draft validation, forcing the :new re-render.
+      name: "Taken",
+      schedule_interval: "1h"
+    }
+    post feeds_path, params: { feed: feed_params, enable_feed: "0" }
+
+    assert_response :unprocessable_entity
+    assert_select "[data-key='token.gate']", count: 1
+    assert_select "input[type=checkbox][name='enable_feed'][disabled]", count: 1
+    assert_select "[data-key='form.enable-blocked-note']", text: /FreeFeed access token/
+  end
+
   test "#update should update feed with valid params" do
     sign_in_as(user)
     new_token = create(:access_token, user: user, host: "https://freefeed.net")

--- a/test/integration/feed_ai_settings_test.rb
+++ b/test/integration/feed_ai_settings_test.rb
@@ -189,4 +189,46 @@ class FeedAiSettingsTest < ActionDispatch::IntegrationTest
     assert_select "button[value='save_as_draft_and_add_credentials']", count: 0
     assert_select "button[value='save_as_draft_and_add_search_credentials']"
   end
+
+  test "#edit should lock the Enable checkbox off when AI credentials are missing" do
+    sign_in_as(user)
+    search_credential
+    feed_without_credential = create(:feed,
+                                     user: user,
+                                     feed_profile_key: "llm",
+                                     ai_credential: nil,
+                                     search_credential: search_credential,
+                                     params: { "prompt" => "https://no-rss.example.com" })
+
+    get edit_feed_path(feed_without_credential)
+
+    assert_select "input[type=checkbox][name='enable_feed'][disabled]", count: 1
+    assert_select "input[type=checkbox][name='enable_feed'][checked]", false,
+                  "Enable checkbox should be unchecked while enabling is unavailable"
+    assert_select "[data-key='form.enable-blocked-note']", text: /AI credentials/
+  end
+
+  test "#edit should lock the Enable checkbox off when only search credentials are missing" do
+    sign_in_as(user)
+    feed_without_search = create(:feed,
+                                 user: user,
+                                 feed_profile_key: "llm",
+                                 ai_credential: credential,
+                                 search_credential: nil,
+                                 params: { "prompt" => "https://no-rss.example.com" })
+
+    get edit_feed_path(feed_without_search)
+
+    assert_select "input[type=checkbox][name='enable_feed'][disabled]", count: 1
+    assert_select "[data-key='form.enable-blocked-note']", text: /search credentials/
+  end
+
+  test "#edit should keep the Enable checkbox interactive when AI setup is complete" do
+    sign_in_as(user)
+
+    get edit_feed_path(ai_feed)
+
+    assert_select "input[type=checkbox][name='enable_feed']:not([disabled])"
+    assert_select "[data-key='form.enable-blocked-note']", false
+  end
 end


### PR DESCRIPTION
When the feed form shows a setup gate instead of the token or AI
credential fields, enabling can only fail — and the validation errors
would render inside fields that aren't on the page, leaving the
"Couldn't enable. See issues below." flash pointing at nothing.

Disable the unchecked Enable checkbox in that state and say what's
missing under it. A still-enabled feed keeps an interactive checkbox
so unchecking-to-pause stays available.
