### PR TITLE
Own content fit math in HtmlTextUtils

### DIFF
--- a/app/services/html_text_utils.rb
+++ b/app/services/html_text_utils.rb
@@ -21,22 +21,20 @@ module HtmlTextUtils
     text.truncate(max_length, separator: " ", omission: "…")
   end
 
+  # How much content survives once the URL is folded in. Callers that only
+  # need to know whether the content fits ask here instead of re-deriving it.
+  def content_fit_limit(url, max_content_length: Post::MAX_CONTENT_LENGTH, max_url_length: Post::MAX_URL_LENGTH)
+    return max_content_length if url.blank? || url.length > max_url_length
+
+    max_content_length - CONTENT_URL_SEPARATOR.length - url.length
+  end
+
   def post_content_with_url(content, url, max_content_length: Post::MAX_CONTENT_LENGTH, max_url_length: Post::MAX_URL_LENGTH)
-    if url.blank?
-      return truncate_text(content, max_length: max_content_length)
-    end
-
-    if content.blank?
-      return url.length > max_url_length ? "" : url
-    end
-
     # Do not include URL to the post content if the URL is too long
-    if url.length > max_url_length
-      return truncate_text(content, max_length: max_content_length)
-    end
+    url = nil if url.present? && url.length > max_url_length
+    return url.to_s if content.blank?
 
-    max_text_length = max_content_length - CONTENT_URL_SEPARATOR.length - url.length
-    truncated_text = truncate_text(content, max_length: max_text_length)
-    "#{truncated_text}#{CONTENT_URL_SEPARATOR}#{url}"
+    text = truncate_text(content, max_length: content_fit_limit(url, max_content_length:, max_url_length:))
+    url.blank? ? text : "#{text}#{CONTENT_URL_SEPARATOR}#{url}"
   end
 end

--- a/app/services/webhook_ingestion.rb
+++ b/app/services/webhook_ingestion.rb
@@ -6,6 +6,8 @@ require "addressable/uri"
 # publish chain. A payload that fails validation persists nothing — the
 # synchronous 422 is the rejection record, so a corrected retry goes through.
 class WebhookIngestion
+  include HtmlTextUtils
+
   MAX_LIST_ITEMS = 8
   SUPPORTED_PUBLISHED_AT_YEARS = (1..9999).freeze
 
@@ -217,20 +219,8 @@ class WebhookIngestion
   end
 
   # Length never fails a request — the normalizer truncates instead — but the
-  # caller deserves to know. Mirrors post_content_with_url's fit math.
+  # caller deserves to know.
   def warnings
-    content_truncated? ? ["content_truncated"] : []
-  end
-
-  def content_truncated?
-    return false if content.blank?
-
-    limit = if source_url.nil? || source_url.length > Post::MAX_URL_LENGTH
-      Post::MAX_CONTENT_LENGTH
-    else
-      Post::MAX_CONTENT_LENGTH - HtmlTextUtils::CONTENT_URL_SEPARATOR.length - source_url.length
-    end
-
-    content.length > limit
+    content.present? && content.length > content_fit_limit(source_url) ? ["content_truncated"] : []
   end
 end

--- a/test/services/html_text_utils_test.rb
+++ b/test/services/html_text_utils_test.rb
@@ -49,4 +49,43 @@ class HtmlTextUtilsTest < ActiveSupport::TestCase
     result = subject.truncate_text(short_text, max_length: 50)
     assert_equal "Hello world", result
   end
+
+  test "#content_fit_limit should leave room for the separator and the URL" do
+    limit = subject.content_fit_limit("https://example.com", max_content_length: 100)
+    assert_equal 100 - HtmlTextUtils::CONTENT_URL_SEPARATOR.length - "https://example.com".length, limit
+  end
+
+  test "#content_fit_limit should return the full limit without a usable URL" do
+    assert_equal 100, subject.content_fit_limit(nil, max_content_length: 100)
+    assert_equal 100, subject.content_fit_limit("https://example.com", max_content_length: 100, max_url_length: 5)
+  end
+
+  test "#post_content_with_url should append the URL to the content" do
+    result = subject.post_content_with_url("Hello", "https://example.com")
+    assert_equal "Hello - https://example.com", result
+  end
+
+  test "#post_content_with_url should truncate the content to the fit limit" do
+    url = "https://example.com"
+    result = subject.post_content_with_url("a" * 100, url, max_content_length: 50)
+
+    assert_equal 50, result.length
+    assert result.ends_with?("…#{HtmlTextUtils::CONTENT_URL_SEPARATOR}#{url}")
+  end
+
+  test "#post_content_with_url should drop a URL longer than the limit" do
+    result = subject.post_content_with_url("Hello", "https://example.com", max_url_length: 5)
+    assert_equal "Hello", result
+  end
+
+  test "#post_content_with_url should return the URL alone for blank content" do
+    assert_equal "https://example.com", subject.post_content_with_url("", "https://example.com")
+    assert_equal "", subject.post_content_with_url("", "https://example.com", max_url_length: 5)
+    assert_equal "", subject.post_content_with_url("", nil)
+  end
+
+  test "#post_content_with_url should truncate content without a URL" do
+    result = subject.post_content_with_url("a" * 100, nil, max_content_length: 50)
+    assert_equal 50, result.length
+  end
 end


### PR DESCRIPTION
Changes:

- Add `HtmlTextUtils#content_fit_limit` and use it from `post_content_with_url`
- Replace `WebhookIngestion#content_truncated?` with a call to the shared limit
- Cover `post_content_with_url` and the new limit with unit tests

`WebhookIngestion` re-derived the three-branch fit computation that
`post_content_with_url` owns, kept honest only by a "mirrors the fit math"
comment and no test forcing the two to agree. The rule now lives in one place,
so touching the composition rules can't silently make the truncation warning
lie.

References:

- Addresses a finding from #1141


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqjKUQV2waGaMYqSWPX4dU)_