### PR TITLE
Support Idempotency-Key header on POST /v1/posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-12
+
+- The posting endpoint now understands the standard `Idempotency-Key` header, so HTTP clients that send it get safe retries without setting `uid` in the payload.
+
 ## 2026-08-09
 
 - Feeds and previews backed by Moonshot (Kimi) credentials work again. Every Kimi request was being rejected because of how instructions were labeled on the way to the provider.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     childprocess (5.1.0)

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::PostsController < ActionController::API
     return reject_throttled(limit) unless limit.allowed?
     return reject_oversized if oversized_body?
 
-    respond(WebhookIngestion.new(endpoint: endpoint, payload: payload).call)
+    respond(WebhookIngestion.new(endpoint: endpoint, payload: payload, idempotency_key: idempotency_key).call)
   end
 
   private
@@ -41,6 +41,10 @@ class Api::V1::PostsController < ActionController::API
 
   def payload
     request.request_parameters.deep_stringify_keys
+  end
+
+  def idempotency_key
+    request.headers["Idempotency-Key"]
   end
 
   def respond(result)

--- a/app/services/webhook_ingestion.rb
+++ b/app/services/webhook_ingestion.rb
@@ -116,12 +116,17 @@ class WebhookIngestion
     end
   end
 
+  # RFC 8941 sf-string: printable ASCII inside double quotes, with backslash
+  # escaping only quotes and backslashes.
+  SF_STRING = /\A"(?<value>(?:[\x20-\x21\x23-\x5B\x5D-\x7E]|\\["\\])*)"\z/
+
   # The Idempotency-Key header is a second spelling of uid, so it gets the same
   # constraints, plus a mismatch check: two different keys on one request almost
   # certainly mean a confused client, and dedup keys are the wrong place to
   # resolve that silently.
   def idempotency_key_errors
     return [] if @raw_idempotency_key.nil?
+    return ["Idempotency-Key must be a well-formed quoted string"] if idempotency_key.nil?
 
     errors = []
     errors << "Idempotency-Key must not be blank" if idempotency_key.blank?
@@ -133,8 +138,24 @@ class WebhookIngestion
     errors
   end
 
+  # Spec-following clients send the header as an sf-string — quotes included on
+  # the wire — so a quoted value is decoded before it is compared or persisted;
+  # otherwise the same logical key supplied via uid and via the header would
+  # never match. A bare value is kept as-is for clients that skip the
+  # structured-field encoding, and a malformed quoted value decodes to nil,
+  # which validation rejects.
   def idempotency_key
-    @raw_idempotency_key.to_s.strip
+    return @idempotency_key if defined?(@idempotency_key)
+
+    @idempotency_key = decode_idempotency_key
+  end
+
+  def decode_idempotency_key
+    raw = @raw_idempotency_key.to_s.strip
+    return raw unless raw.start_with?('"')
+
+    match = SF_STRING.match(raw)
+    match && match[:value].gsub(/\\(.)/, '\1')
   end
 
   def already_ingested?

--- a/app/services/webhook_ingestion.rb
+++ b/app/services/webhook_ingestion.rb
@@ -9,6 +9,7 @@ class WebhookIngestion
   include HtmlTextUtils
 
   MAX_LIST_ITEMS = 8
+  MAX_UID_LENGTH = 255
   SUPPORTED_PUBLISHED_AT_YEARS = (1..9999).freeze
 
   # Caps on images/comments are load-bearing: publishing costs
@@ -30,7 +31,7 @@ class WebhookIngestion
         "items" => { "type" => "string" },
         "maxItems" => MAX_LIST_ITEMS
       },
-      "uid" => { "type" => "string", "minLength" => 1, "maxLength" => 255 },
+      "uid" => { "type" => "string", "minLength" => 1, "maxLength" => MAX_UID_LENGTH },
       "published_at" => { "type" => "string" }
     },
     "additionalProperties" => false
@@ -42,10 +43,11 @@ class WebhookIngestion
     def invalid? = status == :invalid
   end
 
