### PR TITLE
Require an active token to enable a feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-22
 
+- Turning on a feed now always requires a working FreeFeed access token. Previously the feed page's Enable button checked this, but saving the feed with "Enable feed" turned on did not.
+- When a feed's access token stops working, the feed page's Enable button now says exactly what's missing, and the feed's settings explain that saving will switch it to one of your working tokens.
 - Trimmed the redundant "Showing" from event summaries and list counters — they now read like simple labels, e.g. "System-wide most recent events".
 
 ## 2026-07-21

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -75,6 +75,7 @@ class Feed < ApplicationRecord
   validate :engine_fixed_on_edit
   validate :source_change_reverified
   validates :access_token, presence: true, if: :enabled?
+  validate :access_token_active_when_enabled, if: -> { enabled? && will_save_change_to_state? }
   validates :target_group, presence: true, if: :enabled?
 
   validates :target_group,
@@ -525,6 +526,18 @@ class Feed < ApplicationRecord
     key = FeedProfile.source_key_for(feed_profile_key)
     before, after = params_change
     before&.dig(key) != after&.dig(key)
+  end
+
+  # A feed may only become enabled while its token is active, matching
+  # can_be_enabled?. Presence alone let the edit form enable a feed whose token
+  # had been deactivated, while the feed page's Enable button refused. Scoped to
+  # the state change: an already-enabled feed still saves while its token is
+  # mid-revalidation (validating is a routine stop for a live token). nil is
+  # left to the presence validator.
+  def access_token_active_when_enabled
+    return if access_token.nil? || access_token.active?
+
+    errors.add(:access_token, "must be active (currently #{access_token.status})")
   end
 
   def ai_credential_required_when_enabled_ai_profile

--- a/app/views/feeds/_form_expanded.html.erb
+++ b/app/views/feeds/_form_expanded.html.erb
@@ -222,6 +222,10 @@
               <%= render "feeds/token_gate" %>
             <% end %>
           <% else %>
+            <%# A token that went inactive isn't offered in the select, so the
+                feed's own choice can't be kept — preselect a working token
+                and say so below, instead of letting the browser swap silently. %>
+            <% token_swap = feed.access_token.present? && !feed.access_token.active? %>
             <%= render PanelComponent.new do %>
               <div class="space-y-2">
                 <%= f.label :access_token_id, "Access Token", class: "block font-semibold text-heading" %>
@@ -230,7 +234,7 @@
                                active_tokens,
                                :id,
                                :display_name,
-                               feed.access_token_id || active_tokens.first&.id
+                               token_swap ? active_tokens.first&.id : (feed.access_token_id || active_tokens.first&.id)
                              ),
                              {},
                              {
@@ -242,6 +246,8 @@
                              } %>
                 <% if f.object.errors[:access_token].any? %>
                   <p class="text-sm text-danger"><%= f.object.errors[:access_token].first %></p>
+                <% elsif token_swap %>
+                  <p class="text-sm text-warning" data-key="form.token-swap-note">The token this feed was using stopped working. When you save, the feed switches to the token selected here.</p>
                 <% end %>
               </div>
             <% end %>

--- a/app/views/feeds/_header.html.erb
+++ b/app/views/feeds/_header.html.erb
@@ -36,8 +36,12 @@
                       form: { class: "inline-block" } %>
       <% end %>
     <% else %>
+      <%# Name what's actually missing — "Complete setup" misleads when setup
+          was finished and a piece (like the token) stopped working later. %>
+      <% missing_parts = feed_missing_enablement_parts(feed) %>
+      <% enable_hint = missing_parts.any? ? "To enable this feed, add: #{missing_parts.to_sentence}." : "Complete setup to enable this feed" %>
       <% header.with_action_button do %>
-        <button type="button" disabled title="Complete setup to enable this feed" class="<%= action_button %>">Enable</button>
+        <button type="button" disabled title="<%= enable_hint %>" class="<%= action_button %>">Enable</button>
       <% end %>
     <% end %>
     <% header.with_action_button do %>

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -856,6 +856,53 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='form.enable-blocked-note']", text: /FreeFeed access token/
   end
 
