### PR TITLE
Move Moonshot to kimi-k2.6 and drop the experimental probe residue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-15
 
+- Kimi feeds now use K2.6, since Moonshot is retiring K2.5 at the end of August. Feeds still set to the old model switch over on their own — no action needed.
 - Events in the log now start with what happened, so entries that used to show only raw technical output are readable at a glance.
 
 ## 2026-08-12

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -1,25 +1,18 @@
 # Dev-verified allowlist of (provider, model) pairs the AI engine may use.
 #
-# Membership is qualification: a pair appears only once a capability probe run
-# has shown it works through our stack, on the shape production actually calls
-# (LlmCapabilityProbe). There are no readiness tiers and no "experimental" rows.
-# What the model picker offers for a feed is this list intersected with the
-# credential's live model snapshot, so an unverified model is never a silent,
-# async footgun. A provider with no rows here (e.g. OpenRouter) simply isn't
-# selectable for AI feeds.
+# Membership is qualification: a pair appears only once LlmCapabilityProbe has
+# shown it works on the shape production calls. The model picker offers this
+# list intersected with the credential's live snapshot, so an unverified model
+# can't be selected and fail asynchronously mid-run. A provider with no rows
+# isn't selectable for AI feeds at all.
 #
-# Rows carry no per-model capability flags. Every provider retrieves through our
-# own client-side search and fetch tools (LlmClient::Adapter::Base#apply_web),
-# so what a model's hosted retrieval can do never reaches a feed run — and the
-# one thing that does vary, whether schema and tools survive the same call, is
-# already a provider property the adapter carries (`combined_extraction?`).
+# Rows are pairs and nothing else. Per-model capability flags would describe
+# hosted retrieval, which never reaches a feed run — every provider retrieves
+# through our own tools — and the one thing that does vary between models,
+# whether schema and tools survive the same call, is an adapter property
+# (`combined_extraction?`).
 #
 # Adding a pair: docs/llm-provider-qualification.md
-#
-# Verified on staging: Anthropic Sonnet drives the tools and returns
-# strict-schema JSON in one combined call (#914). Kimi k2.6 drives the same
-# tools under a system prompt but needs two-step extraction (#1186; it replaces
-# the retired k2.5, qualified the same way).
 class LlmModelCapability
   ENTRIES = [
     { provider: "anthropic", model: "claude-sonnet-4-6" },

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -14,6 +14,8 @@
 # one thing that does vary, whether schema and tools survive the same call, is
 # already a provider property the adapter carries (`combined_extraction?`).
 #
+# Adding a pair: docs/llm-provider-qualification.md
+#
 # Verified on staging: Anthropic Sonnet drives the tools and returns
 # strict-schema JSON in one combined call (#914). Kimi k2.6 drives the same
 # tools under a system prompt but needs two-step extraction (#1186; it replaces

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -1,29 +1,27 @@
-# Dev-verified allowlist of (provider, model) pairs the AI engine may use, and
-# the capability set each pair actually delivers through our stack (plan-03).
+# Dev-verified allowlist of (provider, model) pairs the AI engine may use.
 #
-# Membership is qualification: a pair appears only once it's verified to work —
-# there are no readiness tiers and no "experimental" rows. What the model picker
-# offers for a feed is this matrix intersected with the credential's live model
-# snapshot, so an unverified or web+schema-incapable model is never a silent,
+# Membership is qualification: a pair appears only once a capability probe run
+# has shown it works through our stack, on the shape production actually calls
+# (LlmCapabilityProbe). There are no readiness tiers and no "experimental" rows.
+# What the model picker offers for a feed is this list intersected with the
+# credential's live model snapshot, so an unverified model is never a silent,
 # async footgun. A provider with no rows here (e.g. OpenRouter) simply isn't
 # selectable for AI feeds.
 #
-# Capabilities:
-#   :fetch      — read a known URL's content
-#   :search     — discover content via web search
-#   :structured — return native, strict-schema JSON
+# Rows carry no per-model capability flags. Every provider retrieves through our
+# own client-side search and fetch tools (LlmClient::Adapter::Base#apply_web),
+# so what a model's hosted retrieval can do never reaches a feed run — and the
+# one thing that does vary, whether schema and tools survive the same call, is
+# already a provider property the adapter carries (`combined_extraction?`).
+#
+# Verified on staging: Anthropic Sonnet drives the tools and returns
+# strict-schema JSON in one combined call (#914). Kimi k2.6 drives the same
+# tools under a system prompt but needs two-step extraction (#1186; it replaces
+# the retired k2.5, qualified the same way).
 class LlmModelCapability
-  CAPABILITIES = %i[fetch search structured].freeze
-
-  # Verified live on staging (plan-03): Anthropic Sonnet does all three in one
-  # combined call (#914). Kimi k2.6 drives the client-side search and fetch tools
-  # under a system prompt and returns schema-valid JSON, but its server-side
-  # search still doesn't engage through RubyLLM, so no :search (#1186; it
-  # replaces the retired k2.5, which qualified the same way). Only pairs actually
-  # probed appear here — Opus stays out until it's verified the same way.
   ENTRIES = [
-    { provider: "anthropic", model: "claude-sonnet-4-6", capabilities: %i[fetch search structured] },
-    { provider: "moonshot", model: "kimi-k2.6", capabilities: %i[fetch structured] }
+    { provider: "anthropic", model: "claude-sonnet-4-6" },
+    { provider: "moonshot", model: "kimi-k2.6" }
   ].freeze
 
   class << self
@@ -42,10 +40,6 @@ class LlmModelCapability
     # Verified model ids for a provider, in matrix order.
     def models_for(provider)
       ENTRIES.select { |entry| entry[:provider] == provider.to_s }.map { |entry| entry[:model] }
-    end
-
-    def capabilities_for(provider, model)
-      find(provider, model)&.fetch(:capabilities) || []
     end
   end
 end

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -16,13 +16,14 @@ class LlmModelCapability
   CAPABILITIES = %i[fetch search structured].freeze
 
   # Verified live on staging (plan-03): Anthropic Sonnet does all three in one
-  # combined call (#914); Kimi drives a client-side fetch tool and de-fenced JSON
-  # but its server-side search doesn't engage through RubyLLM, so no :search
-  # (#917). Only pairs actually probed appear here — Opus stays out until it's
-  # verified the same way.
+  # combined call (#914). Kimi k2.6 drives the client-side search and fetch tools
+  # under a system prompt and returns schema-valid JSON, but its server-side
+  # search still doesn't engage through RubyLLM, so no :search (#1186; it
+  # replaces the retired k2.5, which qualified the same way). Only pairs actually
+  # probed appear here — Opus stays out until it's verified the same way.
   ENTRIES = [
     { provider: "anthropic", model: "claude-sonnet-4-6", capabilities: %i[fetch search structured] },
-    { provider: "moonshot", model: "kimi-k2.5", capabilities: %i[fetch structured] }
+    { provider: "moonshot", model: "kimi-k2.6", capabilities: %i[fetch structured] }
   ].freeze
 
   class << self

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -57,7 +57,7 @@ class LlmProvider
       name: "moonshot",
       display_name: "Moonshot (Kimi)",
       ruby_llm_provider: :openai,
-      default_model: "kimi-k2.5",
+      default_model: "kimi-k2.6",
       api_base: "https://api.moonshot.ai/v1",
       assume_model_exists: true
     )

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -1,9 +1,11 @@
 # Dev-time capability probe for LLM providers (spec 005 §5; issue #913).
 #
