### PR TITLE
Extract CredentialListItemComponent base

### DIFF
--- a/app/components/access_token_list_item_component.rb
+++ b/app/components/access_token_list_item_component.rb
@@ -33,8 +33,7 @@ class AccessTokenListItemComponent < ListItemComponent
   end
 
   def primary_element
-    helpers.link_to(access_token.name, token_url,
-                    class: "truncate text-base text-heading transition hover:text-heading rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-white")
+    helpers.link_to(access_token.name, token_url, class: TITLE_LINK_CSS_CLASS)
   end
 
   def secondary_element

--- a/app/components/ai_credential_list_item_component.rb
+++ b/app/components/ai_credential_list_item_component.rb
@@ -1,90 +1,11 @@
-class AiCredentialListItemComponent < ListItemComponent
-  DELETE_CONFIRM = "Delete this AI credential? Feeds using it will be disabled.".freeze
-
-  def initialize(credential:)
-    super()
-    @credential = credential
-  end
-
-  def before_render
-    with_icon { icon_element }
-    with_primary { primary_element }
-    with_secondary { secondary_element }
-    with_trailing { menu }
-  end
-
+class AiCredentialListItemComponent < CredentialListItemComponent
   private
-
-  attr_reader :credential
-
-  def li_id
-    helpers.dom_id(credential)
-  end
-
-  def li_data
-    { key: "ai_credential.#{credential.id}" }
-  end
-
-  def row_css_class
-    HOVER_ROW_CSS_CLASS
-  end
-
-  def icon_element
-    helpers.tag.span(helpers.credential_status_icon(credential.state),
-                     class: "inline-flex shrink-0", data: { key: "ai_credential.#{credential.id}.status_icon" })
-  end
-
-  def primary_element
-    helpers.tag.div(helpers.safe_join([title_link, default_badge].compact),
-                    class: "flex min-w-0 flex-1 items-center gap-2")
-  end
-
-  def title_link
-    helpers.link_to(credential.display_name, credential_url,
-                    class: "truncate text-base text-heading transition hover:text-heading rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-white")
-  end
-
-  def default_badge
-    return unless credential.default?
-
-    render(BadgeComponent.new(text: "Default", color: :info, key: "ai_credential.default-badge"))
-  end
-
-  def secondary_element
-    helpers.tag.div(provider_name, class: "truncate text-sm text-muted")
-  end
 
   def provider_name
     credential.llm_provider.display_name
   end
 
-  def menu
-    render(DropdownMenuComponent.new(menu_id: menu_id, items: menu_items, width: "w-40"))
-  end
-
-  def menu_items
-    items = [
-      { label: "Details", href: credential_url },
-      { label: "Edit", href: edit_url }
-    ]
-    items << { label: "Make default", href: default_url, data: { turbo_method: :patch } } unless credential.default?
-    items << { label: "Delete…", href: credential_url, data: { turbo_method: :delete, turbo_confirm: DELETE_CONFIRM } }
-    items
-  end
-
-  def credential_url
-    helpers.ai_credential_path(credential)
-  end
-
-  def edit_url
-    helpers.edit_ai_credential_path(credential)
-  end
-
-  def default_url
-    helpers.ai_credential_default_path(credential)
-  end
-
-  def menu_id
-    "ai-credential-menu-#{credential.id}"
+  def credential_noun
+    "AI credential"
   end
 end

