### PR TITLE
Offer feed deletion from the feeds list for inactive feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- Inactive feeds can now be deleted right from the feeds list — handy when a feed's access token is gone and the feed has nowhere left to go.
 - The Invites page now shows only your own invitations. Admins previously saw everyone's invites there, including the one they signed up with.
 - Empty state placeholders now look the same on phones as on larger screens — rounded corners, comfortable spacing, and softer gray text.
 - The default userpic no longer flickers between white and gray backgrounds on token and post pages.

--- a/app/components/feed_list_item_component.rb
+++ b/app/components/feed_list_item_component.rb
@@ -13,7 +13,7 @@ class FeedListItemComponent < ListItemComponent
     with_icon { icon_element }
     with_primary { primary_element }
     with_secondary { secondary_element }
-    with_trailing { menu }
+    with_trailing { helpers.safe_join([menu, delete_modal].compact) }
   end
 
   private
@@ -113,9 +113,33 @@ class FeedListItemComponent < ListItemComponent
       end
 
       items << { label: "Discard…", href: feed_url, data: { key: "feed.#{feed.id}.discard", turbo_method: :delete, turbo_confirm: DISCARD_CONFIRM } } if draft?
+
+      # An inactive feed may be a dead end — its token can be gone for good —
+      # so deletion is offered right here, not just on the feed page.
+      if deletable?
+        items << { label: "Delete…", href: "#",
+                   data: { key: "feed.#{feed.id}.delete", controller: "modal-trigger",
+                           modal_trigger_modal_id_value: delete_modal_id, action: "click->modal-trigger#open" } }
+      end
     end
 
     items
+  end
+
+  def delete_modal
+    return unless deletable?
+
+    render("feeds/delete_modal", feed: feed)
+  end
+
+  # Drafts already have Discard; an enabled feed should be paused before it's
+  # removed, so the list offers deletion only for inactive feeds.
+  def deletable?
+    management_actions? && feed.disabled?
+  end
+
+  def delete_modal_id
+    "delete-feed-modal-#{feed.id}"
   end
 
   def title

--- a/app/views/feeds/_delete_modal.html.erb
+++ b/app/views/feeds/_delete_modal.html.erb
@@ -1,0 +1,15 @@
+<%# locals: (feed:) %>
+<%= render ConfirmationModalComponent.new(
+  title: "Delete Feed",
+  action: "Delete feed",
+  url: feed_path(feed),
+  method: :delete,
+  modal_id: "delete-feed-modal-#{feed.id}"
+) do %>
+  <%= render AlertComponent.new(variant: :warning) do %>
+    <p>This feed will be permanently removed from Feeder, as well as the related reposting history.</p>
+    <p>Associated access token will remain untouched.</p>
+    <p>All FreeFeed posts will remain published.</p>
+    <p>This operation can't be undone.</p>
+  <% end %>
+<% end %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -64,17 +64,4 @@
   <% end %>
 <% end %>
 
-<%= render ConfirmationModalComponent.new(
-  title: "Delete Feed",
-  action: "Delete feed",
-  url: feed_path(@feed),
-  method: :delete,
-  modal_id: "delete-feed-modal-#{@feed.id}"
-) do %>
-  <%= render AlertComponent.new(variant: :warning) do %>
-    <p>This feed will be permanently removed from Feeder, as well as the related reposting history.</p>
-    <p>Associated access token will remain untouched.</p>
-    <p>All FreeFeed posts will remain published.</p>
-    <p>This operation can't be undone.</p>
-  <% end %>
-<% end %>
+<%= render "delete_modal", feed: @feed %>

--- a/test/components/feed_list_item_component_test.rb
+++ b/test/components/feed_list_item_component_test.rb
@@ -150,6 +150,48 @@ class FeedListItemComponentTest < ViewComponent::TestCase
     end
   end
 
+  test "#render should show Delete action and confirmation modal for disabled feeds" do
+    with_request_url("/feeds") do
+      result = render_inline FeedListItemComponent.new(feed: feed)
+
+      delete_item = result.css("[data-key='feed.#{feed.id}.delete']").first
+      assert_not_nil delete_item
+      assert_equal "delete-feed-modal-#{feed.id}", delete_item["data-modal-trigger-modal-id-value"]
+      assert_not_empty result.css("#delete-feed-modal-#{feed.id}")
+    end
+  end
+
+  test "#render should not show Delete action for enabled feeds" do
+    enabled_feed = create(:feed, :enabled, user: user)
+
+    with_request_url("/feeds") do
+      result = render_inline FeedListItemComponent.new(feed: enabled_feed)
+
+      assert_empty result.css("[data-key='feed.#{enabled_feed.id}.delete']")
+      assert_empty result.css("#delete-feed-modal-#{enabled_feed.id}")
+    end
+  end
+
+  test "#render should not show Delete action for draft feeds" do
+    draft_feed = create(:feed, :draft, user: user)
+
+    with_request_url("/feeds") do
+      result = render_inline FeedListItemComponent.new(feed: draft_feed)
+
+      assert_empty result.css("[data-key='feed.#{draft_feed.id}.delete']")
+      assert_empty result.css("#delete-feed-modal-#{draft_feed.id}")
+    end
+  end
+
+  test "#render should not show Delete action in admin mode" do
+    with_request_url("/admin/feeds") do
+      result = render_inline FeedListItemComponent.new(feed: feed, admin: true)
+
+      assert_empty result.css("[data-key='feed.#{feed.id}.delete']")
+      assert_empty result.css("#delete-feed-modal-#{feed.id}")
+    end
+  end
+
   test "#render should show refresh and post time placeholders when never refreshed" do
     result = render_inline FeedListItemComponent.new(feed: feed)
 


### PR DESCRIPTION
Changes:

- Inactive (disabled) feeds get a "Delete…" action in the feeds list row menu, opening the same confirmation modal as the feed page.
- The delete confirmation modal is extracted into a shared partial used by both the feed page and the list rows.

An inactive feed whose access token died or was deleted could feel stuck: Enable is unavailable without an active token, Edit leads to the token gate, and deletion was only reachable through the feed page menu. Deleting a disabled feed already worked server-side with no token required — this makes the action reachable where the user looks for it. Drafts keep "Discard…", enabled feeds are unchanged, and the admin list stays read-only.