### PR TITLE
Keep credential events when the credential is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-08
+
+- Deleting a search credential no longer erases its entries from your activity log. Past events stay put and show the credential as "(removed)", the same way access tokens and AI credentials already worked.
+
 ## 2026-08-01
 
 - Renaming an AI credential no longer sends it back for re-checking. Only a new API key triggers that now, matching how search credentials already worked.

--- a/app/models/search_credential.rb
+++ b/app/models/search_credential.rb
@@ -7,10 +7,6 @@ class SearchCredential < ApplicationRecord
   REMOVED_EVENT_TYPE = "feed_search_credential_removed"
   DEACTIVATED_EVENT_TYPE = "search_credential_deactivated"
 
-  # Unlike AccessToken and AiCredential, whose events outlive them and render
-  # as "(removed)", this one's history goes when the credential does.
-  has_many :events, as: :subject, dependent: :destroy
-
   validates :provider, presence: true, inclusion: { in: ->(_) { WebSearchProvider::REGISTRY.keys } }
 
   def web_search_provider

--- a/test/models/credential_removal_test.rb
+++ b/test/models/credential_removal_test.rb
@@ -60,6 +60,33 @@ class CredentialRemovalTest < ActiveSupport::TestCase
     assert_removal_event(enabled_feed, SearchCredential::REMOVED_EVENT_TYPE, disabled: true)
   end
 
+  # Events are log records: what happened stays recorded even once the thing it
+  # happened to is gone. A removed subject reads as "(removed)" in the log
+  # rather than taking its history with it.
+  test "destroying an access token leaves its own events behind" do
+    token = create(:access_token, user: user)
+    event = create(:event, subject: token, user: user)
+
+    assert_no_difference("Event.count") { token.destroy! }
+    assert_nil event.reload.subject
+  end
+
+  test "destroying an AI credential leaves its own events behind" do
+    credential = create(:ai_credential, user: user)
+    event = create(:event, subject: credential, user: user)
+
+    assert_no_difference("Event.count") { credential.destroy! }
+    assert_nil event.reload.subject
+  end
+
+  test "destroying a search credential leaves its own events behind" do
+    credential = create(:search_credential, user: user)
+    event = create(:event, subject: credential, user: user)
+
+    assert_no_difference("Event.count") { credential.destroy! }
+    assert_nil event.reload.subject
+  end
+
   private
 
   def assert_removal_event(feed, type, disabled:)


### PR DESCRIPTION
Changes:

- Drop `has_many :events, dependent: :destroy` from `SearchCredential`, so removing one no longer deletes its entries from the events log.
- Cover event retention on destroy for all three subject types.

Events are log records. What happened stays recorded even once the thing it happened to is gone — a removed subject reads as "(removed)" in the log rather than taking its history with it. `AccessToken` and `AiCredential` already worked this way; `SearchCredential` was the outlier, silently erasing its own audit trail on delete.

There's no cascade on `events.subject_id`, so the association was the whole mechanism — removing it is the entire fix. Nothing referenced `search_credential.events`, so the association goes rather than just its `dependent:` option, which also matches `AiCredential`, where no such association exists.

The orphaned-subject rendering this now exercises is already proven: `EventDescriptionComponent` has an `orphaned_subject_placeholder` for exactly this case, with a test that destroys an AI credential and asserts the description renders "(removed)". Search credentials now take the same path. The tests here assert the count is unchanged *and* that the surviving event's `subject` reads back as nil, so they'd catch the cascade coming back by another route.

This PR previously pinned the old asymmetry as-is; it now corrects it, which is the better answer to the question that test was holding open.

One caveat worth stating plainly: this only changes behaviour going forward. Events already destroyed alongside a deleted search credential are gone and can't be recovered.
