### PR TITLE
Extend the LLM capability probe to cover the production call shape

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     childprocess (5.1.0)

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -70,8 +70,13 @@ module LlmCapabilityProbe
     Post: "SQLite in production" at https://example.com/blog/sqlite-prod — a guide to running SQLite at scale.
   TEXT
 
-  CLIENT_TOOLS_PROMPT = "Search the web for the IANA reserved example domain page, fetch the most " \
-                        "relevant result with the web fetch tool, and quote the exact text of its main heading."
+  CLIENT_TOOLS_PROMPT = "Search for IANA's reserved documentation domains, fetch the top result with the " \
+                        "fetch tool, and quote the exact text of that page's main heading."
+
+  # The heading lives only on the fetched page — deliberately absent from the
+  # prompt and from the canned search results — so quoting it is evidence the
+  # model read fetched content rather than echoing what it was already told.
+  EXPECTED_HEADING = /example domain/i
 
   # Wire names the production tools present to the model; the client-tools
   # check matches the loop's observed tool calls against these.
@@ -87,9 +92,11 @@ module LlmCapabilityProbe
     description LlmClient::Tools::WebSearch.description
     param :query, desc: "Search query", required: true
 
+    # Withholds the heading the check looks for: if a result disclosed it, a
+    # model could pass by repeating the snippet without fetching anything.
     RESULTS = [
-      { "title" => "Example Domain", "url" => "https://example.com/",
-        "snippet" => "Reserved domain for use in illustrative examples in documents." }
+      { "title" => "IANA-managed Reserved Domains", "url" => "https://example.com/",
+        "snippet" => "Names set aside by IANA for use in documentation. Open the page to read it." }
     ].freeze
 
     def name = SEARCH_TOOL_NAME
@@ -321,22 +328,41 @@ module LlmCapabilityProbe
       chat.with_tool(LlmClient::Tools::WebFetch)
       text = chat.ask(CLIENT_TOOLS_PROMPT).content.to_s
 
-      calls = tool_calls(chat)
-      names = calls.map { |call| call[:name] }
-      evidence = { tool_calls: calls, answer: text[0, 2000] }
-      return { status: "FAIL", note: "search tool never called", evidence: evidence } unless names.include?(SEARCH_TOOL_NAME)
-      return { status: "FAIL", note: "fetch tool never called", evidence: evidence } unless names.include?(FETCH_TOOL_NAME)
+      rounds = tool_rounds(chat)
+      evidence = { tool_rounds: rounds, answer: text[0, 2000] }
+      failure = tool_loop_failure(rounds)
+      return failure.merge(evidence: evidence) if failure
 
-      grounded = text.match?(/example domain/i) && !LlmCapabilityProbe.refusal?(text)
+      grounded = EXPECTED_HEADING.match?(text) && !LlmCapabilityProbe.refusal?(text)
       { status: grounded ? "PASS" : "FAIL",
-        note: grounded ? "#{calls.size} tool calls, answer grounded in fetched page" : "tools called but answer not grounded",
+        note: grounded ? "#{rounds.size} tool calls, answer grounded in fetched page" : "tools ran but answer not grounded",
         evidence: evidence }
     end
 
-    def tool_calls(chat)
-      Array(chat.try(:messages)).select { |message| message.try(:tool_call?) }
-                                .flat_map { |message| message.tool_calls.values }
-                                .map { |call| { name: call.name, arguments: call.arguments } }
+    # Both tools must appear in the loop, and the fetch must have returned the
+    # page itself: a refused URL, a wrong URL or an HTTP error leaves nothing
+    # to ground on, and the heading appears nowhere else in the conversation.
+    def tool_loop_failure(rounds)
+      names = rounds.map { |round| round[:name] }
+      return { status: "FAIL", note: "search tool never called" } unless names.include?(SEARCH_TOOL_NAME)
+
+      fetch = rounds.find { |round| round[:name] == FETCH_TOOL_NAME }
+      return { status: "FAIL", note: "fetch tool never called" } if fetch.nil?
+      return { status: "FAIL", note: "fetch returned no page content" } unless EXPECTED_HEADING.match?(fetch[:result])
+
+      nil
+    end
+
+    # Pairs each tool call with the result the loop fed back, so a check can
+    # assert on what a tool returned and not merely that it was called.
+    def tool_rounds(chat)
+      messages = Array(chat.try(:messages))
+      results = messages.select { |message| message.try(:tool_result?) }.index_by(&:tool_call_id)
+      messages.select { |message| message.try(:tool_call?) }
+              .flat_map { |message| message.tool_calls.values }
+              .map do |call|
+                { name: call.name, arguments: call.arguments, result: results[call.id]&.content.to_s[0, 500] }
+              end
     end
 
     def validate_items(response, gathered: nil)

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -9,6 +9,11 @@
 # unwired provider can be qualified before application integration. Keys
 # come from the environment. Results — evidence included — are recorded as
 # JobRun events and feed plan-03-provider-verification.md.
+#
+# Qualification rule (issue #1187): no (provider, model) pair enters
+# LlmModelCapability without a probe run that covers the production call
+# shape — a system prompt on the wire, the client-side tool loop, and the
+# model id confirmed against the live models listing.
 module LlmCapabilityProbe
   # Mirrors UNIVERSAL_OUTPUT_SCHEMA's shape (strict: additionalProperties false
   # everywhere — the Anthropic requirement confirmed live in Track 2).