-# Live-verifies provider-native behavior through RubyLLM: plain calls,
-# structured output, hosted search/fetch mechanisms, and one-call versus
-# two-step extraction. These checks are deliberately separate from the
-# production managed-search path, which uses LlmClient's client-side tools.
+# Live-verifies what production actually depends on: the model is served under
+# the id we name it by, it honors a system prompt, it returns strict-schema
+# JSON, and it drives our client-side search and fetch tools through a real
+# tool loop. Provider-hosted retrieval is deliberately not probed — every
+# provider goes through LlmClient's own tools (Adapter::Base#apply_web), so a
+# hosted mechanism working or not tells us nothing about a feed run.
 #
 # The probe stays independent of LlmProvider and managed credentials so an
 # unwired provider can be qualified before application integration. Keys
@@ -39,9 +41,6 @@ module LlmCapabilityProbe
     "additionalProperties" => false
   }.freeze
 
-  GATHER_PROMPT = "Search the web for the latest two posts on the Ruby on Rails official blog " \
-                  "(rubyonrails.org/blog). For each, report the title, its full URL, and a one-sentence summary."
-
   # Production always sends a system prompt (LlmClient#call's privileged
   # instruction channel), so the gathering checks carry one too — a pair must
   # not qualify on a call shape production never uses.
@@ -56,14 +55,16 @@ module LlmCapabilityProbe
                               "reply with exactly one word: #{SYSTEM_CHECK_WORD}."
   SYSTEM_CHECK_PROMPT = "What is the capital of France? Answer in one word."
 
-  # A reply can contain URLs and still be a refusal ("I cannot browse the
-  # web... visit rubyonrails.org/blog yourself") — grounding checks must
-  # treat that as no web access, not as evidence.
+  # A reply can be fluent and still be a refusal ("I cannot browse the web...
+  # visit the site yourself") — grounding checks must treat that as no
+  # retrieval, not as evidence.
   REFUSAL_MARKERS = /(?:don't|do not) have the ability|(?:cannot|can't|unable to) (?:browse|access)|no ability to browse/i
 
   def self.refusal?(text)
     text.to_s.match?(REFUSAL_MARKERS)
   end
+  # Mirrors production's structuring stage (LlmPrompts::STRUCTURE_SYSTEM): fixed
+  # text in, strict JSON out, no retrieval involved.
   STRUCTURE_PROMPT_PREFIX = "Convert the gathered web content below into the required JSON object. " \
                             "Use only what is present; do not invent items or fields.\n\nGATHERED CONTENT:\n"
   SAMPLE_TEXT = <<~TEXT
@@ -110,20 +111,6 @@ module LlmCapabilityProbe
     end
   end
 
-  # Moonshot's server-executed web search is invoked through a builtin tool
-  # the client must acknowledge by echoing the arguments back. Modeled as a
-  # RubyLLM function tool so the gem's tool loop performs that round trip.
-  class MoonshotWebSearchEcho < RubyLLM::Tool
-    description "Builtin server-side web search"
-    param :query, desc: "Search query", required: false
-
-    def name = "$web_search"
-
-    def execute(**args)
-      args
-    end
-  end
-
   class Provider
     attr_reader :key
 
@@ -146,8 +133,6 @@ module LlmCapabilityProbe
     end
 
     def assume_model_exists? = false
-    def web_fetch_params(_model) = nil
-    def prepare_web(_chat) = nil
 
     # Structured output is repaired exactly as production repairs it — Kimi
     # fences its JSON, and LlmClient unwraps that before parsing. Without this
@@ -164,20 +149,6 @@ module LlmCapabilityProbe
       end
 
       def ruby_llm_provider = :anthropic
-
-      # Combined hosted-tool shape is probe-local. Production uses the managed
-      # client-side search and fetch tools instead.
-      def web_params(model)
-        { tools: web_search_params(model)[:tools] + web_fetch_params(model)[:tools] }
-      end
-
-      def web_search_params(_model)
-        { tools: [{ type: "web_search_20260209", name: "web_search" }] }
-      end
-
-      def web_fetch_params(_model)
-        { tools: [{ type: "web_fetch_20260209", name: "web_fetch", citations: { enabled: false } }] }
-      end
     end
 
     class Moonshot < Provider
@@ -194,18 +165,6 @@ module LlmCapabilityProbe
 
       def ruby_llm_provider = :openai
       def assume_model_exists? = true
-
-      def web_params(_model)
-        { tools: [{ type: "builtin_function", function: { name: "$web_search" } }] }
-      end
-
-      alias web_search_params web_params
-
-      # The builtin needs the echo round trip; register the tool so RubyLLM's
-      # loop answers the tool call instead of failing on an unknown tool.
-      def prepare_web(chat)
-        chat.with_tool(MoonshotWebSearchEcho)
-      end
     end
 
     REGISTRY = { "anthropic" => Anthropic, "moonshot" => Moonshot }.freeze
@@ -221,8 +180,7 @@ module LlmCapabilityProbe
   end
 
   class Runner
-    CHECKS = %w[models plain system_prompt schema web_search web_fetch two_step combined
-                client_tools client_tools_schema].freeze
+    CHECKS = %w[models plain system_prompt schema client_tools client_tools_schema].freeze
 
     def initialize(provider:, model:, checks: CHECKS)
       @provider = provider
@@ -293,56 +251,6 @@ module LlmCapabilityProbe
       validate_items(response)
     end
 
