### PR TITLE
Show event-specific icons in activity lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- Events in activity lists now carry icons that match what happened — an envelope for email events, arrows for feed refreshes — instead of a generic severity marker.
 - Access token pages no longer show an empty "Associated Feeds" section when no feeds use the token.
 - Inactive feeds can now be deleted right from the feeds list — handy when a feed's access token is gone and the feed has nowhere left to go.
 - The "Enable feed" option now stays off with a note about what's missing — like a FreeFeed token or AI credentials — instead of failing with an error that didn't point anywhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- Warning and error events no longer highlight whole rows in amber and red — severity now shows in the icon's color, keeping activity lists calmer to scan.
 - Events in activity lists now carry icons that match what happened — an envelope for email events, arrows for feed refreshes — instead of a generic severity marker.
 - Access token pages no longer show an empty "Associated Feeds" section when no feeds use the token.
 - Inactive feeds can now be deleted right from the feeds list — handy when a feed's access token is gone and the feed has nowhere left to go.

--- a/app/components/event_list_item_component.rb
+++ b/app/components/event_list_item_component.rb
@@ -1,17 +1,6 @@
 class EventListItemComponent < ListItemComponent
   include EventLogEntryPresentation
 
-  # Warning and error rows lean on the alert palette so problems stand out while
-  # scanning the log; routine events stay neutral. Rows sit inside a single
-  # bordered list, so only the background is tinted — separation comes from the
-  # list's dividers rather than per-row borders.
-  LEVEL_TINTS = {
-    "warning" => "bg-warning-subtle hover:bg-warning-subtle",
-    "error" => "bg-danger-subtle hover:bg-danger-subtle"
-  }.freeze
-
-  DEFAULT_TINT = "bg-surface hover:bg-surface-muted".freeze
-
   # Shows the severity, description and timestamp. Admin::EventListItemComponent
   # adds a footer with the event type, user and subject for the operator log.
   def initialize(event:, href:)
@@ -38,8 +27,10 @@ class EventListItemComponent < ListItemComponent
     }
   end
 
+  # Rows stay neutral regardless of level — severity shows in the leading
+  # icon, not the background — so all event lists hover like every other list.
   def row_css_class
-    helpers.class_names("transition duration-75", tint)
+    helpers.class_names("bg-surface", HOVER_ROW_CSS_CLASS)
   end
 
   def primary_element
@@ -69,10 +60,6 @@ class EventListItemComponent < ListItemComponent
   # enables it for the operator log.
   def show_footer?
     false
-  end
-
-  def tint
-    LEVEL_TINTS.fetch(event.level, DEFAULT_TINT)
   end
 
   # A plain marker by default. Admin::EventListItemComponent turns it into a

--- a/app/components/event_log_entry_presentation.rb
+++ b/app/components/event_log_entry_presentation.rb
@@ -4,16 +4,28 @@
 module EventLogEntryPresentation
   private
 
-  # Every entry carries a severity icon. Warnings and errors stand out in
-  # amber and red; routine events get a muted info circle so the column reads
-  # as a continuous gutter.
+  # Every entry carries a leading icon. Its shape comes from the per-type
+  # configuration (EventIcons) when one exists, otherwise from the event's
+  # level; the color always tracks the level so warnings and errors stand out
+  # in amber and red while routine events stay muted.
   def severity_icon
-    name, color = case event.level
-    when "warning" then ["triangle-alert", "text-warning"]
-    when "error" then ["circle-x", "text-danger"]
-    else ["info", "text-muted"]
-    end
+    name = EventIcons.icon_for(event.type) || level_icon_name
+    helpers.icon(name, css_class: "size-4 #{level_icon_color}", aria_label: event.level.capitalize)
+  end
 
-    helpers.icon(name, css_class: "size-4 #{color}", aria_label: event.level.capitalize)
+  def level_icon_name
+    case event.level
+    when "warning" then "triangle-alert"
+    when "error" then "circle-x"
+    else "info"
+    end
+  end
+
+  def level_icon_color
+    case event.level
+    when "warning" then "text-warning"
+    when "error" then "text-danger"
+    else "text-muted"
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -105,7 +105,9 @@ module ApplicationHelper
       "stroke-width": "2",
       "stroke-linecap": "round",
       "stroke-linejoin": "round",