@@ -81,6 +86,12 @@ module LlmCapabilityProbe
       context.chat(model: model, provider: ruby_llm_provider, assume_model_exists: assume_model_exists?)
     end
 
+    # The provider's live models listing, resolved the way LlmClient does it
+    # (registry names don't always match RubyLLM provider keys).
+    def list_models
+      RubyLLM::Provider.resolve(ruby_llm_provider).new(context.config).list_models
+    end
+
     def assume_model_exists? = false
     def web_fetch_params(_model) = nil
     def prepare_web(_chat) = nil
@@ -150,7 +161,7 @@ module LlmCapabilityProbe
   end
 
   class Runner
-    CHECKS = %w[plain schema web_search web_fetch two_step combined].freeze
+    CHECKS = %w[models plain schema web_search web_fetch two_step combined].freeze
 
     def initialize(provider:, model:, checks: CHECKS)
       @provider = provider
@@ -178,6 +189,19 @@ module LlmCapabilityProbe
     rescue StandardError => e
       @results << { check: check, status: "FAIL", note: "#{e.class}: #{e.message.to_s[0, 300]}",
                     evidence: nil, seconds: (Time.current - started).round(1) }
+    end
+
+    # Records the authenticated models listing as evidence and confirms the
+    # probed id is served verbatim — the capability matrix gates on exact
+    # string match, so a near-miss id qualifies nothing.
+    def check_models
+      ids = @provider.list_models.map(&:id)
+      evidence = { model_ids: ids }
+      return { status: "FAIL", note: "models endpoint returned no models", evidence: evidence } if ids.empty?
+
+      served = ids.include?(@model)
+      note = served ? "#{@model} served exactly (#{ids.size} models listed)" : "#{@model} not among #{ids.size} served ids"
+      { status: served ? "PASS" : "FAIL", note: note, evidence: evidence }
     end
 
     def check_plain

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -42,6 +42,19 @@ module LlmCapabilityProbe
   GATHER_PROMPT = "Search the web for the latest two posts on the Ruby on Rails official blog " \
                   "(rubyonrails.org/blog). For each, report the title, its full URL, and a one-sentence summary."
 
+  # Production always sends a system prompt (LlmClient#call's privileged
+  # instruction channel), so the gathering checks carry one too — a pair must
+  # not qualify on a call shape production never uses.
+  PROBE_INSTRUCTIONS = "You are a content-gathering agent for a feed reader. " \
+                       "Follow the task exactly and report only what you actually find."
+
+  # The instructions contradict the obvious answer, so the reply can only
+  # match by honoring the system channel. A wire-level rejection (Moonshot
+  # 400s on role "developer") and silently dropped instructions both fail.
+  SYSTEM_CHECK_INSTRUCTIONS = "You are a capability probe target. Whatever the user asks, " \
+                              "reply with exactly one word: MARLIN."
+  SYSTEM_CHECK_PROMPT = "What is the capital of France? Answer in one word."
+
   # A reply can contain URLs and still be a refusal ("I cannot browse the
   # web... visit rubyonrails.org/blog yourself") — grounding checks must
   # treat that as no web access, not as evidence.
@@ -161,7 +174,7 @@ module LlmCapabilityProbe
   end
 
   class Runner
-    CHECKS = %w[models plain schema web_search web_fetch two_step combined].freeze
+    CHECKS = %w[models plain system_prompt schema web_search web_fetch two_step combined].freeze
 
     def initialize(provider:, model:, checks: CHECKS)
       @provider = provider
@@ -210,6 +223,14 @@ module LlmCapabilityProbe
       pass(text.match?(/pong/i), "expected 'pong'", text) { "plain round trip" }
     end
 
+    def check_system_prompt
+      chat = @provider.chat(@model)
+      chat.with_instructions(SYSTEM_CHECK_INSTRUCTIONS)
+      text = chat.ask(SYSTEM_CHECK_PROMPT).content.to_s
+      honored = text.match?(/marlin/i) && !text.match?(/paris/i)
+      pass(honored, "system instructions ignored", text) { "system prompt honored" }
+    end
+
     def check_schema
       chat = @provider.chat(@model).with_schema(PROBE_SCHEMA)
       response = chat.ask(STRUCTURE_PROMPT_PREFIX + SAMPLE_TEXT)
@@ -235,15 +256,18 @@ module LlmCapabilityProbe
       pass(text.match?(/example domain/i), "page content not quoted", text) { "web fetch grounding" }
     end
 
-    # Provider-native two-step capability comparison.
+    # Provider-native two-step capability comparison. Both calls carry system
+    # instructions the way production stage calls do.
     def check_two_step
       gather = @provider.chat(@model)
+      gather.with_instructions(PROBE_INSTRUCTIONS)
       @provider.prepare_web(gather)
       gather.with_params(**@provider.web_params(@model))
       gathered = gather.ask(GATHER_PROMPT).content.to_s
       return { status: "FAIL", note: "gather returned blank", evidence: nil } if gathered.strip.empty?
 
       structure = @provider.chat(@model).with_schema(PROBE_SCHEMA)
+      structure.with_instructions(PROBE_INSTRUCTIONS)
       validate_items(structure.ask(STRUCTURE_PROMPT_PREFIX + gathered), gathered: gathered)
     end
 
@@ -251,6 +275,7 @@ module LlmCapabilityProbe
     # PASS here means "works combined", which would simplify the architecture.
     def check_combined
       chat = @provider.chat(@model).with_schema(PROBE_SCHEMA)
