### PR TITLE
Replace expanded feed form partial with view component

### DIFF
--- a/app/components/feed_form_component.html.erb
+++ b/app/components/feed_form_component.html.erb
@@ -1,67 +1,18 @@
-<%# locals: (edit_mode: false, feed:, candidates: [], source_changed: false, profile_changed: false, checking: false, source_error: nil, attempted_url: nil) %>
-<% active_tokens = Current.user.access_tokens.active.order(:host) %>
-<%# The chooser is a real choice only with two or more working candidates; one
-    working candidate is shown as a read-only annotation (spec §7). In edit mode
-    it appears only after a source re-detection resolves to multiple candidates. %>
-<% show_chooser = candidates.size >= 2 %>
-
-<%# preview-button is mounted on the whole form so it can read the selected
-    feed_profile_key (radios or hidden field) and react to candidate changes;
-    the button and the modal's frame are nested targets within it.
-
-    While an edit's source re-detection runs (spec §4), the same form freezes
-    and polls for the outcome; a failure re-renders it enabled with the hint
-    under the source field. %>
-<%
-  wrapper_data = {
-    identification_state: checking ? "checking" : (source_error ? "error" : "complete"),
-    controller: checking ? "preview-button polling" : "preview-button",
-    preview_button_endpoint_value: feed_preview_path,
-    preview_button_source_value: feed.source_input,
-    preview_button_source_keys_value: preview_source_keys(feed, candidates, show_chooser: show_chooser).to_json,
-    preview_button_ai_profiles_value: FeedProfile.ai_profile_keys.to_json,
-    preview_button_modal_id_value: "feed-preview-modal"
-  }
-  if checking
-    wrapper_data.merge!(
-      polling_indicate_busy_value: false,
-      polling_endpoint_value: feed_identifications_path(url: attempted_url, feed_id: feed.id),
-      polling_interval_value: polling_interval_ms,
-      polling_max_polls_value: polling_max_polls,
-      polling_stop_condition_value: "[data-identification-state='complete'], [data-identification-state='error']"
-    )
-  end
-%>
 <%= tag.div id: "feed-form", data: wrapper_data do %>
-  <%= form_with model: feed,
-                url: (edit_mode ? feed_path(feed) : feeds_path),
-                method: (edit_mode ? :patch : :post),
-                data: {
-                  controller: "groups",
-                  # feed_id is nil (and dropped from the URL) for an unpersisted feed.
-                  groups_endpoint_value: access_token_groups_path(":access_token_id", feed_id: feed.id)
-                } do |f| %>
-    <%= tag.fieldset disabled: checking, class: ("opacity-60" if checking) do %>
+  <%= form_with model: feed, url: form_url, method: form_method, data: form_data do |f| %>
+    <%= tag.fieldset disabled: checking?, class: ("opacity-60" if checking?) do %>
     <div class="space-y-10">
       <%# Source stays anchored at the top so the expansion reads as the entry
           field staying put while the rest of the form appears below it. The
           source and feed type are the feed's fixed identity, so they're grouped
           under one "Source" heading. %>
-      <% source_label = feed.source_input_url? ? "Source URL" : "Source prompt" %>
-      <%# For an AI feed the prompt *is* the source: it stays an editable textarea
-          throughout, including edits to a live feed — the uid scheme is unchanged,
-          so there's no duplicate risk, at most some older posts backfilled (spec
-          §4). A deterministic feed's URL is editable when editing an existing feed
-          — a change re-runs detection before saving (spec §4). %>
-      <% ai_prompt_editable = FeedProfile.depends_on_ai?(feed.feed_profile_key) %>
-      <% source_editable = edit_mode && !ai_prompt_editable %>
       <% if feed.sourceless? %>
         <%# A webhook feed has no source; callers push content to its authenticated
             endpoint, so the whole source block collapses into a note. %>
         <div>
           <h2 class="text-xl font-semibold text-heading mb-4">Source</h2>
           <%= render AlertComponent.new(variant: :info, data: { key: "form.webhook-note" }) do %>
-            <p class="text-sm">This feed doesn't follow anything on its own. It publishes whatever you send to its webhook endpoint with the authorization token. <%= feed.persisted? ? "You'll find both on the feed's page." : "Save the feed to get the endpoint and token." %></p>
+            <p class="text-sm">This feed doesn't follow anything on its own. It publishes whatever you send to its webhook endpoint with the authorization token. <%= webhook_endpoint_hint %></p>
           <% end %>
           <%= f.hidden_field :feed_profile_key %>
         </div>
@@ -70,7 +21,7 @@
         <h2 class="text-xl font-semibold text-heading mb-4">Source</h2>
 
         <div class="space-y-6">
-          <% if ai_prompt_editable %>
+          <% if ai_prompt_editable? %>
             <div class="space-y-2">
               <%= label_tag "feed_params_prompt", "What should AI follow?", class: "block font-semibold text-heading" %>
               <%= text_area_tag "feed[params][prompt]", feed.source_input,
@@ -78,23 +29,23 @@
                                 rows: 3,
                                 maxlength: 2000,
                                 required: true,
