### PR TITLE
Read webhook payload through one value object

### DIFF
--- a/app/services/normalizer/webhook_normalizer.rb
+++ b/app/services/normalizer/webhook_normalizer.rb
@@ -5,31 +5,27 @@ module Normalizer
   class WebhookNormalizer < Base
     private
 
-    # Stripped to match the ingress service's reading of the field, so the
-    # truncation-warning math and the stored link agree.
-    def normalize_source_url
-      raw_data["source_url"].to_s.strip.presence
+    def payload
+      @payload ||= WebhookPayload.new(raw_data)
     end
+
+    def normalize_source_url = payload.source_url
 
     # Folds the source link into the body, same shape as pull feeds.
     def normalize_content
-      post_content_with_url(raw_data["content"].to_s, normalize_source_url)
+      post_content_with_url(payload.content, payload.source_url)
     end
 
-    def normalize_attachment_urls
-      Array(raw_data["images"]).map(&:to_s)
-    end
+    def normalize_attachment_urls = payload.images
 
-    def normalize_comments
-      Array(raw_data["comments"]).map(&:to_s)
-    end
+    def normalize_comments = payload.comments
 
     # Content is required unless images are present (spec 006 §3). Checked on
     # the raw payload field: in the composed content a bare source_url would
     # masquerade as content.
     def validate_content
       errors = []
-      errors << "no_content_or_images" if raw_data["content"].to_s.blank? && attachment_urls.empty?
+      errors << "no_content_or_images" if payload.content.blank? && attachment_urls.empty?
       errors.concat(images_only_errors)
       errors
     end

--- a/app/services/webhook_ingestion.rb
+++ b/app/services/webhook_ingestion.rb
@@ -45,7 +45,7 @@ class WebhookIngestion
   def initialize(endpoint:, payload:)
     @endpoint = endpoint
     @feed = endpoint.feed
-    @payload = payload
+    @payload = WebhookPayload.new(payload)
   end
 
   def call
@@ -69,6 +69,8 @@ class WebhookIngestion
 
   attr_reader :endpoint, :feed, :payload
 
+  delegate :content, :source_url, :images, :explicit_uid, :raw_published_at, to: :payload
+
   def validate_payload
     errors = schema_errors
     return errors if errors.any?
@@ -77,7 +79,7 @@ class WebhookIngestion
     return errors if errors.any?
 
     errors << "no_content_or_images" if content.blank? && images.empty?
-    errors << "uid must not be blank" if payload.key?("uid") && explicit_uid.blank?
+    errors << "uid must not be blank" if payload.uid_given? && explicit_uid.blank?
     errors << "source_url must be an absolute http(s) URL" if source_url.present? && !http_url?(source_url)
     images.each_with_index do |url, index|
       errors << "images/#{index} must be a public http(s) URL" unless PublicUrl.safe?(url)
@@ -89,7 +91,7 @@ class WebhookIngestion
   end
 
   def schema_errors
-    JSONSchemer.schema(PAYLOAD_SCHEMA).validate(payload).map do |error|
+    JSONSchemer.schema(PAYLOAD_SCHEMA).validate(payload.to_h).map do |error|
       pointer = error["data_pointer"].to_s
       pointer.empty? ? error["error"] : "#{pointer} #{error['error']}"
     end
@@ -99,7 +101,7 @@ class WebhookIngestion
   # request boundary instead of letting an otherwise valid payload fail during
   # persistence with a 500.
   def null_byte_errors
-    payload.each_with_object([]) do |(key, value), errors|
+    payload.to_h.each_with_object([]) do |(key, value), errors|
       if value.is_a?(String)
         errors << "#{key} must not contain null bytes" if value.include?("\0")
       elsif value.is_a?(Array)
@@ -118,7 +120,7 @@ class WebhookIngestion
     rejection = nil
 
     ActiveRecord::Base.transaction do
-      entry = feed.feed_entries.create!(uid: uid, published_at: published_at, raw_data: payload, status: :pending)
+      entry = feed.feed_entries.create!(uid: uid, published_at: published_at, raw_data: payload.to_h, status: :pending)
       FeedEntryUid.create!(feed: feed, uid: uid, imported_at: Time.current)
 
       post = feed.normalizer_instance(entry).normalize
@@ -154,10 +156,6 @@ class WebhookIngestion
     from_url.presence || SecureRandom.uuid
   end
 
-  def explicit_uid
-    @explicit_uid ||= payload["uid"].to_s.strip
-  end
-
   def uid
     @uid ||= resolve_uid
   end