+      chat.with_instructions(PROBE_INSTRUCTIONS)
       @provider.prepare_web(chat)
       chat.with_params(**@provider.web_params(@model))
       validate_items(chat.ask(GATHER_PROMPT))

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -74,6 +74,9 @@ module LlmCapabilityProbe
   CLIENT_TOOLS_PROMPT = "Search for IANA's reserved documentation domains, fetch the top result with the " \
                         "fetch tool, and quote the exact text of that page's main heading."
 
+  CLIENT_TOOLS_SCHEMA_PROMPT = "#{CLIENT_TOOLS_PROMPT} Return exactly one item: body set to that heading, " \
+                               "uid and source_url set to the page's URL.".freeze
+
   # The heading lives only on the fetched page — deliberately absent from the
   # prompt and from the canned search results — so quoting it is evidence the
   # model read fetched content rather than echoing what it was already told.
@@ -211,7 +214,8 @@ module LlmCapabilityProbe
   end
 
   class Runner
-    CHECKS = %w[models plain system_prompt schema web_search web_fetch two_step combined client_tools].freeze
+    CHECKS = %w[models plain system_prompt schema web_search web_fetch two_step combined
+                client_tools client_tools_schema].freeze
 
     def initialize(provider:, model:, checks: CHECKS)
       @provider = provider
@@ -330,22 +334,61 @@ module LlmCapabilityProbe
     # client-side search and fetch function tools driven through a real
     # multi-round loop. The observed tool calls plus an answer grounded in
     # the fetched page are the evidence that the model drives client tools.
+    # This is production's gather shape for two-step providers (LlmLoader).
     def check_client_tools
+      client_tools_loop
+    end
+
+    # Production's combined shape (LlmLoader#extract when the adapter reports
+    # `combined_extraction?`): the output schema rides on the same chat as the
+    # client-side tools. Schema and tools can each work alone yet break
+    # together, so a pair qualified only by the checks above could still fail
+    # on a real feed load. A FAIL here reads as "use two-step", not as a
+    # disqualification — same as the provider-native `combined` check.
+    def check_client_tools_schema
+      client_tools_loop(schema: PROBE_SCHEMA)
+    end
+
+    def client_tools_loop(schema: nil)
+      chat = client_tools_chat(schema)
+      response = chat.ask(schema ? CLIENT_TOOLS_SCHEMA_PROMPT : CLIENT_TOOLS_PROMPT)
+      answer = answer_text(response)
+      rounds = tool_rounds(chat)
+      evidence = { tool_rounds: rounds, answer: answer[0, 2000] }
+
+      failure = tool_loop_failure(rounds) || grounding_failure(answer)
+      return failure.merge(evidence: evidence) if failure
+      return structured_result(response, rounds, evidence) if schema
+
+      { status: "PASS", note: "#{rounds.size} tool calls, answer grounded in fetched page", evidence: evidence }
+    end
+
+    def client_tools_chat(schema)
       chat = @provider.chat(@model)
       chat.with_instructions(PROBE_INSTRUCTIONS)
+      chat.with_schema(schema) if schema
       chat.with_tool(CannedWebSearch)
       chat.with_tool(LlmClient::Tools::WebFetch)
-      text = chat.ask(CLIENT_TOOLS_PROMPT).content.to_s
+      chat
+    end
 
-      rounds = tool_rounds(chat)
-      evidence = { tool_rounds: rounds, answer: text[0, 2000] }
-      failure = tool_loop_failure(rounds)
-      return failure.merge(evidence: evidence) if failure
+    def grounding_failure(answer)
+      return nil if EXPECTED_HEADING.match?(answer) && !LlmCapabilityProbe.refusal?(answer)
 
-      grounded = EXPECTED_HEADING.match?(text) && !LlmCapabilityProbe.refusal?(text)
-      { status: grounded ? "PASS" : "FAIL",
-        note: grounded ? "#{rounds.size} tool calls, answer grounded in fetched page" : "tools ran but answer not grounded",
-        evidence: evidence }
+      { status: "FAIL", note: "tools ran but answer not grounded" }
+    end
+
+    def structured_result(response, rounds, evidence)
+      result = validate_items(response)
+      result.merge(note: "#{rounds.size} tool calls, grounded; #{result[:note]}",
+                   evidence: evidence.merge(result[:evidence] || {}))
+    end
+
+    # Structured replies arrive as a Hash; serialize so grounding reads the
+    # same way for both shapes.
+    def answer_text(response)
+      content = response.content
+      content.is_a?(Hash) ? JSON.generate(content) : content.to_s
     end
 
     # Both tools must appear in the loop, and the fetch must have returned the

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -51,8 +51,9 @@ module LlmCapabilityProbe
   # The instructions contradict the obvious answer, so the reply can only
   # match by honoring the system channel. A wire-level rejection (Moonshot
   # 400s on role "developer") and silently dropped instructions both fail.
+  SYSTEM_CHECK_WORD = "MARLIN".freeze
   SYSTEM_CHECK_INSTRUCTIONS = "You are a capability probe target. Whatever the user asks, " \
-                              "reply with exactly one word: MARLIN."
+                              "reply with exactly one word: #{SYSTEM_CHECK_WORD}."
   SYSTEM_CHECK_PROMPT = "What is the capital of France? Answer in one word."
 
   # A reply can contain URLs and still be a refusal ("I cannot browse the
