### PR TITLE
Scope Invites page to own invites for admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- The Invites page now shows only your own invitations. Admins previously saw everyone's invites there, including the one they signed up with.
 - Empty state placeholders now look the same on phones as on larger screens — rounded corners, comfortable spacing, and softer gray text.
 - The default userpic no longer flickers between white and gray backgrounds on token and post pages.
 - The sign-in page now keeps your email address in place after a wrong password, so you only need to retype the password.

--- a/app/policies/invite_policy.rb
+++ b/app/policies/invite_policy.rb
@@ -18,9 +18,7 @@ class InvitePolicy < ApplicationPolicy
 
   class Scope < ApplicationPolicy::Scope
     def resolve
-      if admin?
-        scope.all
-      elsif user
+      if user
         scope.where(created_by_user: user)
       else
         scope.none

--- a/test/controllers/invites_controller_test.rb
+++ b/test/controllers/invites_controller_test.rb
@@ -50,6 +50,19 @@ class InvitesControllerTest < ActionDispatch::IntegrationTest
     assert_select '[data-key="invites.copy"]', count: 0
   end
 
+  test "should not list other users' invites for admin" do
+    admin = create(:user).tap { |u| u.permissions.create!(name: "admin") }
+    create(:invite, created_by_user: other_user, invited_user: admin)
+    create(:invite, created_by_user: admin)
+    sign_in_as admin
+
+    get invites_url
+
+    assert_response :success
+    assert_select '[data-key="invites.card"]', count: 1
+    assert_select '[data-key="invites.invited_email"]', count: 0
+  end
+
   test "should render a copy button for an unused invite" do
     invite
     sign_in_as user

--- a/test/policies/invite_policy_test.rb
+++ b/test/policies/invite_policy_test.rb
@@ -83,4 +83,21 @@ class InvitePolicyTest < ActiveSupport::TestCase
     assert_equal 2, scope.count
     assert scope.all? { |i| i.created_by_user_id == user.id }
   end
+
+  test "scope returns only admin's own invites for admin" do
+    create(:invite, created_by_user: admin)
+    create(:invite, created_by_user: other_user)
+    create(:invite, created_by_user: other_user, invited_user: admin)
+
+    scope = InvitePolicy::Scope.new(admin, Invite).resolve
+    assert_equal 1, scope.count
+    assert scope.all? { |i| i.created_by_user_id == admin.id }
+  end
+
+  test "scope returns no invites for unauthenticated user" do
+    create(:invite, created_by_user: user)
+
+    scope = InvitePolicy::Scope.new(nil, Invite).resolve
+    assert_empty scope
+  end
 end


### PR DESCRIPTION
Changes:

- The Invites page now lists only invitations created by the current user — admins no longer see everyone's invites there (including the one they signed up with, which surfaced their own email).
- Added policy and controller tests pinning the admin and unauthenticated scoping behavior.

The admin-wide invite listing had no consumer besides the personal Invites page; per-user invite details remain available in the admin area.