--- a/app/components/credential_list_item_component.rb
+++ b/app/components/credential_list_item_component.rb
@@ -1,0 +1,110 @@
+# A settings-list row for one provider credential: status icon, name with an
+# optional Default badge, provider name underneath, and the actions menu.
+#
+# Subclasses supply the two things that can't come from the record — the
+# provider's display name and the noun used in the delete prompt. Routes, DOM
+# ids, and test hooks are all derived from the model name, so the AI and web
+# search rows stay in step by construction.
+class CredentialListItemComponent < ListItemComponent
+  def initialize(credential:)
+    super()
+    @credential = credential
+  end
+
+  def before_render
+    with_icon { icon_element }
+    with_primary { primary_element }
+    with_secondary { secondary_element }
+    with_trailing { menu }
+  end
+
+  private
+
+  attr_reader :credential
+
+  def provider_name
+    raise NotImplementedError, "#{self.class.name} must implement #provider_name"
+  end
+
+  # Reads mid-sentence in the delete prompt, e.g. "Delete this AI credential?".
+  def credential_noun
+    raise NotImplementedError, "#{self.class.name} must implement #credential_noun"
+  end
+
+  # Namespaces the data-key hooks: "ai_credential", "search_credential".
+  def key_prefix
+    credential.model_name.param_key
+  end
+
+  def li_id
+    helpers.dom_id(credential)
+  end
+
+  def li_data
+    { key: "#{key_prefix}.#{credential.id}" }
+  end
+
+  def row_css_class
+    HOVER_ROW_CSS_CLASS
+  end
+
+  def icon_element
+    helpers.tag.span(helpers.credential_status_icon(credential.state),
+                     class: "inline-flex shrink-0",
+                     data: { key: "#{key_prefix}.#{credential.id}.status_icon" })
+  end
+
+  def primary_element
+    helpers.tag.div(helpers.safe_join([title_link, default_badge].compact),
+                    class: "flex min-w-0 flex-1 items-center gap-2")
+  end
+
+  def title_link
+    helpers.link_to(credential.display_name, credential_url, class: TITLE_LINK_CSS_CLASS)
+  end
+
+  def default_badge
+    return unless credential.default?
+
+    render(BadgeComponent.new(text: "Default", color: :info, key: "#{key_prefix}.default-badge"))
+  end
+
+  def secondary_element
+    helpers.tag.div(provider_name, class: "truncate text-sm text-muted")
+  end
+
+  def menu
+    render(DropdownMenuComponent.new(menu_id: menu_id, items: menu_items, width: "w-40"))
+  end
+
+  def menu_items
+    items = [
+      { label: "Details", href: credential_url },
+      { label: "Edit", href: edit_url }
+    ]
+    items << { label: "Make default", href: default_url, data: { turbo_method: :patch } } unless credential.default?
+    items << { label: "Delete…", href: credential_url,
+               data: { turbo_method: :delete, turbo_confirm: delete_confirm } }
+    items
+  end
+
+  def delete_confirm
+    "Delete this #{credential_noun}? Feeds using it will be disabled."
+  end
+
+  def credential_url
+    helpers.polymorphic_path(credential)
+  end
+
+  def edit_url
+    helpers.edit_polymorphic_path(credential)
+  end
+
+  def default_url
+    helpers.polymorphic_path([credential, :default])
+  end
+
+  def menu_id
+    "#{key_prefix.dasherize}-menu-#{credential.id}"
+  end
+end

--- a/app/components/feed_list_item_component.rb
+++ b/app/components/feed_list_item_component.rb
@@ -43,8 +43,7 @@ class FeedListItemComponent < ListItemComponent
   end
 
   def title_link
-    helpers.link_to(title, feed_url,
-                    class: "truncate text-base text-heading transition hover:text-heading rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-white")
+    helpers.link_to(title, feed_url, class: TITLE_LINK_CSS_CLASS)
   end
 
   def group_element

--- a/app/components/list_item_component.rb
+++ b/app/components/list_item_component.rb
@@ -20,6 +20,12 @@ class ListItemComponent < ViewComponent::Base
   # feeds, posts, tokens, dev tools — highlights rows identically.
   HOVER_ROW_CSS_CLASS = "transition duration-75 hover:bg-surface-muted".freeze
 
+  # The one style for a row's primary link — the record's name, leading to it.
+  # Kept here so the truncation and focus ring stay identical across every list.
+  TITLE_LINK_CSS_CLASS = "truncate text-base text-heading transition hover:text-heading rounded-sm outline-none " \
+                         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 " \
+                         "focus-visible:ring-offset-white".freeze
+
   renders_one :icon
   renders_one :primary
   renders_one :secondary

--- a/app/components/post_list_item_component.rb
+++ b/app/components/post_list_item_component.rb
@@ -108,8 +108,7 @@ class PostListItemComponent < ListItemComponent
   # The title links to the post page. ReadonlyPostListItemComponent overrides
   # this with plain text where those owner-scoped routes aren't reachable.
   def title_element
-    helpers.link_to(title, post_url,
-                    class: "truncate text-base text-heading transition hover:text-heading rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-white")
+    helpers.link_to(title, post_url, class: TITLE_LINK_CSS_CLASS)
   end
 
   # Whether to render the actions menu (Details/Source/Delete). Disabled by

