### PR TITLE
Align empty state styling with cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- Empty state placeholders now look the same on phones as on larger screens — rounded corners, comfortable spacing, and softer gray text.
 - The default userpic no longer flickers between white and gray backgrounds on token and post pages.
 - The sign-in page now keeps your email address in place after a wrong password, so you only need to retype the password.
 - "Back to sign in" links are now a bit taller, making them easier to tap.

--- a/app/components/empty_state_component.rb
+++ b/app/components/empty_state_component.rb
@@ -4,8 +4,8 @@ class EmptyStateComponent < ViewComponent::Base
   end
 
   def call
-    content_tag :div, class: "w-full rounded-none border border-dashed border-border-strong bg-surface p-0 shadow-none sm:rounded-lg sm:p-6", data: { key: "empty-state" } do
-      content_tag :div, class: "space-y-6 text-center py-12", data: { key: "empty-state.body" } do
+    content_tag :div, class: "w-full rounded-lg border border-dashed border-border-strong bg-surface p-6", data: { key: "empty-state" } do
+      content_tag :div, class: "space-y-6 py-12 text-center text-muted", data: { key: "empty-state.body" } do
         body
       end
     end
@@ -14,6 +14,6 @@ class EmptyStateComponent < ViewComponent::Base
   private
 
   def body
-    content.presence || content_tag(:p, @text, class: "text-muted")
+    content.presence || content_tag(:p, @text)
   end
 end

--- a/test/components/empty_state_component_test.rb
+++ b/test/components/empty_state_component_test.rb
@@ -16,7 +16,7 @@ class EmptyStateComponentTest < ViewComponent::TestCase
   test "#render should render text argument as a paragraph" do
     result = render_inline EmptyStateComponent.new("Nothing here yet")
 
-    paragraph = result.css("p.text-muted").first
+    paragraph = result.css('[data-key="empty-state.body"] p').first
 
     assert_not_nil paragraph
     assert_equal "Nothing here yet", paragraph.text.strip


### PR DESCRIPTION
Empty states rendered edge-to-edge with square corners and no
padding on small screens, and block content (like the search
credentials hint) kept the default dark text color instead of the
muted gray used for plain text. Use card-like rounded corners and
consistent padding at every breakpoint, and apply the muted color
to the whole body so all content renders the same.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XCuKv4m4zcqVK4QXxaGH2H