### PR TITLE
Extract CredentialsController base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-01
+
+- Renaming an AI credential no longer sends it back for re-checking. Only a new API key triggers that now, matching how search credentials already worked.
+
 ## 2026-07-22
 
 - "View all" links moved from the Recent Activity and Recent Posts section headers to the bottom of each list, so they look the same everywhere.

--- a/app/controllers/ai_credentials/defaults_controller.rb
+++ b/app/controllers/ai_credentials/defaults_controller.rb
@@ -7,7 +7,7 @@ class AiCredentials::DefaultsController < ApplicationController
     respond_to do |format|
       format.turbo_stream do
         flash.now[:success] = "'#{credential.display_name}' is now the default credential."
-        @ai_credentials = policy_scope(AiCredential).order(created_at: :desc)
+        @credentials = policy_scope(AiCredential).order(created_at: :desc)
       end
       format.html do
         redirect_to ai_credentials_path, success: "'#{credential.display_name}' is now the default credential."

--- a/app/controllers/ai_credentials_controller.rb
+++ b/app/controllers/ai_credentials_controller.rb
@@ -1,105 +1,14 @@
-class AiCredentialsController < ApplicationController
-  include StatePolling
-
-  def index
-    authorize AiCredential
-    @ai_credentials = scope.order(created_at: :desc)
-  end
-
-  def show
-    @ai_credential = find_credential
-    @feed = detour_feed
-    authorize @ai_credential
-  end
-
-  def new
-    @ai_credential = AiCredential.new(provider: params[:provider] || LlmProvider.names.first)
-    @feed = detour_feed
-    authorize @ai_credential
-  end
-
-  def create
-    @ai_credential = build_credential
-    @feed = detour_feed
-    authorize @ai_credential
-
-    if @ai_credential.save
-      @feed&.update_column(:ai_credential_id, @ai_credential.id)
-      AiCredentialValidationJob.perform_later(@ai_credential)
-      redirect_to ai_credential_path(@ai_credential, feed_id: @feed&.id)
-    else
-      render :new, status: :unprocessable_entity
-    end
-  end
-
-  def edit
-    @ai_credential = find_credential
-    authorize @ai_credential
-  end
-
-  def update
-    @ai_credential = find_credential
-    authorize @ai_credential
-
-    if @ai_credential.update(updated_credential_attrs)
-      AiCredentialValidationJob.perform_later(@ai_credential)
-      redirect_to ai_credential_path(@ai_credential)
-    else
-      render :edit, status: :unprocessable_entity
-    end
-  end
-
-  def destroy
-    credential = find_credential
-    authorize credential
-    credential.destroy!
-    redirect_to ai_credentials_path, success: "AI credential '#{credential.display_name}' deleted."
-  end
+class AiCredentialsController < CredentialsController
+  self.credential_class = AiCredential
+  self.validation_job = AiCredentialValidationJob
 
   private
 
-  # The draft feed that detoured here from the feed form (feed_id round-trip),
-  # or nil when entered directly.
-  def detour_feed
-    return nil if params[:feed_id].blank?
-
-    Current.user.feeds.find_by(id: params[:feed_id])
+  def default_provider
+    LlmProvider.names.first
   end
 
