### PR TITLE
Extract Credential concern from credential models

### DIFF
--- a/app/jobs/ai_credential_validation_job.rb
+++ b/app/jobs/ai_credential_validation_job.rb
@@ -13,6 +13,6 @@ class AiCredentialValidationJob < ApplicationJob
     credential.update!(state: :active, available_models: models,
                        last_validated_at: Time.current, last_error: nil)
   rescue LlmClient::Error => e
-    credential.disable_credential_and_feeds(last_error: e.message)
+    credential.deactivate!(last_error: e.message)
   end
 end

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -75,7 +75,7 @@ class AiCredential < ApplicationRecord
     end
   end
 
-  def disable_credential_and_feeds(last_error: nil)
+  def deactivate!(last_error: nil)
     with_lock do
       update!(state: :inactive, last_validated_at: Time.current, last_error: last_error)
       Event.create!(type: "ai_credential_deactivated", level: :warning,

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -1,43 +1,14 @@
-# A user's API credential for one AI provider. Mirrors the AccessToken
-# lifecycle (pending → validating → active|inactive). `credential_data`
-# stores provider-specific fields (e.g. `{ "api_key" => "..." }`) and is
-# encrypted at rest.
+# A user's API credential for one AI provider. `credential_data` stores
+# provider-specific fields (e.g. `{ "api_key" => "..." }`) and is encrypted at
+# rest. Lifecycle, naming, and feed teardown come from Credential; what's here
+# is the model-capability side: which models this key may actually run.
 class AiCredential < ApplicationRecord
-  DISPLAY_NAME_MAX_LENGTH = 80
+  include Credential
+
   REMOVED_EVENT_TYPE = "feed_ai_credential_removed"
-
-  belongs_to :user
-  # `dependent` is handled manually by `disable_dependent_feeds` so we can
-  # both nullify the reference and pull any feed left enabled out of the
-  # enabled state in one pass.
-  has_many :feeds
-
-  # Rails 8 stores the encryption envelope as a JSON object
-  # ({"h": {...}, "p": "<ciphertext>"}) which `jsonb` accepts natively.
-  # The raw column contains only the envelope; the API key is never
-  # stored in plaintext.
-  encrypts :credential_data
-
-  enum :state, { pending: 0, validating: 1, active: 2, inactive: 3 }
+  DEACTIVATED_EVENT_TYPE = "ai_credential_deactivated"
 
   validates :provider, presence: true, inclusion: { in: ->(_) { LlmProvider.names } }
-  validates :display_name,
-            presence: true,
-            length: { maximum: DISPLAY_NAME_MAX_LENGTH },
-            uniqueness: { scope: [:user_id, :provider] }
-
-  validate :api_key_present
-
-  before_validation :assign_name_if_blank, on: :create
-  before_destroy :disable_dependent_feeds
-
-  def default?
-    user.default_ai_credential_id == id
-  end
-
-  def make_default!
-    user.update!(default_ai_credential: self)
-  end
 
   def llm_provider
     LlmProvider.find(provider)
@@ -72,53 +43,6 @@ class AiCredential < ApplicationRecord
   def ruby_llm_context
     RubyLLM.context do |config|
       llm_provider.configure(config, credential_data["api_key"])
-    end
-  end
-
-  def deactivate!(last_error: nil)
-    with_lock do
-      update!(state: :inactive, last_validated_at: Time.current, last_error: last_error)
-      Event.create!(type: "ai_credential_deactivated", level: :warning,
-                    subject: self, user: user)
-      feeds.where(state: Feed.states[:enabled]).update_all(state: Feed.states[:disabled])
-    end
-  end
-
-  private
-
-  def assign_name_if_blank
-    return if display_name.present? || provider.blank?
-
-    self.display_name = generate_unique_name
-  end
-
-  def generate_unique_name
-    label = provider
-    existing = self.class.where(user_id: user_id, provider: provider).pluck(:display_name).map(&:downcase).to_set
-    CredentialNameGenerator.new(label, existing).generate.split.map(&:capitalize).join(" ")
-  end
-
-  def api_key_present
-    return if provider.blank?
-
-    errors.add(:base, "Enter your API key") if credential_data.blank? || credential_data["api_key"].blank?
-  end
-
-  # Detach this credential from every dependent feed. Enabled feeds reuse the
-  # feed's generic disable-and-event transition; drafts and already-disabled
-  # feeds keep their state and receive a removal-only event.
-  def disable_dependent_feeds
-    feeds.find_each do |feed|
-      feed.update_column(:ai_credential_id, nil)
-      next if feed.enabled? && feed.disable_with_event!(REMOVED_EVENT_TYPE, { disabled: true })
-
-      Event.create!(
-        type: REMOVED_EVENT_TYPE,
-        level: :warning,
-        subject: feed,
-        user: user,
-        metadata: { disabled: false }
-      )
     end
   end
 end

--- a/app/models/concerns/credential.rb
+++ b/app/models/concerns/credential.rb
@@ -1,0 +1,106 @@
+# Shared behavior for the provider credential types (AI and web search). Both
+# wrap a user-owned API key in the same pending → validating → active|inactive
+# lifecycle, name themselves after their provider, and take their feeds down
+# with them when deactivated or destroyed.
+#
+# Including models declare their provider vocabulary, the event types they
+# record, and their own domain logic; everything else derives from the model
+# name.
+module Credential
+  extend ActiveSupport::Concern
+
+  DISPLAY_NAME_MAX_LENGTH = 80
+
+  included do
+    belongs_to :user
+    # `dependent` is handled manually by `disable_dependent_feeds` so we can
+    # both nullify the reference and pull any feed left enabled out of the
+    # enabled state in one pass.
+    has_many :feeds
+
+    # Rails 8 stores the encryption envelope as a JSON object
+    # ({"h": {...}, "p": "<ciphertext>"}) which `jsonb` accepts natively.
+    # The raw column contains only the envelope; the API key is never
+    # stored in plaintext.
+    encrypts :credential_data
+
+    enum :state, { pending: 0, validating: 1, active: 2, inactive: 3 }
+
+    validates :display_name,
+              presence: true,
+              length: { maximum: DISPLAY_NAME_MAX_LENGTH },
+              uniqueness: { scope: [:user_id, :provider] }
+
+    validate :api_key_present
+
+    before_validation :assign_name_if_blank, on: :create
+    before_destroy :disable_dependent_feeds
+  end
+
+  def default?
+    user.public_send(:"default_#{param_key}_id") == id
+  end
+
+  def make_default!
+    user.update!("default_#{param_key}": self)
+  end
+
+  # Takes the credential and everything depending on it out of service in one
+  # transaction: a key that just failed cannot back a running feed.
+  def deactivate!(last_error: nil)
+    with_lock do
+      update!(state: :inactive, last_validated_at: Time.current, last_error: last_error)
+
+      Event.create!(
+        type: self.class::DEACTIVATED_EVENT_TYPE,
+        level: :warning,
+        subject: self,
+        user: user
+      )
+
+      feeds.where(state: Feed.states[:enabled]).update_all(state: Feed.states[:disabled])
+    end
+  end
+
+  private
+
+  # Names the feed foreign key and the user's `default_*` columns alike.
+  def param_key
+    self.class.model_name.param_key
+  end
+
+  def assign_name_if_blank
+    return if display_name.present? || provider.blank?
+
+    self.display_name = generate_unique_name
+  end
+
+  def generate_unique_name
+    existing = self.class.where(user_id: user_id, provider: provider).pluck(:display_name).map(&:downcase).to_set
+    CredentialNameGenerator.new(provider, existing).generate.split.map(&:capitalize).join(" ")
+  end
+
+  def api_key_present
+    return if provider.blank?
+
+    errors.add(:base, "Enter your API key") if credential_data.blank? || credential_data["api_key"].blank?
+  end
+
+  # Detach this credential from every dependent feed. Enabled feeds reuse the
+  # feed's generic disable-and-event transition; drafts and already-disabled
+  # feeds keep their state and receive a removal-only event.
+  def disable_dependent_feeds
+    feeds.find_each do |feed|
+      feed.update_column(:"#{param_key}_id", nil)
+      next if feed.enabled? && feed.disable_with_event!(self.class::REMOVED_EVENT_TYPE, { disabled: true })
+
+      Event.create!(
+        type: self.class::REMOVED_EVENT_TYPE,
+        level: :warning,
+        subject: feed,
+        user: user,
+        metadata: { disabled: false }
+      )
+    end
+  end
+end

--- a/app/models/search_credential.rb
+++ b/app/models/search_credential.rb
@@ -1,35 +1,17 @@
-# Stores a user's API credential for a web search provider.
+# A user's API credential for one web search provider. Lifecycle, naming, and
+# feed teardown come from Credential; what's here is the cost side, since
+# search is billed per request and gets estimated before a run.
 class SearchCredential < ApplicationRecord
-  DISPLAY_NAME_MAX_LENGTH = 80
-  REMOVED_EVENT_TYPE = "feed_search_credential_removed"
+  include Credential
 
-  belongs_to :user
-  has_many :feeds
+  REMOVED_EVENT_TYPE = "feed_search_credential_removed"
+  DEACTIVATED_EVENT_TYPE = "search_credential_deactivated"
+
+  # Unlike AccessToken and AiCredential, whose events outlive them and render
+  # as "(removed)", this one's history goes when the credential does.
   has_many :events, as: :subject, dependent: :destroy
 
-  encrypts :credential_data
-
-  enum :state, { pending: 0, validating: 1, active: 2, inactive: 3 }
-
   validates :provider, presence: true, inclusion: { in: ->(_) { WebSearchProvider::REGISTRY.keys } }
-
-  validates :display_name,
-            presence: true,
-            length: { maximum: DISPLAY_NAME_MAX_LENGTH },
-            uniqueness: { scope: [:user_id, :provider] }
-
-  validate :api_key_present
-
-  before_validation :assign_name_if_blank, on: :create
-  before_destroy :disable_dependent_feeds
-
-  def default?
-    user.default_search_credential_id == id
-  end
-
-  def make_default!
-    user.update!(default_search_credential: self)
-  end
 
   def web_search_provider
     WebSearchProvider.for(provider, api_key: credential_data["api_key"])
@@ -41,61 +23,5 @@ class SearchCredential < ApplicationRecord
 
   def estimated_search_cost_cents(call_count)
     BigDecimal(WebSearchProvider.cents_per_1k_requests_for(provider).to_s) * call_count / 1000
-  end
-
-  def deactivate!(last_error: nil)
-    with_lock do
-      update!(
-        state: :inactive,
-        last_validated_at: Time.current,
-        last_error: last_error
-      )
-
-      Event.create!(
-        type: "search_credential_deactivated",
-        level: :warning,
-        subject: self,
-        user: user
-      )
-
-      feeds.where(state: Feed.states[:enabled]).update_all(state: Feed.states[:disabled])
-    end
-  end
-
-  private
-
-  def assign_name_if_blank
-    return if display_name.present? || provider.blank?
-
-    self.display_name = generate_unique_name
-  end
-
-  def generate_unique_name
-    existing = self.class.where(user_id: user_id, provider: provider).pluck(:display_name).map(&:downcase).to_set
-    CredentialNameGenerator.new(provider, existing).generate.split.map(&:capitalize).join(" ")
-  end
-
-  def api_key_present
-    return if provider.blank?
-
-    errors.add(:base, "Enter your API key") if credential_data.blank? || credential_data["api_key"].blank?
-  end
-
-  # Detach this credential from every dependent feed. Enabled feeds reuse the
-  # feed's generic disable-and-event transition; drafts and already-disabled
-  # feeds keep their state and receive a removal-only event.
-  def disable_dependent_feeds
-    feeds.find_each do |feed|
-      feed.update_column(:search_credential_id, nil)
-      next if feed.enabled? && feed.disable_with_event!(REMOVED_EVENT_TYPE, { disabled: true })
-
-      Event.create!(
-        type: REMOVED_EVENT_TYPE,
-        level: :warning,
-        subject: feed,
-        user: user,
-        metadata: { disabled: false }
-      )
-    end
   end
 end

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -414,7 +414,7 @@ class FeedRefreshWorkflow
   def disable_credentials_on_auth_error(error)
     case error
     when LlmClient::AuthError
-      feed.ai_credential&.disable_credential_and_feeds(last_error: error.message)
+      feed.ai_credential&.deactivate!(last_error: error.message)
     when WebSearchProvider::AuthError
       feed.search_credential&.deactivate!(last_error: error.message)
     end

--- a/test/models/ai_credential_test.rb
+++ b/test/models/ai_credential_test.rb
@@ -176,4 +176,33 @@ class AiCredentialTest < ActiveSupport::TestCase
 
     assert_nil credential.default_supported_model
   end
+
+  test "#deactivate! should persist the error and create a warning event" do
+    credential = create(:ai_credential, :active, user: user)
+
+    assert_difference("Event.count", 1) do
+      credential.deactivate!(last_error: "Anthropic: HTTP 401")
+    end
+
+    credential.reload
+    event = Event.order(:created_at).last
+    assert credential.inactive?
+    assert_equal "Anthropic: HTTP 401", credential.last_error
+    assert_not_nil credential.last_validated_at
+    assert_equal "ai_credential_deactivated", event.type
+    assert_equal "warning", event.level
+    assert_equal credential, event.subject
+    assert_equal user, event.user
+  end
+
+  test "#deactivate! should disable feeds running on the credential" do
+    credential = create(:ai_credential, :active, user: user)
+    enabled = create(:feed, :enabled, user: user, ai_credential: credential)
+    draft = create(:feed, :draft, user: user, ai_credential: credential)
+
+    credential.deactivate!
+
+    assert enabled.reload.disabled?
+    assert draft.reload.draft?
+  end
 end


### PR DESCRIPTION
Changes:

- Extract the shared lifecycle, auto-naming, and feed-teardown behavior of `AiCredential` and `SearchCredential` into a `Credential` concern
- Rename `AiCredential#disable_credential_and_feeds` to `deactivate!` so both types expose the same deactivation API
- Give each model explicit `REMOVED_EVENT_TYPE` / `DEACTIVATED_EVENT_TYPE` constants
- Cover `AiCredential#deactivate!` directly, which until now was only exercised through its validation job

The two models back column-identical tables (bar `available_models`) and already
share a base controller and a base policy, so the duplicated halves were the
same concept rather than lookalike code. What stays behind in each model is the
part that genuinely differs: model capability for AI, cost estimation for
search, and each provider's own vocabulary.

Event type strings stay as per-model constants instead of being derived from
the model name — they are stored in the database and referenced from
`config/event_icons.yml` and `config/locales/en.yml`, so they need to stay
greppable.

One asymmetry is preserved rather than smoothed over: `SearchCredential`
destroys its events, while `AccessToken` and `AiCredential` let theirs outlive
the record and render as "(removed)". That association stays declared on
`SearchCredential` with a comment, since unifying it either way is a behavior
change rather than a refactor.

References:

- Related PR: #1226
