### PR TITLE
Make LLM usage accounting honest: tool rounds and cache tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-08
 
+- AI usage now counts every step of a web-search run, so the costs you see reflect what the call actually spent.
 - AI cost estimates no longer count cached-prompt reads at the more expensive write rate.
 - Deleting a search credential no longer erases its entries from your activity log. Past events stay put and show the credential as "(removed)", the same way access tokens and AI credentials already worked.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-08
 
+- AI cost estimates no longer count cached-prompt reads at the more expensive write rate.
 - Deleting a search credential no longer erases its entries from your activity log. Past events stay put and show the credential as "(removed)", the same way access tokens and AI credentials already worked.
 
 ## 2026-08-01

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -167,11 +167,25 @@ class LlmClient
     response = chat.ask(prompt)
     ProviderResponse.new(
       payload: output_schema.present? ? parse_payload(response) : response_text(response),
-      input_tokens: response.try(:input_tokens).to_i,
-      output_tokens: response.try(:output_tokens).to_i,
-      cache_write_tokens: response.try(:cache_write_tokens).to_i,
-      cache_read_tokens: response.try(:cache_read_tokens).to_i
+      **usage_totals(chat, response)
     )
+  end
+
+  # A web-enabled call is several billed completions — one per tool round —
+  # but #ask returns only the final round. Each round's assistant message
+  # stays on the chat, so summing them gives the true per-call total for
+  # the single usage row. Falls back to the response when the chat doesn't
+  # retain messages.
+  def usage_totals(chat, response)
+    rounds = Array(chat.try(:messages)).select { |message| message.try(:role) == :assistant }
+    rounds = [response] if rounds.empty?
+
+    {
+      input_tokens: rounds.sum { |message| message.try(:input_tokens).to_i },
+      output_tokens: rounds.sum { |message| message.try(:output_tokens).to_i },
+      cache_write_tokens: rounds.sum { |message| message.try(:cache_write_tokens).to_i },
+      cache_read_tokens: rounds.sum { |message| message.try(:cache_read_tokens).to_i }
+    }
   end
 
   def search_provider_for(ctx)

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -169,7 +169,7 @@ class LlmClient
       payload: output_schema.present? ? parse_payload(response) : response_text(response),
       input_tokens: response.try(:input_tokens).to_i,
       output_tokens: response.try(:output_tokens).to_i,
-      cache_write_tokens: response.try(:cached_tokens).to_i,
+      cache_write_tokens: response.try(:cache_write_tokens).to_i,
       cache_read_tokens: response.try(:cache_read_tokens).to_i
     )
   end

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -375,6 +375,16 @@ class LlmClientTest < ActiveSupport::TestCase
     end
   end
 
+  # Retains a message history like the real RubyLLM chat does after a
+  # multi-round tool loop.
+  class FakeToolLoopChat < FakeChat
+    attr_reader :messages
+
+    def initialize(messages)
+      @messages = messages
+    end
+  end
+
   # Returns a response carrying distinct cache counts, so a swap between the
   # read and write columns can't cancel out.
   class FakeChatWithUsage < FakeChat
@@ -403,6 +413,31 @@ class LlmClientTest < ActiveSupport::TestCase
 
     assert_equal "SYSTEM PROMPT", chat.instructions
     assert_equal "user text", chat.asked
+  end
+
+  def assistant_round(input:, output:, cached: nil, cache_creation: nil)
+    RubyLLM::Message.new(role: :assistant, content: "round", input_tokens: input, output_tokens: output,
+                         cached_tokens: cached, cache_creation_tokens: cache_creation)
+  end
+
+  test "#invoke_provider should sum usage across all rounds of a tool loop" do
+    client = LlmClient.new(credential)
+    chat = FakeToolLoopChat.new([
+      RubyLLM::Message.new(role: :user, content: "user text"),
+      assistant_round(input: 100, output: 10, cached: 7, cache_creation: 3),
+      RubyLLM::Message.new(role: :tool, content: "tool result", tool_call_id: "t1"),
+      assistant_round(input: 200, output: 20, cached: 5)
+    ])
+
+    response = stub_chat(client, chat) do
+      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "user text",
+                                    output_schema: nil, web: false, system: nil)
+    end
+
+    assert_equal 300, response.input_tokens
+    assert_equal 30, response.output_tokens
+    assert_equal 3, response.cache_write_tokens
+    assert_equal 12, response.cache_read_tokens
   end
 
   test "#invoke_provider should map cache reads and cache writes to their own columns" do

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -375,6 +375,17 @@ class LlmClientTest < ActiveSupport::TestCase
     end
   end
 
+  # Returns a response carrying distinct cache counts, so a swap between the
+  # read and write columns can't cancel out.
+  class FakeChatWithUsage < FakeChat
+    def ask(prompt)
+      @asked = prompt
+      Data.define(:content, :input_tokens, :output_tokens, :cache_write_tokens, :cache_read_tokens)
+          .new(content: "gathered", input_tokens: 42, output_tokens: 7,
+               cache_write_tokens: 3, cache_read_tokens: 11)
+    end
+  end
+
   def stub_chat(client, chat)
     context = Object.new
     context.define_singleton_method(:chat) { |**_| chat }
