### PR TITLE
Tighten empty state padding on wider screens

### DIFF
--- a/app/components/empty_state_component.rb
+++ b/app/components/empty_state_component.rb
@@ -4,7 +4,7 @@ class EmptyStateComponent < ViewComponent::Base
   end
 
   def call
-    content_tag :div, class: "w-full rounded-lg border border-dashed border-border-strong bg-surface p-6", data: { key: "empty-state" } do
+    content_tag :div, class: "w-full rounded-lg border border-dashed border-border-strong bg-surface p-6 sm:p-4", data: { key: "empty-state" } do
       content_tag :div, class: "space-y-6 py-12 text-center text-muted", data: { key: "empty-state.body" } do
         body
       end


### PR DESCRIPTION
Changes:

- Change the empty state container padding from `p-6` to `p-6 sm:p-4`, keeping the roomier padding on small screens and tightening it from the `sm` breakpoint up

A small follow-up to the recent empty state restyling that aligned it with cards.

References:

- Related PR: #1148