-  def updated_credential_attrs
-    attrs = { display_name: credential_params[:display_name], state: :pending }
-    data = credential_data_from_params
-    attrs[:credential_data] = data if data["api_key"].present?
-    attrs
-  end
-
-  def build_credential
-    Current.user.ai_credentials.build(
-      provider: credential_params[:provider],
-      display_name: credential_params[:display_name],
-      credential_data: credential_data_from_params,
-      state: :pending
-    )
-  end
-
-  def find_credential
-    scope.find(params[:id])
-  end
-
-  def scope
-    policy_scope(AiCredential)
-  end
-
-  def credential_params
-    params.require(:ai_credential).permit(:provider, :display_name, credential_data: {})
-  end
-
-  def credential_data_from_params
-    raw = credential_params[:credential_data]
-    case raw
-    when ActionController::Parameters then raw.to_unsafe_h
-    when Hash then raw
-    else {}
-    end
+  def credential_noun
+    "AI credential"
   end
 end

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -1,0 +1,136 @@
+# Shared CRUD for the provider credential types (AI and web search). Both wrap
+# a user-owned API key that gets re-checked asynchronously whenever it changes,
+# and both can be entered mid-feed-setup through a feed_id round-trip.
+#
+# Subclasses declare their model and validation job, plus the two things that
+# can't be derived from the model: the provider chosen by default on the new
+# form, and the noun used in user-facing copy.
+class CredentialsController < ApplicationController
+  include StatePolling
+
+  class_attribute :credential_class, instance_writer: false
+  class_attribute :validation_job, instance_writer: false
+
+  def index
+    authorize credential_class
+    @credentials = scope.order(created_at: :desc)
+  end
+
+  def show
+    @credential = find_credential
+    @feed = detour_feed
+    authorize @credential
+  end
+
+  def new
+    @credential = credential_class.new(provider: params[:provider] || default_provider)
+    @feed = detour_feed
+    authorize @credential
+  end
+
+  def create
+    @credential = build_credential
+    @feed = detour_feed
+    authorize @credential
+
+    if @credential.save
+      @feed&.update_column(feed_foreign_key, @credential.id)
+      validation_job.perform_later(@credential)
+      redirect_to polymorphic_path(@credential, feed_id: @feed&.id)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @credential = find_credential
+    authorize @credential
+  end
+
+  def update
+    @credential = find_credential
+    authorize @credential
+
+    # A blank key field means "keep the current key", so only a submitted key
+    # is worth re-checking — renaming a credential leaves its state alone.
+    key_changed = credential_data_from_params["api_key"].present?
+
+    if @credential.update(updated_credential_attrs(key_changed: key_changed))
+      validation_job.perform_later(@credential) if key_changed
+      redirect_to polymorphic_path(@credential)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    credential = find_credential
+    authorize credential
+    credential.destroy!
+    redirect_to polymorphic_path(credential_class), success: "#{credential_noun} '#{credential.display_name}' deleted."
+  end
+
+  private
+
+  def default_provider
+    raise NotImplementedError, "#{self.class.name} must implement #default_provider"
+  end
+
+  def credential_noun
+    raise NotImplementedError, "#{self.class.name} must implement #credential_noun"
+  end
+
+  # The draft feed that detoured here from the feed form (feed_id round-trip),
+  # or nil when entered directly.
+  def detour_feed
+    return nil if params[:feed_id].blank?
+
+    Current.user.feeds.find_by(id: params[:feed_id])
+  end
+
+  def updated_credential_attrs(key_changed:)
+    attrs = { display_name: credential_params[:display_name] }
+    return attrs unless key_changed
+
+    attrs.merge(credential_data: credential_data_from_params, state: :pending)
+  end
+
+  def build_credential
+    owned_credentials.build(
+      provider: credential_params[:provider],
+      display_name: credential_params[:display_name],
+      credential_data: credential_data_from_params,
+      state: :pending
+    )
+  end
+
+  def find_credential
+    scope.find(params[:id])
+  end
+
+  def scope
+    policy_scope(credential_class)
+  end
+
+  def owned_credentials
+    Current.user.public_send(credential_class.model_name.plural)
+  end
+
+  def feed_foreign_key
+    :"#{credential_class.model_name.param_key}_id"
+  end
+
+  def credential_params
+    params.require(credential_class.model_name.param_key).permit(:provider, :display_name, credential_data: {})
+  end
+
+  def credential_data_from_params
+    raw = credential_params[:credential_data]
+
+    case raw
+    when ActionController::Parameters then raw.to_unsafe_h
+    when Hash then raw
+    else {}
+    end
+  end
+end

--- a/app/controllers/search_credentials/defaults_controller.rb
+++ b/app/controllers/search_credentials/defaults_controller.rb
@@ -6,7 +6,7 @@ class SearchCredentials::DefaultsController < ApplicationController
     respond_to do |format|
       format.turbo_stream do
         flash.now[:success] = "'#{credential.display_name}' is now the default search credential."
-        @search_credentials = policy_scope(SearchCredential).order(created_at: :desc)
+        @credentials = policy_scope(SearchCredential).order(created_at: :desc)
       end
       format.html do
         redirect_to search_credentials_path,

