### PR TITLE
Make auth pages full width on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-22
 
+- On phones, the sign-in, registration, and password pages now use the full screen width instead of a boxed card.
 - Token pages and post previews now show your actual FreeFeed userpic instead of the generic placeholder. Newly validated tokens pick it up automatically.
 - Turning on a feed now always requires a working FreeFeed access token. Previously the feed page's Enable button checked this, but saving the feed with "Enable feed" turned on did not.
 - When a feed's access token stops working, the feed page's Enable button now says exactly what's missing, and the feed's settings explain that saving will switch it to one of your working tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-07-22
 
 - On phones, the sign-in, registration, and password pages now use the full screen width instead of a boxed card.
+- The sign-in page's "Forgot password?" and "Resend confirmation" links now stack on their own lines on phones, making them easier to tap.
 - Token pages and post previews now show your actual FreeFeed userpic instead of the generic placeholder. Newly validated tokens pick it up automatically.
 - Turning on a feed now always requires a working FreeFeed access token. Previously the feed page's Enable button checked this, but saving the feed with "Enable feed" turned on did not.
 - When a feed's access token stops working, the feed page's Enable button now says exactly what's missing, and the feed's settings explain that saving will switch it to one of your working tokens.

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,18 +1,13 @@
 class CardComponent < ViewComponent::Base
   BASE_CLASSES = "w-full rounded-lg border border-border bg-surface shadow-xs"
   PADDED_CLASSES = "p-6"
-  # Frameless-on-mobile cards dissolve into the page below the sm breakpoint,
-  # so narrow screens keep only the surrounding container padding.
-  FRAMELESS_BASE_CLASSES = "w-full sm:rounded-lg sm:border sm:border-border sm:bg-surface sm:shadow-xs"
-  FRAMELESS_PADDED_CLASSES = "sm:p-6"
   SECTIONED_CLASSES = "overflow-hidden divide-y divide-border"
   LINKED_CLASSES = "block no-underline hover:bg-surface-muted hover:shadow-md transition duration-75"
 
   renders_many :sections, CardComponent::SectionComponent
 
-  def initialize(href: nil, frameless_on_mobile: false, **html_options)
+  def initialize(href: nil, **html_options)
     @href = href
-    @frameless_on_mobile = frameless_on_mobile
     @html_options = html_options
   end
 
@@ -34,15 +29,12 @@ class CardComponent < ViewComponent::Base
 
   def merged_options
     classes = helpers.class_names(
-      @frameless_on_mobile ? FRAMELESS_BASE_CLASSES : BASE_CLASSES,
-      sections.any? ? SECTIONED_CLASSES : padded_classes,
+      # Resolved through self.class so subclasses restyle by overriding the constants.
+      self.class::BASE_CLASSES,
+      sections.any? ? SECTIONED_CLASSES : self.class::PADDED_CLASSES,
       (@href && LINKED_CLASSES),
       @html_options[:class]
     )
     @html_options.merge(class: classes)
-  end
-
-  def padded_classes
-    @frameless_on_mobile ? FRAMELESS_PADDED_CLASSES : PADDED_CLASSES
   end
 end

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,13 +1,18 @@
 class CardComponent < ViewComponent::Base
   BASE_CLASSES = "w-full rounded-lg border border-border bg-surface shadow-xs"
   PADDED_CLASSES = "p-6"
+  # Frameless-on-mobile cards dissolve into the page below the sm breakpoint,
+  # so narrow screens keep only the surrounding container padding.
+  FRAMELESS_BASE_CLASSES = "w-full sm:rounded-lg sm:border sm:border-border sm:bg-surface sm:shadow-xs"
+  FRAMELESS_PADDED_CLASSES = "sm:p-6"
   SECTIONED_CLASSES = "overflow-hidden divide-y divide-border"
   LINKED_CLASSES = "block no-underline hover:bg-surface-muted hover:shadow-md transition duration-75"
 
   renders_many :sections, CardComponent::SectionComponent
 
-  def initialize(href: nil, **html_options)
+  def initialize(href: nil, frameless_on_mobile: false, **html_options)
     @href = href
+    @frameless_on_mobile = frameless_on_mobile
     @html_options = html_options
   end
 
