### PR TITLE
Extract StatsPanelComponent base

### DIFF
--- a/app/components/feed_llm_stats_component.rb
+++ b/app/components/feed_llm_stats_component.rb
@@ -1,24 +1,12 @@
-class FeedLlmStatsComponent < ViewComponent::Base
+class FeedLlmStatsComponent < StatsPanelComponent
   def initialize(feed:)
     @feed = feed
   end
 
-  def call
-    tag.div { safe_join([mobile_layout, desktop_layout]) }
-  end
-
   private
 
-  def mobile_layout
-    render(DescriptionListComponent.new(css_class: class_names("md:hidden", DescriptionListComponent::DEFAULT_CSS_CLASSES))) do |list|
-      layout_items.each { |item| list.with_item(mobile_stat_cell(item)) }
-    end
-  end
-
-  def desktop_layout
-    render(StatsBarComponent.new(css_class: class_names("hidden", StatsBarComponent::DEFAULT_CSS_CLASSES))) do |bar|
-      layout_items.each { |item| bar.with_item(desktop_stat_cell(item)) }
-    end
+  def key_prefix
+    "llm_stats"
   end
 
   def layout_items
@@ -48,22 +36,6 @@ class FeedLlmStatsComponent < ViewComponent::Base
         value: formatted_search_cost
       }
     ]
-  end
-
-  def mobile_stat_cell(item)
-    StatListItemComponent.new(
-      label: item[:label],
-      value: item[:value],
-      key: "llm_stats.#{item[:key]}"
-    )
-  end
-
-  def desktop_stat_cell(item)
-    StatBarItemComponent.new(
-      label: item[:label_short],
-      value: item[:value],
-      key: "llm_stats.#{item[:key]}"
-    )
   end
 
   def call_count

--- a/app/components/feed_stats_component.rb
+++ b/app/components/feed_stats_component.rb
@@ -1,25 +1,9 @@
-class FeedStatsComponent < ViewComponent::Base
+class FeedStatsComponent < StatsPanelComponent
   def initialize(feed:)
     @feed = feed
   end
 
-  def call
-    tag.div { safe_join([mobile_layout, desktop_layout]) }
-  end
-
   private
-
-  def mobile_layout
-    render(DescriptionListComponent.new(css_class: class_names("md:hidden", DescriptionListComponent::DEFAULT_CSS_CLASSES))) do |list|
-      layout_items.each { |item| list.with_item(mobile_stat_cell(item)) }
-    end
-  end
-
-  def desktop_layout
-    render(StatsBarComponent.new(css_class: class_names("hidden", StatsBarComponent::DEFAULT_CSS_CLASSES))) do |bar|
-      layout_items.each { |item| bar.with_item(desktop_stat_cell(item)) }
-    end
-  end
 
   def layout_items
     @layout_items ||= [
@@ -59,24 +43,6 @@ class FeedStatsComponent < ViewComponent::Base
         muted: most_recent_repost_at.nil?
       }
     ]
-  end
-
-  def mobile_stat_cell(item)
-    StatListItemComponent.new(
-      label: item[:label],
-      value: item[:value],
-      key: "stats.#{item[:key]}",
-      muted: item[:muted]
-    )
-  end
-
-  def desktop_stat_cell(item)
-    StatBarItemComponent.new(
-      label: item[:label_short],
-      value: item[:value],
-      key: "stats.#{item[:key]}",
-      muted: item[:muted]
-    )
   end
 
   def last_refresh_value

--- a/app/components/global_stats_component.rb
+++ b/app/components/global_stats_component.rb
@@ -1,21 +1,5 @@
-class GlobalStatsComponent < ViewComponent::Base
-  def call
-    tag.div { safe_join([mobile_layout, desktop_layout]) }
-  end
-
+class GlobalStatsComponent < StatsPanelComponent
   private
