### PR TITLE
Move og_title into TitleExtractor::Base

### DIFF
--- a/app/services/title_extractor/base.rb
+++ b/app/services/title_extractor/base.rb
@@ -28,5 +28,17 @@ module TitleExtractor
     rescue URI::InvalidURIError
       nil
     end
+
+    # og:title of the fetched page, for sources whose profile URL resolves to
+    # HTML rather than a feed. Any parse trouble means "no title here" — the
+    # caller falls back to a handle derived from the input.
+    def og_title
+      return nil if fetched_body.blank?
+
+      doc = Nokogiri::HTML.parse(fetched_body, nil, "UTF-8")
+      doc.at_css('meta[property="og:title"]')&.[]("content")&.strip
+    rescue StandardError
+      nil
+    end
   end
 end

--- a/app/services/title_extractor/bluesky_title_extractor.rb
+++ b/app/services/title_extractor/bluesky_title_extractor.rb
@@ -9,15 +9,6 @@ module TitleExtractor
 
     private
 
-    def og_title
-      return nil if fetched_body.blank?
-
-      doc = Nokogiri::HTML.parse(fetched_body, nil, "UTF-8")
-      doc.at_css('meta[property="og:title"]')&.[]("content")&.strip
-    rescue StandardError
-      nil
-    end
-
     def handle
       name = input.to_s.strip.sub(%r{\Ahttps?://}i, "")
                   .sub(%r{\A(?:www\.)?bsky\.app/profile/}i, "")

--- a/app/services/title_extractor/telegram_title_extractor.rb
+++ b/app/services/title_extractor/telegram_title_extractor.rb
@@ -9,15 +9,6 @@ module TitleExtractor
 
     private
 
-    def og_title
-      return nil if fetched_body.blank?
-
-      doc = Nokogiri::HTML.parse(fetched_body, nil, "UTF-8")
-      doc.at_css('meta[property="og:title"]')&.[]("content")&.strip
-    rescue StandardError
-      nil
-    end
-
     def username
       input.to_s.strip.sub(/\A@/, "").sub(%r{\Ahttps?://}i, "")
            .sub(%r{\A(?:www\.)?t\.me/}i, "").sub(%r{\Atelegram\.me/}i, "")

--- a/app/services/title_extractor/twitter_title_extractor.rb
+++ b/app/services/title_extractor/twitter_title_extractor.rb
@@ -9,15 +9,6 @@ module TitleExtractor
 
     private
 
-    def og_title
-      return nil if fetched_body.blank?
-
-      doc = Nokogiri::HTML.parse(fetched_body, nil, "UTF-8")
-      doc.at_css('meta[property="og:title"]')&.[]("content")&.strip
-    rescue StandardError
-      nil
-    end
-
     def handle
       name = input.to_s.strip.sub(/\A@/, "").sub(%r{\Ahttps?://}i, "")
                   .sub(%r{\A(?:www\.|mobile\.)?(?:twitter|x)\.com/}i, "")

--- a/app/services/title_extractor/youtube_title_extractor.rb
+++ b/app/services/title_extractor/youtube_title_extractor.rb
@@ -12,15 +12,6 @@ module TitleExtractor
 
     private
 
-    def og_title
-      return nil if fetched_body.blank?
-
-      doc = Nokogiri::HTML.parse(fetched_body, nil, "UTF-8")
-      doc.at_css('meta[property="og:title"]')&.[]("content")&.strip
-    rescue StandardError
-      nil
-    end
-
     ATOM_NS = { "atom" => "http://www.w3.org/2005/Atom" }.freeze
 
     def atom_title

--- a/test/services/title_extractor/base_test.rb
+++ b/test/services/title_extractor/base_test.rb
@@ -36,4 +36,20 @@ class TitleExtractor::BaseTest < ActiveSupport::TestCase
     e = TitleExtractor::Base.new("not a url")
     assert_nil e.send(:hostname_from_url)
   end
+
+  test "#og_title should return the trimmed og:title content" do
+    body = '<html><head><meta property="og:title" content="  Some Channel  "></head></html>'
+    e = TitleExtractor::Base.new("https://example.com", body)
+    assert_equal "Some Channel", e.send(:og_title)
+  end
+
+  test "#og_title should return nil when the body has no og:title" do
+    e = TitleExtractor::Base.new("https://example.com", "<html><head></head></html>")
+    assert_nil e.send(:og_title)
+  end
+
+  test "#og_title should return nil for a blank body" do
+    assert_nil TitleExtractor::Base.new("https://example.com").send(:og_title)
+    assert_nil TitleExtractor::Base.new("https://example.com", "").send(:og_title)
+  end
 end


### PR DESCRIPTION
Changes:

- Move the `og_title` helper into `TitleExtractor::Base` as a protected method, next to `hostname_from_url`, and drop the four identical copies from the Bluesky, Telegram, Twitter and YouTube extractors.
- Cover it directly in `base_test.rb`.

All four carried the same nine lines of Nokogiri parsing verbatim — same selector, same `rescue StandardError`, same trimming. It belongs with `hostname_from_url`: both answer "what can I derive about this source without knowing which platform it is".

Each extractor keeps its own fallback, which is the part that actually differs — Bluesky and Twitter derive an `@handle` with different host patterns, Telegram a bare username, YouTube tries the Atom `<title>` before falling back to a path segment.