--- a/app/controllers/search_credentials_controller.rb
+++ b/app/controllers/search_credentials_controller.rb
@@ -1,104 +1,14 @@
-class SearchCredentialsController < ApplicationController
-  include StatePolling
-
-  def index
-    authorize SearchCredential
-    @search_credentials = scope.order(created_at: :desc)
-  end
-
-  def show
-    @search_credential = find_credential
-    @feed = detour_feed
-    authorize @search_credential
-  end
-
-  def new
-    @search_credential = SearchCredential.new(provider: params[:provider] || WebSearchProvider::REGISTRY.keys.first)
-    @feed = detour_feed
-    authorize @search_credential
-  end
-
-  def create
-    @search_credential = build_credential
-    @feed = detour_feed
-    authorize @search_credential
-
-    if @search_credential.save
-      @feed&.update_column(:search_credential_id, @search_credential.id)
-      SearchCredentialValidationJob.perform_later(@search_credential)
-      redirect_to search_credential_path(@search_credential, feed_id: @feed&.id)
-    else
-      render :new, status: :unprocessable_entity
-    end
-  end
-
-  def edit
-    @search_credential = find_credential
-    authorize @search_credential
-  end
-
-  def update
-    @search_credential = find_credential
-    authorize @search_credential
-
-    key_changed = credential_data_from_params["api_key"].present?
-    if @search_credential.update(updated_credential_attrs(key_changed: key_changed))
-      SearchCredentialValidationJob.perform_later(@search_credential) if key_changed
-      redirect_to search_credential_path(@search_credential)
-    else
-      render :edit, status: :unprocessable_entity
-    end
-  end
-
-  def destroy
-    credential = find_credential
-    authorize credential
-    credential.destroy!
-    redirect_to search_credentials_path, success: "Search credential '#{credential.display_name}' deleted."
-  end
+class SearchCredentialsController < CredentialsController
+  self.credential_class = SearchCredential
+  self.validation_job = SearchCredentialValidationJob
 
   private
 
-  def detour_feed
-    return nil if params[:feed_id].blank?
-
-    Current.user.feeds.find_by(id: params[:feed_id])
+  def default_provider
+    WebSearchProvider::REGISTRY.keys.first
   end
 
-  def updated_credential_attrs(key_changed:)
-    attrs = { display_name: credential_params[:display_name] }
-    return attrs unless key_changed
-
-    attrs.merge(credential_data: credential_data_from_params, state: :pending)
-  end
-
-  def build_credential
-    Current.user.search_credentials.build(
-      provider: credential_params[:provider],
-      display_name: credential_params[:display_name],
-      credential_data: credential_data_from_params,
-      state: :pending
-    )
-  end
-
-  def find_credential
-    scope.find(params[:id])
-  end
-
-  def scope
-    policy_scope(SearchCredential)
-  end
-
-  def credential_params
-    params.require(:search_credential).permit(:provider, :display_name, credential_data: {})
-  end
-
-  def credential_data_from_params
-    raw = credential_params[:credential_data]
-    case raw
-    when ActionController::Parameters then raw.to_unsafe_h
-    when Hash then raw
-    else {}
-    end
+  def credential_noun
+    "Search credential"
   end
 end

--- a/app/views/ai_credentials/defaults/update.turbo_stream.erb
+++ b/app/views/ai_credentials/defaults/update.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream.replace "ai_credentials_list" do %>
   <div id="ai_credentials_list">
-    <% if @ai_credentials.any? %>
-      <%= render AiCredentialsListComponent.new(credentials: @ai_credentials) %>
+    <% if @credentials.any? %>
+      <%= render AiCredentialsListComponent.new(credentials: @credentials) %>
     <% else %>
       <%= render EmptyStateComponent.new("No AI credentials yet") %>
     <% end %>

--- a/app/views/ai_credentials/edit.html.erb
+++ b/app/views/ai_credentials/edit.html.erb
@@ -6,11 +6,11 @@
   <% end %>
 
   <div class="max-w-2xl">
-    <%= form_with model: @ai_credential do |f| %>
-      <% if @ai_credential.errors.any? %>
+    <%= form_with model: @credential do |f| %>
+      <% if @credential.errors.any? %>
         <%= render AlertComponent.new(variant: :warning) do %>
           <ul class="list-disc list-inside text-sm">
-            <% @ai_credential.errors.full_messages.each do |message| %>
+            <% @credential.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
           </ul>
@@ -21,7 +21,7 @@
         <div class="space-y-2">
           <%= label_tag "ai_credential_provider", "AI Provider", class: "block font-semibold text-heading" %>
           <%= text_field_tag "ai_credential_provider",
