### PR TITLE
Remove key icon from FreeFeed token gate prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-21
 
+- The prompt to add a FreeFeed access token on the feed form dropped its key icon, so everything now lines up along the same left edge.
 - Warning and error events no longer highlight whole rows in amber and red — severity now shows in the icon's color, keeping activity lists calmer to scan.
 - Events in activity lists now carry icons that match what happened — an envelope for email events, arrows for feed refreshes — instead of a generic severity marker.
 - Access token pages no longer show an empty "Associated Feeds" section when no feeds use the token.

--- a/app/views/feeds/_token_gate.html.erb
+++ b/app/views/feeds/_token_gate.html.erb
@@ -1,15 +1,10 @@
 <%# locals: () %>
 <div class="space-y-3" data-key="token.gate">
-  <div class="flex gap-3">
-    <div class="flex-shrink-0 pt-0.5">
-      <%= icon("key-square", css_class: "size-5 text-brand") %>
-    </div>
-    <div class="space-y-1">
-      <p class="font-semibold text-brand-strong">A FreeFeed access token is needed</p>
-      <p class="text-brand-strong text-sm">
-        To post to FreeFeed on your behalf, you'll need to add a FreeFeed access token. We'll come back to this feed once you're set up.
-      </p>
-    </div>
+  <div class="space-y-1">
+    <p class="font-semibold text-brand-strong">A FreeFeed access token is needed</p>
+    <p class="text-brand-strong text-sm">
+      To post to FreeFeed on your behalf, you'll need to add a FreeFeed access token. We'll come back to this feed once you're set up.
+    </p>
   </div>
 
   <div class="space-y-2">


### PR DESCRIPTION
Changes:

- Removed the key icon and its layout wrapper from the FreeFeed access token prompt on the feed form.

The icon didn't add meaning to the message and pushed the text right of the button below it. Without it, the heading, description, and button line up along the same left edge.