### PR TITLE
Stop the capability probe failing and passing on the wrong things

### DIFF
--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -149,6 +149,13 @@ module LlmCapabilityProbe
     def web_fetch_params(_model) = nil
     def prepare_web(_chat) = nil
 
+    # Structured output is repaired exactly as production repairs it — Kimi
+    # fences its JSON, and LlmClient unwraps that before parsing. Without this
+    # the probe fails a model on a quirk the app already absorbs.
+    def unwrap_json(text)
+      LlmClient::Adapter.for(key).unwrap_json(text)
+    end
+
     class Anthropic < Provider
       def self.env_key = "ANTHROPIC_API_KEY"
 
@@ -315,6 +322,12 @@ module LlmCapabilityProbe
       gathered = gather.ask(GATHER_PROMPT).content.to_s
       return { status: "FAIL", note: "gather returned blank", evidence: nil } if gathered.strip.empty?
 
+      # Mirrors LlmLoader: structuring a refusal invites fabricated items, so
+      # the gather step's refusal is the finding — don't launder it downstream.
+      if LlmCapabilityProbe.refusal?(gathered)
+        return { status: "FAIL", note: "gather reports no web access", evidence: gathered[0, 2000] }
+      end
+
       structure = @provider.chat(@model).with_schema(PROBE_SCHEMA)
       structure.with_instructions(PROBE_INSTRUCTIONS)
       validate_items(structure.ask(STRUCTURE_PROMPT_PREFIX + gathered), gathered: gathered)
@@ -419,7 +432,7 @@ module LlmCapabilityProbe
 
     def validate_items(response, gathered: nil)
       raw = response.content
-      payload = raw.is_a?(Hash) ? raw : JSON.parse(raw.to_s)
+      payload = raw.is_a?(Hash) ? raw : JSON.parse(@provider.unwrap_json(raw.to_s))
       errors = JSONSchemer.schema(PROBE_SCHEMA).validate(payload).to_a
       items = payload.is_a?(Hash) ? Array(payload["items"]) : []
       evidence = { items: items.first(3), gathered_preview: gathered&.slice(0, 2000) }.compact
@@ -427,6 +440,11 @@ module LlmCapabilityProbe
         { status: "FAIL", note: "schema violation: #{errors.first['error']}", evidence: evidence }
       elsif items.empty?
         { status: "FAIL", note: "valid but empty items", evidence: evidence }
+      elsif LlmCapabilityProbe.refusal?(JSON.generate(items))
+        # Well-formed JSON whose content is "I cannot browse the web" is a
+        # refusal wearing the schema, not a capability. Passing it would
+        # qualify a model for gathering it never did.
+        { status: "FAIL", note: "schema-valid but the items are a refusal", evidence: evidence }
       else
         { status: "PASS", note: "#{items.size} items, schema-valid", evidence: evidence }
       end

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -75,6 +75,7 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     def web_search_params(_model) = { tools: [] }
     def web_fetch_params(_model) = @fetch_params
     def list_models = @models.map { |id| FakeModel.new(id) }
+    def unwrap_json(text) = LlmClient::Adapter::Moonshot.new.unwrap_json(text)
   end
 
   def run_checks(responses, checks, fetch_params: nil, models: [], tool_rounds: [])
@@ -186,6 +187,28 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
 
     assert_equal "FAIL", outcome[:results].first[:status]
     assert_match(/empty items/, outcome[:results].first[:note])
+  end
+
+  test "#run should pass the schema check on fenced JSON the app unwraps" do
+    outcome = run_checks("```json\n#{JSON.generate(valid_payload)}\n```", ["schema"])
+
+    assert_equal "PASS", outcome[:results].first[:status]
+  end
+
+  test "#run should fail the schema check when schema-valid items are a refusal" do
+    payload = { "items" => [{ "uid" => "u1", "source_url" => "https://example.com/",
+                              "body" => "I cannot browse the live web, so I am unable to retrieve the posts." }] }
+    outcome = run_checks(payload, ["schema"])
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_equal "schema-valid but the items are a refusal", outcome[:results].first[:note]
+  end
+
+  test "#run should fail two_step when the gather step reports no web access" do
+    outcome = run_checks(["I don't have the ability to browse the web.", valid_payload], ["two_step"])
+
+    assert_equal "FAIL", outcome[:results].first[:status]
+    assert_equal "gather reports no web access", outcome[:results].first[:note]
   end
 
   test "#run should fail the schema check on a non-JSON reply" do


### PR DESCRIPTION
Changes:

- Repair structured output through the production adapter, so a provider that fences its JSON is judged the way `LlmClient` actually treats it
- Fail schema-valid items whose content is a refusal, instead of counting them as a capability
- Fail the two-step gather on a refusal, mirroring `LlmLoader`'s rule that structuring one invites fabricated items

The first live Kimi run surfaced both defects at once. `schema` and `two_step` failed only because the model wrapped its JSON in a ```` ```json ```` fence — a quirk `Adapter::Moonshot#unwrap_json` already absorbs in production, so the probe was failing a model on something the app handles. In the other direction `combined` passed on `"I cannot browse the live web..."`: schema-valid, non-empty, and entirely ungrounded. Both directions produce misleading qualification evidence, which is the one thing the probe exists to get right.

References:

- Related issue: #1187
- Parent issue: #1184
- Related issue: #1186