--- a/app/components/search_credential_list_item_component.rb
+++ b/app/components/search_credential_list_item_component.rb
@@ -1,73 +1,11 @@
-class SearchCredentialListItemComponent < ListItemComponent
-  DELETE_CONFIRM = "Delete this search credential? Feeds using it will be disabled.".freeze
-
-  def initialize(credential:)
-    super()
-    @credential = credential
-  end
-
-  def before_render
-    with_icon { icon_element }
-    with_primary { primary_element }
-    with_secondary { secondary_element }
-    with_trailing { menu }
-  end
-
+class SearchCredentialListItemComponent < CredentialListItemComponent
   private
-
-  attr_reader :credential
-
-  def li_id = helpers.dom_id(credential)
-  def li_data = { key: "search_credential.#{credential.id}" }
-  def row_css_class = HOVER_ROW_CSS_CLASS
-
-  def icon_element
-    helpers.tag.span(helpers.credential_status_icon(credential.state),
-                     class: "inline-flex shrink-0",
-                     data: { key: "search_credential.#{credential.id}.status_icon" })
-  end
-
-  def primary_element
-    helpers.tag.div(helpers.safe_join([title_link, default_badge].compact),
-                    class: "flex min-w-0 flex-1 items-center gap-2")
-  end
-
-  def title_link
-    helpers.link_to(credential.display_name, credential_url,
-                    class: "truncate text-base text-heading transition hover:text-heading rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-white")
-  end
-
-  def default_badge
-    return unless credential.default?
-
-    render(BadgeComponent.new(text: "Default", color: :info, key: "search_credential.default-badge"))
-  end
-
-  def secondary_element
-    helpers.tag.div(provider_name, class: "truncate text-sm text-muted")
-  end
 
   def provider_name
     credential.provider_label
   end
 
-  def menu
-    render(DropdownMenuComponent.new(menu_id: menu_id, items: menu_items, width: "w-40"))
+  def credential_noun
+    "search credential"
   end
-
-  def menu_items
-    items = [
-      { label: "Details", href: credential_url },
-      { label: "Edit", href: edit_url }
-    ]
-    items << { label: "Make default", href: default_url, data: { turbo_method: :patch } } unless credential.default?
-    items << { label: "Delete…", href: credential_url,
-               data: { turbo_method: :delete, turbo_confirm: DELETE_CONFIRM } }
-    items
-  end
-
-  def credential_url = helpers.search_credential_path(credential)
-  def edit_url = helpers.edit_search_credential_path(credential)
-  def default_url = helpers.search_credential_default_path(credential)
-  def menu_id = "search-credential-menu-#{credential.id}"
 end