-  def initialize(endpoint:, payload:)
+  def initialize(endpoint:, payload:, idempotency_key: nil)
     @endpoint = endpoint
     @feed = endpoint.feed
     @payload = WebhookPayload.new(payload)
+    @raw_idempotency_key = idempotency_key
   end
 
   def call
@@ -79,6 +81,7 @@ class WebhookIngestion
     errors = null_byte_errors
     return errors if errors.any?
 
+    errors.concat(idempotency_key_errors)
     errors << "no_content_or_images" if content.blank? && images.empty?
     errors << "uid must not be blank" if payload.uid_given? && explicit_uid.blank?
     errors << "source_url must be an absolute http(s) URL" if source_url.present? && !http_url?(source_url)
@@ -113,6 +116,27 @@ class WebhookIngestion
     end
   end
 
+  # The Idempotency-Key header is a second spelling of uid, so it gets the same
+  # constraints, plus a mismatch check: two different keys on one request almost
+  # certainly mean a confused client, and dedup keys are the wrong place to
+  # resolve that silently.
+  def idempotency_key_errors
+    return [] if @raw_idempotency_key.nil?
+
+    errors = []
+    errors << "Idempotency-Key must not be blank" if idempotency_key.blank?
+    errors << "Idempotency-Key must be at most #{MAX_UID_LENGTH} characters" if idempotency_key.length > MAX_UID_LENGTH
+    errors << "Idempotency-Key must not contain null bytes" if idempotency_key.include?("\0")
+    if idempotency_key.present? && explicit_uid.present? && idempotency_key != explicit_uid
+      errors << "uid and Idempotency-Key must match"
+    end
+    errors
+  end
+
+  def idempotency_key
+    @raw_idempotency_key.to_s.strip
+  end
+
   def already_ingested?
     FeedEntryUid.exists?(feed_id: feed.id, uid: uid)
   end
@@ -142,11 +166,14 @@ class WebhookIngestion
   # the delivery falls back to a random uid instead of a 500.
   MAX_URL_UID_BYTES = 2048
 
-  # Uid precedence (spec 006 §4): explicit idempotency key, then the permalink
-  # normalized exactly like pull feeds', then a random uuid (each request is a
-  # new post; callers with retrying pipelines should pass uid).
+  # Uid precedence (spec 006 §4): explicit idempotency key (the uid field or
+  # the equivalent Idempotency-Key header — validation guarantees they agree),
+  # then the permalink normalized exactly like pull feeds', then a random uuid
+  # (each request is a new post; callers with retrying pipelines should pass a
+  # key).
   def resolve_uid
     return explicit_uid if explicit_uid.present?
+    return idempotency_key if idempotency_key.present?
 
     from_url = Uid::Resolver.from_url(source_url)
     return SecureRandom.uuid if from_url.nil? || from_url.bytesize > MAX_URL_UID_BYTES

--- a/app/views/feeds/_webhook_endpoint_panel.html.erb
+++ b/app/views/feeds/_webhook_endpoint_panel.html.erb
@@ -59,7 +59,7 @@
                          data: { key: "webhook.curl" } %>
         <%= clipboard_button curl_snippet, label: "Copy curl example", key: "webhook.copy-curl", css_class: "mt-2" %>
       </div>
-      <p class="text-sm text-muted">You can also send <code>source_url</code>, <code>images</code>, <code>comments</code>, and a <code>uid</code> to keep retries from double-posting.</p>
+      <p class="text-sm text-muted">You can also send <code>source_url</code>, <code>images</code>, <code>comments</code>, and a <code>uid</code> to keep retries from double-posting. The standard <code>Idempotency-Key</code> header works the same as <code>uid</code>.</p>
     </div>
 
     <p class="text-sm text-muted" data-key="webhook.last-received">

--- a/test/controllers/api/v1/posts_controller_test.rb
+++ b/test/controllers/api/v1/posts_controller_test.rb
@@ -102,6 +102,13 @@ class Api::V1::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "duplicate", response_json["status"]
   end
 