@@ -392,6 +403,21 @@ class LlmClientTest < ActiveSupport::TestCase
 
     assert_equal "SYSTEM PROMPT", chat.instructions
     assert_equal "user text", chat.asked
+  end
+
+  test "#invoke_provider should map cache reads and cache writes to their own columns" do
+    client = LlmClient.new(credential)
+    chat = FakeChatWithUsage.new
+
+    response = stub_chat(client, chat) do
+      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "user text",
+                                    output_schema: nil, web: false, system: nil)
+    end
+
+    assert_equal 42, response.input_tokens
+    assert_equal 7, response.output_tokens
+    assert_equal 3, response.cache_write_tokens
+    assert_equal 11, response.cache_read_tokens
   end
 
   test "#invoke_provider should not set instructions when no system prompt is given" do

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -189,9 +189,14 @@ class LlmClientTest < ActiveSupport::TestCase
 
   def fake_model(**attrs)
     defaults = {
-      id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", family: "claude",
-      context_window: 200_000, max_output_tokens: 8_192, capabilities: ["function_calling"]
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      family: "claude",
+      context_window: 200_000,
+      max_output_tokens: 8_192,
+      capabilities: ["function_calling"]
     }
+
     Struct.new(*defaults.keys, keyword_init: true).new(**defaults.merge(attrs))
   end
 
@@ -277,8 +282,7 @@ class LlmClientTest < ActiveSupport::TestCase
   end
 
   test "#available_models should resolve providers by their RubyLLM key, not the registry name" do
-    moonshot = create(:ai_credential, :active, user: user, provider: "moonshot",
-                      credential_data: { "api_key" => "sk-#{SecureRandom.hex(16)}" })
+    moonshot = create(:ai_credential, :active, user: user, provider: "moonshot", credential_data: { "api_key" => "sk-#{SecureRandom.hex(16)}" })
     client = LlmClient.new(moonshot)
 
     fake_provider_class = Class.new do
@@ -391,8 +395,13 @@ class LlmClientTest < ActiveSupport::TestCase
     def ask(prompt)
       @asked = prompt
       Data.define(:content, :input_tokens, :output_tokens, :cache_write_tokens, :cache_read_tokens)
-          .new(content: "gathered", input_tokens: 42, output_tokens: 7,
-               cache_write_tokens: 3, cache_read_tokens: 11)
+          .new(
+            content: "gathered",
+            input_tokens: 42,
+            output_tokens: 7,
+            cache_write_tokens: 3,
+            cache_read_tokens: 11
+          )
     end
   end
 
@@ -407,8 +416,7 @@ class LlmClientTest < ActiveSupport::TestCase
     chat = FakeChat.new
 
     stub_chat(client, chat) do
-      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "user text",
-                                    output_schema: nil, web: false, system: "SYSTEM PROMPT")
+      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "user text", output_schema: nil, web: false, system: "SYSTEM PROMPT")
     end
 
     assert_equal "SYSTEM PROMPT", chat.instructions
@@ -416,8 +424,14 @@ class LlmClientTest < ActiveSupport::TestCase
   end
 
   def assistant_round(input:, output:, cached: nil, cache_creation: nil)
-    RubyLLM::Message.new(role: :assistant, content: "round", input_tokens: input, output_tokens: output,
-                         cached_tokens: cached, cache_creation_tokens: cache_creation)
+    RubyLLM::Message.new(
+      role: :assistant,
+      content: "round",
+      input_tokens: input,
+      output_tokens: output,
+      cached_tokens: cached,
+      cache_creation_tokens: cache_creation
+    )
   end
 
   test "#invoke_provider should sum usage across all rounds of a tool loop" do
@@ -430,8 +444,7 @@ class LlmClientTest < ActiveSupport::TestCase
     ])
 
     response = stub_chat(client, chat) do
-      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "user text",
-                                    output_schema: nil, web: false, system: nil)
+      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "user text", output_schema: nil, web: false, system: nil)
     end
 
     assert_equal 300, response.input_tokens
@@ -460,8 +473,7 @@ class LlmClientTest < ActiveSupport::TestCase
     chat = FakeChat.new
 
     stub_chat(client, chat) do
-      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "user text",
-                                    output_schema: nil, web: false, system: nil)
+      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "user text", output_schema: nil, web: false, system: nil)
     end
 
     assert_nil chat.instructions


### PR DESCRIPTION
Changes:

- Usage rows now sum tokens across every billed round of a tool-loop call, instead of reading only the final response. Each round's assistant message is retained on the chat, so the single-row-per-call invariant holds while the row records the true per-call total.
- Cache reads and cache writes now land in their own columns. The write column previously received the cache-read count (`cached_tokens` aliases the read counter in ruby_llm), so reads were recorded twice and billed once at the higher write rate.

The third defect from the ticket — Moonshot cache hits invisible to the gem's usage parser — needs an upstream ruby_llm report, not an app-side change; zeros are accepted meanwhile as the ticket proposes.

References:

- Closes #1190
- Parent issue: #1184