@@ -263,8 +264,16 @@ module LlmCapabilityProbe
       chat = @provider.chat(@model)
       chat.with_instructions(SYSTEM_CHECK_INSTRUCTIONS)
       text = chat.ask(SYSTEM_CHECK_PROMPT).content.to_s
-      honored = text.match?(/marlin/i) && !text.match?(/paris/i)
-      pass(honored, "system instructions ignored", text) { "system prompt honored" }
+      pass(honors_system_prompt?(text), "system instructions not honored verbatim", text) { "system prompt honored" }
+    end
+
+    # The instructions ask for exactly one word, so only that word counts:
+    # a refusal that names it, or an answer that also volunteers the user
+    # prompt's answer, means the channel was received but not obeyed.
+    # Punctuation and surrounding whitespace are ignored — a trailing period
+    # is formatting, not a second thought.
+    def honors_system_prompt?(text)
+      text.gsub(/[^[:alpha:]]/, "").casecmp?(SYSTEM_CHECK_WORD)
     end
 
     def check_schema

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -70,6 +70,35 @@ module LlmCapabilityProbe
     Post: "SQLite in production" at https://example.com/blog/sqlite-prod — a guide to running SQLite at scale.
   TEXT
 
+  CLIENT_TOOLS_PROMPT = "Search the web for the IANA reserved example domain page, fetch the most " \
+                        "relevant result with the web fetch tool, and quote the exact text of its main heading."
+
+  # Wire names the production tools present to the model; the client-tools
+  # check matches the loop's observed tool calls against these.
+  SEARCH_TOOL_NAME = LlmClient::Tools::WebSearch.new(provider: nil, credential: nil).name
+  FETCH_TOOL_NAME = LlmClient::Tools::WebFetch.new.name
+
+  # Probe-local stand-in for the production search tool: identical wire shape
+  # (name, description, parameter) but canned results pointing at fixed real
+  # URLs, so the tool loop can be qualified without managed search
+  # credentials. The follow-up fetch is the real production tool, which is
+  # credential-free.
+  class CannedWebSearch < RubyLLM::Tool
+    description LlmClient::Tools::WebSearch.description
+    param :query, desc: "Search query", required: true
+
+    RESULTS = [
+      { "title" => "Example Domain", "url" => "https://example.com/",
+        "snippet" => "Reserved domain for use in illustrative examples in documents." }
+    ].freeze
+
+    def name = SEARCH_TOOL_NAME
+
+    def execute(query:)
+      { results: RESULTS }
+    end
+  end
+
   # Moonshot's server-executed web search is invoked through a builtin tool
   # the client must acknowledge by echoing the arguments back. Modeled as a
   # RubyLLM function tool so the gem's tool loop performs that round trip.
@@ -174,7 +203,7 @@ module LlmCapabilityProbe
   end
 
   class Runner
-    CHECKS = %w[models plain system_prompt schema web_search web_fetch two_step combined].freeze
+    CHECKS = %w[models plain system_prompt schema web_search web_fetch two_step combined client_tools].freeze
 
     def initialize(provider:, model:, checks: CHECKS)
       @provider = provider
@@ -279,6 +308,35 @@ module LlmCapabilityProbe
       @provider.prepare_web(chat)
       chat.with_params(**@provider.web_params(@model))
       validate_items(chat.ask(GATHER_PROMPT))
+    end
+
+    # The production mechanism end to end: a system prompt plus the
+    # client-side search and fetch function tools driven through a real
+    # multi-round loop. The observed tool calls plus an answer grounded in
+    # the fetched page are the evidence that the model drives client tools.
+    def check_client_tools
+      chat = @provider.chat(@model)
+      chat.with_instructions(PROBE_INSTRUCTIONS)
+      chat.with_tool(CannedWebSearch)
+      chat.with_tool(LlmClient::Tools::WebFetch)
+      text = chat.ask(CLIENT_TOOLS_PROMPT).content.to_s
+
+      calls = tool_calls(chat)
+      names = calls.map { |call| call[:name] }
+      evidence = { tool_calls: calls, answer: text[0, 2000] }
+      return { status: "FAIL", note: "search tool never called", evidence: evidence } unless names.include?(SEARCH_TOOL_NAME)
+      return { status: "FAIL", note: "fetch tool never called", evidence: evidence } unless names.include?(FETCH_TOOL_NAME)
+
+      grounded = text.match?(/example domain/i) && !LlmCapabilityProbe.refusal?(text)
+      { status: grounded ? "PASS" : "FAIL",
+        note: grounded ? "#{calls.size} tool calls, answer grounded in fetched page" : "tools called but answer not grounded",
+        evidence: evidence }
+    end
+
+    def tool_calls(chat)
+      Array(chat.try(:messages)).select { |message| message.try(:tool_call?) }
+                                .flat_map { |message| message.tool_calls.values }
+                                .map { |call| { name: call.name, arguments: call.arguments } }
     end
 
     def validate_items(response, gathered: nil)

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -3,15 +3,21 @@ require "test_helper"
 class LlmCapabilityProbeTest < ActiveSupport::TestCase
   FakeResponse = Struct.new(:content)
 
+  FakeToolCallMessage = Struct.new(:tool_calls) do
+    def tool_call? = tool_calls.present?
+  end
+
   class FakeChat
     attr_reader :instructions
 
-    def initialize(response)
+    def initialize(response, tool_call_names: [])
       @response = response
