### PR TITLE
Extract LinkedCardComponent from CardComponent

### DIFF
--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -2,21 +2,15 @@ class CardComponent < ViewComponent::Base
   BASE_CLASSES = "w-full rounded-lg border border-border bg-surface shadow-xs"
   PADDED_CLASSES = "p-6"
   SECTIONED_CLASSES = "overflow-hidden divide-y divide-border"
-  LINKED_CLASSES = "block no-underline hover:bg-surface-muted hover:shadow-md transition duration-75"
 
   renders_many :sections, CardComponent::SectionComponent
 
-  def initialize(href: nil, **html_options)
-    @href = href
+  def initialize(**html_options)
     @html_options = html_options
   end
 
   def call
-    if @href
-      link_to(@href, **merged_options) { body }
-    else
-      content_tag(:div, body, merged_options)
-    end
+    content_tag(:div, body, merged_options)
   end
 
   private
@@ -32,7 +26,6 @@ class CardComponent < ViewComponent::Base
       # Resolved through self.class so subclasses restyle by overriding the constants.
       self.class::BASE_CLASSES,
       sections.any? ? SECTIONED_CLASSES : self.class::PADDED_CLASSES,
-      (@href && LINKED_CLASSES),
       @html_options[:class]
     )
     @html_options.merge(class: classes)

