### PR TITLE
Rename Credential concern to ProviderCredential

### DIFF
--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -1,9 +1,10 @@
 # A user's API credential for one AI provider. `credential_data` stores
 # provider-specific fields (e.g. `{ "api_key" => "..." }`) and is encrypted at
-# rest. Lifecycle, naming, and feed teardown come from Credential; what's here
-# is the model-capability side: which models this key may actually run.
+# rest. Lifecycle, naming, and feed teardown come from ProviderCredential;
+# what's here is the model-capability side: which models this key may actually
+# run.
 class AiCredential < ApplicationRecord
-  include Credential
+  include ProviderCredential
 
   REMOVED_EVENT_TYPE = "feed_ai_credential_removed"
   DEACTIVATED_EVENT_TYPE = "ai_credential_deactivated"

--- a/app/models/concerns/provider_credential.rb
+++ b/app/models/concerns/provider_credential.rb
@@ -6,7 +6,7 @@
 # Including models declare their provider vocabulary, the event types they
 # record, and their own domain logic; everything else derives from the model
 # name.
-module Credential
+module ProviderCredential
   extend ActiveSupport::Concern
 
   DISPLAY_NAME_MAX_LENGTH = 80

--- a/app/models/search_credential.rb
+++ b/app/models/search_credential.rb
@@ -1,8 +1,8 @@
 # A user's API credential for one web search provider. Lifecycle, naming, and
-# feed teardown come from Credential; what's here is the cost side, since
-# search is billed per request and gets estimated before a run.
+# feed teardown come from ProviderCredential; what's here is the cost side,
+# since search is billed per request and gets estimated before a run.
 class SearchCredential < ApplicationRecord
-  include Credential
+  include ProviderCredential
 
   REMOVED_EVENT_TYPE = "feed_search_credential_removed"
   DEACTIVATED_EVENT_TYPE = "search_credential_deactivated"


### PR DESCRIPTION
Changes:

- Rename the `Credential` concern to `ProviderCredential` and update the two `include`s and the doc comments that name it.

The bare `Credential` reads like the record itself rather than the behaviour two records share, and it sits awkwardly next to `CredentialsController`, `CredentialPolicy`, `CredentialDefaultsController` and `CredentialListItemComponent` — all of which are bases for a *family* of credential things, not things belonging to a `Credential`. `ProviderCredential` says which credentials it covers and leaves that prefix unambiguous.

Rename only: no behaviour, no structure, no other files. `DISPLAY_NAME_MAX_LENGTH` is referenced solely inside the concern, so nothing outside had to change. The `Credential` constant is now unused, confirmed by a `defined?` check in the running app. The many "Credential" strings in views are UI copy and are untouched.

The file move is recorded as a rename, so `git log --follow` still reaches #1228.

One thing I did **not** do: my original suggestion paired this name with turning the concern into an abstract base class (`AiCredential < ProviderCredential`), which would match the nine `Family::Base` classes elsewhere in the app and the base-class shape of the other four credential extractions. That's a structural change rather than a rename, so it isn't here — say the word if you want it as a follow-up.