### PR TITLE
Extract entity_link in EventDescriptionComponent

### DIFF
--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -17,6 +17,10 @@ class EventDescriptionComponent < ViewComponent::Base
     "feed_search_credential_removed" => "FeedCredentialRemovedDescriptionComponent"
   }.freeze
 
+  # Shared styling for every entity link a description interpolates, so the
+  # subject and the metadata feed list read as the same kind of link.
+  ENTITY_LINK_CLASSES = "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover".freeze
+
   def self.for(event)
     klass = SUBCLASSES[event.type]&.constantize || self
     klass.new(event: event)
@@ -58,20 +62,20 @@ class EventDescriptionComponent < ViewComponent::Base
   end
 
   def subject_link
-    case event.subject
-    when Feed
-      helpers.link_to(event.subject.display_name, feed_link_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
-    when AccessToken
-      helpers.link_to(event.subject.name, access_token_link_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
-    when Post
-      helpers.link_to("Post", helpers.post_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
-    when AiCredential
-      helpers.link_to(event.subject.display_name, ai_credential_link_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
-    when SearchCredential
-      helpers.link_to(event.subject.display_name, search_credential_link_path(event.subject), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
-    else
-      orphaned_subject_placeholder
+    subject = event.subject
+
+    case subject
+    when Feed then entity_link(subject.display_name, feed_link_path(subject))
+    when AccessToken then entity_link(subject.name, access_token_link_path(subject))
+    when Post then entity_link("Post", helpers.post_path(subject))
+    when AiCredential then entity_link(subject.display_name, ai_credential_link_path(subject))
+    when SearchCredential then entity_link(subject.display_name, search_credential_link_path(subject))
+    else orphaned_subject_placeholder
     end
+  end
+
+  def entity_link(label, path)
+    helpers.link_to(label, path, class: ENTITY_LINK_CLASSES)
   end
 
   # A recorded subject_type with no loadable subject means the record was
@@ -117,9 +121,7 @@ class EventDescriptionComponent < ViewComponent::Base
   def metadata_feed_links_html
     return "" if disabled_feed_ids.blank?
 
-    links = disabled_feeds.map do |feed|
-      helpers.link_to(feed.display_name, feed_link_path(feed), class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover")
-    end
+    links = disabled_feeds.map { |feed| entity_link(feed.display_name, feed_link_path(feed)) }
 
     linked_feeds = helpers.safe_join(links, ", ")
     deleted_feeds_count = disabled_feed_ids.size - disabled_feeds.size


### PR DESCRIPTION
Changes:

- Pull the entity link styling into an `ENTITY_LINK_CLASSES` constant and an `entity_link(label, path)` helper.
- Rewrite `#subject_link` as one-line `case` branches over the extracted helper, and use it for the metadata feed list too.

The same 96-character Tailwind class string was spelled out six times in this one file, five of them inside `#subject_link`. That made a five-way type dispatch — which is all the method actually does — read as a wall of near-identical lines, and it meant a styling tweak was a six-place edit.

Rendering is unchanged: same markup, same classes, same `(removed)` placeholder for an orphaned subject. The `Admin::EventEntityLinks` overrides still work, since they hook the `*_link_path` methods rather than `#subject_link` itself.

Worth noting the class string appears in about a dozen more views, helpers, and components. Centralising it app-wide is a bigger change than this one and would be better done alongside the ongoing color-token migration.