@@ -29,11 +34,15 @@ class CardComponent < ViewComponent::Base
 
   def merged_options
     classes = helpers.class_names(
-      BASE_CLASSES,
-      sections.any? ? SECTIONED_CLASSES : PADDED_CLASSES,
+      @frameless_on_mobile ? FRAMELESS_BASE_CLASSES : BASE_CLASSES,
+      sections.any? ? SECTIONED_CLASSES : padded_classes,
       (@href && LINKED_CLASSES),
       @html_options[:class]
     )
     @html_options.merge(class: classes)
+  end
+
+  def padded_classes
+    @frameless_on_mobile ? FRAMELESS_PADDED_CLASSES : PADDED_CLASSES
   end
 end

--- a/app/components/modal_card_component.rb
+++ b/app/components/modal_card_component.rb
@@ -1,0 +1,8 @@
+# The sole card on a modal-layout page (sign-in, registration, password
+# flows). Framed like a regular card from the sm breakpoint up; below it the
+# card dissolves into the page, leaving the layout's own padding as the only
+# inset.
+class ModalCardComponent < CardComponent
+  BASE_CLASSES = "w-full sm:rounded-lg sm:border sm:border-border sm:bg-surface sm:shadow-xs"
+  PADDED_CLASSES = "sm:p-6"
+end

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Update Password" %>
 
-<%= render CardComponent.new(frameless_on_mobile: true) do %>
+<%= render ModalCardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Choose a new password</h1>
     <p class="text-sm text-body">Enter and confirm a new password to finish resetting your account.</p>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Update Password" %>
 
-<%= render CardComponent.new do %>
+<%= render CardComponent.new(frameless_on_mobile: true) do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Choose a new password</h1>
     <p class="text-sm text-body">Enter and confirm a new password to finish resetting your account.</p>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Forgot Password?" %>
 
-<%= render CardComponent.new(frameless_on_mobile: true) do %>
+<%= render ModalCardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Forgot your password?</h1>
     <p class="text-body">Enter your email address and we’ll send you a reset link.</p>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Forgot Password?" %>
 
-<%= render CardComponent.new do %>
+<%= render CardComponent.new(frameless_on_mobile: true) do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Forgot your password?</h1>
     <p class="text-body">Enter your email address and we’ll send you a reset link.</p>

--- a/app/views/registration/confirmation_pendings/show.html.erb
+++ b/app/views/registration/confirmation_pendings/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Check Your Email" %>
 
-<%= render CardComponent.new(frameless_on_mobile: true) do %>
+<%= render ModalCardComponent.new do %>
   <div class="space-y-6">
     <div class="space-y-3">
       <h1 class="text-4xl font-semibold mb-6 text-heading">Check your email</h1>

--- a/app/views/registration/confirmation_pendings/show.html.erb
+++ b/app/views/registration/confirmation_pendings/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Check Your Email" %>
 
-<%= render CardComponent.new do %>
+<%= render CardComponent.new(frameless_on_mobile: true) do %>
   <div class="space-y-6">
     <div class="space-y-3">
       <h1 class="text-4xl font-semibold mb-6 text-heading">Check your email</h1>

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Resend Confirmation" %>
 
-<%= render CardComponent.new(frameless_on_mobile: true) do %>
+<%= render ModalCardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Resend Confirmation</h1>
     <p class="text-body">Enter your email and we'll send you a new confirmation link.</p>

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Resend Confirmation" %>
 
-<%= render CardComponent.new do %>
+<%= render CardComponent.new(frameless_on_mobile: true) do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Resend Confirmation</h1>
     <p class="text-body">Enter your email and we'll send you a new confirmation link.</p>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Register" %>
 
 <% if @invite.nil? %>
-  <%= render CardComponent.new(frameless_on_mobile: true) do %>
+  <%= render ModalCardComponent.new do %>
     <div class="space-y-6">
       <h1 class="text-4xl font-semibold mb-6 text-heading">This invite link doesn't look right</h1>
       <p class="text-body">We couldn't find an invitation with that code. It might have been removed or copied incorrectly.</p>
@@ -21,7 +21,7 @@
     </div>
   <% end %>
 <% elsif @invite.used? %>
