### PR TITLE
Extract DomainMatcher for host-only profile matchers

### DIFF
--- a/app/services/profile_matcher/aerostat_profile_matcher.rb
+++ b/app/services/profile_matcher/aerostat_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class AerostatProfileMatcher < Base
+  class AerostatProfileMatcher < DomainMatcher
     match_specificity 100
 
-    AEROSTAT_DOMAIN = "aerostatbg.ru"
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      [AEROSTAT_DOMAIN, "www.#{AEROSTAT_DOMAIN}"].include?(uri.host)
-    end
+    match_domains "aerostatbg.ru"
   end
 end

--- a/app/services/profile_matcher/buni_profile_matcher.rb
+++ b/app/services/profile_matcher/buni_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class BuniProfileMatcher < Base
+  class BuniProfileMatcher < DomainMatcher
     match_specificity 100
 
-    BUNI_DOMAIN = "bunicomic.com"
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      [BUNI_DOMAIN, "www.#{BUNI_DOMAIN}"].include?(uri.host)
-    end
+    match_domains "bunicomic.com"
   end
 end

--- a/app/services/profile_matcher/domain_matcher.rb
+++ b/app/services/profile_matcher/domain_matcher.rb
@@ -1,0 +1,34 @@
+module ProfileMatcher
+  # Base class for matchers that key off the URL host alone. Subclasses
+  # declare the domains they own; each is matched bare and with a "www."
+  # prefix:
+  #
+  #   class XkcdProfileMatcher < DomainMatcher
+  #     match_specificity 100
+  #     match_domains "xkcd.com"
+  #   end
+  #
+  # Matchers needing path, handle, or body rules subclass Base and write
+  # their own #match?.
+  class DomainMatcher < Base
+    class << self
+      def match_domains(*domains)
+        raise ArgumentError, "match_domains requires at least one domain" if domains.empty?
+
+        @hosts = domains.flat_map { |domain| [domain, "www.#{domain}"] }.freeze
+      end
+
+      def hosts
+        @hosts || raise(NotImplementedError, "#{name} must declare its domains via match_domains")
+      end
+    end
+
+    # Invalid URLs raise URI::InvalidURIError rather than matching nothing:
+    # detection treats an unparseable source as a user error, not a miss.
+    def match?
+      return false if input.blank?
+
+      self.class.hosts.include?(URI.parse(input).host)
+    end
+  end
+end

--- a/app/services/profile_matcher/elementy_profile_matcher.rb
+++ b/app/services/profile_matcher/elementy_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class ElementyProfileMatcher < Base
+  class ElementyProfileMatcher < DomainMatcher
     match_specificity 100
 
-    ELEMENTY_DOMAIN = "elementy.ru"
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      [ELEMENTY_DOMAIN, "www.#{ELEMENTY_DOMAIN}"].include?(uri.host)
-    end
+    match_domains "elementy.ru"
   end
 end

--- a/app/services/profile_matcher/melodymae_profile_matcher.rb
+++ b/app/services/profile_matcher/melodymae_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class MelodymaeProfileMatcher < Base
+  class MelodymaeProfileMatcher < DomainMatcher
     match_specificity 100
 
-    MELODYMAE_DOMAIN = "melodymae.co.uk"
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      [MELODYMAE_DOMAIN, "www.#{MELODYMAE_DOMAIN}"].include?(uri.host)
-    end
+    match_domains "melodymae.co.uk"
   end
 end

--- a/app/services/profile_matcher/monkeyuser_profile_matcher.rb
+++ b/app/services/profile_matcher/monkeyuser_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class MonkeyuserProfileMatcher < Base
+  class MonkeyuserProfileMatcher < DomainMatcher
     match_specificity 100
 
-    MONKEYUSER_DOMAIN = "monkeyuser.com"
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      [MONKEYUSER_DOMAIN, "www.#{MONKEYUSER_DOMAIN}"].include?(uri.host)
-    end
+    match_domains "monkeyuser.com"
   end
 end

--- a/app/services/profile_matcher/nextbigfuture_profile_matcher.rb
+++ b/app/services/profile_matcher/nextbigfuture_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class NextbigfutureProfileMatcher < Base
+  class NextbigfutureProfileMatcher < DomainMatcher
     match_specificity 100
 
-    NEXTBIGFUTURE_DOMAINS = ["nextbigfuture.com", "www.nextbigfuture.com"].freeze
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      NEXTBIGFUTURE_DOMAINS.include?(uri.host)
-    end
+    match_domains "nextbigfuture.com"
   end
 end

--- a/app/services/profile_matcher/oglaf_profile_matcher.rb
+++ b/app/services/profile_matcher/oglaf_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class OglafProfileMatcher < Base
+  class OglafProfileMatcher < DomainMatcher
     match_specificity 100
 
-    OGLAF_DOMAIN = "oglaf.com"
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      [OGLAF_DOMAIN, "www.#{OGLAF_DOMAIN}"].include?(uri.host)
-    end
+    match_domains "oglaf.com"
   end
 end

--- a/app/services/profile_matcher/pluralistic_profile_matcher.rb
+++ b/app/services/profile_matcher/pluralistic_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class PluralisticProfileMatcher < Base
+  class PluralisticProfileMatcher < DomainMatcher
     match_specificity 100
 
-    PLURALISTIC_DOMAIN = "pluralistic.net"
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      [PLURALISTIC_DOMAIN, "www.#{PLURALISTIC_DOMAIN}"].include?(uri.host)
-    end
+    match_domains "pluralistic.net"
   end
 end