-                             @ai_credential.llm_provider.display_name,
+                             @credential.llm_provider.display_name,
                              disabled: true,
                              class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2 disabled:bg-surface-sunken disabled:text-muted disabled:border-border disabled:cursor-not-allowed" %>
         </div>
@@ -51,7 +51,7 @@
         <%= f.submit "Update Credential",
                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring",
                      data: { turbo_submits_with: "Saving…" } %>
-        <%= link_to "Cancel", ai_credential_path(@ai_credential), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-6 py-3 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted" %>
+        <%= link_to "Cancel", ai_credential_path(@credential), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-6 py-3 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted" %>
       </div>
     <% end %>
   </div>

--- a/app/views/ai_credentials/index.html.erb
+++ b/app/views/ai_credentials/index.html.erb
@@ -13,8 +13,8 @@
   <% end %>
 
   <div id="ai_credentials_list">
-    <% if @ai_credentials.any? %>
-      <%= render AiCredentialsListComponent.new(credentials: @ai_credentials) %>
+    <% if @credentials.any? %>
+      <%= render AiCredentialsListComponent.new(credentials: @credentials) %>
     <% else %>
       <%= render EmptyStateComponent.new("No AI credentials yet") %>
     <% end %>

--- a/app/views/ai_credentials/new.html.erb
+++ b/app/views/ai_credentials/new.html.erb
@@ -6,11 +6,11 @@
   <% end %>
 
   <div class="max-w-2xl">
-    <%= form_with model: @ai_credential, url: ai_credentials_path(feed_id: @feed&.id) do |f| %>
-      <% if @ai_credential.errors.any? %>
+    <%= form_with model: @credential, url: ai_credentials_path(feed_id: @feed&.id) do |f| %>
+      <% if @credential.errors.any? %>
         <%= render AlertComponent.new(variant: :warning) do %>
           <ul class="list-disc list-inside text-sm">
-            <% @ai_credential.errors.full_messages.each do |message| %>
+            <% @credential.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
           </ul>
@@ -39,7 +39,7 @@
         <div class="space-y-2">
           <%= label_tag "ai_credential_credential_data_api_key", "API key", class: "block font-semibold text-heading" %>
           <%= password_field_tag "ai_credential[credential_data][api_key]",
-                                 @ai_credential.credential_data&.dig("api_key"),
+                                 @credential.credential_data&.dig("api_key"),
                                  id: "ai_credential_credential_data_api_key",
                                  class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
                                  required: true,

--- a/app/views/ai_credentials/show.html.erb
+++ b/app/views/ai_credentials/show.html.erb
@@ -1,15 +1,15 @@
 <% content_for :title, "AI Credential" %>
 
-<% if @ai_credential.pending? || @ai_credential.validating? %>
+<% if @credential.pending? || @credential.validating? %>
   <div
     data-controller="polling"
-    data-polling-endpoint-value="<%= ai_credential_validation_path(@ai_credential, feed_id: @feed&.id) %>"
+    data-polling-endpoint-value="<%= ai_credential_validation_path(@credential, feed_id: @feed&.id) %>"
     data-polling-interval-value="<%= polling_interval_ms %>"
     data-polling-max-polls-value="<%= polling_max_polls %>"
     data-polling-stop-condition-value="[data-credential-state]"
     aria-busy="true">
     <div id="ai-credential-show" class="space-y-8">
-      <%= render "ai_credentials/show_content", ai_credential: @ai_credential, feed_id: @feed&.id %>
+      <%= render "ai_credentials/show_content", ai_credential: @credential, feed_id: @feed&.id %>
     </div>
     <div data-polling-target="timeoutMessage" hidden class="mt-4">
       <%= render AlertComponent.new(variant: :warning) do %>
@@ -20,6 +20,6 @@
   </div>
 <% else %>
   <div id="ai-credential-show" class="space-y-8">
-    <%= render "ai_credentials/show_content", ai_credential: @ai_credential, feed_id: @feed&.id %>
+    <%= render "ai_credentials/show_content", ai_credential: @credential, feed_id: @feed&.id %>
   </div>
 <% end %>

--- a/app/views/search_credentials/defaults/update.turbo_stream.erb
+++ b/app/views/search_credentials/defaults/update.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream.replace "search_credentials_list" do %>
   <div id="search_credentials_list">
