### PR TITLE
Extract clipboard button and curl example helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,6 +40,22 @@ module ApplicationHelper
       "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1"
   end
 
+  def icon_button_classes
+    "inline-flex size-7 shrink-0 items-center justify-center rounded text-muted transition " \
+      "hover:bg-surface-sunken hover:text-body focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+  end
+
+  # Copy-to-clipboard icon button. The label serves as both the tooltip and
+  # the screen-reader text.
+  def clipboard_button(value, label:, key:, css_class: nil)
+    tag.button type: "button",
+               class: class_names(icon_button_classes, css_class),
+               title: label,
+               data: { controller: "clipboard", clipboard_text_value: value, action: "click->clipboard#copy", key: key } do
+      icon("clipboard", css_class: "size-4") + tag.span(label, class: "sr-only")
+    end
+  end
+
   # Decorative separator between card footer items. Hidden from assistive tech
   # so the items read as distinct entries rather than "dot".
   def middot

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -69,6 +69,17 @@ module FeedHelper
     items
   end
 
+  # Copy-paste request for the webhook endpoint panel, showing the smallest
+  # payload that gets a post published.
+  def webhook_curl_example(url, token)
+    <<~CURL.chomp
+      curl --request POST #{url} \\
+        --header "Authorization: Bearer #{token}" \\
+        --header "Content-Type: application/json" \\
+        --data '{"content":"Hello world"}'
+    CURL
+  end
+
   def feed_summary_line(active_count:, inactive_count:, draft_count:)
     counts = { "active feed" => active_count, "inactive feed" => inactive_count, "draft feed" => draft_count }
     parts = counts.reject { |_label, count| count.zero? }

--- a/app/views/feeds/_webhook_endpoint_panel.html.erb
+++ b/app/views/feeds/_webhook_endpoint_panel.html.erb
@@ -2,14 +2,8 @@
 <%
   hook_url = api_v1_posts_url
   token = endpoint.encrypted_token
-  curl_snippet = <<~CURL.chomp
-    curl --request POST #{hook_url} \\
-      --header "Authorization: Bearer #{token}" \\
-      --header "Content-Type: application/json" \\
-      --data '{"content":"Hello world"}'
-  CURL
+  curl_snippet = webhook_curl_example(hook_url, token)
   field_class = "min-w-0 flex-1 rounded-md border border-border-strong bg-surface px-3 py-2 font-mono text-sm leading-normal text-heading shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2"
-  icon_button_class = "inline-flex size-7 shrink-0 items-center justify-center rounded text-muted transition hover:bg-surface-sunken hover:text-body focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 %>
 <%= render PanelComponent.new(data: { key: "webhook.panel" }) do %>
   <div class="space-y-6">
@@ -22,17 +16,7 @@
                       class: field_class,
                       aria: { label: "Endpoint URL" },
                       data: { key: "webhook.url" } %>
-        <button
-          type="button"
-          class="<%= icon_button_class %>"
-          data-controller="clipboard"
-          data-clipboard-text-value="<%= hook_url %>"
-          data-action="click->clipboard#copy"
-          data-key="webhook.copy-url"
-          title="Copy endpoint URL">
-          <%= icon("clipboard", css_class: "size-4") %>
-          <span class="sr-only">Copy endpoint URL</span>
-        </button>
+        <%= clipboard_button hook_url, label: "Copy endpoint URL", key: "webhook.copy-url" %>
       </div>
     </div>
 
@@ -46,17 +30,7 @@
                       class: field_class,
                       aria: { label: "Authorization token" },
                       data: { key: "webhook.token" } %>
-        <button
-          type="button"
-          class="<%= icon_button_class %>"
-          data-controller="clipboard"
-          data-clipboard-text-value="<%= token %>"
-          data-action="click->clipboard#copy"
-          data-key="webhook.copy-token"
-          title="Copy authorization token">
-          <%= icon("clipboard", css_class: "size-4") %>
-          <span class="sr-only">Copy authorization token</span>
-        </button>
+        <%= clipboard_button token, label: "Copy authorization token", key: "webhook.copy-token" %>
       </div>
       <p class="text-sm text-muted">
         Send this token as <code>Authorization: Bearer &lt;token&gt;</code> and treat it like a password.
@@ -83,17 +57,7 @@
                          class: "#{field_class} resize-none whitespace-pre",
                          aria: { label: "curl example" },
                          data: { key: "webhook.curl" } %>
-        <button
-          type="button"
-          class="<%= icon_button_class %> mt-2"
-          data-controller="clipboard"
-          data-clipboard-text-value="<%= curl_snippet %>"
-          data-action="click->clipboard#copy"
-          data-key="webhook.copy-curl"
-          title="Copy curl example">
-          <%= icon("clipboard", css_class: "size-4") %>
-          <span class="sr-only">Copy curl example</span>
-        </button>
+        <%= clipboard_button curl_snippet, label: "Copy curl example", key: "webhook.copy-curl", css_class: "mt-2" %>
       </div>
       <p class="text-sm text-muted">You can also send <code>source_url</code>, <code>images</code>, <code>comments</code>, and a <code>uid</code> to keep retries from double-posting.</p>
     </div>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -259,6 +259,18 @@ class ApplicationHelperTest < ActionView::TestCase
     end
   end
 
+  test "#clipboard_button should carry the copied value and label the button" do
+    result = clipboard_button("secret", label: "Copy token", key: "webhook.copy-token", css_class: "mt-2")
+
+    assert_includes result, 'data-clipboard-text-value="secret"'
+    assert_includes result, 'data-action="click-&gt;clipboard#copy"'
+    assert_includes result, 'data-key="webhook.copy-token"'
+    assert_includes result, 'title="Copy token"'
+    assert_includes result, 'data-icon="clipboard"'
+    assert_includes result, '<span class="sr-only">Copy token</span>'
+    assert_includes result, "mt-2"
+  end
+
   test "#navbar_items should include dev tools when allowed" do
     user = create(:user)
     Current.session = create(:session, user: user)

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -232,6 +232,13 @@ class FeedHelperTest < ActionView::TestCase
     assert_includes result, "source"
   end
 
+  test "#webhook_curl_example should include the endpoint URL and the token" do
+    snippet = webhook_curl_example("https://example.com/v1/posts", "secret-token")
+
+    assert_includes snippet, "curl --request POST https://example.com/v1/posts"
+    assert_includes snippet, "Authorization: Bearer secret-token"
+  end
+
   test "#candidate_summary should fall back to the profile display name for URL profiles" do
     assert_equal "RSS Feed", candidate_summary("rss", "https://example.com/feed.xml")
     assert_equal "Reddit", candidate_summary("reddit", "https://reddit.com/r/ruby/")


### PR DESCRIPTION
Changes:

- Add `clipboard_button` and `icon_button_classes` helpers
- Move the webhook curl snippet into `webhook_curl_example`
- Collapse the three copy buttons in the webhook endpoint panel to one call each

The panel carried three near-identical ten-line copy buttons and assembled the
curl example inside an inline ERB block. Both now live in helpers, so the panel
markup only describes what it shows.

References:

- Addresses a finding from #1141


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqjKUQV2waGaMYqSWPX4dU)_