-                                class: input_field_classes,
+                                class: helpers.input_field_classes,
                                 data: { preview_button_target: "source", action: "input->preview-button#refreshAvailability", key: "form.ai-prompt" } %>
-              <% if edit_mode && !feed.draft? %>
+              <% if prompt_backfill_warning? %>
                 <p class="text-sm text-muted" data-key="form.prompt-backfill-note">Reworking the prompt may pull in some older posts you haven't seen yet. To hold those back, switch on “Skip older posts” below.</p>
               <% else %>
                 <p class="text-sm text-muted">Describe a source or topic in your own words. You can tweak this before saving.</p>
               <% end %>
             </div>
-          <% elsif source_editable %>
+          <% elsif source_editable? %>
             <div class="space-y-2">
               <%= f.label :url, source_label, class: "block font-semibold text-heading" %>
-              <%= text_field_tag "feed[params][url]", attempted_url || feed.source_input,
+              <%= text_field_tag "feed[params][url]", source_url_value,
                                  id: "feed_params_url",
                                  required: true,
-                                 class: input_field_classes(disabled: true),
+                                 class: helpers.input_field_classes(disabled: true),
                                  data: { preview_button_target: "source", action: "input->preview-button#refreshAvailability", key: "form.source-edit" } %>
-              <% if checking %>
+              <% if checking? %>
                 <p class="text-sm text-muted" role="status" data-key="form.source-checking">Checking this feed. This usually takes a few seconds.</p>
               <% elsif source_error %>
                 <p class="text-sm text-danger" data-key="form.source-error"><%= source_error %></p>
@@ -108,7 +59,7 @@
               <%= f.text_field :url_display,
                                value: feed.source_input,
                                disabled: true,
-                               class: input_field_classes(disabled: true),
+                               class: helpers.input_field_classes(disabled: true),
                                aria: { label: "#{source_label} (cannot be changed)" },
                                data: { key: "form.source-display" } %>
               <% feed.params&.each do |key, value| %>
@@ -119,16 +70,16 @@
 
           <%# Feed type belongs to every deterministic feed: the chooser after a
               multi-candidate re-detection, otherwise a read-only annotation. %>
-          <% unless ai_prompt_editable %>
-            <% if show_chooser %>
+          <% unless ai_prompt_editable? %>
+            <% if show_chooser? %>
               <%= render "feeds/candidate_chooser", candidates: candidates, input: feed.source_input, selected: feed.feed_profile_key %>
             <% else %>
               <div class="space-y-2">
                 <%= label_tag nil, "Feed type", class: "block font-semibold text-heading" %>
                 <%= f.text_field :feed_type_display,
-                                 value: candidate_summary(feed.feed_profile_key, feed.source_input),
+                                 value: feed_type_summary,
                                  disabled: true,
-                                 class: input_field_classes(disabled: true),
+                                 class: helpers.input_field_classes(disabled: true),
                                  aria: { label: "Feed type" },
                                  data: { key: "form.feed-type-display" } %>
               </div>
@@ -139,23 +90,19 @@
         <%# A read-only annotation or the editable AI prompt won't submit the
             profile key, so a hidden field carries it whenever the chooser isn't
             offering a live selection. %>
-        <% unless show_chooser %>
+        <% unless show_chooser? %>
           <%= f.hidden_field :feed_profile_key %>
-        <% end %>
-
-        <% if edit_mode && !ai_prompt_editable && !source_editable %>
-          <p class="mt-3 text-sm text-muted" data-key="form.source-locked-note">This feed's source is fixed. To follow a different source, just start a new feed.</p>
         <% end %>
 
         <%# Duplicate-risk warning for a pending source/profile change (spec §4).
             A profile change reworks how posts are identified, so it's the louder
             warning and turns the "skip older posts" threshold on by default. %>
-        <% if source_changed && profile_changed %>
+        <% if source_changed? && profile_changed? %>
           <%= render AlertComponent.new(variant: :warning, class: "mt-4", data: { key: "form.dup-risk-warning" }) do %>
             <p class="font-semibold">This changes how posts are identified</p>
             <p class="text-sm">Reading this source a different way can bring some recent posts back through. We've switched on “Skip older posts” below to hold them back. Pick a start date that suits you. It can't promise zero repeats.</p>
           <% end %>
-        <% elsif source_changed %>
+        <% elsif source_changed? %>
           <%= render AlertComponent.new(variant: :info, class: "mt-4", data: { key: "form.dup-risk-warning" }) do %>
             <p class="font-semibold">Heads up: you're pointing this feed somewhere new</p>
             <p class="text-sm">If the same posts live at new addresses there, they might arrive again. To skip ones you've already seen, switch on “Skip older posts” below.</p>
@@ -169,21 +116,16 @@
         <%= f.text_field :name,
                          placeholder: "Enter a name for this feed",
                          maxlength: Feed::NAME_MAX_LENGTH,
-                         class: input_field_classes,
+                         class: helpers.input_field_classes,
                          data: { key: "form.name" } %>
         <% if f.object.errors[:name].any? %>
           <p class="text-sm text-danger"><%= f.object.errors[:name].to_sentence.capitalize %></p>