-    <% if @search_credentials.any? %>
-      <%= render SearchCredentialsListComponent.new(credentials: @search_credentials) %>
+    <% if @credentials.any? %>
+      <%= render SearchCredentialsListComponent.new(credentials: @credentials) %>
     <% else %>
       <%= render EmptyStateComponent.new("No search credentials yet") %>
     <% end %>

--- a/app/views/search_credentials/edit.html.erb
+++ b/app/views/search_credentials/edit.html.erb
@@ -6,11 +6,11 @@
   <% end %>
 
   <div class="max-w-2xl">
-    <%= form_with model: @search_credential do |f| %>
-      <% if @search_credential.errors.any? %>
+    <%= form_with model: @credential do |f| %>
+      <% if @credential.errors.any? %>
         <%= render AlertComponent.new(variant: :warning) do %>
           <ul class="list-disc list-inside text-sm">
-            <% @search_credential.errors.full_messages.each do |message| %>
+            <% @credential.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
           </ul>
@@ -21,7 +21,7 @@
         <div class="space-y-2">
           <%= label_tag "search_credential_provider", "Search Provider", class: "block font-semibold text-heading" %>
           <%= text_field_tag "search_credential_provider",
-                             @search_credential.provider_label,
+                             @credential.provider_label,
                              disabled: true,
                              class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2 disabled:bg-surface-sunken disabled:text-muted disabled:border-border disabled:cursor-not-allowed" %>
         </div>
@@ -50,7 +50,7 @@
         <%= f.submit "Update Credential",
                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-6 py-3 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring",
                      data: { turbo_submits_with: "Saving…" } %>
-        <%= link_to "Cancel", search_credential_path(@search_credential), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-6 py-3 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted" %>
+        <%= link_to "Cancel", search_credential_path(@credential), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-6 py-3 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted" %>
       </div>
     <% end %>
   </div>

--- a/app/views/search_credentials/index.html.erb
+++ b/app/views/search_credentials/index.html.erb
@@ -13,8 +13,8 @@
   <% end %>
 
   <div id="search_credentials_list">
-    <% if @search_credentials.any? %>
-      <%= render SearchCredentialsListComponent.new(credentials: @search_credentials) %>
+    <% if @credentials.any? %>
+      <%= render SearchCredentialsListComponent.new(credentials: @credentials) %>
     <% else %>
       <%= render EmptyStateComponent.new("No search credentials yet") do %>
         <p>AI feeds need a search-provider API key to search the web. Non-AI feeds never need one.</p>

--- a/app/views/search_credentials/new.html.erb
+++ b/app/views/search_credentials/new.html.erb
@@ -6,11 +6,11 @@
   <% end %>
 
   <div class="max-w-2xl">
-    <%= form_with model: @search_credential, url: search_credentials_path(feed_id: @feed&.id) do |f| %>
-      <% if @search_credential.errors.any? %>
+    <%= form_with model: @credential, url: search_credentials_path(feed_id: @feed&.id) do |f| %>
+      <% if @credential.errors.any? %>
         <%= render AlertComponent.new(variant: :warning) do %>
           <ul class="list-disc list-inside text-sm">
-            <% @search_credential.errors.full_messages.each do |message| %>
+            <% @credential.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
           </ul>
@@ -39,7 +39,7 @@
         <div class="space-y-2">
           <%= label_tag "search_credential_credential_data_api_key", "API key", class: "block font-semibold text-heading" %>
           <%= password_field_tag "search_credential[credential_data][api_key]",
-                                 @search_credential.credential_data&.dig("api_key"),
+                                 @credential.credential_data&.dig("api_key"),
                                  id: "search_credential_credential_data_api_key",
                                  class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
                                  required: true,

--- a/app/views/search_credentials/show.html.erb
+++ b/app/views/search_credentials/show.html.erb
@@ -1,15 +1,15 @@
 <% content_for :title, "Search Credential" %>
 
-<% if @search_credential.pending? || @search_credential.validating? %>
+<% if @credential.pending? || @credential.validating? %>
   <div
     data-controller="polling"
-    data-polling-endpoint-value="<%= search_credential_validation_path(@search_credential, feed_id: @feed&.id) %>"
+    data-polling-endpoint-value="<%= search_credential_validation_path(@credential, feed_id: @feed&.id) %>"
     data-polling-interval-value="<%= polling_interval_ms %>"
     data-polling-max-polls-value="<%= polling_max_polls %>"
     data-polling-stop-condition-value="[data-credential-state]"
     aria-busy="true">
     <div id="search-credential-show" class="space-y-8">