-      class: class_names("shrink-0", css_class)
+      class: class_names("shrink-0", css_class),
+      # Tests select icons by name through this hook; path data carries no name.
+      "data-icon": name
     }
 
     options[:title] = title if title.present?

--- a/app/services/event_icons.rb
+++ b/app/services/event_icons.rb
@@ -1,0 +1,33 @@
+# Per-event-type icons for the event log, loaded from config/event_icons.yml.
+#
+# Lets an entry's icon say what happened (an envelope for mail events) instead
+# of only how severe it was. Types without an entry — and entries naming an
+# icon the app doesn't bundle — resolve to nil so callers fall back to the
+# level-based icon; a stale or misspelled configuration can never leave an
+# entry without an icon.
+class EventIcons
+  PATH = Rails.root.join("config/event_icons.yml")
+
+  class << self
+    def icon_for(type)
+      name = table[type.to_s]
+      name if name && ApplicationHelper::ICONS.key?(name)
+    end
+
+    def reload!
+      @table = nil
+    end
+
+    private
+
+    def table
+      @table ||= load_table
+    end
+
+    def load_table
+      return {} unless File.exist?(PATH)
+
+      YAML.safe_load(File.read(PATH)) || {}
+    end
+  end
+end

--- a/app/services/event_icons.rb
+++ b/app/services/event_icons.rb
@@ -14,10 +14,6 @@ class EventIcons
       name if name && ApplicationHelper::ICONS.key?(name)
     end
 
-    def reload!
-      @table = nil
-    end
-
     private
 
     def table

--- a/config/event_icons.yml
+++ b/config/event_icons.yml
@@ -1,0 +1,35 @@
+# Icons for event log entries, keyed by event type.
+#
+# Values are lucide.dev icon names. Each must also exist in
+# ApplicationHelper::ICONS (the app inlines its icon set) — add the icon's
+# path data there when introducing a new name. Event types without an entry,
+# and entries naming an unbundled icon, fall back to the icon for the event's
+# level (info / triangle-alert / circle-x).
+
+feed_refresh: refresh-ccw
+feed_refresh_skipped: circle-dashed
+feed_refresh_ai_empty: sparkles
+feed_ai_model_unavailable: sparkles
+feed_ai_credential_removed: sparkles
+feed_search_credential_removed: search
+feed_target_group_unavailable: users
+feed_post_comments_failed: message-circle
+feed_auto_disabled: circle-pause
+ai_credential_deactivated: sparkles
+search_credential_deactivated: search
+access_token_validation_failed: key
+email_changed: mail
+user_suspended: circle-pause
+user_unsuspended: circle-play
+group_purge_started: trash-2
+mail.passwords_mailer.reset: mail
+mail.profile_mailer.email_change_confirmation: mail
+mail.profile_mailer.account_confirmation: mail
+resend.email.email_bounced: mail
+resend.email.email_complained: mail
+resend.email.email_failed: mail
+resend.email.email_sent: mail
+resend.email.email_delivered: mail
+resend.email.email_delayed: mail
+resend.email.email_opened: mail
+resend.email.email_clicked: mail

--- a/test/components/event_list_item_component_test.rb
+++ b/test/components/event_list_item_component_test.rb
@@ -51,6 +51,7 @@ class EventListItemComponentTest < ViewComponent::TestCase
 
     icon = result.at_css("[data-key='events.severity'] svg")
     assert_not_nil icon
+    assert_equal "circle-x", icon["data-icon"]
     assert_includes icon["class"], "text-danger"
   end
 
@@ -61,17 +62,39 @@ class EventListItemComponentTest < ViewComponent::TestCase
 
     icon = result.at_css("[data-key='events.severity'] svg")
     assert_not_nil icon
+    assert_equal "triangle-alert", icon["data-icon"]
     assert_includes icon["class"], "text-warning"
   end
 
   test "#call should mark routine info events with a light gray info icon" do
-    event = create(:event, type: "feed_refresh", level: :info, user: user)
+    event = create(:event, type: "unconfigured_event", level: :info, user: user)
 
     result = render_item(event)
 
     icon = result.at_css("[data-key='events.severity'] svg")
     assert_not_nil icon