+      @tool_call_names = tool_call_names
     end
 
     def with_schema(_schema) = self
     def with_params(**) = self
+    def with_tool(_tool) = self
 
     def with_instructions(text)
       @instructions = text
@@ -23,6 +29,13 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
 
       FakeResponse.new(@response)
     end
+
+    def messages
+      @tool_call_names.map.with_index do |name, index|
+        call = RubyLLM::ToolCall.new(id: index.to_s, name: name, arguments: { "query" => "example" })
+        FakeToolCallMessage.new({ call.id => call })
+      end
+    end
   end
 
   FakeModel = Struct.new(:id)
@@ -30,16 +43,17 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   class FakeProvider
     attr_reader :key, :chats
 
-    def initialize(responses, fetch_params: nil, models: [])
+    def initialize(responses, fetch_params: nil, models: [], tool_call_names: [])
       @responses = responses.is_a?(Array) ? responses.dup : [responses]
       @fetch_params = fetch_params
       @models = models
+      @tool_call_names = tool_call_names
       @chats = []
       @key = "fake"
     end
 
     def chat(_model)
-      FakeChat.new(@responses.shift).tap { |chat| @chats << chat }
+      FakeChat.new(@responses.shift, tool_call_names: @tool_call_names).tap { |chat| @chats << chat }
     end
     def prepare_web(_chat) = nil
     def web_params(_model) = { tools: [] }
@@ -48,8 +62,9 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     def list_models = @models.map { |id| FakeModel.new(id) }
   end
 
-  def run_checks(responses, checks, fetch_params: nil, models: [])
-    provider = FakeProvider.new(responses, fetch_params: fetch_params, models: models)
+  def run_checks(responses, checks, fetch_params: nil, models: [], tool_call_names: [])
+    provider = FakeProvider.new(responses, fetch_params: fetch_params, models: models,
+                                tool_call_names: tool_call_names)
     LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: checks).run
   end
 
@@ -189,6 +204,53 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
 
     assert_equal "PASS", outcome[:results].first[:status]
     assert_equal "https://example.com/p", outcome[:results].first[:evidence][:items].first["source_url"]
+  end
+
+  test "#run should fail the client tools check when the search tool is never called" do
+    outcome = run_checks("Example Domain", ["client_tools"])
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_equal "search tool never called", outcome[:results].first[:note]
+  end
+
+  test "#run should fail the client tools check when the fetch tool is never called" do
+    outcome = run_checks("Example Domain", ["client_tools"],
+                         tool_call_names: [LlmCapabilityProbe::SEARCH_TOOL_NAME])
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_equal "fetch tool never called", outcome[:results].first[:note]
+  end
+
+  test "#run should pass the client tools check on a full loop with a grounded answer" do
+    names = [LlmCapabilityProbe::SEARCH_TOOL_NAME, LlmCapabilityProbe::FETCH_TOOL_NAME]
+    outcome = run_checks('The main heading reads: "Example Domain"', ["client_tools"], tool_call_names: names)
+
+    assert_equal "PASS", outcome[:results].first[:status]
+    assert_match(/2 tool calls/, outcome[:results].first[:note])
+    assert_equal names, outcome[:results].first[:evidence][:tool_calls].map { |call| call[:name] }
+  end
+
+  test "#run should fail the client tools check when tools ran but the answer is not grounded" do
+    names = [LlmCapabilityProbe::SEARCH_TOOL_NAME, LlmCapabilityProbe::FETCH_TOOL_NAME]
+    outcome = run_checks("I could not determine the heading.", ["client_tools"], tool_call_names: names)
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_equal "tools called but answer not grounded", outcome[:results].first[:note]
+  end
+
+  test "canned web search should present the production search tool's wire shape" do
+    tool = LlmCapabilityProbe::CannedWebSearch.new
+    production = LlmClient::Tools::WebSearch.new(provider: nil, credential: nil)
+
+    assert_equal production.name, tool.name
+    assert_equal production.description, tool.description
+    assert_equal %i[query], tool.parameters.keys
+  end
+
+  test "canned web search should return fixed real URLs without touching a search provider" do
+    result = LlmCapabilityProbe::CannedWebSearch.new.execute(query: "anything")
+
+    assert_equal ["https://example.com/"], result[:results].map { |r| r["url"] }
   end
 
   test "#run should send system instructions on both two_step calls" do

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -14,16 +14,25 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   end
 
   class FakeChat
-    attr_reader :instructions
+    attr_reader :instructions, :schema, :tools
 
     def initialize(response, tool_rounds: [])
       @response = response
       @tool_rounds = tool_rounds
+      @tools = []
     end
 
-    def with_schema(_schema) = self
     def with_params(**) = self
-    def with_tool(_tool) = self
+
+    def with_schema(schema)
+      @schema = schema
+      self
+    end
+
+    def with_tool(tool)
+      @tools << tool
+      self
+    end
 
     def with_instructions(text)
       @instructions = text
@@ -82,6 +91,11 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
 
   def valid_payload
     { "items" => [{ "uid" => "u1", "body" => "b", "source_url" => "https://example.com/p" }] }
+  end
+
+  def grounded_payload
+    { "items" => [{ "uid" => "https://example.com/", "body" => "Example Domain",
+                    "source_url" => "https://example.com/" }] }
   end
 
   test "#run should pass the models check when the probed id is served exactly" do