-    def check_web_search
-      chat = @provider.chat(@model)
-      @provider.prepare_web(chat)
-      chat.with_params(**@provider.web_search_params(@model))
-      text = chat.ask(GATHER_PROMPT).content.to_s
-      return { status: "FAIL", note: "model reports no web access", evidence: text[0, 2000] } if LlmCapabilityProbe.refusal?(text)
-
-      pass(text.match?(%r{https?://}) && text.length > 80, "no URLs in response", text) { "web search grounding" }
-    end
-
-    def check_web_fetch
-      params = @provider.web_fetch_params(@model)
-      return { status: "SKIP", note: "provider declares no web-fetch mechanism", evidence: nil } if params.nil?
-
-      chat = @provider.chat(@model).with_params(**params)
-      text = chat.ask("Fetch https://example.com/ and quote the exact text of its <h1> heading.").content.to_s
-      pass(text.match?(/example domain/i), "page content not quoted", text) { "web fetch grounding" }
-    end
-
-    # Provider-native two-step capability comparison. Both calls carry system
-    # instructions the way production stage calls do.
-    def check_two_step
-      gather = @provider.chat(@model)
-      gather.with_instructions(PROBE_INSTRUCTIONS)
-      @provider.prepare_web(gather)
-      gather.with_params(**@provider.web_params(@model))
-      gathered = gather.ask(GATHER_PROMPT).content.to_s
-      return { status: "FAIL", note: "gather returned blank", evidence: nil } if gathered.strip.empty?
-
-      # Mirrors LlmLoader: structuring a refusal invites fabricated items, so
-      # the gather step's refusal is the finding — don't launder it downstream.
-      if LlmCapabilityProbe.refusal?(gathered)
-        return { status: "FAIL", note: "gather reports no web access", evidence: gathered[0, 2000] }
-      end
-
-      structure = @provider.chat(@model).with_schema(PROBE_SCHEMA)
-      structure.with_instructions(PROBE_INSTRUCTIONS)
-      validate_items(structure.ask(STRUCTURE_PROMPT_PREFIX + gathered), gathered: gathered)
-    end
-
-    # Provider-native combined capability check — recorded as evidence;
-    # PASS here means "works combined", which would simplify the architecture.
-    def check_combined
-      chat = @provider.chat(@model).with_schema(PROBE_SCHEMA)
-      chat.with_instructions(PROBE_INSTRUCTIONS)
-      @provider.prepare_web(chat)
-      chat.with_params(**@provider.web_params(@model))
-      validate_items(chat.ask(GATHER_PROMPT))
-    end
-
     # The production mechanism end to end: a system prompt plus the
     # client-side search and fetch function tools driven through a real
     # multi-round loop. The observed tool calls plus an answer grounded in
@@ -356,8 +264,8 @@ module LlmCapabilityProbe
     # `combined_extraction?`): the output schema rides on the same chat as the
     # client-side tools. Schema and tools can each work alone yet break
     # together, so a pair qualified only by the checks above could still fail
-    # on a real feed load. A FAIL here reads as "use two-step", not as a
-    # disqualification — same as the provider-native `combined` check.
+    # on a real feed load. A FAIL here means the pair needs two-step
+    # extraction, not that it fails qualification.
     def check_client_tools_schema
       client_tools_loop(schema: PROBE_SCHEMA)
     end
@@ -430,12 +338,12 @@ module LlmCapabilityProbe
               end
     end
 
-    def validate_items(response, gathered: nil)
+    def validate_items(response)
       raw = response.content
       payload = raw.is_a?(Hash) ? raw : JSON.parse(@provider.unwrap_json(raw.to_s))
       errors = JSONSchemer.schema(PROBE_SCHEMA).validate(payload).to_a
       items = payload.is_a?(Hash) ? Array(payload["items"]) : []
-      evidence = { items: items.first(3), gathered_preview: gathered&.slice(0, 2000) }.compact
+      evidence = { items: items.first(3) }
       if errors.any?
         { status: "FAIL", note: "schema violation: #{errors.first['error']}", evidence: evidence }
       elsif items.empty?

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -16,6 +16,9 @@
 # LlmModelCapability without a probe run that covers the production call
 # shape — a system prompt on the wire, the client-side tool loop, and the
 # model id confirmed against the live models listing.
+#
+# How to run it, read the results, and add a pair or a provider:
+# docs/llm-provider-qualification.md
 module LlmCapabilityProbe
   # Mirrors UNIVERSAL_OUTPUT_SCHEMA's shape (strict: additionalProperties false
   # everywhere — the Anthropic requirement confirmed live in Track 2).

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -1,27 +1,18 @@
-# Dev-time capability probe for LLM providers (spec 005 §5; issue #913).
+# Dev-time capability probe: no (provider, model) pair enters
+# LlmModelCapability without a run that passes here.
 #
-# Live-verifies what production actually depends on: the model is served under
-# the id we name it by, it honors a system prompt, it returns strict-schema
-# JSON, and it drives our client-side search and fetch tools through a real
-# tool loop. Provider-hosted retrieval is deliberately not probed — every
-# provider goes through LlmClient's own tools (Adapter::Base#apply_web), so a
-# hosted mechanism working or not tells us nothing about a feed run.
+# Every check mirrors something a feed run does. Provider-hosted retrieval is
+# deliberately not probed — every provider retrieves through our own tools
+# (LlmClient::Adapter::Base#apply_web), so a hosted mechanism tells us nothing
+# about a feed run.
 #
-# The probe stays independent of LlmProvider and managed credentials so an
-# unwired provider can be qualified before application integration. Keys
-# come from the environment. Results — evidence included — are recorded as
-# JobRun events and feed plan-03-provider-verification.md.
+# Keys come from the environment rather than managed credentials, so a provider
+# can be qualified before it is wired into the app.
 #
-# Qualification rule (issue #1187): no (provider, model) pair enters
-# LlmModelCapability without a probe run that covers the production call
-# shape — a system prompt on the wire, the client-side tool loop, and the
-# model id confirmed against the live models listing.
-#
-# How to run it, read the results, and add a pair or a provider:
-# docs/llm-provider-qualification.md
+# See docs/llm-provider-qualification.md.
 module LlmCapabilityProbe
-  # Mirrors UNIVERSAL_OUTPUT_SCHEMA's shape (strict: additionalProperties false
-  # everywhere — the Anthropic requirement confirmed live in Track 2).
+  # Mirrors UNIVERSAL_OUTPUT_SCHEMA's shape. Anthropic requires strict schemas:
+  # additionalProperties false at every level.
   PROBE_SCHEMA = {
     "type" => "object",
     "properties" => {
@@ -44,30 +35,25 @@ module LlmCapabilityProbe
     "additionalProperties" => false
   }.freeze
 
-  # Production always sends a system prompt (LlmClient#call's privileged
-  # instruction channel), so the gathering checks carry one too — a pair must
-  # not qualify on a call shape production never uses.
+  # Production always sends a system prompt, so every check carries one.
   PROBE_INSTRUCTIONS = "You are a content-gathering agent for a feed reader. " \
                        "Follow the task exactly and report only what you actually find."
 
-  # The instructions contradict the obvious answer, so the reply can only
-  # match by honoring the system channel. A wire-level rejection (Moonshot
-  # 400s on role "developer") and silently dropped instructions both fail.
+  # The instructions contradict the obvious answer, so the expected reply is
+  # unreachable unless the system channel arrived and was obeyed.
   SYSTEM_CHECK_WORD = "MARLIN".freeze
   SYSTEM_CHECK_INSTRUCTIONS = "You are a capability probe target. Whatever the user asks, " \
                               "reply with exactly one word: #{SYSTEM_CHECK_WORD}."
   SYSTEM_CHECK_PROMPT = "What is the capital of France? Answer in one word."
 
-  # A reply can be fluent and still be a refusal ("I cannot browse the web...
-  # visit the site yourself") — grounding checks must treat that as no
-  # retrieval, not as evidence.
+  # A fluent reply can still be a refusal ("I cannot browse the web, visit the
+  # site yourself") — grounding checks must not read that as retrieval.
   REFUSAL_MARKERS = /(?:don't|do not) have the ability|(?:cannot|can't|unable to) (?:browse|access)|no ability to browse/i
 
   def self.refusal?(text)
     text.to_s.match?(REFUSAL_MARKERS)
   end
-  # Mirrors production's structuring stage (LlmPrompts::STRUCTURE_SYSTEM): fixed
-  # text in, strict JSON out, no retrieval involved.
+  # Mirrors production's structuring stage: fixed text in, strict JSON out.
   STRUCTURE_PROMPT_PREFIX = "Convert the gathered web content below into the required JSON object. " \
                             "Use only what is present; do not invent items or fields.\n\nGATHERED CONTENT:\n"
   SAMPLE_TEXT = <<~TEXT
@@ -81,21 +67,17 @@ module LlmCapabilityProbe
   CLIENT_TOOLS_SCHEMA_PROMPT = "#{CLIENT_TOOLS_PROMPT} Return exactly one item: body set to that heading, " \
                                "uid and source_url set to the page's URL.".freeze
 
-  # The heading lives only on the fetched page — deliberately absent from the
-  # prompt and from the canned search results — so quoting it is evidence the
-  # model read fetched content rather than echoing what it was already told.
+  # Appears only on the fetched page — never in the prompt or the canned search
+  # results — so quoting it requires having read fetched content. Keep it that
+  # way when editing either.
   EXPECTED_HEADING = /example domain/i
 
-  # Wire names the production tools present to the model; the client-tools
-  # check matches the loop's observed tool calls against these.
   SEARCH_TOOL_NAME = LlmClient::Tools::WebSearch.new(provider: nil, credential: nil).name
   FETCH_TOOL_NAME = LlmClient::Tools::WebFetch.new.name
 
-  # Probe-local stand-in for the production search tool: identical wire shape
-  # (name, description, parameter) but canned results pointing at fixed real
-  # URLs, so the tool loop can be qualified without managed search
-  # credentials. The follow-up fetch is the real production tool, which is
-  # credential-free.
+  # Stand-in for the production search tool: same wire shape, canned results, so
+  # the loop can be driven without managed search credentials. The fetch tool
+  # needs no stand-in — the production one is credential-free.
   class CannedWebSearch < RubyLLM::Tool
     description LlmClient::Tools::WebSearch.description
     param :query, desc: "Search query", required: true
@@ -129,17 +111,16 @@ module LlmCapabilityProbe
       context.chat(model: model, provider: ruby_llm_provider, assume_model_exists: assume_model_exists?)
     end
 
-    # The provider's live models listing, resolved the way LlmClient does it
-    # (registry names don't always match RubyLLM provider keys).
+    # Resolved the way LlmClient does it — registry names don't always match
+    # RubyLLM provider keys.
     def list_models
       RubyLLM::Provider.resolve(ruby_llm_provider).new(context.config).list_models
     end
 
     def assume_model_exists? = false
 
-    # Structured output is repaired exactly as production repairs it — Kimi
-    # fences its JSON, and LlmClient unwraps that before parsing. Without this
-    # the probe fails a model on a quirk the app already absorbs.
+    # Repairs structured output the way production does, so the probe doesn't
+    # fail a model on a quirk the app already absorbs (Kimi fences its JSON).
     def unwrap_json(text)
       LlmClient::Adapter.for(key).unwrap_json(text)
     end
@@ -160,9 +141,8 @@ module LlmCapabilityProbe
       def configure(config)
         config.openai_api_key = ENV.fetch(self.class.env_key)
         config.openai_api_base = ENV.fetch("MOONSHOT_API_BASE", "https://api.moonshot.ai/v1")
-        # Mirror production (LlmProvider#configure): Moonshot rejects the
-        # "developer" role RubyLLM sends by default, so the probe must use
-        # the same wire shape or its results won't transfer.
+        # Must match LlmProvider#configure or results won't transfer: Moonshot
+        # rejects the "developer" role RubyLLM sends by default.
         config.openai_use_system_role = true
       end
 
@@ -193,9 +173,9 @@ module LlmCapabilityProbe
     end
 
     # Returns { results:, passed: }. Every check is attempted; failures are
-    # recorded, never raised — the probe's job is to report what a provider
-    # does, not to crash on it. Evidence rides along in each result so the
-    # caller can persist everything (no separate transcript to chase).
+    # recorded, never raised — the job is to report what a provider does, not
+    # to crash on it. `passed` is a summary; the per-check results are the
+    # verdict (see docs/llm-provider-qualification.md).
     def run
       @checks.each { |check| record(check) { send("check_#{check}") } }
       { results: @results, passed: @results.none? { |r| r[:status] == "FAIL" } }
@@ -213,9 +193,8 @@ module LlmCapabilityProbe
                     evidence: nil, seconds: (Time.current - started).round(1) }
     end
 
-    # Records the authenticated models listing as evidence and confirms the
-    # probed id is served verbatim — the capability matrix gates on exact
-    # string match, so a near-miss id qualifies nothing.
+    # LlmModelCapability matches on exact string, so a near-miss id qualifies
+    # nothing. The listing is recorded as evidence.
     def check_models
       ids = @provider.list_models.map(&:id)
       evidence = { model_ids: ids }
@@ -239,11 +218,9 @@ module LlmCapabilityProbe
       pass(honors_system_prompt?(text), "system instructions not honored verbatim", text) { "system prompt honored" }
     end
 
-    # The instructions ask for exactly one word, so only that word counts:
-    # a refusal that names it, or an answer that also volunteers the user
-    # prompt's answer, means the channel was received but not obeyed.
-    # Punctuation and surrounding whitespace are ignored — a trailing period
-    # is formatting, not a second thought.
+    # Only the word alone counts: a refusal that names it, or an answer that
+    # also volunteers the real one, means the prompt arrived but wasn't obeyed.
+    # Punctuation is ignored — a trailing period is formatting.
     def honors_system_prompt?(text)
       text.gsub(/[^[:alpha:]]/, "").casecmp?(SYSTEM_CHECK_WORD)
     end
@@ -254,21 +231,16 @@ module LlmCapabilityProbe
       validate_items(response)
     end
 
-    # The production mechanism end to end: a system prompt plus the
-    # client-side search and fetch function tools driven through a real
-    # multi-round loop. The observed tool calls plus an answer grounded in
-    # the fetched page are the evidence that the model drives client tools.
-    # This is production's gather shape for two-step providers (LlmLoader).
+    # Production's gather step: system prompt plus the client-side tools driven
+    # through a real multi-round loop.
     def check_client_tools
       client_tools_loop
     end
 
-    # Production's combined shape (LlmLoader#extract when the adapter reports
-    # `combined_extraction?`): the output schema rides on the same chat as the
-    # client-side tools. Schema and tools can each work alone yet break
-    # together, so a pair qualified only by the checks above could still fail
-    # on a real feed load. A FAIL here means the pair needs two-step
-    # extraction, not that it fails qualification.
+    # Production's combined shape: schema on the same chat as the tools. Schema
+    # and tools can each work alone yet break together. A FAIL means the pair
+    # needs two-step extraction (Adapter#combined_extraction?), not that it
+    # fails qualification.
     def check_client_tools_schema
       client_tools_loop(schema: PROBE_SCHEMA)
     end
@@ -308,16 +280,15 @@ module LlmCapabilityProbe
                    evidence: evidence.merge(result[:evidence] || {}))
     end
 
-    # Structured replies arrive as a Hash; serialize so grounding reads the
-    # same way for both shapes.
+    # Structured replies arrive as a Hash; serialize so grounding reads the same
+    # way for both shapes.
     def answer_text(response)
       content = response.content
       content.is_a?(Hash) ? JSON.generate(content) : content.to_s
     end
 
-    # Both tools must appear in the loop, and the fetch must have returned the
-    # page itself: a refused URL, a wrong URL or an HTTP error leaves nothing
-    # to ground on, and the heading appears nowhere else in the conversation.
+    # The fetch must have returned the page itself: a refused URL, a wrong URL
+    # or an HTTP error leaves the model nothing to ground on.
     def tool_loop_failure(rounds)
       names = rounds.map { |round| round[:name] }
       return { status: "FAIL", note: "search tool never called" } unless names.include?(SEARCH_TOOL_NAME)
@@ -352,9 +323,8 @@ module LlmCapabilityProbe
       elsif items.empty?
         { status: "FAIL", note: "valid but empty items", evidence: evidence }
       elsif LlmCapabilityProbe.refusal?(JSON.generate(items))
-        # Well-formed JSON whose content is "I cannot browse the web" is a
-        # refusal wearing the schema, not a capability. Passing it would
-        # qualify a model for gathering it never did.
+        # A refusal wearing the schema would otherwise qualify a model for
+        # gathering it never did.
         { status: "FAIL", note: "schema-valid but the items are a refusal", evidence: evidence }
       else
         { status: "PASS", note: "#{items.size} items, schema-valid", evidence: evidence }

--- a/config/llm_rates.yml
+++ b/config/llm_rates.yml
@@ -48,15 +48,10 @@ openrouter:
     input_per_million: 0.12
     output_per_million: 0.40
 
-# Moonshot (Kimi). Approximate published rates — verify against your billing.
-# k2.6 verified 2026-08-15 against platform.kimi.ai/docs/pricing/chat-k26.
-# k2.5 is retired but kept so any straggling usage row still prices correctly.
+# Moonshot (Kimi). Verified 2026-08-15 against
+# platform.kimi.ai/docs/pricing/chat-k26.
 moonshot:
   kimi-k2.6:
     input_per_million: 0.95
     output_per_million: 4.00
     cache_read_per_million: 0.16
-  kimi-k2.5:
-    input_per_million: 0.60
-    output_per_million: 2.50
-    cache_read_per_million: 0.15

--- a/config/llm_rates.yml
+++ b/config/llm_rates.yml
@@ -49,7 +49,13 @@ openrouter:
     output_per_million: 0.40
 
 # Moonshot (Kimi). Approximate published rates — verify against your billing.
+# k2.6 verified 2026-08-15 against platform.kimi.ai/docs/pricing/chat-k26.
+# k2.5 is retired but kept so any straggling usage row still prices correctly.
 moonshot:
+  kimi-k2.6:
+    input_per_million: 0.95
+    output_per_million: 4.00
+    cache_read_per_million: 0.16
   kimi-k2.5:
     input_per_million: 0.60
     output_per_million: 2.50

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -222,7 +222,7 @@ The workflows read these repository secrets:
 | `STAGING_SSH_PRIVATE_KEY` | staging | SSH key for `dev-origin.fffeeder.com` |
 | `PRODUCTION_SSH_PRIVATE_KEY` | production | SSH key for `app-origin.fffeeder.com` |
 | `CF_ORIGIN_CERT` / `CF_ORIGIN_KEY` | both | Cloudflare Origin Certificate for kamal-proxy |
-| `ANTHROPIC_API_KEY` / `MOONSHOT_API_KEY` | staging | optional LLM keys for the capability probe job |
+| `ANTHROPIC_API_KEY` / `MOONSHOT_API_KEY` | staging | optional LLM keys for the capability probe job (see [llm-provider-qualification.md](llm-provider-qualification.md)) |
 
 ## Database
 

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -6,10 +6,9 @@ probe run shows it works on the shape production actually calls. The model
 picker offers that list intersected with the credential's own model snapshot, so
 an unqualified model can never be selected and fail asynchronously mid-run.
 
-The probe (`LlmCapabilityProbe`) is the gate. It runs against the real provider
-API — never recorded cassettes, because the question is live third-party
-behavior — and it stays independent of managed credentials, so a provider can be
-qualified before it is wired into the app at all.
+`LlmCapabilityProbe` is the gate. It runs against the real provider API, and
+takes its keys from the environment rather than managed credentials, so a
+provider can be qualified before it is wired into the app.
 
 ## Running it
 
@@ -17,7 +16,8 @@ Keys come from the environment: `ANTHROPIC_API_KEY`, `MOONSHOT_API_KEY`
 (`MOONSHOT_API_BASE` overrides the endpoint). Without a key the run records a
 skip event and ends.
 
-From the dev area — the usual path, and the one that keeps the evidence:
+From the dev area — the usual path, and the one that keeps the evidence
+searchable afterwards:
 
 1. Set the key on the target environment (staging; see
    [deployment-setup.md](deployment-setup.md)).
@@ -68,17 +68,14 @@ schema-valid payload whose content is a refusal fails too.
 
 1. Run the probe against the pair and confirm `models`, `system_prompt`,
    `schema` and `client_tools` pass.
-2. Add the row to `LlmModelCapability::ENTRIES`, with the verification noted in
-   the comment above it.
+2. Add the row to `LlmModelCapability::ENTRIES`.
 3. Add a rates entry in `config/llm_rates.yml`, verified against the provider's
    published pricing — costs shown to users come from it.
 4. If the pair becomes a provider's default, `LlmProvider#default_model` moves
    too; an invariant test requires every provider's default to be in the matrix.
 
-Re-run the probe when the production call shape changes, not just when adding a
-pair. Pinning system prompts to role `system` for Moonshot invalidated the
-earlier Kimi evidence, and that gap is exactly how a wire-format bug reached
-production.
+Re-run the probe when the production call shape changes, not only when adding a
+pair — a change to how requests are built invalidates earlier evidence.
 
 ## Adding a provider
 
@@ -93,6 +90,3 @@ Before a pair can be probed, the provider needs:
 
 The probe's `configure` must mirror production's `LlmProvider#configure`. If
 they drift, the probe qualifies a wire shape the app never sends.
-
-A provider with no matrix rows is simply not selectable for AI feeds, which is
-why an unqualified or unpayable provider can sit in the registry harmlessly.

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -1,0 +1,98 @@
+# Qualifying an LLM provider or model
+
+`LlmModelCapability` is an allowlist of `(provider, model)` pairs the AI engine
+may use, and **membership is qualification**: a pair goes in only after a live
+probe run shows it works on the shape production actually calls. The model
+picker offers that list intersected with the credential's own model snapshot, so
+an unqualified model can never be selected and fail asynchronously mid-run.
+
+The probe (`LlmCapabilityProbe`) is the gate. It runs against the real provider
+API — never recorded cassettes, because the question is live third-party
+behavior — and it stays independent of managed credentials, so a provider can be
+qualified before it is wired into the app at all.
+
+## Running it
+
+Keys come from the environment: `ANTHROPIC_API_KEY`, `MOONSHOT_API_KEY`
+(`MOONSHOT_API_BASE` overrides the endpoint). Without a key the run records a
+skip event and ends.
+
+From the dev area — the usual path, and the one that keeps the evidence:
+
+1. Set the key on the target environment (staging; see
+   [deployment-setup.md](deployment-setup.md)).
+2. Open `/development/jobs`, run `KimiCapabilityProbeJob` or
+   `AnthropicCapabilityProbeJob`, and read the run under `job_runs`.
+
+Each check writes one event with its full evidence — the models listing, the
+tool calls with their arguments and results, the returned payload — so there is
+no separate transcript to chase.
+
+For a one-off pair, or a subset of checks, use the CLI instead:
+
+```sh
+bundle exec ruby script/llm_capability_probe.rb --provider moonshot --model kimi-k3
+bundle exec ruby script/llm_capability_probe.rb --provider anthropic --model claude-sonnet-4-6 --checks models,client_tools
+```
+
+## What it checks, and why only these
+
+Every check mirrors something a feed run does. Provider-hosted retrieval is
+deliberately **not** probed: every provider retrieves through our own
+client-side tools (`LlmClient::Adapter::Base#apply_web`), so whether a model's
+own web search works tells us nothing about a feed.
+
+| Check | What it proves |
+| --- | --- |
+| `models` | The id is served verbatim by the provider's listing — the allowlist matches on exact string |
+| `plain` | Basic round trip |
+| `system_prompt` | The system channel arrives and is obeyed; instructions contradict the obvious answer, so a dropped or rejected prompt fails |
+| `schema` | Strict-schema JSON, repaired the way production repairs it (`Adapter#unwrap_json`) |
+| `client_tools` | The model drives our search and fetch tools through a real multi-round loop and grounds its answer in fetched content — production's gather step |
+| `client_tools_schema` | Schema and tools survive the *same* call — production's combined shape |
+
+Two results need interpretation rather than a pass/fail reading:
+
+- **`client_tools_schema` failing is not disqualifying.** It means the pair needs
+  two-step extraction: gather with tools, then structure in a second call. That
+  is what `LlmClient::Adapter#combined_extraction?` selects, and it is why
+  Moonshot uses two calls where Anthropic uses one.
+- **The run-level `passed` flag is a summary, not a verdict.** Read the checks.
+
+Grounding is judged on what the tools returned, not on what the model says: the
+expected page heading appears in neither the prompt nor the canned search
+results, so an answer can only contain it via a fetch that really happened. A
+schema-valid payload whose content is a refusal fails too.
+
+## Adding a pair
+
+1. Run the probe against the pair and confirm `models`, `system_prompt`,
+   `schema` and `client_tools` pass.
+2. Add the row to `LlmModelCapability::ENTRIES`, with the verification noted in
+   the comment above it.
+3. Add a rates entry in `config/llm_rates.yml`, verified against the provider's
+   published pricing — costs shown to users come from it.
+4. If the pair becomes a provider's default, `LlmProvider#default_model` moves
+   too; an invariant test requires every provider's default to be in the matrix.
+
+Re-run the probe when the production call shape changes, not just when adding a
+pair. Pinning system prompts to role `system` for Moonshot invalidated the
+earlier Kimi evidence, and that gap is exactly how a wire-format bug reached
+production.
+
+## Adding a provider
+
+Before a pair can be probed, the provider needs:
+
+- an `LlmProvider` entry (RubyLLM provider key, default model, API base if it
+  rides another provider's adapter);
+- an `LlmClient::Adapter` subclass, if it needs response repair or one-call
+  extraction;
+- a `LlmCapabilityProbe::Provider` subclass with `env_key`, `configure` and
+  `ruby_llm_provider`, registered in that class's `REGISTRY`.
+
+The probe's `configure` must mirror production's `LlmProvider#configure`. If
+they drift, the probe qualifies a wire shape the app never sends.
+
+A provider with no matrix rows is simply not selectable for AI feeds, which is
+why an unqualified or unpayable provider can sit in the registry harmlessly.

--- a/lib/tasks/ai_schema_verify.rake
+++ b/lib/tasks/ai_schema_verify.rake
@@ -15,7 +15,7 @@ namespace :ai do
       and source_url set to JSON null. Do not include a uid field.
     PROMPT
 
-    [%w[anthropic claude-sonnet-4-6], %w[moonshot kimi-k2.5]].each do |provider_key, model|
+    [%w[anthropic claude-sonnet-4-6], %w[moonshot kimi-k2.6]].each do |provider_key, model|
       unless LlmCapabilityProbe::Provider.configured?(provider_key)
         puts "[#{provider_key}/#{model}] SKIP: no API key in environment"
         next

--- a/script/llm_capability_probe.rb
+++ b/script/llm_capability_probe.rb
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   bundle exec ruby script/llm_capability_probe.rb --provider anthropic --model claude-sonnet-4-6
-#   bundle exec ruby script/llm_capability_probe.rb --provider moonshot --model kimi-k2.6 --checks web_search,two_step
+#   bundle exec ruby script/llm_capability_probe.rb --provider moonshot --model kimi-k2.6 --checks models,client_tools
 #
 # Keys via env: ANTHROPIC_API_KEY, MOONSHOT_API_KEY (MOONSHOT_API_BASE to override).
 

--- a/script/llm_capability_probe.rb
+++ b/script/llm_capability_probe.rb
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   bundle exec ruby script/llm_capability_probe.rb --provider anthropic --model claude-sonnet-4-6
-#   bundle exec ruby script/llm_capability_probe.rb --provider moonshot --model kimi-k2.5 --checks web_search,two_step
+#   bundle exec ruby script/llm_capability_probe.rb --provider moonshot --model kimi-k2.6 --checks web_search,two_step
 #
 # Keys via env: ANTHROPIC_API_KEY, MOONSHOT_API_KEY (MOONSHOT_API_BASE to override).
 

--- a/test/controllers/feed_previews_controller_test.rb
+++ b/test/controllers/feed_previews_controller_test.rb
@@ -162,14 +162,14 @@ class FeedPreviewsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     anthropic = create(:ai_credential, :active, user: user, available_models: models)
     moonshot = create(:ai_credential, :active, user: user, provider: "moonshot",
-                                                available_models: [{ "id" => "kimi-k2.5", "name" => "Kimi K2.5" }])
+                                                available_models: [{ "id" => "kimi-k2.6", "name" => "Kimi K2.6" }])
     source = { prompt: "anything here" }
 
     assert_difference("FeedPreview.count", 2) do
       get feed_preview_url(profile_key: "llm", "params" => source,
                            ai_credential_id: anthropic.id, ai_model: "claude-sonnet-4-6")
       get feed_preview_url(profile_key: "llm", "params" => source,
-                           ai_credential_id: moonshot.id, ai_model: "kimi-k2.5")
+                           ai_credential_id: moonshot.id, ai_model: "kimi-k2.6")
     end
   end
 

--- a/test/models/ai_credential_test.rb
+++ b/test/models/ai_credential_test.rb
@@ -165,9 +165,9 @@ class AiCredentialTest < ActiveSupport::TestCase
 
   test "#default_supported_model should resolve a moonshot credential to its verified model" do
     credential = build(:ai_credential, provider: "moonshot",
-                                       available_models: [{ "id" => "kimi-k2.5" }])
+                                       available_models: [{ "id" => "kimi-k2.6" }])
 
