### PR TITLE
Move "View all" links to list footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-07-22
 
+- "View all" links moved from the Recent Activity and Recent Posts section headers to the bottom of each list, so they look the same everywhere.
 - The webhook feed page now shows the complete endpoint address (including the host) in both the Endpoint URL and the terminal example, so you can copy and run them as-is.
 - Picking Refresh from a feed's actions menu now closes the menu and confirms the refresh has started, instead of leaving you guessing whether the click did anything.
 - On phones, the sign-in, registration, and password pages now use the full screen width instead of a boxed card.

--- a/app/components/events_list_component.rb
+++ b/app/components/events_list_component.rb
@@ -6,11 +6,13 @@ class EventsListComponent < ViewComponent::Base
 
   # `endpoint` enables polling (first page only). `older_url`/`newer_url` enable
   # cursor pagination links; omit them for an unpaginated list (the status page).
-  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil)
+  # `view_all_url` appends a "View all" row linking to the full events log.
+  def initialize(events:, endpoint: nil, older_url: nil, newer_url: nil, view_all_url: nil)
     @events = events
     @endpoint = endpoint
     @older_url = older_url
     @newer_url = newer_url
+    @view_all_url = view_all_url
   end
 
   def call
@@ -26,6 +28,7 @@ class EventsListComponent < ViewComponent::Base
 
     render(ListComponent.new(data: { key: "events.list" })) do |list|
       @events.each { |event| list.with_item(item_component(event)) }
+      list.with_item(ViewAllListItemComponent.new(url: @view_all_url, data: { key: "events.view_all" })) if @view_all_url
     end
   end
 

--- a/app/components/posts_list_component.rb
+++ b/app/components/posts_list_component.rb
@@ -1,12 +1,15 @@
 class PostsListComponent < ListComponent
-  def initialize(posts:, show_feed: false, item_component: PostListItemComponent)
+  # `view_all_url` appends a "View all" row linking to the full posts list.
+  def initialize(posts:, show_feed: false, item_component: PostListItemComponent, view_all_url: nil)
     super()
     @posts = posts
     @show_feed = show_feed
     @item_component = item_component
+    @view_all_url = view_all_url
   end
 
   def before_render
     @posts.each { |post| with_item(@item_component.new(post: post, show_feed: @show_feed)) }
+    with_item(ViewAllListItemComponent.new(url: @view_all_url, data: { key: "posts.view_all" })) if @view_all_url
   end
 end

--- a/app/components/view_all_list_item_component.rb
+++ b/app/components/view_all_list_item_component.rb
@@ -1,0 +1,15 @@
+# A footer row for ListComponent lists that links to the full collection.
+# Renders a centered, muted "View all" link styled to sit as the last item
+# of the list.
+class ViewAllListItemComponent < ViewComponent::Base
+  def initialize(url:, data: {})
+    @url = url
+    @data = data
+  end
+
+  def call
+    tag.li class: "px-5 py-3 text-center first:rounded-t-lg last:rounded-b-lg" do
+      link_to "View all", @url, class: "text-sm font-medium text-muted transition hover:text-body", data: @data
+    end
+  end
+end

--- a/app/controllers/concerns/event_streaming.rb
+++ b/app/controllers/concerns/event_streaming.rb
@@ -57,9 +57,11 @@ module EventStreaming
     helpers.render(EventsListComponent.new(events: @events, endpoint: @log_endpoint, older_url: @older_url, newer_url: @newer_url))
   end
 
+  # The brief list keeps its "View all" footer row across poll refreshes, so
+  # the stream body must mirror the initial render on the status page.
   def render_brief_events_stream
     @events = events_scope.includes(:user, :subject, :event_references).order(created_at: :desc, id: :desc).limit(brief_events_limit)
-    body = helpers.render(EventsListComponent.new(events: @events, endpoint: brief_polling_endpoint))
+    body = helpers.render(EventsListComponent.new(events: @events, endpoint: brief_polling_endpoint, view_all_url: events_log_path))
     render turbo_stream: turbo_stream.replace(EventsListComponent::DOM_ID, body)
   end
 