@@ -282,6 +296,47 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     result = LlmCapabilityProbe::CannedWebSearch.new.execute(query: "anything")
 
     assert_equal ["https://example.com/"], result[:results].map { |r| r["url"] }
+  end
+
+  test "#run should attach the schema and both client tools to one chat for client_tools_schema" do
+    provider = FakeProvider.new(grounded_payload, tool_rounds: full_tool_loop)
+    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["client_tools_schema"]).run
+    chat = provider.chats.first
+
+    assert_equal LlmCapabilityProbe::PROBE_SCHEMA, chat.schema
+    assert_equal [LlmCapabilityProbe::CannedWebSearch, LlmClient::Tools::WebFetch], chat.tools
+    assert_equal LlmCapabilityProbe::PROBE_INSTRUCTIONS, chat.instructions
+  end
+
+  test "#run should leave the plain client tools check unstructured" do
+    provider = FakeProvider.new("The main heading reads: Example Domain", tool_rounds: full_tool_loop)
+    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["client_tools"]).run
+
+    assert_nil provider.chats.first.schema
+  end
+
+  test "#run should pass client_tools_schema on a grounded schema-valid payload" do
+    outcome = run_checks(grounded_payload, ["client_tools_schema"], tool_rounds: full_tool_loop)
+
+    assert_equal "PASS", outcome[:results].first[:status]
+    assert_match(/2 tool calls, grounded; 1 items, schema-valid/, outcome[:results].first[:note])
+    assert_equal 2, outcome[:results].first[:evidence][:tool_rounds].size
+  end
+
+  test "#run should fail client_tools_schema when the grounded payload violates the schema" do
+    payload = { "items" => [grounded_payload["items"].first.merge("extra" => 1)] }
+    outcome = run_checks(payload, ["client_tools_schema"], tool_rounds: full_tool_loop)
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_match(/schema violation/, outcome[:results].first[:note])
+  end
+
+  test "#run should fail client_tools_schema when the payload is not grounded in the fetched page" do
+    payload = { "items" => [{ "uid" => "u1", "body" => "Something else", "source_url" => "https://example.com/" }] }
+    outcome = run_checks(payload, ["client_tools_schema"], tool_rounds: full_tool_loop)
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_equal "tools ran but answer not grounded", outcome[:results].first[:note]
   end
 
   test "the client tools check should not disclose the expected heading outside the fetched page" do

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -4,12 +4,19 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   FakeResponse = Struct.new(:content)
 
   class FakeChat
+    attr_reader :instructions
+
     def initialize(response)
       @response = response
     end
 
     def with_schema(_schema) = self
     def with_params(**) = self
+
+    def with_instructions(text)
+      @instructions = text
+      self
+    end
 
     def ask(_prompt)
       raise @response if @response.is_a?(StandardError)
@@ -21,16 +28,19 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   FakeModel = Struct.new(:id)
 
   class FakeProvider
-    attr_reader :key
+    attr_reader :key, :chats
 
     def initialize(responses, fetch_params: nil, models: [])
       @responses = responses.is_a?(Array) ? responses.dup : [responses]
       @fetch_params = fetch_params
       @models = models
+      @chats = []
       @key = "fake"
     end
 
-    def chat(_model) = FakeChat.new(@responses.shift)
+    def chat(_model)
+      FakeChat.new(@responses.shift).tap { |chat| @chats << chat }
+    end
     def prepare_web(_chat) = nil
     def web_params(_model) = { tools: [] }
     def web_search_params(_model) = { tools: [] }
@@ -80,6 +90,26 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     outcome = run_checks("hello", ["plain"])
 
     assert_not outcome[:passed]
+    assert_equal "FAIL", outcome[:results].first[:status]
+  end
+
+  test "#run should pass the system prompt check when instructions are honored" do
+    outcome = run_checks("MARLIN", ["system_prompt"])
+
+    assert outcome[:passed]
+    assert_equal "PASS", outcome[:results].first[:status]
+  end
+
+  test "#run should fail the system prompt check when instructions are ignored" do
+    outcome = run_checks("Paris", ["system_prompt"])
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_equal "system instructions ignored", outcome[:results].first[:note]
+  end
+
+  test "#run should fail the system prompt check on a hedged reply naming both answers" do
+    outcome = run_checks("You asked for MARLIN, but the capital is Paris.", ["system_prompt"])
+
     assert_equal "FAIL", outcome[:results].first[:status]
   end
 
@@ -159,6 +189,21 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
 
     assert_equal "PASS", outcome[:results].first[:status]
     assert_equal "https://example.com/p", outcome[:results].first[:evidence][:items].first["source_url"]
+  end
+
+  test "#run should send system instructions on both two_step calls" do
+    provider = FakeProvider.new(["gathered post text https://example.com/p", valid_payload])
+    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["two_step"]).run
+
+    assert_equal 2, provider.chats.size
+    assert(provider.chats.all? { |chat| chat.instructions == LlmCapabilityProbe::PROBE_INSTRUCTIONS })
+  end
+
+  test "#run should send system instructions on the combined call" do
+    provider = FakeProvider.new(valid_payload)
+    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["combined"]).run
+
+    assert_equal LlmCapabilityProbe::PROBE_INSTRUCTIONS, provider.chats.first.instructions
   end
 
   test "#run should record an exception as a failed check" do

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -127,15 +127,27 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     assert_equal "PASS", outcome[:results].first[:status]
   end
 