--- a/app/services/profile_matcher/smbc_profile_matcher.rb
+++ b/app/services/profile_matcher/smbc_profile_matcher.rb
@@ -1,13 +1,7 @@
 module ProfileMatcher
-  class SmbcProfileMatcher < Base
+  class SmbcProfileMatcher < DomainMatcher
     match_specificity 100
 
-    HOSTS = %w[smbc-comics.com www.smbc-comics.com].freeze
-
-    def match?
-      return false if input.blank?
-
-      HOSTS.include?(URI.parse(input).host)
-    end
+    match_domains "smbc-comics.com"
   end
 end

--- a/app/services/profile_matcher/tomorrows_profile_matcher.rb
+++ b/app/services/profile_matcher/tomorrows_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class TomorrowsProfileMatcher < Base
+  class TomorrowsProfileMatcher < DomainMatcher
     match_specificity 100
 
-    TOMORROWS_DOMAIN = "365tomorrows.com"
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      [TOMORROWS_DOMAIN, "www.#{TOMORROWS_DOMAIN}"].include?(uri.host)
-    end
+    match_domains "365tomorrows.com"
   end
 end

--- a/app/services/profile_matcher/xkcd_profile_matcher.rb
+++ b/app/services/profile_matcher/xkcd_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class XkcdProfileMatcher < Base
+  class XkcdProfileMatcher < DomainMatcher
     match_specificity 100
 
-    XKCD_DOMAIN = "xkcd.com"
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      [XKCD_DOMAIN, "www.#{XKCD_DOMAIN}"].include?(uri.host)
-    end
+    match_domains "xkcd.com"
   end
 end

--- a/app/services/profile_matcher/youtube_profile_matcher.rb
+++ b/app/services/profile_matcher/youtube_profile_matcher.rb
@@ -1,14 +1,7 @@
 module ProfileMatcher
-  class YoutubeProfileMatcher < Base
+  class YoutubeProfileMatcher < DomainMatcher
     match_specificity 100
 
-    YOUTUBE_DOMAINS = %w[youtube.com www.youtube.com youtu.be www.youtu.be].freeze
-
-    def match?
-      return false if input.blank?
-
-      uri = URI.parse(input)
-      YOUTUBE_DOMAINS.include?(uri.host)
-    end
+    match_domains "youtube.com", "youtu.be"
   end
 end

--- a/test/services/profile_matcher/domain_matcher_test.rb
+++ b/test/services/profile_matcher/domain_matcher_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class ProfileMatcher::DomainMatcherTest < ActiveSupport::TestCase
+  def declared_class
+    @declared_class ||= Class.new(ProfileMatcher::DomainMatcher) do
+      def self.name
+        "ProfileMatcher::SampleProfileMatcher"
+      end
+
+      match_specificity 100
+
+      match_domains "example.com", "example.net"
+    end
+  end
+
+  def undeclared_class
+    @undeclared_class ||= Class.new(ProfileMatcher::DomainMatcher) do
+      def self.name
+        "ProfileMatcher::UndeclaredProfileMatcher"
+      end
+    end
+  end
+
+  def matcher(url)
+    declared_class.new(url)
+  end
+
+  test ".match_domains should expand each domain into bare and www hosts" do
+    assert_equal %w[example.com www.example.com example.net www.example.net], declared_class.hosts
+  end
+
+  test ".match_domains should reject an empty domain list" do
+    assert_raises(ArgumentError) { Class.new(ProfileMatcher::DomainMatcher).match_domains }
+  end
+
+  test ".hosts should raise NotImplementedError when no domains are declared" do
+    error = assert_raises(NotImplementedError) { undeclared_class.hosts }
+    assert_includes error.message, "must declare its domains via match_domains"
+  end
+
+  test "#match? should match every declared domain" do
+    assert matcher("https://example.com/feed.xml").match?
+    assert matcher("https://www.example.com/feed.xml").match?
+    assert matcher("https://example.net/feed.xml").match?
+    assert matcher("https://www.example.net/feed.xml").match?
+  end
+
+  test "#match? should not match other subdomains" do
+    assert_not matcher("https://media.example.com/feed.xml").match?
+  end
+
+  test "#match? should not match undeclared hosts" do
+    assert_not matcher("https://notexample.com/feed.xml").match?
+  end
+
+  test "#match? should not match declared domains appearing only in the path" do
+    assert_not matcher("https://other.test/example.com/feed.xml").match?
+  end
+
+  test "#match? should handle blank inputs" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+
+  test "#match? should raise error for invalid URLs" do
+    assert_raises(URI::InvalidURIError) { matcher("not a url").match? }
+  end
+end


### PR DESCRIPTION
Changes:

- Add `ProfileMatcher::DomainMatcher`, a base class for matchers that key off the URL host alone. Subclasses declare their domains via `match_domains`; each is matched bare and with a `www.` prefix.
- Convert twelve matchers to it: aerostat, buni, elementy, melodymae, monkeyuser, nextbigfuture, oglaf, pluralistic, smbc, tomorrows, xkcd, youtube.

These twelve carried the same nine-line `#match?`, differing only in the domain constant — adding a new single-domain source meant copying that body again. They now declare what they own and inherit the comparison.

Behavior is unchanged: the existing per-matcher tests all still pass untouched, including the ones asserting that invalid URLs raise `URI::InvalidURIError` rather than quietly missing.

Matchers with real logic stay on `Base` and keep their own `#match?` — bluesky, telegram, twitter, and reddit have path rules, litterbox and theycantalk have a Feedburner fallback, rss and json_feed inspect the body. Lobsters is also left alone: it matches `lobste.rs` without a `www.` variant, and folding it in would widen what it accepts.