-    assert_equal "kimi-k2.5", credential.default_supported_model
+    assert_equal "kimi-k2.6", credential.default_supported_model
   end
 
   test "#default_supported_model should be nil when nothing is supported" do

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -843,8 +843,8 @@ class FeedTest < ActiveSupport::TestCase
     assert_equal "claude-sonnet-4-6", feed.effective_ai_model
   end
 
-  # The k2.5 retirement (#1186) rides this path: nothing rewrites the feed's
-  # saved model, it just stops being supported and resolves to the successor.
+  # A retired model is never rewritten on the feed; it just stops being
+  # supported and resolves to the successor.
   test "#effective_ai_model should resolve a feed pinned to the retired kimi model" do
     credential = create(:ai_credential, :active, provider: "moonshot",
                                                  available_models: [{ "id" => "kimi-k2.6" }, { "id" => "kimi-k2.5" }])

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -843,6 +843,18 @@ class FeedTest < ActiveSupport::TestCase
     assert_equal "claude-sonnet-4-6", feed.effective_ai_model
   end
 
+  # The k2.5 retirement (#1186) rides this path: nothing rewrites the feed's
+  # saved model, it just stops being supported and resolves to the successor.
+  test "#effective_ai_model should resolve a feed pinned to the retired kimi model" do
+    credential = create(:ai_credential, :active, provider: "moonshot",
+                                                 available_models: [{ "id" => "kimi-k2.6" }, { "id" => "kimi-k2.5" }])
+    feed = build(:feed, user: credential.user, feed_profile_key: "llm",
+                        params: { "prompt" => "x" }, ai_credential: credential, ai_model: "kimi-k2.5")
+
+    assert_not feed.ai_model_supported?
+    assert_equal "kimi-k2.6", feed.effective_ai_model
+  end
+
   test "#ai_model_supported? should follow the credential's matrix-intersected snapshot" do
     credential = create(:ai_credential, :active, available_models: [{ "id" => "claude-sonnet-4-6" }])
     feed = build(:feed, user: credential.user, feed_profile_key: "llm",

--- a/test/models/llm_model_capability_test.rb
+++ b/test/models/llm_model_capability_test.rb
@@ -17,12 +17,6 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
     assert_empty LlmModelCapability.models_for("openrouter")
   end
 
-  test "#capabilities_for should reflect plan-03 verification (Kimi has no server search)" do
-    assert_equal %i[fetch search structured], LlmModelCapability.capabilities_for("anthropic", "claude-sonnet-4-6")
-    assert_equal %i[fetch structured], LlmModelCapability.capabilities_for("moonshot", "kimi-k2.6")
-    assert_not_includes LlmModelCapability.capabilities_for("moonshot", "kimi-k2.6"), :search
-  end
-
   test "every provider with matrix rows should have a supported default_model" do
     providers_with_rows = LlmModelCapability.all.map { |entry| entry[:provider] }.uniq
     providers_with_rows.each do |name|
@@ -32,10 +26,10 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "matrix entries should only use known capability symbols" do
+  test "matrix entries should carry a provider and model and nothing else" do
     LlmModelCapability.all.each do |entry|
-      assert (entry[:capabilities] - LlmModelCapability::CAPABILITIES).empty?,
-             "#{entry[:model]} declares an unknown capability"
+      assert_equal %i[provider model], entry.keys,
+                   "#{entry[:model]} carries metadata no production code reads"
     end
   end
 

--- a/test/models/llm_model_capability_test.rb
+++ b/test/models/llm_model_capability_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class LlmModelCapabilityTest < ActiveSupport::TestCase
   test "#supported? should be true only for allowlisted pairs" do
     assert LlmModelCapability.supported?("anthropic", "claude-sonnet-4-6")
-    assert LlmModelCapability.supported?("moonshot", "kimi-k2.5")
+    assert LlmModelCapability.supported?("moonshot", "kimi-k2.6")
     assert_not LlmModelCapability.supported?("anthropic", "some-unverified-model")
     assert_not LlmModelCapability.supported?("openrouter", "anthropic/claude-sonnet-4-6")
   end
@@ -19,8 +19,8 @@ class LlmModelCapabilityTest < ActiveSupport::TestCase
 
   test "#capabilities_for should reflect plan-03 verification (Kimi has no server search)" do
     assert_equal %i[fetch search structured], LlmModelCapability.capabilities_for("anthropic", "claude-sonnet-4-6")
-    assert_equal %i[fetch structured], LlmModelCapability.capabilities_for("moonshot", "kimi-k2.5")
-    assert_not_includes LlmModelCapability.capabilities_for("moonshot", "kimi-k2.5"), :search
+    assert_equal %i[fetch structured], LlmModelCapability.capabilities_for("moonshot", "kimi-k2.6")
+    assert_not_includes LlmModelCapability.capabilities_for("moonshot", "kimi-k2.6"), :search
   end
 
   test "every provider with matrix rows should have a supported default_model" do

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -34,7 +34,7 @@ class LlmProviderTest < ActiveSupport::TestCase
     provider = LlmProvider.find("moonshot")
     assert_equal "moonshot", provider.name
     assert_equal :openai, provider.ruby_llm_provider
-    assert_equal "kimi-k2.5", provider.default_model
+    assert_equal "kimi-k2.6", provider.default_model
     assert_equal "https://api.moonshot.ai/v1", provider.api_base
     assert provider.assume_model_exists?
   end

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -58,9 +58,8 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   class FakeProvider
     attr_reader :key, :chats
 
-    def initialize(responses, fetch_params: nil, models: [], tool_rounds: [])
+    def initialize(responses, models: [], tool_rounds: [])
       @responses = responses.is_a?(Array) ? responses.dup : [responses]
-      @fetch_params = fetch_params
       @models = models
       @tool_rounds = tool_rounds
       @chats = []
@@ -70,16 +69,12 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     def chat(_model)
       FakeChat.new(@responses.shift, tool_rounds: @tool_rounds).tap { |chat| @chats << chat }
     end
-    def prepare_web(_chat) = nil
-    def web_params(_model) = { tools: [] }
-    def web_search_params(_model) = { tools: [] }
-    def web_fetch_params(_model) = @fetch_params
     def list_models = @models.map { |id| FakeModel.new(id) }
     def unwrap_json(text) = LlmClient::Adapter::Moonshot.new.unwrap_json(text)
   end
 
-  def run_checks(responses, checks, fetch_params: nil, models: [], tool_rounds: [])
-    provider = FakeProvider.new(responses, fetch_params: fetch_params, models: models, tool_rounds: tool_rounds)
+  def run_checks(responses, checks, models: [], tool_rounds: [])
+    provider = FakeProvider.new(responses, models: models, tool_rounds: tool_rounds)
     LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: checks).run
   end
 