-  <%= render CardComponent.new(frameless_on_mobile: true) do %>
+  <%= render ModalCardComponent.new do %>
     <div class="space-y-6">
       <h1 class="text-4xl font-semibold mb-6 text-heading">This invite was already used</h1>
       <p class="text-body">This link has already been used to create an account.</p>
@@ -48,7 +48,7 @@
     </div>
   <% end %>
 <% else %>
-  <%= render CardComponent.new(frameless_on_mobile: true) do %>
+  <%= render ModalCardComponent.new do %>
     <div class="space-y-6">
       <div class="space-y-4">
         <h1 class="text-4xl font-semibold mb-6 text-heading">Create your account</h1>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -1,95 +1,92 @@
 <% content_for :title, "Register" %>
-<% content_for :body_class, "sm:bg-surface-sunken" %>
 
-<div class="mx-auto w-full max-w-full space-y-6 sm:max-w-2xl sm:px-0 px-4" data-controller="autofocus">
-  <% if @invite.nil? %>
-    <%= render CardComponent.new do %>
-      <div class="space-y-6">
-        <h1 class="text-4xl font-semibold mb-6 text-heading">This invite link doesn't look right</h1>
-        <p class="text-body">We couldn't find an invitation with that code. It might have been removed or copied incorrectly.</p>
+<% if @invite.nil? %>
+  <%= render CardComponent.new(frameless_on_mobile: true) do %>
+    <div class="space-y-6">
+      <h1 class="text-4xl font-semibold mb-6 text-heading">This invite link doesn't look right</h1>
+      <p class="text-body">We couldn't find an invitation with that code. It might have been removed or copied incorrectly.</p>
 
-        <div class="space-y-2">
-          <p class="font-semibold text-heading">Already have an account?</p>
-          <p class="text-body">
-            <%= link_to "Sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
+      <div class="space-y-2">
+        <p class="font-semibold text-heading">Already have an account?</p>
+        <p class="text-body">
+          <%= link_to "Sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
+          with your email and password.
+        </p>
+      </div>
+
+      <div class="space-y-2">
+        <p class="font-semibold text-heading">Need an invitation?</p>
+        <p class="text-body">Ask someone who already uses Feeder to send you a new link.</p>
+      </div>
+    </div>
+  <% end %>
+<% elsif @invite.used? %>
+  <%= render CardComponent.new(frameless_on_mobile: true) do %>
+    <div class="space-y-6">
+      <h1 class="text-4xl font-semibold mb-6 text-heading">This invite was already used</h1>
+      <p class="text-body">This link has already been used to create an account.</p>
+
+      <div class="space-y-4">
+        <p class="font-semibold text-heading">Already have an account?</p>
+        <ul class="list-disc space-y-1 ps-5 text-body">
+          <li>
+            Forgot your password?
+            <%= link_to "Reset it here", new_password_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>.
+          </li>
+          <li>
+            Otherwise,
+            <%= link_to "sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
             with your email and password.
+          </li>
+        </ul>
+      </div>
+
+      <div class="space-y-4">
+        <p class="font-semibold text-heading">Need a fresh invitation?</p>
+        <p class="text-body">Ask the person who sent this link to share a new one.</p>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <%= render CardComponent.new(frameless_on_mobile: true) do %>
+    <div class="space-y-6">
+      <div class="space-y-4">
+        <h1 class="text-4xl font-semibold mb-6 text-heading">Create your account</h1>
+        <% if @invite&.created_by_user %>
+          <p class="text-body">
+            <%= @invite.created_by_user.name.presence || "Somebody" %> invited you to join Feeder.
           </p>