+  test "#create should decode a quoted Idempotency-Key header" do
+    post_hook params: { content: "Hello" }, headers: { "Idempotency-Key" => '"key-1"' }, as: :json
+
+    assert_response :created
+    assert_equal "key-1", response_json["uid"]
+  end
+
   test "#create should reject mismatched uid and Idempotency-Key" do
     post_hook params: { content: "Hello", uid: "article-42" },
               headers: { "Idempotency-Key" => "other-key" }, as: :json

--- a/test/controllers/api/v1/posts_controller_test.rb
+++ b/test/controllers/api/v1/posts_controller_test.rb
@@ -88,6 +88,28 @@ class Api::V1::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "article-42", response_json["uid"]
   end
 
+  test "#create should dedupe on the Idempotency-Key header" do
+    post_hook params: { content: "Hello" }, headers: { "Idempotency-Key" => "key-1" }, as: :json
+
+    assert_response :created
+    assert_equal "key-1", response_json["uid"]
+
+    assert_no_difference ["FeedEntry.count", "Post.count"] do
+      post_hook params: { content: "Hello" }, headers: { "Idempotency-Key" => "key-1" }, as: :json
+    end
+
+    assert_response :ok
+    assert_equal "duplicate", response_json["status"]
+  end
+
+  test "#create should reject mismatched uid and Idempotency-Key" do
+    post_hook params: { content: "Hello", uid: "article-42" },
+              headers: { "Idempotency-Key" => "other-key" }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_includes response_json["errors"], "uid and Idempotency-Key must match"
+  end
+
   test "#create should reject an invalid payload without persisting" do
     assert_no_difference ["FeedEntry.count", "Post.count"] do
       post_hook params: { comments: ["No content here"] }, as: :json

--- a/test/services/webhook_ingestion_test.rb
+++ b/test/services/webhook_ingestion_test.rb
@@ -11,8 +11,8 @@ class WebhookIngestionTest < ActiveSupport::TestCase
     @endpoint ||= create(:webhook_endpoint, feed: feed)
   end
 
-  def ingest(payload)
-    WebhookIngestion.new(endpoint: endpoint, payload: payload).call
+  def ingest(payload, idempotency_key: nil)
+    WebhookIngestion.new(endpoint: endpoint, payload: payload, idempotency_key: idempotency_key).call
   end
 
   test "#call should persist entry, uid record, and enqueued post" do
@@ -61,6 +61,64 @@ class WebhookIngestionTest < ActiveSupport::TestCase
 
     assert result.invalid?
     assert_includes result.errors, "uid must not be blank"
+  end
+
+  test "#call should use the Idempotency-Key header as the uid" do
+    result = ingest({ "content" => "Hello", "source_url" => "https://example.com/a" }, idempotency_key: "key-1")
+
+    assert result.enqueued?
+    assert_equal "key-1", result.uid
+  end
+
+  test "#call should treat Idempotency-Key and uid as one dedup key" do
+    ingest({ "content" => "Hello", "uid" => "article-42" })
+
+    result = nil
+    assert_no_difference ["FeedEntry.count", "Post.count"] do
+      result = ingest({ "content" => "Hello" }, idempotency_key: "article-42")
+    end
+
+    assert result.duplicate?
+    assert_equal "article-42", result.uid
+  end
+
+  test "#call should accept matching uid and Idempotency-Key" do
+    result = ingest({ "content" => "Hello", "uid" => "article-42" }, idempotency_key: "article-42")
+
+    assert result.enqueued?
+    assert_equal "article-42", result.uid
+  end
+
+  test "#call should reject mismatched uid and Idempotency-Key" do
+    result = nil
+
+    assert_no_difference ["FeedEntry.count", "FeedEntryUid.count", "Post.count"] do
+      result = ingest({ "content" => "Hello", "uid" => "article-42" }, idempotency_key: "other-key")
+    end
+
+    assert result.invalid?
+    assert_includes result.errors, "uid and Idempotency-Key must match"
+  end
+
+  test "#call should reject a blank Idempotency-Key" do
+    result = ingest({ "content" => "Hello" }, idempotency_key: "   ")
+
+    assert result.invalid?
+    assert_includes result.errors, "Idempotency-Key must not be blank"
+  end
+
+  test "#call should reject an overlong Idempotency-Key" do
+    result = ingest({ "content" => "Hello" }, idempotency_key: "k" * 256)
+
+    assert result.invalid?
+    assert_includes result.errors, "Idempotency-Key must be at most 255 characters"
+  end
+
+  test "#call should reject an Idempotency-Key with null bytes" do
+    result = ingest({ "content" => "Hello" }, idempotency_key: "ke\0y")
+
+    assert result.invalid?
+    assert_includes result.errors, "Idempotency-Key must not contain null bytes"
   end
 
   test "#call should derive the uid from source_url like pull feeds" do