-        <% elsif feed.name.present? %>
-          <p class="text-sm text-muted">You can edit this name if you'd like.</p>
-        <% elsif feed.sourceless? %>
-          <p class="text-sm text-muted">Choose a name for this feed.</p>
         <% else %>
-          <p class="text-sm text-muted">We couldn't automatically detect a name. Please enter one.</p>
+          <p class="text-sm text-muted"><%= name_hint %></p>
         <% end %>
       </div>
 
-      <% ai_settings = FeedAiSettingsComponent.new(feed: feed, form: f) %>
-      <%= render ai_settings %>
+      <%= render ai_settings(f) %>
 
       <% unless feed.sourceless? %>
       <div class="mt-2" data-key="form.preview">
@@ -200,7 +142,7 @@
            data-key="preview.hint"></p>
 
         <%= render ModalComponent.new(title: "Feed preview", modal_id: "feed-preview-modal") do %>
-          <%= turbo_frame_tag "feed-preview", data: { preview_button_target: "frame" } do %>
+          <%= helpers.turbo_frame_tag "feed-preview", data: { preview_button_target: "frame" } do %>
             <%# Shown right away when the modal opens so the spinner is visible
                 before the frame's first response lands (the JS controller
                 re-injects this markup on each open). %>
@@ -222,23 +164,14 @@
               <%= render "feeds/token_gate" %>
             <% end %>
           <% else %>
-            <%# A token that went inactive isn't offered in the select, so the
-                feed's own choice can't be kept — preselect a working token
-                and say so below, instead of letting the browser swap silently. %>
-            <% token_swap = feed.access_token.present? && !feed.access_token.active? %>
             <%= render PanelComponent.new do %>
               <div class="space-y-2">
                 <%= f.label :access_token_id, "Access Token", class: "block font-semibold text-heading" %>
                 <%= f.select :access_token_id,
