### PR TITLE
Point the Kimi probe at kimi-k2.6

### DIFF
--- a/app/jobs/kimi_capability_probe_job.rb
+++ b/app/jobs/kimi_capability_probe_job.rb
@@ -2,5 +2,9 @@
 # See LlmCapabilityProbeJob.
 class KimiCapabilityProbeJob < LlmCapabilityProbeJob
   PROVIDER = "moonshot".freeze
-  MODEL = "kimi-k2.5".freeze
+  # kimi-k2.5 is retiring; k2.6 is the cost-faithful successor (k3 is priced at
+  # flagship level, which would undo Kimi's reason for being here). Pointing the
+  # probe first is deliberate — nothing else moves to k2.6 until a run qualifies
+  # it, since the capability matrix is gated on probe evidence (#1187).
+  MODEL = "kimi-k2.6".freeze
 end

--- a/app/jobs/kimi_capability_probe_job.rb
+++ b/app/jobs/kimi_capability_probe_job.rb
@@ -2,9 +2,5 @@
 # See LlmCapabilityProbeJob.
 class KimiCapabilityProbeJob < LlmCapabilityProbeJob
   PROVIDER = "moonshot".freeze
-  # kimi-k2.5 is retiring; k2.6 is the cost-faithful successor (k3 is priced at
-  # flagship level, which would undo Kimi's reason for being here). Pointing the
-  # probe first is deliberate — nothing else moves to k2.6 until a run qualifies
-  # it, since the capability matrix is gated on probe evidence (#1187).
   MODEL = "kimi-k2.6".freeze
 end

--- a/test/jobs/llm_capability_probe_job_test.rb
+++ b/test/jobs/llm_capability_probe_job_test.rb
@@ -17,7 +17,7 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
   test "should pin one provider and model per job" do
     assert_equal %w[anthropic claude-sonnet-4-6],
                  [AnthropicCapabilityProbeJob::PROVIDER, AnthropicCapabilityProbeJob::MODEL]
-    assert_equal %w[moonshot kimi-k2.5], [KimiCapabilityProbeJob::PROVIDER, KimiCapabilityProbeJob::MODEL]
+    assert_equal %w[moonshot kimi-k2.6], [KimiCapabilityProbeJob::PROVIDER, KimiCapabilityProbeJob::MODEL]
   end
 
   test "#perform should record a skip event when the API key is not configured" do


### PR DESCRIPTION
Changes:

- Repoint `KimiCapabilityProbeJob` from the retiring `kimi-k2.5` to `kimi-k2.6`, so the successor can be qualified from the dev-area jobs runner

Deliberately the probe constant and nothing else. `kimi-k2.6` is the cost-faithful successor — `kimi-k3` is priced at flagship level, which would undo Kimi's reason for being here as the cheap provider — but neither is qualified yet, and the capability matrix only takes pairs backed by a probe run covering the production call shape. The provider default, the matrix row and the rates entry move once that run says they can.

The last k2.5 run confirmed `kimi-k2.6` is served verbatim by `/v1/models`, so the exact-match check should pass.

References:

- Part of #1186
- Parent issue: #1184
- Related issue: #1187
