### PR TITLE
Lead untranslated events with their name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-15
+
+- Events in the log now start with what happened, so entries that used to show only raw technical output are readable at a glance.
+
 ## 2026-08-12
 
 - The posting endpoint now understands the standard `Idempotency-Key` header, so HTTP clients that send it get safe retries without setting `uid` in the payload.

--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -48,8 +48,13 @@ class EventDescriptionComponent < ViewComponent::Base
     ).html_safe
   end
 
+  # Types without a translated sentence fall back to the stored message, which
+  # is raw operational text ("combined: PASS (52.8s)") that says nothing about
+  # what produced it — so the event name leads and the message follows.
   def fallback_description
-    (event.message.present? ? escaped_message : default_description).html_safe
+    return ERB::Util.html_escape(default_description) if event.message.blank?
+
+    helpers.safe_join([helpers.tag.span(default_description, class: "font-medium"), helpers.middot, escaped_message])
   end
 
   def description_key
@@ -115,7 +120,7 @@ class EventDescriptionComponent < ViewComponent::Base
   end
 
   def default_description
-    I18n.t("events.#{event.type}.name", default: event.type.humanize)
+    I18n.t("events.#{event_type}.name", default: event.type.tr(".", " ").humanize)
   end
 
   def metadata_feed_links_html

--- a/app/components/event_description_component.rb
+++ b/app/components/event_description_component.rb
@@ -48,9 +48,8 @@ class EventDescriptionComponent < ViewComponent::Base
     ).html_safe
   end
 
-  # Types without a translated sentence fall back to the stored message, which
-  # is raw operational text ("combined: PASS (52.8s)") that says nothing about
-  # what produced it — so the event name leads and the message follows.
+  # A stored message is raw operational text that doesn't say what produced it,
+  # so the event name leads it.
   def fallback_description
     return ERB::Util.html_escape(default_description) if event.message.blank?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,23 @@ en:
     resend_email_failed:
       name: "Email failed"
       description_html: "Email delivery failed"
+    mail_profile_mailer_account_confirmation:
+      name: "Confirmation email"
+      description_html: "Account confirmation email sent"
+    mail_profile_mailer_email_change_confirmation:
+      name: "Email change confirmation"
+      description_html: "Email change confirmation sent"
+    mail_passwords_mailer_reset:
+      name: "Password reset email"
+      description_html: "Password reset email sent"
+    job_purge_expired_events_completed:
+      name: "Old events cleaned up"
+    job_llm_capability_probe_skipped:
+      name: "Capability probe skipped"
+    job_llm_capability_probe_check:
+      name: "Capability check"
+    job_llm_capability_probe_completed:
+      name: "Capability probe finished"
     metadata:
       stats:
         started_at: "Started at"

--- a/test/components/event_description_component_test.rb
+++ b/test/components/event_description_component_test.rb
@@ -195,6 +195,45 @@ class EventDescriptionComponentTest < ViewComponent::TestCase
     assert_includes result.to_html, "Custom message"
   end
 
+  test "#call should lead the stored message with the event name" do
+    event = Event.create!(
+      type: "job.llm_capability_probe.check",
+      level: :info,
+      user: user,
+      message: "combined: PASS (52.8s)",
+      metadata: {}
+    )
+
+    result = render_inline(EventDescriptionComponent.new(event: event))
+
+    assert_includes result.text, "Capability check"
+    assert_includes result.text, "combined: PASS (52.8s)"
+  end
+
+  test "#call should name a dotted type with no translation" do
+    event = Event.create!(
+      type: "job.something.happened",
+      level: :info,
+      user: user,
+      message: "Details",
+      metadata: {}
+    )
+
+    assert_includes render_inline(EventDescriptionComponent.new(event: event)).text, "Job something happened"
+  end
+
+  test "#call should render the translated name for a message-less event" do
+    event = Event.create!(
+      type: "job.purge_expired_events.completed",
+      level: :info,
+      user: user,
+      message: "",
+      metadata: {}
+    )
+
+    assert_includes render_inline(EventDescriptionComponent.new(event: event)).text, "Old events cleaned up"
+  end
+
   test "#call should escape HTML in fallback messages" do
     event = Event.create!(
       type: "test_event",


### PR DESCRIPTION
Changes:

- Event rows without a translated description now lead with the event name instead of showing only the raw stored message
- Named the job and mail event types
- Fixed the name lookup, which never resolved for dotted types like `job.llm_capability_probe.check`
