### PR TITLE
Extract CredentialDefaultsController base

### DIFF
--- a/app/controllers/ai_credentials/defaults_controller.rb
+++ b/app/controllers/ai_credentials/defaults_controller.rb
@@ -1,27 +1,9 @@
-class AiCredentials::DefaultsController < ApplicationController
-  def update
-    authorize credential, :update?
-
-    credential.make_default!
-
-    respond_to do |format|
-      format.turbo_stream do
-        flash.now[:success] = "'#{credential.display_name}' is now the default credential."
-        @credentials = policy_scope(AiCredential).order(created_at: :desc)
-      end
-      format.html do
-        redirect_to ai_credentials_path, success: "'#{credential.display_name}' is now the default credential."
-      end
-    end
-  end
+class AiCredentials::DefaultsController < CredentialDefaultsController
+  self.credential_class = AiCredential
 
   private
 
-  def credential
-    @credential ||= scope.find(params[:ai_credential_id])
-  end
-
-  def scope
-    policy_scope(AiCredential)
+  def credential_noun
+    "credential"
   end
 end

--- a/app/controllers/credential_defaults_controller.rb
+++ b/app/controllers/credential_defaults_controller.rb
@@ -1,0 +1,43 @@
+# Promotes one of the user's credentials to be their default for that provider
+# type. The list re-renders in place over Turbo, or falls back to a redirect.
+#
+# Subclasses declare their model and the noun used in the confirmation; the
+# nested param and the list path follow from the model.
+class CredentialDefaultsController < ApplicationController
+  class_attribute :credential_class, instance_writer: false
+
+  def update
+    authorize credential, :update?
+    credential.make_default!
+
+    respond_to do |format|
+      format.turbo_stream do
+        flash.now[:success] = success_message
+        @credentials = scope.order(created_at: :desc)
+      end
+      format.html do
+        redirect_to helpers.polymorphic_path(credential_class), success: success_message
+      end
+    end
+  end
+
+  private
+
+  # Completes "'<name>' is now the default …". The AI wording omits the type,
+  # which is why this is a subclass hook rather than something derived.
+  def credential_noun
+    raise NotImplementedError, "#{self.class.name} must implement #credential_noun"
+  end
+
+  def success_message
+    "'#{credential.display_name}' is now the default #{credential_noun}."
+  end
+
+  def credential
+    @credential ||= scope.find(params[:"#{credential_class.model_name.param_key}_id"])
+  end
+
+  def scope
+    policy_scope(credential_class)
+  end
+end

--- a/app/controllers/search_credentials/defaults_controller.rb
+++ b/app/controllers/search_credentials/defaults_controller.rb
@@ -1,27 +1,9 @@
-class SearchCredentials::DefaultsController < ApplicationController
-  def update
-    authorize credential, :update?
-    credential.make_default!
-
-    respond_to do |format|
-      format.turbo_stream do
-        flash.now[:success] = "'#{credential.display_name}' is now the default search credential."
-        @credentials = policy_scope(SearchCredential).order(created_at: :desc)
-      end
-      format.html do
-        redirect_to search_credentials_path,
-                    success: "'#{credential.display_name}' is now the default search credential."
-      end
-    end
-  end
+class SearchCredentials::DefaultsController < CredentialDefaultsController
+  self.credential_class = SearchCredential
 
   private
 
-  def credential
-    @credential ||= scope.find(params[:search_credential_id])
-  end
-
-  def scope
-    policy_scope(SearchCredential)
+  def credential_noun
+    "search credential"
   end
 end

--- a/test/controllers/ai_credentials/defaults_controller_test.rb
+++ b/test/controllers/ai_credentials/defaults_controller_test.rb
@@ -29,6 +29,15 @@ class AiCredentials::DefaultsControllerTest < ActionDispatch::IntegrationTest
     assert_equal credential.id, user.reload.default_ai_credential_id
   end
 
+  test "#update should confirm the promotion without naming the credential type" do
+    sign_in_as(user)
+    credential = create(:ai_credential, user: user, provider: "anthropic", display_name: "Working Key")
+
+    patch ai_credential_default_url(credential)
+
+    assert_equal "'Working Key' is now the default credential.", flash[:success]
+  end
+
   test "#update should 404 for another user's credential" do
     sign_in_as(user)
     other = create(:ai_credential, user: other_user, provider: "anthropic")

--- a/test/controllers/search_credentials/defaults_controller_test.rb
+++ b/test/controllers/search_credentials/defaults_controller_test.rb
@@ -29,6 +29,15 @@ class SearchCredentials::DefaultsControllerTest < ActionDispatch::IntegrationTes
     assert_equal credential.id, user.reload.default_search_credential_id
   end
 
+  test "#update should name the credential type in the confirmation" do
+    sign_in_as(user)
+    credential = create(:search_credential, user: user, display_name: "Working Key")
+
+    patch search_credential_default_url(credential)
+
+    assert_equal "'Working Key' is now the default search credential.", flash[:success]
+  end
+
   test "#update should 404 for another user's credential" do
     sign_in_as(user)
     other = create(:search_credential, user: other_user)


### PR DESCRIPTION
Changes:

- Add `CredentialDefaultsController` and reduce the AI and search `DefaultsController`s to a model and a noun each.
- Pin the confirmation wording in both controllers' tests.

Same shape as `ValidationsController` from #1226. The nested param comes from `model_name.param_key` and the redirect from `polymorphic_path`, so the only thing a subclass states is which model it manages.

The one piece that isn't derivable is the flash copy, and the two disagreed: the AI controller said *"'X' is now the default credential."* while search said *"'X' is now the default **search** credential."* I kept both strings exactly as they were behind a `credential_noun` hook rather than normalising them, since changing either is user-visible and wasn't part of this. Neither controller had a test covering that wording, which is how they drifted in the first place — both now assert their own sentence, so the next person to touch this has to do it deliberately.

The per-namespace `update.turbo_stream.erb` templates are untouched and still resolve off each subclass's controller path.