### PR TITLE
Remove redundant "Showing" from event and list summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-07-22
+
+- Trimmed the redundant "Showing" from event summaries and list counters — they now read like simple labels, e.g. "System-wide most recent events".
+
 ## 2026-07-21
 
 - The prompt to add a FreeFeed access token on the feed form dropped its key icon, so everything now lines up along the same left edge.

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -5,7 +5,7 @@ module EventsHelper
   # numbers: the offset is how many newer events come before what's shown.
   def events_offset_summary(offset, system_wide: false)
     if offset.zero?
-      system_wide ? "Showing system-wide most recent events." : "Showing the most recent events."
+      system_wide ? "System-wide most recent events." : "The most recent events."
     else
       "#{pluralize(offset, 'newer event')} above what's shown here."
     end

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -21,7 +21,7 @@
 
     <% if pagination_total_pages > 1 %>
       <div class="text-center text-sm text-body">
-        Showing <%= @feeds.size %> of <%= pagination_total_count %> feeds
+        <%= @feeds.size %> of <%= pagination_total_count %> feeds
       </div>
     <% end %>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,7 +6,7 @@
     <% if @feed %>
       <% group = @feed.target_group.presence %>
       <% label = @feed.display_name + (group ? " (@#{group})" : "") %>
-      <% header.with_context_paragraph("Showing posts from #{label}.") %>
+      <% header.with_context_paragraph("Posts from #{label}.") %>
     <% else %>
       <% header.with_context_paragraph("Everything Feeder imports from your feeds shows up here, along with each post's status on FreeFeed.") %>
     <% end %>
@@ -39,7 +39,7 @@
 
   <% if pagination_total_pages > 1 %>
     <div class="text-center text-sm text-body">
-      Showing <%= @posts.size %> of <%= pagination_total_count %> posts
+      <%= @posts.size %> of <%= pagination_total_count %> posts
     </div>
   <% end %>
 

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -60,7 +60,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
     get admin_events_path
 
     assert_response :success
-    assert_select "[data-key='events.offset']", "Showing system-wide most recent events."
+    assert_select "[data-key='events.offset']", "System-wide most recent events."
   end
 
   test "should describe the offset when paging into older events" do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -73,7 +73,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     get events_path
 
     assert_response :success
-    assert_select "[data-key='events.offset']", "Showing the most recent events."
+    assert_select "[data-key='events.offset']", "The most recent events."
   end
 
   test "#index should describe the offset when paging into older events" do

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -55,7 +55,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "nav[aria-label='Feeds pagination']"
     assert_select "nav[aria-label='Feeds pagination'] ul[class*='inline-flex']", minimum: 1
-    assert_select "div.text-center", text: /Showing/
+    assert_select "div.text-center", text: /3 of 4 feeds/
   end
 
   test "#new should render when authenticated" do


### PR DESCRIPTION
Changes:

- Event offset summaries now read "System-wide most recent events." / "The most recent events." instead of starting with "Showing".
- Same treatment for the posts page context line ("Posts from …") and the feeds/posts pagination counters ("3 of 12 feeds").

The leading verb added nothing — these lines describe what's on the page, so they now read as plain labels.