--- a/app/views/admin/feeds/show.html.erb
+++ b/app/views/admin/feeds/show.html.erb
@@ -20,20 +20,14 @@
 
   <% if @recent_events.any? %>
     <section class="space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
-        <%= link_to "View all", admin_events_path(filter: { subject_type: "Feed", subject_id: @feed.id }), class: "text-sm font-semibold text-brand hover:text-brand-hover", data: { key: "feed.events.view_all" } %>
-      </div>
-      <%= render Admin::EventsListComponent.new(events: @recent_events) %>
+      <h2 class="text-2xl font-semibold mb-3 text-heading">Recent Activity</h2>
+      <%= render Admin::EventsListComponent.new(events: @recent_events, view_all_url: admin_events_path(filter: { subject_type: "Feed", subject_id: @feed.id })) %>
     </section>
   <% end %>
 
   <% if @recent_posts.any? %>
     <section class="space-y-4">
-      <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <h2 class="text-2xl font-semibold mb-0 text-heading">Recent Posts</h2>
-      </div>
-
+      <h2 class="text-2xl font-semibold mb-3 text-heading">Recent Posts</h2>
       <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false, item_component: ReadonlyPostListItemComponent) %>
     </section>
   <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -51,11 +51,8 @@
 
   <% if @recent_events.any? %>
     <section class="space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
-        <%= link_to "View all", admin_events_path(filter: { user_id: @user.id }), class: "text-sm font-semibold text-brand hover:text-brand-hover", data: { key: "user.events.view_all" } %>
-      </div>
-      <%= render Admin::EventsListComponent.new(events: @recent_events) %>
+      <h2 class="text-2xl font-semibold mb-3 text-heading">Recent Activity</h2>
+      <%= render Admin::EventsListComponent.new(events: @recent_events, view_all_url: admin_events_path(filter: { user_id: @user.id })) %>
     </section>
   <% end %>
 

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -27,22 +27,15 @@
 
   <% if @recent_events.any? %>
     <section class="space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
-        <%= link_to "View all", events_path(filter: { subject_type: "Feed", subject_id: @feed.id }), class: "text-sm font-semibold text-brand hover:text-brand-hover", data: { key: "feed.events.view_all" } %>
-      </div>
-      <%= render EventsListComponent.new(events: @recent_events) %>
+      <h2 class="text-2xl font-semibold mb-3 text-heading">Recent Activity</h2>
+      <%= render EventsListComponent.new(events: @recent_events, view_all_url: events_path(filter: { subject_type: "Feed", subject_id: @feed.id })) %>
     </section>
   <% end %>
 
   <% if @recent_posts.any? %>
     <section class="space-y-4">
-      <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <h2 class="text-2xl font-semibold mb-0 text-heading">Recent Posts</h2>
-        <%= link_to "View all posts", posts_path(feed_id: @feed.id), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover text-sm" %>
-      </div>
-
-      <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false) %>
+      <h2 class="text-2xl font-semibold mb-3 text-heading">Recent Posts</h2>
+      <%= render PostsListComponent.new(posts: @recent_posts, show_feed: false, view_all_url: posts_path(feed_id: @feed.id)) %>
     </section>
   <% end %>
 </div>

--- a/app/views/statuses/show.html.erb
+++ b/app/views/statuses/show.html.erb
@@ -40,13 +40,11 @@
     <%= render PostsHeatmapComponent.new(user: @user) %>
 
     <section class="space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-2xl font-semibold text-heading">Recent Activity</h2>
-        <%= link_to "View all", events_path(filter: @filter.to_h.presence), class: "text-sm font-semibold text-brand hover:text-brand-hover", data: { key: "recent_events.view_all" } %>
-      </div>
+      <h2 class="text-2xl font-semibold mb-3 text-heading">Recent Activity</h2>
       <%= render(EventsListComponent.new(
         events: @recent_events,
-        endpoint: events_path(format: :turbo_stream, display: :brief, filter: @filter.to_h.presence)
+        endpoint: events_path(format: :turbo_stream, display: :brief, filter: @filter.to_h.presence),
+        view_all_url: events_path(filter: @filter.to_h.presence)
       )) %>
     </section>
   <% end %>

