### PR TITLE
Close feed actions menu and confirm manual refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-22
 
+- Picking Refresh from a feed's actions menu now closes the menu and confirms the refresh has started, instead of leaving you guessing whether the click did anything.
 - Token pages and post previews now show your actual FreeFeed userpic instead of the generic placeholder. Newly validated tokens pick it up automatically.
 - Turning on a feed now always requires a working FreeFeed access token. Previously the feed page's Enable button checked this, but saving the feed with "Enable feed" turned on did not.
 - When a feed's access token stops working, the feed page's Enable button now says exactly what's missing, and the feed's settings explain that saving will switch it to one of your working tokens.

--- a/app/controllers/feeds/refreshes_controller.rb
+++ b/app/controllers/feeds/refreshes_controller.rb
@@ -13,7 +13,10 @@ class Feeds::RefreshesController < ApplicationController
     FeedRefreshJob.perform_later(@feed.id, manual: true)
 
     respond_to do |format|
-      format.turbo_stream { render turbo_stream: "" }
+      format.turbo_stream do
+        flash.now[:notice] = "Feed refresh started"
+        render turbo_stream: turbo_stream.replace("flash-messages", partial: "layouts/flash")
+      end
       format.html { redirect_to feed_path(@feed), notice: "Feed refresh started" }
     end
   end

--- a/app/javascript/tailwind.js
+++ b/app/javascript/tailwind.js
@@ -19,3 +19,16 @@ document.addEventListener("turbo:before-cache", () => {
     }
   })
 })
+
+// Close the enclosing dropdown as soon as a menu action submits (e.g. Refresh
+// in the feed actions menu). Turbo intercepts these form submits, so no page
+// visit closes the menu, and Flowbite only reacts to clicks outside it.
+// Closing through the Flowbite instance keeps its internal open state in
+// sync — hiding the element directly would make the next trigger click a
+// no-op toggle back to hidden.
+document.addEventListener("turbo:submit-start", (event) => {
+  const menu = event.target.closest('[role="menu"]')
+  if (!menu) return
+
+  window.FlowbiteInstances?.getInstance("Dropdown", menu.id)?.hide()
+})

--- a/test/controllers/feeds/refreshes_controller_test.rb
+++ b/test/controllers/feeds/refreshes_controller_test.rb
@@ -75,6 +75,10 @@ class Feeds::RefreshesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_select "turbo-stream[action='replace'][target='flash-messages']" do
+      assert_select "div[id='flash-messages']"
+      assert_select ".bg-brand-subtle", text: /Feed refresh started/
+    end
   end
 
   test "create throttles repeated refreshes for the same feed" do


### PR DESCRIPTION
Changes:

- Close the feed actions dropdown as soon as a menu action submits, instead of leaving it hanging open
- Show a "Feed refresh started" notice after a manual refresh, matching the throttled and non-Turbo paths

Previously the refresh responded with an empty Turbo Stream, so the menu stayed open and nothing confirmed the click. The dropdown now closes through the Flowbite instance API, which keeps its internal open state in sync (a plain class toggle would make reopening take two clicks), and the success response reuses the existing flash pattern used by the neighboring Enable/Disable actions.