+    assert_equal "info", icon["data-icon"]
     assert_includes icon["class"], "text-muted"
+  end
+
+  test "#call should use the configured icon for the event type" do
+    event = create(:event, type: "feed_refresh", level: :info, user: user)
+
+    result = render_item(event)
+
+    icon = result.at_css("[data-key='events.severity'] svg")
+    assert_equal "refresh-ccw", icon["data-icon"]
+    assert_includes icon["class"], "text-muted"
+  end
+
+  test "#call should keep the level color on configured icons" do
+    event = create(:event, type: "feed_refresh", level: :error, user: user)
+
+    result = render_item(event)
+
+    icon = result.at_css("[data-key='events.severity'] svg")
+    assert_equal "refresh-ccw", icon["data-icon"]
+    assert_includes icon["class"], "text-danger"
   end
 
   test "#call should tint warning rows with the alert palette" do

--- a/test/components/event_list_item_component_test.rb
+++ b/test/components/event_list_item_component_test.rb
@@ -97,24 +97,24 @@ class EventListItemComponentTest < ViewComponent::TestCase
     assert_includes icon["class"], "text-danger"
   end
 
-  test "#call should tint warning rows with the alert palette" do
+  test "#call should keep warning rows on the neutral background" do
     event = create(:event, level: :warning, user: user)
 
     result = render_item(event)
 
     item = result.css("[data-key='events.entry']").first
-    assert_includes item["class"], "bg-warning-subtle"
-    assert_includes item["class"], "hover:bg-warning-subtle"
+    assert_not_includes item["class"], "bg-warning-subtle"
+    assert_includes item["class"], "bg-surface"
   end
 
-  test "#call should tint error rows with the alert palette" do
+  test "#call should keep error rows on the neutral background" do
     event = create(:event, level: :error, user: user)
 
     result = render_item(event)
 
     item = result.css("[data-key='events.entry']").first
-    assert_includes item["class"], "bg-danger-subtle"
-    assert_includes item["class"], "hover:bg-danger-subtle"
+    assert_not_includes item["class"], "bg-danger-subtle"
+    assert_includes item["class"], "bg-surface"
   end
 
   test "#call should keep routine rows neutral" do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -109,6 +109,11 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_includes result, 'class="shrink-0 size-4 text-warning"'
   end
 
+  test "#icon carries the icon name as a data hook" do
+    result = icon("info")
+    assert_includes result, 'data-icon="info"'
+  end
+
   test "#icon renders intrinsic width and height so it stays sized without CSS" do
     result = icon("info")
     assert_includes result, 'width="24"'

--- a/test/services/event_icons_test.rb
+++ b/test/services/event_icons_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class EventIconsTest < ActiveSupport::TestCase
+  test "#icon_for should return the configured icon for a mapped type" do
+    assert_equal "refresh-ccw", EventIcons.icon_for("feed_refresh")
+  end
+
+  test "#icon_for should return nil for an unmapped type" do
+    assert_nil EventIcons.icon_for("some_unmapped_type")
+  end
+
+  test "#icon_for should ignore entries naming an unbundled icon" do
+    EventIcons.stub(:table, { "custom_event" => "no-such-icon" }) do
+      assert_nil EventIcons.icon_for("custom_event")
+    end
+  end
+
+  test "every configured icon should be in the bundled icon set" do
+    YAML.safe_load(File.read(EventIcons::PATH)).each do |type, name|
+      assert ApplicationHelper::ICONS.key?(name), "#{type} names unbundled icon #{name}"
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Event log entries now show a per-type icon configured in `config/event_icons.yml` (lucide.dev names), falling back to the level icons for unmapped types or unbundled icon names
- Warning and error rows no longer tint the whole row — severity reads from the icon color alone
- The shared `icon` helper exposes the icon name as a `data-icon` test hook

Event lists previously signaled only severity. A configurable per-type icon says what happened — an envelope for mail events, arrows for feed refreshes — while color keeps carrying the level, and dropping the alert-palette row backgrounds keeps the logs calmer to scan.