-        </div>
-
-        <div class="space-y-2">
-          <p class="font-semibold text-heading">Need an invitation?</p>
-          <p class="text-body">Ask someone who already uses Feeder to send you a new link.</p>
-        </div>
-      </div>
-    <% end %>
-  <% elsif @invite.used? %>
-    <%= render CardComponent.new do %>
-      <div class="space-y-6">
-        <h1 class="text-4xl font-semibold mb-6 text-heading">This invite was already used</h1>
-        <p class="text-body">This link has already been used to create an account.</p>
-
-        <div class="space-y-4">
-          <p class="font-semibold text-heading">Already have an account?</p>
-          <ul class="list-disc space-y-1 ps-5 text-body">
-            <li>
-              Forgot your password?
-              <%= link_to "Reset it here", new_password_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>.
-            </li>
-            <li>
-              Otherwise,
-              <%= link_to "sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
-              with your email and password.
-            </li>
-          </ul>
-        </div>
-
-        <div class="space-y-4">
-          <p class="font-semibold text-heading">Need a fresh invitation?</p>
-          <p class="text-body">Ask the person who sent this link to share a new one.</p>
-        </div>
-      </div>
-    <% end %>
-  <% else %>
-    <%= render CardComponent.new do %>
-      <div class="space-y-6">
-        <div class="space-y-4">
-          <h1 class="text-4xl font-semibold mb-6 text-heading">Create your account</h1>
-          <% if @invite&.created_by_user %>
-            <p class="text-body">
-              <%= @invite.created_by_user.name.presence || "Somebody" %> invited you to join Feeder.
-            </p>
-          <% end %>
-        </div>
-        <% @user ||= User.new %>
-        <%= form_with model: @user, url: registration_path(code: params[:code]), method: :post, local: true do |form| %>
-          <div class="space-y-10">
-            <% if @user.errors.any? %>
-              <%= render AlertComponent.new(variant: :error) do %>
-                <span><%= @user.errors.full_messages.to_sentence.capitalize %></span>
-              <% end %>
-            <% end %>
-
-            <div class="space-y-2">
-              <%= form.label :email_address, "Email", class: "block font-semibold text-heading" %>
-              <%= form.email_field :email_address, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2", required: true, autofocus: true %>
-              <p class="text-sm text-muted">Only used for password resets—we don't send marketing emails.</p>
-            </div>
-
-            <div class="space-y-2">
-              <%= form.label :password, class: "block font-semibold text-heading" %>
-              <%= form.password_field :password, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2", required: true %>
-              <p class="text-sm text-muted">Choose at least <%= User::PASSWORD_MIN_LENGTH %> characters to keep things secure.</p>
-            </div>
-          </div>
-          <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-body flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <%= form.submit "Create account", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
-            <span class="text-body">
-              Already use Feeder?
-              <%= link_to "Sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
-            </span>
-          </div>
         <% end %>
       </div>
-    <% end %>
+      <% @user ||= User.new %>
+      <%= form_with model: @user, url: registration_path(code: params[:code]), method: :post, local: true do |form| %>
+        <div class="space-y-10">
+          <% if @user.errors.any? %>
+            <%= render AlertComponent.new(variant: :error) do %>
+              <span><%= @user.errors.full_messages.to_sentence.capitalize %></span>
+            <% end %>
+          <% end %>
+
+          <div class="space-y-2">
+            <%= form.label :email_address, "Email", class: "block font-semibold text-heading" %>
+            <%= form.email_field :email_address, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2", required: true, autofocus: true %>
+            <p class="text-sm text-muted">Only used for password resets—we don't send marketing emails.</p>
+          </div>
+
+          <div class="space-y-2">
+            <%= form.label :password, class: "block font-semibold text-heading" %>
+            <%= form.password_field :password, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2", required: true %>
+            <p class="text-sm text-muted">Choose at least <%= User::PASSWORD_MIN_LENGTH %> characters to keep things secure.</p>
+          </div>
+        </div>
+        <div class="mt-6 flex flex-col items-start gap-4 text-body sm:flex-row sm:items-center sm:justify-between">
+          <%= form.submit "Create account", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
+          <span class="text-body">
+            Already use Feeder?
+            <%= link_to "Sign in", new_session_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
+          </span>
+        </div>
+      <% end %>
+    </div>
   <% end %>
-</div>
+<% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Sign In" %>
 
-<%= render CardComponent.new do %>
+<%= render CardComponent.new(frameless_on_mobile: true) do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Sign in to Feeder</h1>
 
@@ -17,12 +17,12 @@
         </div>
       </div>
 
-      <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-body flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="mt-6 flex flex-col items-start gap-4 text-body sm:flex-row sm:items-center sm:justify-between">
         <%= form.submit "Sign in", class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 w-full sm:w-auto" %>