+  test "#edit should explain the token swap when the feed's token is inactive" do
+    sign_in_as(user)
+    access_token
+    inactive_token = create(:access_token, :inactive, user: user)
+    pinned = create(:feed, user: user, access_token: inactive_token)
+
+    get edit_feed_url(pinned)
+
+    assert_response :success
+    assert_select "[data-key='form.token-swap-note']", text: /stopped working/
+    assert_select "select#feed_access_token_id option[value='#{access_token.id}'][selected]"
+    assert_select "input[type=checkbox][name='enable_feed']:not([disabled])"
+  end
+
+  test "#edit should not show the token swap note when the feed's token is active" do
+    sign_in_as(user)
+    with_token = create(:feed, user: user, access_token: access_token)
+
+    get edit_feed_url(with_token)
+
+    assert_response :success
+    assert_select "[data-key='form.token-swap-note']", false
+  end
+
+  test "#update should not enable a feed still pinned to an inactive token" do
+    sign_in_as(user)
+    inactive_token = create(:access_token, :inactive, user: user)
+    pinned = create(:feed, user: user, access_token: inactive_token)
+
+    patch feed_url(pinned), params: { feed: { name: pinned.name }, enable_feed: "1" }
+
+    assert_response :unprocessable_entity
+    assert_predicate pinned.reload, :disabled?
+    assert_equal inactive_token.id, pinned.access_token_id
+  end
+
+  test "#show should name the missing piece on the disabled Enable button" do
+    sign_in_as(user)
+    inactive_token = create(:access_token, :inactive, user: user)
+    pinned = create(:feed, user: user, access_token: inactive_token)
+
+    get feed_url(pinned)
+
+    assert_response :success
+    assert_select "button[disabled][title=?]", "To enable this feed, add: active access token."
+  end
+
   test "#update should update feed with valid params" do
     sign_in_as(user)
     new_token = create(:access_token, user: user, host: "https://freefeed.net")

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -288,10 +288,13 @@ class AccessTokenTest < ActiveSupport::TestCase
 
   test "should disable enabled feeds when token validation service marks token inactive" do
     user = create(:user)
-    access_token = create(:access_token, status: :validating, user: user)
+    # Feeds can only become enabled while the token is active; re-validation
+    # of the live token starts after that.
+    access_token = create(:access_token, :active, user: user)
     enabled_feed = create(:feed, user: user, access_token: access_token, state: :enabled)
     another_disabled_feed = create(:feed, user: user, access_token: access_token, state: :disabled)
     disabled_feed = create(:feed, user: user, access_token: access_token, state: :disabled)
+    access_token.update!(status: :validating)
 
     # Stub HTTP request to return 401 Unauthorized, triggering the rescue block
     stub_request(:get, "#{access_token.host}/v4/users/whoami")

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -648,6 +648,27 @@ class FeedTest < ActiveSupport::TestCase
     assert_predicate feed.reload, :disabled?
   end
 
+  test "#enable should fail when the access token is inactive" do
+    feed = create(:feed, :disabled,
+      user: preview_user,
+      access_token: create(:access_token, :inactive, user: preview_user),
+      target_group: "tg",
+      feed_profile_key: "rss",
+      params: { "url" => "https://example.com/feed.xml" })
+
+    assert_not feed.enable
+    assert_includes feed.errors[:access_token], "must be active (currently inactive)"
+    assert_predicate feed.reload, :disabled?
+  end
+
+  test "#disable should still work for an enabled feed whose token went inactive" do
+    feed = create(:feed, :enabled, user: preview_user, access_token: access_token_for(preview_user))
+    feed.access_token.update!(status: :inactive)
+
+    assert feed.disable
+    assert_predicate feed.reload, :disabled?
+  end
+
   test "should reject an ai_credential belonging to a different user" do
     owner = create(:user)
     stranger = create(:user)

--- a/test/services/access_token_validation_service_test.rb
+++ b/test/services/access_token_validation_service_test.rb
@@ -184,9 +184,13 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
   end
 
   test "#call should disable enabled feeds on invalid token error" do
+    # Feeds can only become enabled while the token is active; re-validation
+    # of the live token starts after that.
+    access_token.update!(status: :active)
     feed1 = create(:feed, user: user, access_token: access_token, state: :enabled)
     feed2 = create(:feed, user: user, access_token: access_token, state: :enabled)
     feed3 = create(:feed, user: user, access_token: access_token, state: :disabled)
+    access_token.update!(status: :validating)
 
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(


### PR DESCRIPTION
Changes:

- Validate that a feed's access token is active when the feed becomes enabled, matching the Enable button's `can_be_enabled?` check
- Explain the token swap on the feed edit page when the feed's previous token stopped working, instead of switching silently
- Name the missing pieces in the feed page's disabled Enable button hint instead of the generic "Complete setup" message

Previously the Enable button on the feed page refused a feed pinned to a deactivated token, while saving from the edit page could still enable it: the enabled-state validators only required token presence, and the token picker silently swapped the dead token for the first active one. The gap surfaced on staging when a rejected FreeFeed token auto-disabled all feeds at once. The new validation is scoped to the state transition, so an already-enabled feed keeps saving while its token is mid-revalidation.