--- a/test/components/credential_list_item_component_test.rb
+++ b/test/components/credential_list_item_component_test.rb
@@ -1,0 +1,107 @@
+require "test_helper"
+require "view_component/test_case"
+
+# Drives both concrete rows, so a subclass that stops inheriting — or a derived
+# route, DOM id, or test hook that drifts — fails here rather than silently
+# rendering a different row for one credential type.
+class CredentialListItemComponentTest < ViewComponent::TestCase
+  CASES = {
+    AiCredentialListItemComponent => {
+      factory: :ai_credential,
+      key_prefix: "ai_credential",
+      path_segment: "ai_credentials",
+      menu_id: "ai-credential-menu",
+      noun: "AI credential"
+    },
+    SearchCredentialListItemComponent => {
+      factory: :search_credential,
+      key_prefix: "search_credential",
+      path_segment: "search_credentials",
+      menu_id: "search-credential-menu",
+      noun: "search credential"
+    }
+  }.freeze
+
+  def user
+    @user ||= create(:user)
+  end
+
+  def each_case(trait = :active)
+    CASES.each do |component_class, expected|
+      credential = create(expected[:factory], trait, user: user)
+      yield render_inline(component_class.new(credential: credential)), credential, expected
+    end
+  end
+
+  def menu_item(result, label)
+    result.css("a[role='menuitem']").find { |a| a.text.strip == label }
+  end
+
+  test "#render should namespace the row and status icon hooks per credential type" do
+    each_case do |result, credential, expected|
+      prefix = expected[:key_prefix]
+
+      assert_not_nil result.css("[data-key='#{prefix}.#{credential.id}']").first, prefix
+      assert_not_nil result.at_css("[data-key='#{prefix}.#{credential.id}.status_icon'] svg"), prefix
+    end
+  end
+
+  test "#render should link the title to the credential" do
+    each_case do |result, credential, expected|
+      link = result.css("a").first
+
+      assert_includes link["href"], "/#{expected[:path_segment]}/#{credential.id}"
+      assert_equal credential.display_name, link.text.strip
+    end
+  end
+
+  test "#render should show the provider name on the second line" do
+    each_case do |result, credential, expected|
+      assert_includes result.to_html, provider_name_for(credential), expected[:key_prefix]
+    end
+  end
+
+  test "#render should offer Details, Edit, Make default and Delete" do
+    each_case do |result, credential, expected|
+      assert_includes menu_item(result, "Details")["href"], "/#{expected[:path_segment]}/#{credential.id}"
+      assert_includes menu_item(result, "Edit")["href"], "/#{expected[:path_segment]}/#{credential.id}/edit"
+      assert_includes menu_item(result, "Make default")["href"],
+                      "/#{expected[:path_segment]}/#{credential.id}/default"
+      assert_not_nil menu_item(result, "Delete…")
+    end
+  end
+
+  test "#render should name the credential type in the delete prompt" do
+    each_case do |result, _credential, expected|
+      assert_equal "Delete this #{expected[:noun]}? Feeds using it will be disabled.",
+                   menu_item(result, "Delete…")["data-turbo-confirm"]
+    end
+  end
+
+  test "#render should derive the menu id from the credential type" do
+    each_case do |result, credential, expected|
+      assert_not_nil result.css("##{expected[:menu_id]}-#{credential.id}").first, expected[:menu_id]
+    end
+  end
+
+  test "#render should badge the default credential and drop its Make default action" do
+    ai = create(:ai_credential, :active, user: user)
+    user.update!(default_ai_credential: ai)
+    result = render_inline(AiCredentialListItemComponent.new(credential: ai))
+
+    assert_not_nil result.css("[data-key='ai_credential.default-badge']").first
+    assert_nil menu_item(result, "Make default")
+  end
+
+  test "#render should omit the badge for a non-default credential" do
+    each_case do |result, _credential, expected|
+      assert_empty result.css("[data-key='#{expected[:key_prefix]}.default-badge']")
+    end
+  end
+
+  private
+
+  def provider_name_for(credential)
+    credential.is_a?(AiCredential) ? credential.llm_provider.display_name : credential.provider_label
+  end
+end


### PR DESCRIPTION
Changes:

- Add `CredentialListItemComponent` with the row both credential types render, and reduce `AiCredentialListItemComponent` and `SearchCredentialListItemComponent` to a provider name and a noun each.
- Lift the shared title-link styling into `ListItemComponent::TITLE_LINK_CSS_CLASS` and use it from all five list rows.
- Add `credential_list_item_component_test.rb`, driving both concrete rows.

The two credential rows were the same 80-odd lines — same slots, same icon span, same badge, same menu — differing only in the provider call, the delete copy, and the four names baked into routes and hooks. Everything nameable now comes from the record: `polymorphic_path` for the three URLs, `model_name.param_key` for the `data-key` namespace and the menu id. Adding a third credential type would be a two-method subclass.

The delete prompt is now built from a `credential_noun` hook rather than a per-class constant, which keeps the sentence in one place. Note the nouns differ in case by design — "Delete this **AI** credential?" but "Delete this **search** credential?" — matching what each row said before.

`AccessTokenListItemComponent` is **not** folded in. It shares the scaffolding but almost none of the content: its second line is a middot-joined owner/created/used summary rather than a provider name, it has no default badge or "Make default" action, and its delete goes through a modal trigger instead of a Turbo confirm. Forcing it into this base would be more overrides than inheritance. What it genuinely shared was the title-link styling, so it gets that and nothing else.

That styling — a 150-character Tailwind string — was spelled out identically in five components. It's a decision about how a list row's primary link looks, so it now sits next to `HOVER_ROW_CSS_CLASS` on `ListItemComponent`. Feed and post rows pick it up too. Three dev-only views carry the same string inline; those are left alone.

Neither credential row had a direct test — they were covered incidentally through the list components. The new test drives both concrete rows so a subclass that stops inheriting, or a derived route that drifts, fails loudly; I confirmed it by temporarily re-parenting `SearchCredentialListItemComponent` and watching 3 failures and 3 errors appear.

Rendering is unchanged: same markup, same classes, same hooks, same menu items and hrefs. The existing list component tests pass untouched.