### PR TITLE
Use Lucide check icon for copy feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- Copy buttons now confirm with a crisp checkmark icon that matches the rest of the interface, instead of a plain text tick.
 - Warning and error events no longer highlight whole rows in amber and red — severity now shows in the icon's color, keeping activity lists calmer to scan.
 - Events in activity lists now carry icons that match what happened — an envelope for email events, arrows for feed refreshes — instead of a generic severity marker.
 - Access token pages no longer show an empty "Associated Feeds" section when no feeds use the token.

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,5 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
+// Lucide "check" (https://lucide.dev/icons/check), matching the markup the
+// server-side icon helper renders.
+const CHECK_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" ' +
+  'fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" ' +
+  'stroke-linejoin="round" class="shrink-0 size-4" data-icon="check" aria-hidden="true">' +
+  '<path d="M20 6 9 17l-5-5"/></svg>'
+
 export default class extends Controller {
   static values = {
     text: String
@@ -18,7 +26,7 @@ export default class extends Controller {
     clearTimeout(this.resetTimer)
 
     navigator.clipboard.writeText(this.textValue).then(() => {
-      button.innerHTML = '✓'
+      button.innerHTML = CHECK_ICON
       button.title = 'Copied!'
       button.classList.add('text-success')
       button.classList.remove('text-muted')


### PR DESCRIPTION
Changes:

- Replace the plain-text `✓` shown as copy-button feedback with the Lucide `check` icon
- Mirror the SVG markup rendered by the server-side icon helper so the glyph matches the rest of the iconography

All copy buttons (invite links, webhook endpoint URL, authorization token, curl snippet) share the clipboard Stimulus controller, so they all pick up the new icon.