--- a/test/services/webhook_ingestion_test.rb
+++ b/test/services/webhook_ingestion_test.rb
@@ -89,6 +89,41 @@ class WebhookIngestionTest < ActiveSupport::TestCase
     assert_equal "article-42", result.uid
   end
 
+  test "#call should decode a structured-field quoted Idempotency-Key" do
+    ingest({ "content" => "Hello", "uid" => "key-1" })
+
+    result = nil
+    assert_no_difference ["FeedEntry.count", "Post.count"] do
+      result = ingest({ "content" => "Hello" }, idempotency_key: '"key-1"')
+    end
+
+    assert result.duplicate?
+    assert_equal "key-1", result.uid
+  end
+
+  test "#call should match a quoted Idempotency-Key against a bare uid" do
+    result = ingest({ "content" => "Hello", "uid" => "key-1" }, idempotency_key: '"key-1"')
+
+    assert result.enqueued?
+    assert_equal "key-1", result.uid
+  end
+
+  test "#call should unescape quoted characters in the Idempotency-Key" do
+    result = ingest({ "content" => "Hello" }, idempotency_key: '"a\\"b\\\\c"')
+
+    assert result.enqueued?
+    assert_equal 'a"b\\c', result.uid
+  end
+
+  test "#call should reject a malformed quoted Idempotency-Key" do
+    ['"unterminated', '"bad\\x"', %("tab\there")].each do |key|
+      result = ingest({ "content" => "Hello" }, idempotency_key: key)
+
+      assert result.invalid?
+      assert_includes result.errors, "Idempotency-Key must be a well-formed quoted string"
+    end
+  end
+
   test "#call should reject mismatched uid and Idempotency-Key" do
     result = nil
 
@@ -101,10 +136,12 @@ class WebhookIngestionTest < ActiveSupport::TestCase
   end
 
   test "#call should reject a blank Idempotency-Key" do
-    result = ingest({ "content" => "Hello" }, idempotency_key: "   ")
+    ["   ", '""'].each do |key|
+      result = ingest({ "content" => "Hello" }, idempotency_key: key)
 
-    assert result.invalid?
-    assert_includes result.errors, "Idempotency-Key must not be blank"
+      assert result.invalid?
+      assert_includes result.errors, "Idempotency-Key must not be blank"
+    end
   end
 
   test "#call should reject an overlong Idempotency-Key" do


### PR DESCRIPTION
Changes:

- Accept the standard `Idempotency-Key` request header on `POST /v1/posts` and treat it as equivalent to `uid` for deduplication.
- Decode RFC 8941 structured-field values: a quoted header (`"key-1"`) is unquoted/unescaped before comparison, a bare value is used as-is, and a malformed quoted value is rejected.
- Validate the header like `uid` (non-blank, 255 chars max, no null bytes); when both are present they must match, and a mismatch is rejected with 422 instead of resolved silently.
- Mention the header in the webhook endpoint panel.

The uid already acts as an idempotency key at ingestion, so the header is just a second way to supply it — no new storage or dedup paths, and existing `uid` behavior is unchanged.

References:

- Closes #1118