### PR TITLE
Hide empty Associated Feeds section on access token pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- Access token pages no longer show an empty "Associated Feeds" section when no feeds use the token.
 - The "Enable feed" option now stays off with a note about what's missing — like a FreeFeed token or AI credentials — instead of failing with an error that didn't point anywhere.
 - The Invites page now shows only your own invitations. Admins previously saw everyone's invites there, including the one they signed up with.
 - Empty state placeholders now look the same on phones as on larger screens — rounded corners, comfortable spacing, and softer gray text.

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -88,14 +88,12 @@
     </div>
   <% end %>
 
-  <div class="space-y-4">
-    <h2 class="text-2xl font-semibold mb-3 text-heading">Associated Feeds</h2>
-    <% if access_token.feeds.any? %>
+  <% if access_token.feeds.any? %>
+    <div class="space-y-4">
+      <h2 class="text-2xl font-semibold mb-3 text-heading">Associated Feeds</h2>
       <%= render FeedsListComponent.new(feeds: access_token.feeds) %>
-    <% else %>
-      <%= render EmptyStateComponent.new("No associated feeds yet") %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 <% elsif access_token.inactive? %>
   <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive" }) do %>
     <span>Token is inactive and cannot be used to access FreeFeed API. This token failed validation. It may be expired, revoked, or incorrectly copied.</span>

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -62,6 +62,27 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", access_token.name
   end
 
+  test "#show should render Associated Feeds section when token has feeds" do
+    sign_in_as user
+    active = create(:access_token, :active, user: user)
+    create(:feed, user: user, access_token: active)
+
+    get access_token_path(active)
+
+    assert_response :success
+    assert_select "h2", text: "Associated Feeds"
+  end
+
+  test "#show should not render Associated Feeds section when token has no feeds" do
+    sign_in_as user
+    active = create(:access_token, :active, user: user)
+
+    get access_token_path(active)
+
+    assert_response :success
+    assert_select "h2", text: "Associated Feeds", count: 0
+  end
+
   test "#show should not render for other user's token" do
     other_token = create(:access_token, user: create(:user))
     sign_in_as user


### PR DESCRIPTION
Changes:

- The access token page no longer renders the "Associated Feeds" section when the token has no associated feeds
- Removed the "No associated feeds yet" empty-state placeholder
- Added controller tests covering the section's presence and absence

An empty section with a placeholder added noise without telling the user anything useful — the page is cleaner when a token isn't used by any feeds yet.