@@ -204,67 +199,11 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     assert_equal "schema-valid but the items are a refusal", outcome[:results].first[:note]
   end
 
-  test "#run should fail two_step when the gather step reports no web access" do
-    outcome = run_checks(["I don't have the ability to browse the web.", valid_payload], ["two_step"])
-
-    assert_equal "FAIL", outcome[:results].first[:status]
-    assert_equal "gather reports no web access", outcome[:results].first[:note]
-  end
-
   test "#run should fail the schema check on a non-JSON reply" do
     outcome = run_checks("not json at all", ["schema"])
 
     assert_equal "FAIL", outcome[:results].first[:status]
     assert_match(/non-JSON/, outcome[:results].first[:note])
-  end
-
-  test "#run should pass the web search check on grounded output with URLs" do
-    text = "Latest posts: https://example.com/a — release notes. #{'x' * 80}"
-    outcome = run_checks(text, ["web_search"])
-
-    assert_equal "PASS", outcome[:results].first[:status]
-  end
-
-  test "#run should fail the web search check without URLs" do
-    outcome = run_checks("no links here #{'x' * 80}", ["web_search"])
-
-    assert_equal "FAIL", outcome[:results].first[:status]
-  end
-
-  test "#run should fail the web search check on a refusal that contains URLs" do
-    refusal = "I don't have the ability to browse the live web. Visit https://rubyonrails.org/blog " \
-              "or subscribe to https://rubyonrails.org/feed.xml for updates."
-    outcome = run_checks(refusal, ["web_search"])
-
-    assert_equal "FAIL", outcome[:results].first[:status]
-    assert_equal "model reports no web access", outcome[:results].first[:note]
-  end
-
-  test "#run should skip the web fetch check when the provider has no mechanism" do
-    outcome = run_checks([], ["web_fetch"])
-
-    assert_equal "SKIP", outcome[:results].first[:status]
-    assert outcome[:passed]
-  end
-
-  test "#run should pass the web fetch check when page content is quoted" do
-    outcome = run_checks("The heading says: Example Domain", ["web_fetch"], fetch_params: { tools: [] })
-
-    assert_equal "PASS", outcome[:results].first[:status]
-  end
-
-  test "#run should fail two_step when gather returns blank" do
-    outcome = run_checks("   ", ["two_step"])
-
-    assert_equal "FAIL", outcome[:results].first[:status]
-    assert_match(/gather returned blank/, outcome[:results].first[:note])
-  end
-
-  test "#run should pass two_step when gather feeds a schema-valid structure step" do
-    outcome = run_checks(["gathered post text https://example.com/p", valid_payload], ["two_step"])
-
-    assert_equal "PASS", outcome[:results].first[:status]
-    assert_equal "https://example.com/p", outcome[:results].first[:evidence][:items].first["source_url"]
   end
 
   test "#run should fail the client tools check when the search tool is never called" do
