### PR TITLE
Scope access tokens to their owner only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- The access tokens page now shows only your own tokens. Admins previously saw everyone's tokens there and could open or edit them.
 - Copy buttons now confirm with a crisp checkmark icon that matches the rest of the interface, instead of a plain text tick.
 - Warning and error events no longer highlight whole rows in amber and red — severity now shows in the icon's color, keeping activity lists calmer to scan.
 - Events in activity lists now carry icons that match what happened — an envelope for email events, arrows for feed refreshes — instead of a generic severity marker.

--- a/app/policies/access_token_policy.rb
+++ b/app/policies/access_token_policy.rb
@@ -4,7 +4,7 @@ class AccessTokenPolicy < ApplicationPolicy
   end
 
   def show?
-    owner_or_admin?
+    owner?
   end
 
   def create?
@@ -12,24 +12,22 @@ class AccessTokenPolicy < ApplicationPolicy
   end
 
   def update?
-    owner_or_admin?
+    owner?
   end
 
   def destroy?
-    owner_or_admin?
+    owner?
   end
 
   private
 
-  def owner_or_admin?
-    authenticated? && (user == record.user || admin?)
+  def owner?
+    authenticated? && user == record.user
   end
 
   class Scope < ApplicationPolicy::Scope
     def resolve
-      if admin?
-        scope.all
-      elsif user
+      if user
         scope.where(user: user)
       else
         scope.none

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -40,6 +40,15 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='settings.access_tokens.#{access_token.id}']"
   end
 
+  test "#index should not display other users' tokens to admins" do
+    other_token = create(:access_token, user: create(:user))
+    sign_in_as create(:user, :admin)
+    get access_tokens_path
+
+    assert_response :success
+    assert_select "[data-key='settings.access_tokens.#{other_token.id}']", count: 0
+  end
+
   test "#index should display host when token owner is not set" do
     sign_in_as user
     token = create(:access_token, user: user, owner: nil)
@@ -86,6 +95,14 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
   test "#show should not render for other user's token" do
     other_token = create(:access_token, user: create(:user))
     sign_in_as user
+    get access_token_path(other_token)
+
+    assert_response :not_found
+  end
+
+  test "#show should not render other user's token for admins" do
+    other_token = create(:access_token, user: create(:user))
+    sign_in_as create(:user, :admin)
     get access_token_path(other_token)
 
     assert_response :not_found

--- a/test/policies/access_token_policy_test.rb
+++ b/test/policies/access_token_policy_test.rb
@@ -49,9 +49,9 @@ class AccessTokenPolicyTest < ActiveSupport::TestCase
     assert_not policy.show?
   end
 
-  test "should allow show access to admin users" do
+  test "should deny show access to admin users for other users' tokens" do
     policy = policy_for_user(admin_user, access_token)
-    assert policy.show?
+    assert_not policy.show?
   end
 
   test "should allow create access to authenticated users" do
@@ -74,9 +74,9 @@ class AccessTokenPolicyTest < ActiveSupport::TestCase
     assert_not policy.update?
   end
 
-  test "should allow update access to admin users" do
+  test "should deny update access to admin users for other users' tokens" do
     policy = policy_for_user(admin_user, access_token)
-    assert policy.update?
+    assert_not policy.update?
   end
 
   test "edit? should delegate to update?" do
@@ -94,9 +94,9 @@ class AccessTokenPolicyTest < ActiveSupport::TestCase
     assert_not policy.destroy?
   end
 
-  test "should allow destroy access to admin users" do
+  test "should deny destroy access to admin users for other users' tokens" do
     policy = policy_for_user(admin_user, access_token)
-    assert policy.destroy?
+    assert_not policy.destroy?
   end
 
   test "should handle nil user gracefully" do
@@ -116,12 +116,12 @@ class AccessTokenPolicyTest < ActiveSupport::TestCase
     assert_not_includes result, other_access_token
   end
 
-  test "#scope should return all tokens for admin users" do
+  test "#scope should return only owned tokens for admin users" do
     scope = scope_for_user(admin_user)
     result = scope.resolve
 
-    assert_includes result, access_token
-    assert_includes result, other_access_token
+    assert_not_includes result, access_token
+    assert_not_includes result, other_access_token
   end
 
   test "#scope should return no tokens for nil user" do
@@ -131,23 +131,23 @@ class AccessTokenPolicyTest < ActiveSupport::TestCase
     assert_equal 0, result.count
   end
 
-  test "owner_or_admin? returns true for token owner" do
+  test "owner? returns true for token owner" do
     policy = policy_for_user(user, access_token)
-    assert policy.send(:owner_or_admin?)
+    assert policy.send(:owner?)
   end
 
-  test "owner_or_admin? returns false for other users" do
+  test "owner? returns false for other users" do
     policy = policy_for_user(user, other_access_token)
-    assert_not policy.send(:owner_or_admin?)
+    assert_not policy.send(:owner?)
   end
 
-  test "owner_or_admin? returns true for admin users" do
+  test "owner? returns false for admin users on other users' tokens" do
     policy = policy_for_user(admin_user, other_access_token)
-    assert policy.send(:owner_or_admin?)
+    assert_not policy.send(:owner?)
   end
 
-  test "owner_or_admin? returns false for nil user" do
+  test "owner? returns false for nil user" do
     policy = AccessTokenPolicy.new(nil, access_token)
-    assert_not policy.send(:owner_or_admin?)
+    assert_not policy.send(:owner?)
   end
 end


### PR DESCRIPTION
Changes:

- The access tokens page now lists only the current user's tokens — admins previously saw everyone's.
- Admins can no longer view, edit, or delete other users' tokens through the user-facing token pages.
- Flipped admin policy tests to assert denial and added controller regression tests for the admin scenarios.

`AccessTokenPolicy` granted admins full scope and `owner_or_admin?` on member actions, leaking admin access into the user-facing token pages. Admin inspection already has its own `Admin::AccessTokenPolicy`, so the user-facing policy is now strictly owner-scoped. Token validation lookups go through the same policy scope, so they tighten automatically.