### PR TITLE
Send Moonshot system prompts as role "system"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-09
+
+- Feeds and previews backed by Moonshot (Kimi) credentials work again. Every Kimi request was being rejected because of how instructions were labeled on the way to the provider.
+
 ## 2026-08-08
 
 - AI usage now counts every step of a web-search run, so the costs you see reflect what the call actually spent.

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -33,6 +33,11 @@ class LlmProvider
   def configure(config, api_key)
     config.public_send("#{ruby_llm_provider}_api_key=", api_key)
     config.public_send("#{ruby_llm_provider}_api_base=", api_base) if api_base
+    # RubyLLM's :openai provider sends system prompts as role "developer"
+    # unless this flag is set, and OpenAI-compatible APIs like Moonshot reject
+    # that role with a 400. Scoped per-provider, not set globally, because
+    # OpenRouter reads the same attribute and expects the default.
+    config.openai_use_system_role = true if ruby_llm_provider == :openai
   end
 
   PROVIDERS = {

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -115,6 +115,10 @@ module LlmCapabilityProbe
       def configure(config)
         config.openai_api_key = ENV.fetch(self.class.env_key)
         config.openai_api_base = ENV.fetch("MOONSHOT_API_BASE", "https://api.moonshot.ai/v1")
+        # Mirror production (LlmProvider#configure): Moonshot rejects the
+        # "developer" role RubyLLM sends by default, so the probe must use
+        # the same wire shape or its results won't transfer.
+        config.openai_use_system_role = true
       end
 
       def ruby_llm_provider = :openai

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -51,10 +51,22 @@ class LlmProviderTest < ActiveSupport::TestCase
   end
 
   test "#configure should set the openai key and base for moonshot" do
-    config = Struct.new(:openai_api_key, :openai_api_base).new
+    config = Struct.new(:openai_api_key, :openai_api_base, :openai_use_system_role).new
     LlmProvider.find("moonshot").configure(config, "sk-moon-x")
     assert_equal "sk-moon-x", config.openai_api_key
     assert_equal "https://api.moonshot.ai/v1", config.openai_api_base
+  end
+
+  test "#configure should pin system prompts to role system for providers riding :openai" do
+    config = Struct.new(:openai_api_key, :openai_api_base, :openai_use_system_role).new
+    LlmProvider.find("moonshot").configure(config, "sk-moon-x")
+    assert config.openai_use_system_role
+  end
+
+  test "#configure should leave the system-role flag alone for other providers" do
+    config = Struct.new(:openrouter_api_key, :openai_use_system_role).new
+    LlmProvider.find("openrouter").configure(config, "sk-or-x")
+    assert_nil config.openai_use_system_role
   end
 
   test "every provider should declare a default_model with a known rate" do

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -170,6 +170,18 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     assert_nil moonshot.web_fetch_params("m")
   end
 
+  test "moonshot provider should configure the same system-role flag as production" do
+    original = ENV.fetch("MOONSHOT_API_KEY", nil)
+    ENV["MOONSHOT_API_KEY"] = "k"
+    config = Struct.new(:openai_api_key, :openai_api_base, :openai_use_system_role).new
+
+    LlmCapabilityProbe::Provider.build("moonshot").configure(config)
+
+    assert config.openai_use_system_role
+  ensure
+    ENV["MOONSHOT_API_KEY"] = original
+  end
+
   test "moonshot echo tool should return its arguments verbatim" do
     tool = LlmCapabilityProbe::MoonshotWebSearchEcho.new
     assert_equal "$web_search", tool.name


### PR DESCRIPTION
Changes:

- Set `openai_use_system_role` at the provider-configuration seam (`LlmProvider#configure`) for providers riding RubyLLM's `:openai` adapter — today only Moonshot — so system prompts go out as role `system` instead of `developer`, which Moonshot rejects with a 400.
- Mirror the same flag in the capability probe's Moonshot configuration, so the probe exercises the production wire shape.

The flag is scoped to the provider rather than set globally because RubyLLM's OpenRouter provider reads the same attribute; a global default would silently change its rendering too.

References:

- Closes #1185
- Parent issue: #1184