@@ -370,21 +309,6 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     assert_no_match LlmCapabilityProbe::EXPECTED_HEADING, LlmCapabilityProbe::PROBE_INSTRUCTIONS
   end
 
-  test "#run should send system instructions on both two_step calls" do
-    provider = FakeProvider.new(["gathered post text https://example.com/p", valid_payload])
-    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["two_step"]).run
-
-    assert_equal 2, provider.chats.size
-    assert(provider.chats.all? { |chat| chat.instructions == LlmCapabilityProbe::PROBE_INSTRUCTIONS })
-  end
-
-  test "#run should send system instructions on the combined call" do
-    provider = FakeProvider.new(valid_payload)
-    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["combined"]).run
-
-    assert_equal LlmCapabilityProbe::PROBE_INSTRUCTIONS, provider.chats.first.instructions
-  end
-
   test "#run should record an exception as a failed check" do
     outcome = run_checks(RuntimeError.new("boom"), ["plain"])
 
@@ -409,15 +333,9 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     ENV["MOONSHOT_API_KEY"] = original
   end
 
-  test "provider web params should declare the production tool shapes" do
-    anthropic = LlmCapabilityProbe::Provider.build("anthropic")
-    assert_equal %w[web_search web_fetch], anthropic.web_params("m")[:tools].map { |t| t[:name] }
-    assert_equal 1, anthropic.web_search_params("m")[:tools].size
-    assert_equal "web_fetch_20260209", anthropic.web_fetch_params("m")[:tools].first[:type]
-
-    moonshot = LlmCapabilityProbe::Provider.build("moonshot")
-    assert_equal "$web_search", moonshot.web_params("m")[:tools].first[:function][:name]
-    assert_nil moonshot.web_fetch_params("m")
+  test "checks should cover only what production calls" do
+    assert_equal %w[models plain system_prompt schema client_tools client_tools_schema],
+                 LlmCapabilityProbe::Runner::CHECKS
   end
 
   test "moonshot provider should configure the same system-role flag as production" do