-
-  def mobile_layout
-    render(DescriptionListComponent.new(css_class: class_names("md:hidden", DescriptionListComponent::DEFAULT_CSS_CLASSES))) do |list|
-      layout_items.each { |item| list.with_item(mobile_stat_cell(item)) }
-    end
-  end
-
-  def desktop_layout
-    render(StatsBarComponent.new(css_class: class_names("hidden", StatsBarComponent::DEFAULT_CSS_CLASSES))) do |bar|
-      layout_items.each { |item| bar.with_item(desktop_stat_cell(item)) }
-    end
-  end
 
   def layout_items
     @layout_items ||= [
@@ -56,14 +40,6 @@ class GlobalStatsComponent < ViewComponent::Base
         value: most_recent_repost_at.present? ? helpers.short_time_ago(most_recent_repost_at) : "—"
       }
     ]
-  end
-
-  def mobile_stat_cell(item)
-    StatListItemComponent.new(label: item[:label], value: item[:value], key: "stats.#{item[:key]}")
-  end
-
-  def desktop_stat_cell(item)
-    StatBarItemComponent.new(label: item[:label_short], value: item[:value], key: "stats.#{item[:key]}")
   end
 
   def total_users_count

--- a/app/components/stats_panel_component.rb
+++ b/app/components/stats_panel_component.rb
@@ -1,0 +1,55 @@
+# Base for the panels that render a row of figures two ways: a stacked
+# description list on narrow screens, a horizontal bar on wider ones.
+#
+# Subclasses supply #layout_items — one hash per figure with :key, :label,
+# :label_short, :value, and an optional :muted — and override #key_prefix when
+# their data-key hooks live under a different namespace.
+class StatsPanelComponent < ViewComponent::Base
+  def call
+    tag.div { safe_join([mobile_layout, desktop_layout]) }
+  end
+
+  private
+
+  def layout_items
+    raise NotImplementedError, "Subclasses must implement #layout_items"
+  end
+
+  def key_prefix
+    "stats"
+  end
+
+  def mobile_layout
+    render(DescriptionListComponent.new(css_class: class_names("md:hidden", DescriptionListComponent::DEFAULT_CSS_CLASSES))) do |list|
+      layout_items.each { |item| list.with_item(mobile_stat_cell(item)) }
+    end
+  end
+
+  def desktop_layout
+    render(StatsBarComponent.new(css_class: class_names("hidden", StatsBarComponent::DEFAULT_CSS_CLASSES))) do |bar|
+      layout_items.each { |item| bar.with_item(desktop_stat_cell(item)) }
+    end
+  end
+
+  def mobile_stat_cell(item)
+    StatListItemComponent.new(
+      label: item[:label],
+      value: item[:value],
+      key: item_key(item),
+      muted: item.fetch(:muted, false)
+    )
+  end
+
+  def desktop_stat_cell(item)
+    StatBarItemComponent.new(
+      label: item[:label_short],
+      value: item[:value],
+      key: item_key(item),
+      muted: item.fetch(:muted, false)
+    )
+  end
+
+  def item_key(item)
+    "#{key_prefix}.#{item[:key]}"
+  end
+end

--- a/app/components/user_stats_component.rb
+++ b/app/components/user_stats_component.rb
@@ -1,27 +1,11 @@
-class UserStatsComponent < ViewComponent::Base
+class UserStatsComponent < StatsPanelComponent
   def initialize(user:)
     @user = user
-  end
-
-  def call
-    tag.div { safe_join([mobile_layout, desktop_layout]) }
   end
 
   private
 
   attr_reader :user
-
-  def mobile_layout
-    render(DescriptionListComponent.new(css_class: class_names("md:hidden", DescriptionListComponent::DEFAULT_CSS_CLASSES))) do |list|
-      layout_items.each { |item| list.with_item(mobile_stat_cell(item)) }
-    end
-  end
-
-  def desktop_layout
-    render(StatsBarComponent.new(css_class: class_names("hidden", StatsBarComponent::DEFAULT_CSS_CLASSES))) do |bar|
-      layout_items.each { |item| bar.with_item(desktop_stat_cell(item)) }
-    end
-  end
 
   def layout_items
     @layout_items ||= [
@@ -56,13 +40,5 @@ class UserStatsComponent < ViewComponent::Base
         value: user.most_recent_repost_at.present? ? helpers.short_time_ago(user.most_recent_repost_at) : "—"
       }
     ]
