### PR TITLE
Remove unused page_header helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,14 +1,4 @@
 module ApplicationHelper
-  def page_header(title, class: nil, &block)
-    content_tag :div, class: class_names("d-flex justify-content-between align-items-center mb-4", binding.local_variable_get(:class)) do
-      content_tag(:h1, title) + (capture(&block) if block_given?)
-    end
-  end
-
-  def page_section_header(title, class: nil)
-    content_tag(:h2, title, class: class_names("mt-5 mb-4", binding.local_variable_get(:class)))
-  end
-
   def post_content_preview(content, length = 120)
     return "" unless content.present?
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -22,55 +22,6 @@ class ApplicationHelperTest < ActionView::TestCase
     self.policy_override = nil
   end
 
-  test "#page_header without block renders title with simple layout" do
-    result = page_header("Test Title")
-
-    expected = <<~HTML.strip
-      <div class="d-flex justify-content-between align-items-center mb-4"><h1>Test Title</h1></div>
-    HTML
-
-    assert_equal expected, result
-  end
-
-  test "#page_header with block renders title and content with flex layout" do
-    result = page_header("Test Title") do
-      content_tag(:a, "Link", href: "/test", class: "btn btn-primary")
-    end
-
-    expected = <<~HTML.strip
-      <div class="d-flex justify-content-between align-items-center mb-4"><h1>Test Title</h1><a href="/test" class="btn btn-primary">Link</a></div>
-    HTML
-
-    assert_equal expected, result
-  end
-
-  test "#page_section_header renders h2 with title and classes" do
-    result = page_section_header("Title")
-
-    expected = '<h2 class="mt-5 mb-4">Title</h2>'
-
-    assert_equal expected, result
-  end
-
-  test "#page_section_header accepts custom class argument" do
-    result = page_section_header("Title", class: "text-primary")
-
-    expected = '<h2 class="mt-5 mb-4 text-primary">Title</h2>'
-
-    assert_equal expected, result
-  end
-
-  test "#page_header accepts custom class argument" do
-    result = page_header("Test Title", class: "border-bottom")
-
-    expected = <<~HTML.strip
-      <div class="d-flex justify-content-between align-items-center mb-4 border-bottom"><h1>Test Title</h1></div>
-    HTML
-
-    assert_equal expected, result
-  end
-
-
   test "#post_content_preview returns empty string for nil content" do
     assert_equal "", post_content_preview(nil)
   end


### PR DESCRIPTION
Changes:

- Delete `ApplicationHelper#page_header` and `#page_section_header`, along with the five tests that were their only callers.

Neither helper is referenced from any view, component, or other helper — the only thing keeping them alive was their own test file. They also emit Bootstrap classes (`d-flex justify-content-between align-items-center`, `mt-5 mb-4`) that no longer correspond to anything in the Tailwind theme, so a reader reaching for them would get invisible markup.

Both used `binding.local_variable_get(:class)` to work around `class` being a keyword, which is the kind of thing worth keeping only if something actually depends on it.