-        <div class="flex flex-wrap items-center gap-2 text-muted">
-          <%= link_to "Forgot password?", new_password_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
+        <div class="text-muted sm:flex sm:items-center sm:gap-2">
+          <p><%= link_to "Forgot password?", new_password_path, class: "inline-block font-medium leading-loose text-brand underline underline-offset-4 transition hover:text-brand-hover" %></p>
           <span aria-hidden="true" class="hidden sm:inline">·</span>
-          <%= link_to "Resend confirmation", new_registration_confirmation_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
+          <p><%= link_to "Resend confirmation", new_registration_confirmation_path, class: "inline-block font-medium leading-loose text-brand underline underline-offset-4 transition hover:text-brand-hover" %></p>
         </div>
       </div>
     <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Sign In" %>
 
-<%= render CardComponent.new(frameless_on_mobile: true) do %>
+<%= render ModalCardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Sign in to Feeder</h1>
 

--- a/test/components/card_component_test.rb
+++ b/test/components/card_component_test.rb
@@ -13,18 +13,6 @@ class CardComponentTest < ViewComponent::TestCase
     assert_includes card["class"], "p-6"
   end
 
-  test "#call should scope the card frame to sm+ when frameless_on_mobile" do
-    result = render_inline(CardComponent.new(frameless_on_mobile: true)) { "Card body" }
-
-    classes = result.at_css("div")["class"].split
-    assert_includes classes, "sm:border"
-    assert_includes classes, "sm:rounded-lg"
-    assert_includes classes, "sm:p-6"
-    refute_includes classes, "border"
-    refute_includes classes, "rounded-lg"
-    refute_includes classes, "p-6"
-  end
-
   test "#call should render sections divided border-to-border" do
     result = render_inline(CardComponent.new) do |card|
       card.with_section { "Header" }

--- a/test/components/card_component_test.rb
+++ b/test/components/card_component_test.rb
@@ -13,6 +13,18 @@ class CardComponentTest < ViewComponent::TestCase
     assert_includes card["class"], "p-6"
   end
 
+  test "#call should scope the card frame to sm+ when frameless_on_mobile" do
+    result = render_inline(CardComponent.new(frameless_on_mobile: true)) { "Card body" }
+
+    classes = result.at_css("div")["class"].split
+    assert_includes classes, "sm:border"
+    assert_includes classes, "sm:rounded-lg"
+    assert_includes classes, "sm:p-6"
+    refute_includes classes, "border"
+    refute_includes classes, "rounded-lg"
+    refute_includes classes, "p-6"
+  end
+
   test "#call should render sections divided border-to-border" do
     result = render_inline(CardComponent.new) do |card|
       card.with_section { "Header" }

--- a/test/components/modal_card_component_test.rb
+++ b/test/components/modal_card_component_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+require "view_component/test_case"
+
+class ModalCardComponentTest < ViewComponent::TestCase
+  test "#call should scope the card frame to sm+" do
+    result = render_inline(ModalCardComponent.new) { "Card body" }
+
+    card = result.at_css("div")
+    assert_equal "Card body", card.text.strip
+
+    classes = card["class"].split
+    assert_includes classes, "sm:border"
+    assert_includes classes, "sm:rounded-lg"
+    assert_includes classes, "sm:p-6"
+    refute_includes classes, "border"
+    refute_includes classes, "rounded-lg"
+    refute_includes classes, "p-6"
+  end
+end


### PR DESCRIPTION
Changes:

- Add `ModalCardComponent`, a `CardComponent` subclass for the sole card on a modal-layout page that scopes the card frame (border, rounding, shadow, background, padding) to `sm` and up
- Use it on the sign-in, registration, password, and confirmation pages so they stretch full width on phones, with the layout's own padding as the only inset
- Rework the sign-in helper links into exactly two states: a single row with a middot next to the button on wider screens, and stacked left-aligned paragraphs below the full-width button on phones
- Remove the registration page's redundant wrapper that duplicated the modal layout's width, padding, and autofocus

On phones the auth forms previously sat in a bordered card that wasted horizontal space, and the sign-in links had a third in-between state (centered, no separator). The card now dissolves below the `sm` breakpoint, and the stacked links use a loose line height so they're comfortable to tap.