@@ -169,22 +167,6 @@ class WebhookIngestion
 
   def invalid(errors)
     Result.new(status: :invalid, uid: nil, errors: errors, warnings: [])
-  end
-
-  def content
-    payload["content"].to_s
-  end
-
-  def source_url
-    payload["source_url"].to_s.strip.presence
-  end
-
-  def images
-    Array(payload["images"])
-  end
-
-  def raw_published_at
-    payload["published_at"].to_s
   end
 
   def parsed_published_at

--- a/app/services/webhook_payload.rb
+++ b/app/services/webhook_payload.rb
@@ -1,0 +1,30 @@
+# One reader for a webhook delivery payload (spec 006 §3). Both the ingress
+# service, which answers a 422 synchronously, and the normalizer, which builds
+# the Post later from the stored copy, go through it — so there is no second
+# reading of a field to keep in sync with the first.
+class WebhookPayload
+  def initialize(data)
+    @data = data
+  end
+
+  def content = data["content"].to_s
+
+  def source_url = data["source_url"].to_s.strip.presence
+
+  def images = Array(data["images"]).map(&:to_s)
+
+  def comments = Array(data["comments"]).map(&:to_s)
+
+  def explicit_uid = data["uid"].to_s.strip
+
+  # Tells a missing uid apart from a blank one: only the latter is an error.
+  def uid_given? = data.key?("uid")
+
+  def raw_published_at = data["published_at"].to_s
+
+  def to_h = data
+
+  private
+
+  attr_reader :data
+end

--- a/test/services/webhook_payload_test.rb
+++ b/test/services/webhook_payload_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class WebhookPayloadTest < ActiveSupport::TestCase
+  test "#content should return an empty string when absent" do
+    assert_equal "", WebhookPayload.new({}).content
+    assert_equal "Hello", WebhookPayload.new({ "content" => "Hello" }).content
+  end
+
+  test "#source_url should strip surrounding whitespace" do
+    assert_equal "https://example.com", WebhookPayload.new({ "source_url" => "  https://example.com  " }).source_url
+  end
+
+  test "#source_url should return nil when blank" do
+    assert_nil WebhookPayload.new({}).source_url
+    assert_nil WebhookPayload.new({ "source_url" => "   " }).source_url
+  end
+
+  test "#images should return an array of strings" do
+    assert_equal [], WebhookPayload.new({}).images
+    assert_equal ["https://example.com/a.jpg"], WebhookPayload.new({ "images" => ["https://example.com/a.jpg"] }).images
+  end
+
+  test "#comments should return an array of strings" do
+    assert_equal [], WebhookPayload.new({}).comments
+    assert_equal ["Nice"], WebhookPayload.new({ "comments" => ["Nice"] }).comments
+  end
+
+  test "#explicit_uid should strip surrounding whitespace" do
+    assert_equal "article-42", WebhookPayload.new({ "uid" => "  article-42  " }).explicit_uid
+    assert_equal "", WebhookPayload.new({}).explicit_uid
+  end
+
+  test "#uid_given? should tell a missing uid from a blank one" do
+    assert_not WebhookPayload.new({}).uid_given?
+    assert WebhookPayload.new({ "uid" => "   " }).uid_given?
+  end
+
+  test "#raw_published_at should return an empty string when absent" do
+    assert_equal "", WebhookPayload.new({}).raw_published_at
+    assert_equal "2026-01-01T00:00:00Z", WebhookPayload.new({ "published_at" => "2026-01-01T00:00:00Z" }).raw_published_at
+  end
+
+  test "#to_h should return the wrapped hash for storage and schema checks" do
+    data = { "content" => "Hello" }
+
+    assert_same data, WebhookPayload.new(data).to_h
+  end
+end


### PR DESCRIPTION
Changes:

- Add `WebhookPayload`, a value object over a delivery payload
- Read fields through it in `WebhookIngestion` and `Normalizer::WebhookNormalizer`

The payload's field semantics — how `content`, `source_url`, `images`, and
`comments` are read — used to be implemented once in the ingress service and
again in the normalizer, kept in agreement by a "matches the ingress service's
reading" comment. Both now read the same object, so a payload-shape change has
one place to happen.

The normalizer keeps checking its own `attachment_urls` for the
`no_content_or_images` rule rather than the raw list: those are the
SSRF-filtered ones, and that safety net is worth keeping even though ingestion
already rejects unsafe image URLs with a 422.

References:

- Addresses a finding from #1141


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqjKUQV2waGaMYqSWPX4dU)_