+  test "#run should pass the system prompt check ignoring punctuation and whitespace" do
+    outcome = run_checks("  Marlin.\n", ["system_prompt"])
+
+    assert_equal "PASS", outcome[:results].first[:status]
+  end
+
   test "#run should fail the system prompt check when instructions are ignored" do
     outcome = run_checks("Paris", ["system_prompt"])
 
     assert_equal "FAIL", outcome[:results].first[:status]
-    assert_equal "system instructions ignored", outcome[:results].first[:note]
+    assert_equal "system instructions not honored verbatim", outcome[:results].first[:note]
   end
 
   test "#run should fail the system prompt check on a hedged reply naming both answers" do
     outcome = run_checks("You asked for MARLIN, but the capital is Paris.", ["system_prompt"])
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+  end
+
+  test "#run should fail the system prompt check on a refusal that names the word" do
+    outcome = run_checks("I cannot follow the instruction to reply MARLIN.", ["system_prompt"])
 
     assert_equal "FAIL", outcome[:results].first[:status]
   end

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -18,12 +18,15 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     end
   end
 
+  FakeModel = Struct.new(:id)
+
   class FakeProvider
     attr_reader :key
 
-    def initialize(responses, fetch_params: nil)
+    def initialize(responses, fetch_params: nil, models: [])
       @responses = responses.is_a?(Array) ? responses.dup : [responses]
       @fetch_params = fetch_params
+      @models = models
       @key = "fake"
     end
 
@@ -32,15 +35,38 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     def web_params(_model) = { tools: [] }
     def web_search_params(_model) = { tools: [] }
     def web_fetch_params(_model) = @fetch_params
+    def list_models = @models.map { |id| FakeModel.new(id) }
   end
 
-  def run_checks(responses, checks, fetch_params: nil)
-    provider = FakeProvider.new(responses, fetch_params: fetch_params)
+  def run_checks(responses, checks, fetch_params: nil, models: [])
+    provider = FakeProvider.new(responses, fetch_params: fetch_params, models: models)
     LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: checks).run
   end
 
   def valid_payload
     { "items" => [{ "uid" => "u1", "body" => "b", "source_url" => "https://example.com/p" }] }
+  end
+
+  test "#run should pass the models check when the probed id is served exactly" do
+    outcome = run_checks([], ["models"], models: %w[other-model test-model])
+
+    assert outcome[:passed]
+    assert_equal "PASS", outcome[:results].first[:status]
+    assert_equal %w[other-model test-model], outcome[:results].first[:evidence][:model_ids]
+  end
+
+  test "#run should fail the models check when the probed id is not served" do
+    outcome = run_checks([], ["models"], models: %w[test-model-v2])
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_match(/not among 1 served ids/, outcome[:results].first[:note])
+  end
+
+  test "#run should fail the models check on an empty listing" do
+    outcome = run_checks([], ["models"])
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_match(/no models/, outcome[:results].first[:note])
   end
 
   test "#run should pass the plain check on a pong reply" do

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -4,15 +4,21 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   FakeResponse = Struct.new(:content)
 
   FakeToolCallMessage = Struct.new(:tool_calls) do
-    def tool_call? = tool_calls.present?
+    def tool_call? = true
+    def tool_result? = false
+  end
+
+  FakeToolResultMessage = Struct.new(:tool_call_id, :content) do
+    def tool_call? = false
+    def tool_result? = true
   end
 
   class FakeChat
     attr_reader :instructions
 
-    def initialize(response, tool_call_names: [])
+    def initialize(response, tool_rounds: [])
       @response = response
-      @tool_call_names = tool_call_names
+      @tool_rounds = tool_rounds
     end
 
     def with_schema(_schema) = self
@@ -31,9 +37,9 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     end
 
     def messages
-      @tool_call_names.map.with_index do |name, index|
-        call = RubyLLM::ToolCall.new(id: index.to_s, name: name, arguments: { "query" => "example" })
-        FakeToolCallMessage.new({ call.id => call })
+      @tool_rounds.flat_map.with_index do |round, index|
+        call = RubyLLM::ToolCall.new(id: index.to_s, name: round[:name], arguments: { "url" => "https://example.com/" })
+        [FakeToolCallMessage.new({ call.id => call }), FakeToolResultMessage.new(call.id, round[:result])]
       end
     end
   end
@@ -43,17 +49,17 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   class FakeProvider
     attr_reader :key, :chats
 
-    def initialize(responses, fetch_params: nil, models: [], tool_call_names: [])
+    def initialize(responses, fetch_params: nil, models: [], tool_rounds: [])
       @responses = responses.is_a?(Array) ? responses.dup : [responses]
       @fetch_params = fetch_params
       @models = models
-      @tool_call_names = tool_call_names
+      @tool_rounds = tool_rounds
       @chats = []
       @key = "fake"
     end
 
     def chat(_model)
-      FakeChat.new(@responses.shift, tool_call_names: @tool_call_names).tap { |chat| @chats << chat }
+      FakeChat.new(@responses.shift, tool_rounds: @tool_rounds).tap { |chat| @chats << chat }
     end
     def prepare_web(_chat) = nil
     def web_params(_model) = { tools: [] }
@@ -62,10 +68,16 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     def list_models = @models.map { |id| FakeModel.new(id) }
   end
 