-  end
-
-  def mobile_stat_cell(item)
-    StatListItemComponent.new(label: item[:label], value: item[:value], key: "stats.#{item[:key]}")
-  end
-
-  def desktop_stat_cell(item)
-    StatBarItemComponent.new(label: item[:label_short], value: item[:value], key: "stats.#{item[:key]}")
   end
 end

--- a/test/components/stats_panel_component_test.rb
+++ b/test/components/stats_panel_component_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+require "view_component/test_case"
+
+class StatsPanelComponentTest < ViewComponent::TestCase
+  class SampleStatsComponent < StatsPanelComponent
+    private
+
+    def layout_items
+      [
+        { key: "plain", label: "Plain figure", label_short: "Plain", value: "1" },
+        { key: "dimmed", label: "Dimmed figure", label_short: "Dimmed", value: "0", muted: true }
+      ]
+    end
+  end
+
+  class NamespacedStatsComponent < SampleStatsComponent
+    private
+
+    def key_prefix
+      "custom_stats"
+    end
+  end
+
+  test "#render should render every item in both layouts" do
+    result = render_inline(SampleStatsComponent.new)
+
+    assert_equal "Plain figure", result.css('.md\\:hidden [data-key="stats.plain.label"]').first.text
+    assert_equal "Plain", result.css('.hidden.md\\:flex [data-key="stats.plain.label"]').first.text
+    assert_equal "1", result.css('.hidden.md\\:flex [data-key="stats.plain.value"]').first.text
+  end
+
+  test "#render should mute only the items that ask for it" do
+    result = render_inline(SampleStatsComponent.new)
+
+    assert_includes result.css('.md\\:hidden [data-key="stats.dimmed.value"]').first["class"], "text-muted"
+    assert_not_includes result.css('.md\\:hidden [data-key="stats.plain.value"]').first["class"], "text-muted"
+  end
+
+  test "#render should namespace data keys with the subclass key_prefix" do
+    result = render_inline(NamespacedStatsComponent.new)
+
+    assert_not_nil result.css('[data-key="custom_stats.plain.label"]').first
+    assert_nil result.css('[data-key="stats.plain.label"]').first
+  end
+
+  test "#layout_items should raise NotImplementedError when not overridden" do
+    error = assert_raises(NotImplementedError) { render_inline(StatsPanelComponent.new) }
+    assert_includes error.message, "must implement #layout_items"
+  end
+end


### PR DESCRIPTION
Changes:

- Add `StatsPanelComponent` holding the mobile/desktop rendering the stat panels share, with `#layout_items` as the one method subclasses must supply.
- Reparent `GlobalStatsComponent`, `UserStatsComponent`, `FeedStatsComponent` and `FeedLlmStatsComponent` onto it, leaving each with just its figures and the queries behind them.

All four repeated the same `call`, `mobile_layout`, `desktop_layout`, `mobile_stat_cell` and `desktop_stat_cell` — about 30 lines each of identical wiring around the one method that actually differed. The dual-layout arrangement is a decision about how stat panels look, so it belongs in one place: changing the breakpoint or swapping the mobile container is now a single edit rather than four.

Two variations are kept as hooks rather than flattened. `#key_prefix` defaults to `stats` and `FeedLlmStatsComponent` overrides it with `llm_stats`, preserving its existing data-key namespace. `:muted` stays optional per item — `FeedStatsComponent` is the only panel that dims zero values, and items that omit it get the same `false` the components passed before.

`SearchCredentialUsageStatsComponent` is deliberately left out: it renders a flat `ListComponent` with no mobile/desktop split, so it shares the name but not the structure.

Rendering is unchanged — the four components' existing tests pass untouched. The new `stats_panel_component_test.rb` covers the base directly through a sample subclass: both layouts, the muted flag, the `key_prefix` override, and the `NotImplementedError` when a subclass forgets `#layout_items`.