--- a/test/components/events_list_component_test.rb
+++ b/test/components/events_list_component_test.rb
@@ -61,6 +61,25 @@ class EventsListComponentTest < ViewComponent::TestCase
     assert_empty result.css("[data-key='events.pagination']")
   end
 
+  test "#call should render a view all row as the last list item when url is given" do
+    event = create(:event, user: user)
+
+    result = render_inline(EventsListComponent.new(events: [event], view_all_url: "/events"))
+
+    link = result.at_css("[data-key='events.list'] > li:last-child a[data-key='events.view_all']")
+    assert_not_nil link
+    assert_equal "/events", link["href"]
+    assert_equal "View all", link.text
+  end
+
+  test "#call should omit the view all row when no url is given" do
+    event = create(:event, user: user)
+
+    result = render_inline(EventsListComponent.new(events: [event]))
+
+    assert_empty result.css("[data-key='events.view_all']")
+  end
+
   test "#call should render the empty state when events array is empty" do
     result = render_inline(EventsListComponent.new(events: []))
 

--- a/test/components/posts_list_component_test.rb
+++ b/test/components/posts_list_component_test.rb
@@ -17,6 +17,23 @@ class PostsListComponentTest < ViewComponent::TestCase
     assert_not_empty result.css("##{ActionView::RecordIdentifier.dom_id(post)}")
   end
 
+  test "#render should render a view all row as the last list item when url is given" do
+    post = create(:post, feed: feed)
+    result = render_inline PostsListComponent.new(posts: [post], view_all_url: "/posts")
+
+    link = result.at_css("li:last-child a[data-key='posts.view_all']")
+    assert_not_nil link
+    assert_equal "/posts", link["href"]
+    assert_equal "View all", link.text
+  end
+
+  test "#render should omit the view all row when no url is given" do
+    post = create(:post, feed: feed)
+    result = render_inline PostsListComponent.new(posts: [post])
+
+    assert_empty result.css("[data-key='posts.view_all']")
+  end
+
   test "#render should not render an empty state when there are no posts" do
     result = render_inline PostsListComponent.new(posts: [])
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -118,7 +118,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     get admin_user_path(user)
 
     assert_response :success
-    assert_select "[data-key='user.events.view_all'][href=?]", admin_events_path(filter: { user_id: user.id }), text: "View all"
+    assert_select "[data-key='events.view_all'][href=?]", admin_events_path(filter: { user_id: user.id }), text: "View all"
   end
 
   test "#show should not render recent activity section when user has no events" do


### PR DESCRIPTION
Changes:

- Add `ViewAllListItemComponent` — a centered, muted "View all" link rendered as the last item of a list
- Let `EventsListComponent` and `PostsListComponent` accept an optional `view_all_url` that appends the footer row
- Simplify the Recent Activity / Recent Posts section headers to plain `h2`s on the status, feed, and admin pages
- Keep the footer link in the brief events stream so polling refreshes don't drop it

The "View all" links in section headers were styled inconsistently across pages (bold vs. underlined). Moving them into the lists themselves gives them one shared look and keeps section headers uniform.

## Screenshots

| Status page | Feed page |
| --- | --- |
| ![Status page](https://raw.githubusercontent.com/dreikanter/f2/2f12419c95ba3905e4090db18bd6620fcf715b6b/status-page.png) | ![Feed page](https://raw.githubusercontent.com/dreikanter/f2/2f12419c95ba3905e4090db18bd6620fcf715b6b/feed-page.png) |

| Admin feed page | Admin user page |
| --- | --- |
| ![Admin feed page](https://raw.githubusercontent.com/dreikanter/f2/2f12419c95ba3905e4090db18bd6620fcf715b6b/admin-feed-page.png) | ![Admin user page](https://raw.githubusercontent.com/dreikanter/f2/2f12419c95ba3905e4090db18bd6620fcf715b6b/admin-user-page.png) |