-  def run_checks(responses, checks, fetch_params: nil, models: [], tool_call_names: [])
-    provider = FakeProvider.new(responses, fetch_params: fetch_params, models: models,
-                                tool_call_names: tool_call_names)
+  def run_checks(responses, checks, fetch_params: nil, models: [], tool_rounds: [])
+    provider = FakeProvider.new(responses, fetch_params: fetch_params, models: models, tool_rounds: tool_rounds)
     LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: checks).run
+  end
+
+  FETCHED_PAGE = "Example Domain This domain is for use in illustrative examples in documents.".freeze
+
+  def full_tool_loop(fetch_result: FETCHED_PAGE)
+    [{ name: LlmCapabilityProbe::SEARCH_TOOL_NAME, result: "canned results" },
+     { name: LlmCapabilityProbe::FETCH_TOOL_NAME, result: fetch_result }]
   end
 
   def valid_payload
@@ -215,27 +227,34 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
 
   test "#run should fail the client tools check when the fetch tool is never called" do
     outcome = run_checks("Example Domain", ["client_tools"],
-                         tool_call_names: [LlmCapabilityProbe::SEARCH_TOOL_NAME])
+                         tool_rounds: [{ name: LlmCapabilityProbe::SEARCH_TOOL_NAME, result: "canned results" }])
 
     assert_equal "FAIL", outcome[:results].first[:status]
     assert_equal "fetch tool never called", outcome[:results].first[:note]
   end
 
+  test "#run should fail the client tools check when the fetch returned no page content" do
+    outcome = run_checks("The heading is Example Domain.", ["client_tools"],
+                         tool_rounds: full_tool_loop(fetch_result: '{"error":"HTTP 403"}'))
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_equal "fetch returned no page content", outcome[:results].first[:note]
+  end
+
   test "#run should pass the client tools check on a full loop with a grounded answer" do
-    names = [LlmCapabilityProbe::SEARCH_TOOL_NAME, LlmCapabilityProbe::FETCH_TOOL_NAME]
-    outcome = run_checks('The main heading reads: "Example Domain"', ["client_tools"], tool_call_names: names)
+    outcome = run_checks('The main heading reads: "Example Domain"', ["client_tools"], tool_rounds: full_tool_loop)
 
     assert_equal "PASS", outcome[:results].first[:status]
     assert_match(/2 tool calls/, outcome[:results].first[:note])
-    assert_equal names, outcome[:results].first[:evidence][:tool_calls].map { |call| call[:name] }
+    assert_equal [LlmCapabilityProbe::SEARCH_TOOL_NAME, LlmCapabilityProbe::FETCH_TOOL_NAME],
+                 outcome[:results].first[:evidence][:tool_rounds].map { |round| round[:name] }
   end
 
   test "#run should fail the client tools check when tools ran but the answer is not grounded" do
-    names = [LlmCapabilityProbe::SEARCH_TOOL_NAME, LlmCapabilityProbe::FETCH_TOOL_NAME]
-    outcome = run_checks("I could not determine the heading.", ["client_tools"], tool_call_names: names)
+    outcome = run_checks("I could not determine the heading.", ["client_tools"], tool_rounds: full_tool_loop)
 
     assert_equal "FAIL", outcome[:results].first[:status]
-    assert_equal "tools called but answer not grounded", outcome[:results].first[:note]
+    assert_equal "tools ran but answer not grounded", outcome[:results].first[:note]
   end
 
   test "canned web search should present the production search tool's wire shape" do
@@ -251,6 +270,14 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     result = LlmCapabilityProbe::CannedWebSearch.new.execute(query: "anything")
 
     assert_equal ["https://example.com/"], result[:results].map { |r| r["url"] }
+  end
+
+  test "the client tools check should not disclose the expected heading outside the fetched page" do
+    canned = JSON.generate(LlmCapabilityProbe::CannedWebSearch.new.execute(query: "anything"))
+
+    assert_no_match LlmCapabilityProbe::EXPECTED_HEADING, canned
+    assert_no_match LlmCapabilityProbe::EXPECTED_HEADING, LlmCapabilityProbe::CLIENT_TOOLS_PROMPT
+    assert_no_match LlmCapabilityProbe::EXPECTED_HEADING, LlmCapabilityProbe::PROBE_INSTRUCTIONS
   end
 
   test "#run should send system instructions on both two_step calls" do


### PR DESCRIPTION
Changes:

- Probe the provider's live model listing, and record it as evidence — a pair qualifies only if its id is served verbatim, since the capability matrix gates on exact string match
- Probe the system prompt channel with instructions that contradict the obvious answer, so a prompt that never reaches the model can't pass
- Probe the client-side tool loop end to end, in both production shapes: gather-only, and the combined schema-plus-tools call
- Thread system instructions through the existing `two_step` and `combined` checks, mirroring production
- Record the qualification rule: no (provider, model) pair enters the capability matrix without a probe run covering the production call shape

The probe qualified Kimi without ever exercising two things production always does — sending a system prompt, and driving the client-side web tools through a real tool loop. The first gap is exactly how the role-`developer` 400 reached the shipped integration.

Grounding is judged against what the tools actually returned rather than what the model says: the expected page heading appears in neither the prompt nor the canned search results, so an answer can only contain it by way of a fetch that really succeeded. The probe-local search tool returns canned results in the production tool's wire shape, keeping the probe credential-independent.

The matrix design question from the issue — keep per-model capability sets or strip to a plain allowlist — stays open on purpose: it needs the live search-on-Kimi verdict this probe is meant to produce.

References:

- Closes #1187
- Parent issue: #1184
- Related issue: #1186