-      <%= render "search_credentials/show_content", search_credential: @search_credential, feed_id: @feed&.id %>
+      <%= render "search_credentials/show_content", search_credential: @credential, feed_id: @feed&.id %>
     </div>
     <div data-polling-target="timeoutMessage" hidden class="mt-4">
       <%= render AlertComponent.new(variant: :warning) do %>
@@ -20,6 +20,6 @@
   </div>
 <% else %>
   <div id="search-credential-show" class="space-y-8">
-    <%= render "search_credentials/show_content", search_credential: @search_credential, feed_id: @feed&.id %>
+    <%= render "search_credentials/show_content", search_credential: @credential, feed_id: @feed&.id %>
   </div>
 <% end %>

--- a/test/controllers/ai_credentials_controller_test.rb
+++ b/test/controllers/ai_credentials_controller_test.rb
@@ -286,11 +286,11 @@ class AiCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "#update should update display_name, reset to pending, and re-enqueue validation" do
+  test "#update should rename without resetting state or enqueuing validation" do
     sign_in_as(user)
     active = create(:ai_credential, :active, user: user)
 
-    assert_enqueued_with(job: AiCredentialValidationJob) do
+    assert_no_enqueued_jobs only: AiCredentialValidationJob do
       patch ai_credential_url(active), params: {
         ai_credential: {
           display_name: "Renamed Key",
@@ -302,23 +302,26 @@ class AiCredentialsControllerTest < ActionDispatch::IntegrationTest
     active.reload
     assert_redirected_to ai_credential_path(active)
     assert_equal "Renamed Key", active.display_name
-    assert_equal "pending", active.state
+    assert_equal "active", active.state
   end
 
-  test "#update should replace credential_data when a new api_key is provided" do
+  test "#update should replace a new key, reset state, and enqueue validation" do
     sign_in_as(user)
     active = create(:ai_credential, :active, user: user)
     new_key = "sk-ant-#{SecureRandom.hex(16)}"
 
-    patch ai_credential_url(active), params: {
-      ai_credential: {
-        display_name: active.display_name,
-        credential_data: { api_key: new_key }
+    assert_enqueued_with(job: AiCredentialValidationJob) do
+      patch ai_credential_url(active), params: {
+        ai_credential: {
+          display_name: active.display_name,
+          credential_data: { api_key: new_key }
+        }
       }
-    }
+    end
 
     active.reload
     assert_equal new_key, active.credential_data["api_key"]
+    assert_equal "pending", active.state
   end
 
   test "#update should keep existing credential_data when api_key is blank" do


### PR DESCRIPTION
Changes:

- Add `CredentialsController` holding the seven CRUD actions both credential types share, and reduce `AiCredentialsController` and `SearchCredentialsController` to a model, a validation job, a default provider and a noun.
- Align the AI `update` action with the search one: only a newly submitted key resets state and re-enqueues validation.
- Rename the assigned instance variables to `@credential` / `@credentials` in the two controllers' views.

Normalising the class names, the two controllers differed in five small hunks across 105 lines. Everything else — the detour-feed round-trip, the scope and lookup, the credential-data param coercion, all seven actions — was duplicated verbatim, so a fix to either one had to be remembered twice.

The parts that genuinely differ are declared rather than reimplemented. The model drives what can be derived from it (`policy_scope`, the strong-params key, the `Current.user` association, the feed's foreign key, and the routes via `polymorphic_path`), leaving `default_provider` and `credential_noun` as the only subclass hooks.

**Behaviour change.** The two `update` actions disagreed, and unifying them forced a choice. `AiCredentialsController` reset `state` to `pending` and enqueued a validation job on every save, so renaming an active credential knocked it back into "Checking your credential…" and spent an API call re-verifying a key that hadn't changed. `SearchCredentialsController` only did that when a new key was actually submitted. The search behaviour is the correct one and is now shared. The AI controller test that pinned the old behaviour has been rewritten to match its search counterpart, and the AI side gains the state/job assertions the search side already had.

The view rename follows from the base class assigning one name. The `_show_content` partials already take locals and are untouched; the admin credential views have their own controllers and are unaffected.