@@ -432,9 +350,8 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     ENV["MOONSHOT_API_KEY"] = original
   end
 
-  test "moonshot echo tool should return its arguments verbatim" do
-    tool = LlmCapabilityProbe::MoonshotWebSearchEcho.new
-    assert_equal "$web_search", tool.name
-    assert_equal({ query: "ruby" }, tool.execute(query: "ruby"))
+  test "probe providers should unwrap structured output the way production does" do
+    assert_equal '{"a":1}', LlmCapabilityProbe::Provider.build("moonshot").unwrap_json("```json\n{\"a\":1}\n```")
+    assert_equal '{"a":1}', LlmCapabilityProbe::Provider.build("anthropic").unwrap_json('{"a":1}')
   end
 end

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -312,13 +312,13 @@ class LlmClientTest < ActiveSupport::TestCase
       .with(headers: { "Authorization" => "Bearer sk-moon-test" })
       .to_return(
         status: 200,
-        body: { data: [{ id: "kimi-k2.5", object: "model", owned_by: "moonshot" }] }.to_json,
+        body: { data: [{ id: "kimi-k2.6", object: "model", owned_by: "moonshot" }] }.to_json,
         headers: { "Content-Type" => "application/json" }
       )
 
     models = client.available_models
 
-    assert_equal ["kimi-k2.5"], models.map { |m| m["id"] }
+    assert_equal ["kimi-k2.6"], models.map { |m| m["id"] }
   end
 
   test "#call should raise AuthError for RubyLLM::UnauthorizedError" do


### PR DESCRIPTION
Changes:

- Move Moonshot to `kimi-k2.6`: provider default, matrix row, and a verified rates entry replacing the retired k2.5
- Reduce the matrix to a plain `(provider, model)` allowlist
- Drop the probe's hosted-retrieval checks — `web_search`, `web_fetch`, `two_step`, `combined`, and the Moonshot builtin echo tool
- Add `docs/llm-provider-qualification.md`

A staging run qualified k2.6 on the shape production calls: system prompt honored, client-side tools driven through a real loop with the answer grounded in fetched content, schema-valid structured output. Rates are $0.95 in / $4.00 out per M — up from k2.5, still far below Sonnet.

Feeds pinned to k2.5 need no migration: the saved value simply stops being supported, `effective_ai_model` resolves to the credential's default, and the existing event prompts a re-pick.

The capability sets were read by nothing but their own test — only membership gates anything. They described hosted retrieval, which no feed run touches, since every provider retrieves through our own tools; the one thing that varies between models is already `Adapter#combined_extraction?`. The probe checks that fed those flags go with them.

References:

- Closes #1186