--- a/app/components/linked_card_component.rb
+++ b/app/components/linked_card_component.rb
@@ -1,0 +1,14 @@
+# A card that is itself a link: renders as an anchor and layers hover
+# affordances on top of the regular card frame.
+class LinkedCardComponent < CardComponent
+  BASE_CLASSES = "#{CardComponent::BASE_CLASSES} block no-underline hover:bg-surface-muted hover:shadow-md transition duration-75"
+
+  def initialize(href:, **html_options)
+    @href = href
+    super(**html_options)
+  end
+
+  def call
+    link_to(@href, **merged_options) { body }
+  end
+end

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -9,7 +9,7 @@
   </section>
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <%= render CardComponent.new(href: admin_users_path) do %>
+    <%= render LinkedCardComponent.new(href: admin_users_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("users", css_class: "size-5") %>
@@ -19,7 +19,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: admin_events_path) do %>
+    <%= render LinkedCardComponent.new(href: admin_events_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("calendar", css_class: "size-5") %>
@@ -29,7 +29,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: admin_feeds_path) do %>
+    <%= render LinkedCardComponent.new(href: admin_feeds_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("layers", css_class: "size-5") %>

--- a/app/views/development/email_previews/index.html.erb
+++ b/app/views/development/email_previews/index.html.erb
@@ -7,7 +7,7 @@
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
     <% @previews.each do |preview| %>
-      <%= render CardComponent.new(href: development_email_preview_path(preview[:id])) do %>
+      <%= render LinkedCardComponent.new(href: development_email_preview_path(preview[:id])) do %>
         <div class="space-y-4">
           <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
             <%= icon("mail", css_class: "size-5") %>

--- a/app/views/developments/show.html.erb
+++ b/app/views/developments/show.html.erb
@@ -4,7 +4,7 @@
   <%= render PageHeaderComponent.new(title: "Dev Tools") %>
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <%= render CardComponent.new(href: development_system_status_path) do %>
+    <%= render LinkedCardComponent.new(href: development_system_status_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("hard-drive", css_class: "size-5") %>
@@ -14,7 +14,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: mission_control_jobs.root_path, target: "_blank", rel: "noopener noreferrer") do %>
+    <%= render LinkedCardComponent.new(href: mission_control_jobs.root_path, target: "_blank", rel: "noopener noreferrer") do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("hard-hat", css_class: "size-5") %>
@@ -25,7 +25,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: development_jobs_path) do %>
+    <%= render LinkedCardComponent.new(href: development_jobs_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("circle-play", css_class: "size-5") %>
@@ -35,7 +35,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: development_email_previews_path) do %>
+    <%= render LinkedCardComponent.new(href: development_email_previews_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("mail", css_class: "size-5") %>
@@ -45,11 +45,10 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(
-          **(@sent_emails_available \
-            ? { href: development_sent_emails_path } \
-            : { class: "opacity-50 cursor-not-allowed", title: "Email capture is not configured" })
-        ) do %>
+    <% sent_emails_card = @sent_emails_available \
+         ? LinkedCardComponent.new(href: development_sent_emails_path) \
+         : CardComponent.new(class: "opacity-50 cursor-not-allowed", title: "Email capture is not configured") %>
+    <%= render sent_emails_card do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("inbox", css_class: "size-5") %>
@@ -59,7 +58,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: development_components_path) do %>
+    <%= render LinkedCardComponent.new(href: development_components_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("layout-grid", css_class: "size-5") %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <%= render CardComponent.new(href: edit_settings_email_update_path) do %>
+    <%= render LinkedCardComponent.new(href: edit_settings_email_update_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("mail", css_class: "size-5") %>
@@ -21,7 +21,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: edit_settings_password_update_path) do %>
+    <%= render LinkedCardComponent.new(href: edit_settings_password_update_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("lock", css_class: "size-5") %>
@@ -33,7 +33,7 @@
   </div>
 
   <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <%= render CardComponent.new(href: access_tokens_path) do %>
+    <%= render LinkedCardComponent.new(href: access_tokens_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("key-square", css_class: "size-5") %>
@@ -43,7 +43,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: ai_credentials_path) do %>
+    <%= render LinkedCardComponent.new(href: ai_credentials_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("sparkles", css_class: "size-5") %>
@@ -53,7 +53,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: search_credentials_path) do %>
+    <%= render LinkedCardComponent.new(href: search_credentials_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("search", css_class: "size-5") %>
@@ -63,7 +63,7 @@
       </div>
     <% end %>
 
-    <%= render CardComponent.new(href: invites_path) do %>
+    <%= render LinkedCardComponent.new(href: invites_path) do %>
       <div class="space-y-4">
         <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
           <%= icon("mail", css_class: "size-5") %>

--- a/test/components/card_component_test.rb
+++ b/test/components/card_component_test.rb
@@ -45,19 +45,4 @@ class CardComponentTest < ViewComponent::TestCase
     assert_equal "Polling...", card.css("p").first.text
     assert_includes card["class"], "test"
   end
-
-  test "#call should render an anchor when href is given" do
-    result = render_inline(
-      CardComponent.new(href: "/somewhere", target: "_blank", rel: "noopener")
-    ) { "Linked card" }
-
-    card = result.at_css("a")
-    assert_not_nil card
-    assert_equal "/somewhere", card["href"]
-    assert_equal "_blank", card["target"]
-    assert_equal "noopener", card["rel"]
-    assert_includes card["class"], "hover:shadow-md"
-    assert_includes card["class"], "hover:bg-surface-muted"
-    assert_includes card["class"], "no-underline"
-  end
 end

--- a/test/components/linked_card_component_test.rb
+++ b/test/components/linked_card_component_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "view_component/test_case"
+
+class LinkedCardComponentTest < ViewComponent::TestCase
+  test "#call should render an anchor with hover affordances" do
+    result = render_inline(
+      LinkedCardComponent.new(href: "/somewhere", target: "_blank", rel: "noopener")
+    ) { "Linked card" }
+
+    card = result.at_css("a")
+    assert_not_nil card
+    assert_equal "/somewhere", card["href"]
+    assert_equal "Linked card", card.text.strip
+    assert_equal "_blank", card["target"]
+    assert_equal "noopener", card["rel"]
+    assert_includes card["class"], "bg-surface"
+    assert_includes card["class"], "p-6"
+    assert_includes card["class"], "hover:shadow-md"
+    assert_includes card["class"], "hover:bg-surface-muted"
+    assert_includes card["class"], "no-underline"
+  end
+end


### PR DESCRIPTION
Changes:

- Extract the `href` mode of `CardComponent` into a `LinkedCardComponent` subclass; the base card now always renders a plain `div`
- Update the linked-card call sites (settings, admin, and development dashboards) and move the anchor rendering test to the new component

Follows the `ModalCardComponent` pattern from #1165: subclasses customize the shared card rendering through constant and method overrides instead of constructor flags. The one conditionally-linked card (Sent Emails on the development dashboard) now picks the component class instead of splatting options. Rendering is unchanged at every call site.

References:

- Related PR: #1165