### PR TITLE
Add CHECK constraints for non-negative counters

### DIFF
--- a/db/migrate/20260801120000_add_non_negative_counter_check_constraints.rb
+++ b/db/migrate/20260801120000_add_non_negative_counter_check_constraints.rb
@@ -1,0 +1,15 @@
+class AddNonNegativeCounterCheckConstraints < ActiveRecord::Migration[8.0]
+  CONSTRAINTS = {
+    users: %w[available_invites],
+    post_publications: %w[attachments_processed_count comments_published_count],
+    feed_metrics: %w[posts_count invalid_posts_count published_posts_count]
+  }.freeze
+
+  def change
+    CONSTRAINTS.each do |table, columns|
+      columns.each do |column|
+        add_check_constraint table, "#{column} >= 0", name: "#{table}_#{column}_non_negative"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_25_130000) do
+ActiveRecord::Schema[8.2].define(version: 2026_08_01_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -124,6 +124,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_25_130000) do
     t.integer "published_posts_count", default: 0, null: false
     t.index ["date"], name: "index_feed_metrics_on_date"
     t.index ["feed_id", "date"], name: "index_feed_metrics_on_feed_id_and_date", unique: true
+    t.check_constraint "invalid_posts_count >= 0", name: "feed_metrics_invalid_posts_count_non_negative"
+    t.check_constraint "posts_count >= 0", name: "feed_metrics_posts_count_non_negative"
+    t.check_constraint "published_posts_count >= 0", name: "feed_metrics_published_posts_count_non_negative"
   end
 
   create_table "feed_previews", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -247,6 +250,8 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_25_130000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_post_publications_on_post_id", unique: true
+    t.check_constraint "attachments_processed_count >= 0", name: "post_publications_attachments_processed_count_non_negative"
+    t.check_constraint "comments_published_count >= 0", name: "post_publications_comments_published_count_non_negative"
   end
 
   create_table "posts", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -467,6 +472,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_25_130000) do
     t.index ["email_deactivated_at"], name: "index_users_on_email_deactivated_at"
     t.index ["state"], name: "index_users_on_state"
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email", where: "(unconfirmed_email IS NOT NULL)"
+    t.check_constraint "available_invites >= 0", name: "users_available_invites_non_negative"
   end
 
   create_table "webhook_endpoints", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|


### PR DESCRIPTION
Changes:

- Add `>= 0` CHECK constraints for `users.available_invites`, `post_publications.attachments_processed_count`, `post_publications.comments_published_count`, and `feed_metrics.posts_count` / `invalid_posts_count` / `published_posts_count`.

CI on main is failing: `database_consistency` reports six `NumericalityConstraintChecker` findings for columns that have a `greater_than_or_equal_to: 0` validator but nothing enforcing it in the database. These are new findings rather than baseline ones, so they fail the run instead of being covered by `.database_consistency.todo.yml`.

Adding the constraints is the fix the todo file asks for — it exists to hold pre-existing findings to burn down, not to absorb new ones. All six columns are already `NOT NULL` with a default of `0`, and nothing decrements them: `available_invites` is only ever assigned by the admin update action, the publication counters only increment as attachments and comments go out, and the feed metric counters are written from non-negative tallies. So no existing row can violate the new constraints.

Verified `db:migrate` and `db:rollback` both apply cleanly, `database_consistency` now exits 0, and the full suite passes. No test accompanies this — the constraints are a database-level backstop for rules the model validators already cover, so there's no new application behaviour to assert.