-                             options_from_collection_for_select(
-                               active_tokens,
-                               :id,
-                               :display_name,
-                               token_swap ? active_tokens.first&.id : (feed.access_token_id || active_tokens.first&.id)
-                             ),
+                             token_options,
                              {},
                              {
-                               class: "#{input_field_classes} pb-2",
+                               class: "#{helpers.input_field_classes} pb-2",
                                data: {
                                  action: "change->groups#refresh",
                                  groups_target: "tokenSelect"
@@ -246,7 +179,7 @@
                              } %>
                 <% if f.object.errors[:access_token].any? %>
                   <p class="text-sm text-danger"><%= f.object.errors[:access_token].first %></p>
-                <% elsif token_swap %>
+                <% elsif token_swap? %>
                   <p class="text-sm text-warning" data-key="form.token-swap-note">The token this feed was using stopped working. When you save, the feed switches to the token selected here.</p>
                 <% end %>
               </div>
@@ -267,8 +200,8 @@
                 <%= f.label :schedule_interval, "Check for new posts every", class: "block font-semibold text-heading" %>
                 <%= f.select :schedule_interval,
                              Feed.schedule_intervals_for_select,
-                             { selected: feed.schedule_interval || Feed::DEFAULT_SCHEDULE_INTERVAL },
-                             { class: input_field_classes } %>
+                             { selected: selected_schedule_interval },
+                             { class: helpers.input_field_classes } %>
                 <% if f.object.errors[:cron_expression].any? %>
                   <p class="text-sm text-danger"><%= f.object.errors[:cron_expression].first %></p>
                 <% end %>
@@ -282,14 +215,11 @@
         <div class="mt-6">
           <h2 class="text-xl font-semibold text-heading mb-4">Advanced options</h2>
 
-          <%# A profile change defaults the threshold on (spec §4); checkbox and
-              panel visibility must agree. %>
-          <% import_after_on = feed.import_after_enabled || profile_changed %>
           <%= render PanelComponent.new(data: { controller: "field-toggle", key: "form.advanced-options" }) do %>
             <div class="flex items-start">
               <div class="flex h-6 items-center">
                 <%= f.check_box :import_after_enabled,
-                                checked: import_after_on,
+                                checked: import_after_on?,
                                 data: {
                                   field_toggle_target: "checkbox",
                                   action: "change->field-toggle#toggle",
@@ -305,21 +235,19 @@
             <%# mt-6 lives on the toggled panel (not a wrapper space-y) so the gap
                 only appears when the fields are shown — a hidden element renders
                 no margin. %>
-            <div class="mt-6 space-y-2 <%= "hidden" unless import_after_on %>"
+            <div class="mt-6 space-y-2 <%= "hidden" unless import_after_on? %>"
                  data-field-toggle-target="panel"
                  data-key="form.import-after-fields">
               <div class="grid gap-4 sm:grid-cols-2">
                 <div class="relative">
                   <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
-                    <%= icon("calendar", css_class: "size-5 text-muted") %>
+                    <%= helpers.icon("calendar", css_class: "size-5 text-muted") %>
                   </div>
-                  <%# A profile change defaults the threshold on (spec §4); seed
-                      today so "on" reads as a complete cutoff, not a blank field. %>
                   <%= f.text_field :import_after_date,
-                                   value: feed.import_after_date || (Date.current.iso8601 if profile_changed),
+                                   value: import_after_date_value,
                                    placeholder: "Pick a date",
                                    autocomplete: "off",
-                                   class: input_field_classes(icon_padding: true),
+                                   class: helpers.input_field_classes(icon_padding: true),
                                    aria: { label: "Import posts published after this date" },
                                    data: {
                                      controller: "datepicker",
@@ -330,18 +258,18 @@
                 </div>
                 <div class="relative">
                   <div class="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3">
-                    <%= icon("clock", css_class: "size-5 text-muted") %>
+                    <%= helpers.icon("clock", css_class: "size-5 text-muted") %>
                   </div>
                   <%# Plain 24-hour text field rather than a native time input: the
                       native control renders 12h or 24h based on the browser locale,
                       which we can't override, so we pin the format to HH:MM here. %>
                   <%= f.text_field :import_after_time,
-                                   value: feed.import_after_time.presence || "00:00",
+                                   value: import_after_time_value,
                                    inputmode: "numeric",
                                    placeholder: "HH:MM",
                                    pattern: "([01][0-9]|2[0-3]):[0-5][0-9]",
                                    maxlength: 5,
-                                   class: input_field_classes(icon_padding: true),
+                                   class: helpers.input_field_classes(icon_padding: true),
                                    aria: { label: "Import posts published after this time (24-hour HH:MM, UTC)" },
                                    data: {
                                      field_toggle_target: "input",
@@ -367,38 +295,19 @@
         </div>
       <% end %>
 
-      <%# When a setup gate replaced the token or credential fields, enabling
-          can only fail — and the failure's errors would render inside the
-          missing fields, i.e. nowhere. Lock the checkbox off and say what's
-          missing instead. A (legacy) still-enabled feed keeps an interactive
-          checkbox so unchecking-to-pause stays available. %>
-      <%
-        enable_missing = []
-        enable_missing << "a FreeFeed access token" if active_tokens.empty?
-        if ai_settings.section_visible?
-          enable_missing << "AI credentials" unless ai_settings.credentials?
-          enable_missing << "search credentials" unless ai_settings.search_credentials?
-        end
-        enable_blocked = enable_missing.any? && !feed.enabled?
-      %>
       <div class="mt-6">
         <div class="flex items-start">
           <div class="flex items-center h-6">
             <%= check_box_tag "enable_feed",
                               "1",
-                              !enable_blocked && (params[:enable_feed] == "1" || feed.enabled?),
+                              enable_checked?(f),
                               id: "enable_feed",
-                              disabled: enable_blocked %>
+                              disabled: enable_blocked?(f) %>
           </div>
           <div class="ml-3">
-            <%= label_tag "enable_feed", "Enable feed", class: "block font-semibold #{enable_blocked ? 'text-muted' : 'text-heading'} mb-0" %>
-            <% if enable_blocked %>
-              <p class="text-sm text-muted" data-key="form.enable-blocked-note">Add <%= enable_missing.to_sentence %> first, then you can enable this feed.</p>
-            <% elsif feed.scheduled? %>
-              <p class="text-sm text-muted">Start checking for new posts and publish them to FreeFeed.</p>
-            <% else %>
-              <p class="text-sm text-muted">Enable this feed so its webhook endpoint can publish to FreeFeed.</p>
-            <% end %>
+            <%= label_tag "enable_feed", "Enable feed", class: enable_label_classes(f) %>
+            <%= tag.p enable_hint(f), class: "text-sm text-muted",
+                      data: ({ key: "form.enable-blocked-note" } if enable_blocked?(f)) %>
           </div>
         </div>
       </div>
@@ -406,11 +315,11 @@
     <% end %>
 
     <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-body">
-      <%= f.submit checking ? "Checking…" : "Save feed",
-                   disabled: checking,
-                   class: "#{primary_button_classes} disabled:bg-brand disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-brand",
+      <%= f.submit submit_label,
+                   disabled: checking?,
+                   class: submit_classes,
                    data: { turbo_submits_with: "Saving…" } %>
-      <%= link_to "Cancel", feeds_path, class: secondary_button_classes %>
+      <%= link_to "Cancel", helpers.feeds_path, class: helpers.secondary_button_classes %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/feed_form_component.rb
+++ b/app/components/feed_form_component.rb
@@ -1,0 +1,247 @@
+# The expanded feed form: the full editor a feed lands on once its source is
+# known (or when it needs none) — source identity, name, AI settings, preview,
+# reposting settings, advanced options, and the enable checkbox.
+#
+# Also paints the identification states of an edit's source re-detection
+# (spec §4/§7): frozen and polling while a check runs, or re-enabled with the
+# failure hint under the source field.
+class FeedFormComponent < ViewComponent::Base
+  POLLING_STOP_CONDITION = "[data-identification-state='complete'], [data-identification-state='error']"
+
+  def initialize(feed:, candidates: [], source_changed: false, profile_changed: false,
+                 checking: false, source_error: nil, attempted_url: nil)
+    @feed = feed
+    @candidates = candidates
+    @source_changed = source_changed
+    @profile_changed = profile_changed
+    @checking = checking
+    @source_error = source_error
+    @attempted_url = attempted_url
+  end
+
+  attr_reader :feed, :candidates, :source_error, :attempted_url
+
+  def checking? = @checking
+  def source_changed? = @source_changed
+  def profile_changed? = @profile_changed
+
+  # Editing an existing feed vs. creating one. Every caller passes a persisted
+  # feed only from the edit flow (creation always builds a fresh record), so
+  # the flag needn't travel as a separate parameter.
+  def edit_mode?
+    feed.persisted?
+  end
+
+  # preview-button is mounted on the whole form so it can read the selected
+  # feed_profile_key (radios or hidden field) and react to candidate changes;
+  # the button and the modal's frame are nested targets within it. While an
+  # edit's source re-detection runs (spec §4), the same wrapper freezes the
+  # form and polls for the outcome; a failure re-renders it enabled with the
+  # hint under the source field.
+  def wrapper_data
+    data = {
+      identification_state: identification_state,
+      controller: checking? ? "preview-button polling" : "preview-button",
+      preview_button_endpoint_value: helpers.feed_preview_path,
+      preview_button_source_value: feed.source_input,
+      preview_button_source_keys_value: preview_source_keys.to_json,
+      preview_button_ai_profiles_value: FeedProfile.ai_profile_keys.to_json,
+      preview_button_modal_id_value: "feed-preview-modal"
+    }
+    data.merge!(polling_data) if checking?
+    data
+  end
+
+  # Profile-key → source-param-key map the preview button reads to build
+  # preview requests: every offered candidate while the chooser is live,
+  # otherwise just the feed's own profile.
+  def preview_source_keys
+    if show_chooser?
+      candidates.to_h { |candidate| [candidate.profile_key, FeedProfile.source_key_for(candidate.profile_key)] }
+    else
+      { feed.feed_profile_key => FeedProfile.source_key_for(feed.feed_profile_key) }
+    end
+  end
+
+  def form_url
+    edit_mode? ? helpers.feed_path(feed) : helpers.feeds_path
+  end
+
+  def form_method
+    edit_mode? ? :patch : :post
+  end
+
+  # feed_id is nil (and dropped from the URL) for an unpersisted feed.
+  def form_data
+    {
+      controller: "groups",
+      groups_endpoint_value: helpers.access_token_groups_path(":access_token_id", feed_id: feed.id)
+    }
+  end
+
+  # The chooser is a real choice only with two or more working candidates; one
+  # working candidate is shown as a read-only annotation (spec §7). In edit
+  # mode it appears only after a source re-detection resolves to multiple
+  # candidates.
+  def show_chooser?
+    candidates.size >= 2
+  end
+
+  def source_label
+    feed.source_input_url? ? "Source URL" : "Source prompt"
+  end
+
+  # For an AI feed the prompt *is* the source: it stays an editable textarea
+  # throughout, including edits to a live feed — the uid scheme is unchanged,
+  # so there's no duplicate risk, at most some older posts backfilled (spec §4).
+  def ai_prompt_editable?
+    FeedProfile.depends_on_ai?(feed.feed_profile_key)
+  end
+
+  # A deterministic feed's URL is editable when editing an existing feed — a
+  # change re-runs detection before saving (spec §4).
+  def source_editable?
+    edit_mode? && !ai_prompt_editable?
+  end
+
+  def source_url_value
+    attempted_url || feed.source_input
+  end
+
+  # Reworking a live feed's prompt may pull in older posts; a draft's prompt
+  # can change freely.
+  def prompt_backfill_warning?
+    edit_mode? && !feed.draft?
+  end
+
+  def feed_type_summary
+    helpers.candidate_summary(feed.feed_profile_key, feed.source_input)
+  end
+
+  def webhook_endpoint_hint
+    feed.persisted? ? "You'll find both on the feed's page." : "Save the feed to get the endpoint and token."
+  end
+
+  def name_hint
+    if feed.name.present?
+      "You can edit this name if you'd like."
+    elsif feed.sourceless?
+      "Choose a name for this feed."
+    else
+      "We couldn't automatically detect a name. Please enter one."
+    end
+  end
+
+  def active_tokens
+    @active_tokens ||= feed.user.access_tokens.active.order(:host)
+  end
+
+  # A token that went inactive isn't offered in the select, so the feed's own
+  # choice can't be kept — preselect a working token and say so below, instead
+  # of letting the browser swap silently.
+  def token_swap?
+    feed.access_token.present? && !feed.access_token.active?
+  end
+
+  def selected_token_id
+    return active_tokens.first&.id if token_swap?
+
+    feed.access_token_id || active_tokens.first&.id
+  end
+
+  def token_options
+    options_from_collection_for_select(active_tokens, :id, :display_name, selected_token_id)
+  end
+
+  def selected_schedule_interval
+    feed.schedule_interval || Feed::DEFAULT_SCHEDULE_INTERVAL
+  end
+
+  # A profile change reworks how posts are identified, so it defaults the
+  # skip-older-posts threshold on (spec §4); checkbox and panel visibility
+  # must agree.
+  def import_after_on?
+    feed.import_after_enabled || profile_changed?
+  end
+
+  # Seed today when a profile change turned the threshold on, so "on" reads as
+  # a complete cutoff rather than a blank field.
+  def import_after_date_value
+    feed.import_after_date || (Date.current.iso8601 if profile_changed?)
+  end
+
+  def import_after_time_value
+    feed.import_after_time.presence || "00:00"
+  end
+
+  # Memoized so the rendered section and the enable-gate checks share one
+  # instance (and its credential lookups).
+  def ai_settings(form)
+    @ai_settings ||= FeedAiSettingsComponent.new(feed: feed, form: form)
+  end
+
+  # When a setup gate replaced the token or credential fields, enabling can
+  # only fail — and the failure's errors would render inside the missing
+  # fields, i.e. nowhere. The checkbox locks off and says what's missing
+  # instead. A (legacy) still-enabled feed keeps an interactive checkbox so
+  # unchecking-to-pause stays available.
+  def enable_blocked?(form)
+    enable_missing(form).any? && !feed.enabled?
+  end
+
+  def enable_missing(form)
+    @enable_missing ||= [].tap do |missing|
+      missing << "a FreeFeed access token" if active_tokens.empty?
+      next unless ai_settings(form).section_visible?
+
+      missing << "AI credentials" unless ai_settings(form).credentials?
+      missing << "search credentials" unless ai_settings(form).search_credentials?
+    end
+  end
+
+  def enable_checked?(form)
+    !enable_blocked?(form) && (helpers.params[:enable_feed] == "1" || feed.enabled?)
+  end
+
+  def enable_label_classes(form)
+    "block font-semibold #{enable_blocked?(form) ? 'text-muted' : 'text-heading'} mb-0"
+  end
+
+  def enable_hint(form)
+    if enable_blocked?(form)
+      "Add #{enable_missing(form).to_sentence} first, then you can enable this feed."
+    elsif feed.scheduled?
+      "Start checking for new posts and publish them to FreeFeed."
+    else
+      "Enable this feed so its webhook endpoint can publish to FreeFeed."
+    end
+  end
+
+  def submit_label
+    checking? ? "Checking…" : "Save feed"
+  end
+
+  def submit_classes
+    "#{helpers.primary_button_classes} disabled:bg-brand disabled:opacity-60 " \
+      "disabled:cursor-not-allowed disabled:hover:bg-brand"
+  end
+
+  private
+
+  def identification_state
+    return "checking" if checking?
+    return "error" if source_error
+
+    "complete"
+  end
+
+  def polling_data
+    {
+      polling_indicate_busy_value: false,
+      polling_endpoint_value: helpers.feed_identifications_path(url: attempted_url, feed_id: feed.id),
+      polling_interval_value: helpers.polling_interval_ms,
+      polling_max_polls_value: helpers.polling_max_polls,
+      polling_stop_condition_value: POLLING_STOP_CONDITION
+    }
+  end
+end

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -50,7 +50,7 @@ class FeedIdentificationsController < ApplicationController
     original_url = feed_identification.persisted? ? feed_identification.input : raw_url
     feed_identification.destroy if feed_identification.persisted?
 
-    render feed_form_stream("form_collapsed", url: original_url)
+    render entry_form(url: original_url)
   end
 
   private
@@ -179,23 +179,25 @@ class FeedIdentificationsController < ApplicationController
     end
   end
 
-  # Every response in this flow swaps the same "feed-form" frame; partial names
-  # are relative to feeds/.
-  def feed_form_stream(partial, **locals)
-    { turbo_stream: turbo_stream.replace("feed-form", partial: "feeds/#{partial}", locals: locals) }
+  # Creation states re-render the entry form itself (spec §1/§7): frozen while
+  # checking, or enabled with the hint under the active mode's input. Every
+  # response in this flow swaps the same "feed-form" frame.
+  def entry_form(mode: "link", url: raw_url, prompt: nil, checking: false, error: nil)
+    { turbo_stream: turbo_stream.replace(
+      "feed-form",
+      partial: "feeds/form_collapsed",
+      locals: { mode: mode, url: url, prompt: prompt, checking: checking, error: error }
+    ) }
   end
 
-  # Creation states re-render the entry form itself (spec §1/§7): frozen while
-  # checking, or enabled with the hint under the active mode's input.
-  def entry_form(mode: "link", url: raw_url, prompt: nil, checking: false, error: nil)
-    feed_form_stream("form_collapsed", mode: mode, url: url, prompt: prompt, checking: checking, error: error)
+  def expanded_form(feed, **options)
+    { turbo_stream: turbo_stream.replace("feed-form", FeedFormComponent.new(feed: feed, **options)) }
   end
 
   # Edit states re-render the edit form — the engine is fixed (spec §4), so
   # there's no AI mode to switch to, just the hint under the source field.
   def edit_form(attempted_url:, error: nil)
-    feed_form_stream("form_expanded", feed: edit_feed, edit_mode: true,
-                                      attempted_url: attempted_url, source_error: error)
+    expanded_form(edit_feed, attempted_url: attempted_url, source_error: error)
   end
 
   def identification_error(error:, url: raw_url, prompt: nil)
@@ -232,8 +234,8 @@ class FeedIdentificationsController < ApplicationController
   end
 
   def identification_success(feed, candidates: [], source_changed: false, profile_changed: false)
-    feed_form_stream("form_expanded", feed: feed, candidates: candidates, edit_mode: editing?,
-                                      source_changed: source_changed, profile_changed: profile_changed)
+    expanded_form(feed, candidates: candidates,
+                        source_changed: source_changed, profile_changed: profile_changed)
   end
 
   # The feed being edited (spec §4 source re-detection), or nil in the creation

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -257,9 +257,8 @@ class FeedsController < ApplicationController
   def render_identification_state(attempted_url:, checking: false, source_error: nil, status: :ok)
     render turbo_stream: turbo_stream.replace(
       "feed-form",
-      partial: "feeds/form_expanded",
-      locals: { feed: @feed, edit_mode: true, attempted_url: attempted_url,
-                checking: checking, source_error: source_error }
+      FeedFormComponent.new(feed: @feed, attempted_url: attempted_url,
+                            checking: checking, source_error: source_error)
     ), status: status
   end
 

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -11,17 +11,6 @@ module FeedHelper
     end
   end
 
-  # Profile-key → source-param-key map the preview button reads to build
-  # preview requests: every offered candidate while the chooser is live,
-  # otherwise just the feed's own profile.
-  def preview_source_keys(feed, candidates, show_chooser:)
-    if show_chooser
-      candidates.to_h { |candidate| [candidate.profile_key, FeedProfile.source_key_for(candidate.profile_key)] }
-    else
-      { feed.feed_profile_key => FeedProfile.source_key_for(feed.feed_profile_key) }
-    end
-  end
-
   def feed_missing_enablement_parts(feed)
     missing_parts = []
     missing_parts << "source" unless feed.sourceless? || feed.source_input.present?

--- a/app/views/feeds/edit.html.erb
+++ b/app/views/feeds/edit.html.erb
@@ -4,6 +4,6 @@
   <%= render PageHeaderComponent.new(title: "Edit Feed") %>
 
   <div class="max-w-3xl">
-    <%= render "form_expanded", feed: @feed, edit_mode: true %>
+    <%= render FeedFormComponent.new(feed: @feed) %>
   </div>
 </div>

--- a/app/views/feeds/new.html.erb
+++ b/app/views/feeds/new.html.erb
@@ -8,7 +8,7 @@
         land back on the expanded form — the collapsed entry would silently
         drop the draft's fields and errors. %>
     <% if @feed.source_input.present? || @feed.sourceless? %>
-      <%= render "form_expanded", feed: @feed, edit_mode: false %>
+      <%= render FeedFormComponent.new(feed: @feed) %>
     <% else %>
       <%= render "form_collapsed", mode: mode %>
     <% end %>

--- a/test/components/feed_form_component_test.rb
+++ b/test/components/feed_form_component_test.rb
@@ -1,0 +1,144 @@
+require "test_helper"
+require "view_component/test_case"
+
+# The component's logic is tested directly (no render needed); the rendered
+# markup is covered by the feeds and feed identifications controller tests.
+class FeedFormComponentTest < ViewComponent::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def feed(*traits, **attrs)
+    build(:feed, *traits, user: user, **attrs)
+  end
+
+  def ai_feed(**attrs)
+    feed(feed_profile_key: "llm", params: { "prompt" => "follow the news" }, **attrs)
+  end
+
+  def component(feed, **options)
+    FeedFormComponent.new(feed: feed, **options)
+  end
+
+  def candidate(profile_key)
+    FeedIdentification::Candidate.new({ "profile_key" => profile_key, "test_status" => "passed", "posts_found" => 1 })
+  end
+
+  test "#edit_mode? should follow feed persistence" do
+    assert_not component(feed).edit_mode?
+    assert component(create(:feed, user: user)).edit_mode?
+  end
+
+  test "#show_chooser? should require at least two candidates" do
+    assert_not component(feed).show_chooser?
+    assert_not component(feed, candidates: [candidate("rss")]).show_chooser?
+    assert component(feed, candidates: [candidate("rss"), candidate("llm")]).show_chooser?
+  end
+
+  test "#preview_source_keys should map every candidate while the chooser is live" do
+    subject = component(feed, candidates: [candidate("rss"), candidate("llm")])
+    assert_equal({ "rss" => "url", "llm" => "prompt" }, subject.preview_source_keys)
+  end
+
+  test "#preview_source_keys should fall back to the feed's own profile without a chooser" do
+    assert_equal({ "rss" => "url" }, component(feed, candidates: [candidate("rss")]).preview_source_keys)
+  end
+
+  test "#ai_prompt_editable? should be true only for AI-backed profiles" do
+    assert component(ai_feed).ai_prompt_editable?
+    assert_not component(feed).ai_prompt_editable?
+  end
+
+  test "#source_editable? should allow URL edits only when editing a deterministic feed" do
+    assert component(create(:feed, user: user)).source_editable?
+    assert_not component(feed).source_editable?
+    assert_not component(create(:feed, user: user, feed_profile_key: "llm", params: { "prompt" => "x" })).source_editable?
+  end
+
+  test "#prompt_backfill_warning? should appear only for a live feed" do
+    assert component(create(:feed, user: user)).prompt_backfill_warning?
+    assert_not component(create(:feed, :draft, user: user)).prompt_backfill_warning?
+    assert_not component(feed).prompt_backfill_warning?
+  end
+
+  test "#source_url_value should prefer the attempted URL over the saved source" do
+    assert_equal "https://example.com/feed.xml", component(feed).source_url_value
+    assert_equal "https://new.example.com", component(feed, attempted_url: "https://new.example.com").source_url_value
+  end
+
+  test "#name_hint should invite editing a detected name" do
+    assert_equal "You can edit this name if you'd like.", component(feed).name_hint
+  end
+
+  test "#name_hint should ask for a name for a sourceless feed" do
+    assert_equal "Choose a name for this feed.", component(feed(:webhook, name: nil)).name_hint
+  end
+
+  test "#name_hint should explain when detection found no name" do
+    assert_equal "We couldn't automatically detect a name. Please enter one.", component(feed(name: nil)).name_hint
+  end
+
+  test "#token_swap? should be true only when the feed's token went inactive" do
+    assert component(feed(access_token: build(:access_token, :inactive, user: user))).token_swap?
+    assert_not component(feed).token_swap?
+    assert_not component(feed(:without_access_token)).token_swap?
+  end
+
+  test "#selected_token_id should keep the feed's own active token" do
+    token = create(:access_token, :active, user: user)
+    create(:access_token, :active, user: user, host: "https://a.example.com")
+    assert_equal token.id, component(feed(access_token: token)).selected_token_id
+  end
+
+  test "#selected_token_id should preselect a working token on a swap" do
+    replacement = create(:access_token, :active, user: user)
+    inactive = create(:access_token, :inactive, user: user)
+    assert_equal replacement.id, component(feed(access_token: inactive)).selected_token_id
+  end
+
+  test "#import_after_on? should switch on for a pending profile change" do
+    assert component(feed, profile_changed: true).import_after_on?
+    assert_not component(feed).import_after_on?
+    assert component(feed(import_after: 1.day.ago)).import_after_on?
+  end
+
+  test "#import_after_date_value should seed today when a profile change turned it on" do
+    assert_equal Date.current.iso8601, component(feed, profile_changed: true).import_after_date_value
+    assert_nil component(feed).import_after_date_value
+    assert_equal "2026-01-15", component(feed(import_after: Time.utc(2026, 1, 15, 10, 30))).import_after_date_value
+  end
+
+  test "#import_after_time_value should default to midnight" do
+    assert_equal "00:00", component(feed).import_after_time_value
+    assert_equal "10:30", component(feed(import_after: Time.utc(2026, 1, 15, 10, 30))).import_after_time_value
+  end
+
+  test "#selected_schedule_interval should fall back to the default interval" do
+    assert_equal "6h", component(feed).selected_schedule_interval
+    assert_equal Feed::DEFAULT_SCHEDULE_INTERVAL, component(feed(cron_expression: nil)).selected_schedule_interval
+  end
+
+  test "#enable_missing should list every missing setup piece" do
+    assert_equal ["a FreeFeed access token"], component(feed).enable_missing(nil)
+    assert_equal ["a FreeFeed access token", "AI credentials", "search credentials"],
+                 component(ai_feed).enable_missing(nil)
+  end
+
+  test "#enable_missing should be empty when the setup is complete" do
+    create(:access_token, :active, user: user)
+    assert_empty component(feed).enable_missing(nil)
+  end
+
+  test "#enable_blocked? should lock the checkbox while setup pieces are missing" do
+    assert component(feed).enable_blocked?(nil)
+  end
+
+  test "#enable_blocked? should keep an enabled feed's checkbox interactive" do
+    assert_not component(feed(:enabled)).enable_blocked?(nil)
+  end
+
+  test "#submit_label should reflect the checking state" do
+    assert_equal "Save feed", component(feed).submit_label
+    assert_equal "Checking…", component(feed, checking: true).submit_label
+  end
+end


### PR DESCRIPTION
Changes:

- Convert the `feeds/_form_expanded` partial into `FeedFormComponent`, moving all inline ERB logic (wrapper/polling data, source editability, token swap, import-after defaults, enable gating) into the Ruby class
- Reduce the form's inputs from eight loosely-typed locals to one required param (`feed`) plus defaulted options; `edit_mode` is derived from `feed.persisted?`
- Absorb the single-use `preview_source_keys` helper into the component and drop a provably unreachable source-locked-note branch
- Unit-test the component logic directly; rendered markup is unchanged and stays covered by the existing controller tests

The template is now purely presentational with identical markup and data-keys, so the form's behavior can be read and changed in one place instead of being scattered through the template.