### PR TITLE
Trim Docker build context via .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,6 +45,33 @@
 
 # Ignore development files
 /.devcontainer
+/.claude
+/.specify
+/.editorconfig
+/.gitattributes
+/.codecov.yml
+/.database_consistency.todo.yml
+/.erb_lint.yml
+/.herb.yml
+/.rubocop.yml
+/.ruby-lsp.yml
+/.tool-versions
+/AGENTS.md
+/CLAUDE.md
+/Procfile.dev
+/REVIEW.yml
+/compose.yaml
+/script
+
+# Ignore docs and design records. CHANGELOG.md must stay: the /changelog page
+# reads it at runtime (app/models/changelog.rb).
+/README.md
+/docs
+/specs
+
+# Ignore tests and coverage output.
+/test
+/coverage
 
 # Ignore Docker-related files
 /.dockerignore


### PR DESCRIPTION
Changes:

- Exclude development tooling, docs, specs, tests, and coverage output from the Docker build context
- Build context shrinks from 9.3MB / 1,398 files to 1.7MB / 733 files (81% smaller)

Beyond size, this stabilizes layer caching: the production image does `COPY . .`, so docs/spec/test-only changes were invalidating that layer and forcing `bootsnap precompile` and `assets:precompile` to rerun on every such deploy. It also stops stale local `coverage/` output from leaking into production images.

`CHANGELOG.md` is deliberately kept — `app/models/changelog.rb` reads it at runtime to render the `/changelog` page (a comment in `.dockerignore` notes this). Verified safe: Tailwind's explicit `content` globs don't scan any excluded directory, Kamal reads its config from the checkout rather than the image, and `Dockerfile.dev` only copies the dependency manifests.