### PR TITLE
Bound the tool loop, stop transient errors disabling feeds, close client gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-15
 
+- A temporary hiccup while checking an AI credential no longer switches off your feeds — only a key the provider actually rejects does.
+- Fixed AI feeds failing when the model wrapped its answer in a code block or added a line of preamble.
 - Kimi feeds now use K2.6, since Moonshot is retiring K2.5 at the end of August. Feeds still set to the old model switch over on their own — no action needed.
 - Events in the log now start with what happened, so entries that used to show only raw technical output are readable at a glance.
 

--- a/app/jobs/ai_credential_validation_job.rb
+++ b/app/jobs/ai_credential_validation_job.rb
@@ -7,9 +7,10 @@ class AiCredentialValidationJob < ApplicationJob
   queue_as :default
 
   def perform(credential)
-    # Never "validating": restoring that would re-strand a credential a
-    # previous run left stuck.
-    fallback_state = credential.active? ? :active : :pending
+    # Both alternatives are terminal: the validation page polls silently while a
+    # credential is pending or validating, so leaving it either way would spin
+    # forever without ever showing the error.
+    fallback_state = credential.active? ? :active : :inactive
     credential.validating!
 
     models = LlmClient.for(credential).available_models
@@ -20,7 +21,8 @@ class AiCredentialValidationJob < ApplicationJob
     # and a dead key cannot back a running feed.
     credential.deactivate!(last_error: e.message)
   rescue LlmClient::Error => e
-    # Everything else says nothing about the key, so the feeds stay up.
+    # Everything else says nothing about the key, so the feeds stay up — this
+    # deliberately does not take the deactivate! path.
     credential.update!(state: fallback_state, last_error: e.message)
   end
 end

--- a/app/jobs/ai_credential_validation_job.rb
+++ b/app/jobs/ai_credential_validation_job.rb
@@ -7,8 +7,8 @@ class AiCredentialValidationJob < ApplicationJob
   queue_as :default
 
   def perform(credential)
-    # Where a transient failure puts the credential back. Never "validating":
-    # restoring that would re-strand a credential a previous run left stuck.
+    # Never "validating": restoring that would re-strand a credential a
+    # previous run left stuck.
     fallback_state = credential.active? ? :active : :pending
     credential.validating!
 
@@ -16,14 +16,11 @@ class AiCredentialValidationJob < ApplicationJob
     credential.update!(state: :active, available_models: models,
                        last_validated_at: Time.current, last_error: nil)
   rescue LlmClient::AuthError => e
-    # A rejected key is dead, and a dead key cannot back a running feed.
-    # Matched before the provider error it descends from.
+    # Must precede the provider error it descends from. A rejected key is dead,
+    # and a dead key cannot back a running feed.
     credential.deactivate!(last_error: e.message)
   rescue LlmClient::Error => e
-    # A timeout, a 429 or a provider fault says nothing about the key — and
-    # low-tier accounts are rate-limited often enough that treating one as a
-    # dead key would take a user's feeds down routinely. Record it, put the
-    # credential back where it was, and leave the feeds alone.
+    # Everything else says nothing about the key, so the feeds stay up.
     credential.update!(state: fallback_state, last_error: e.message)
   end
 end

--- a/app/jobs/ai_credential_validation_job.rb
+++ b/app/jobs/ai_credential_validation_job.rb
@@ -7,7 +7,9 @@ class AiCredentialValidationJob < ApplicationJob
   queue_as :default
 
   def perform(credential)
-    previous_state = credential.state
+    # Where a transient failure puts the credential back. Never "validating":
+    # restoring that would re-strand a credential a previous run left stuck.
+    fallback_state = credential.active? ? :active : :pending
     credential.validating!
 
     models = LlmClient.for(credential).available_models
@@ -22,6 +24,6 @@ class AiCredentialValidationJob < ApplicationJob
     # low-tier accounts are rate-limited often enough that treating one as a
     # dead key would take a user's feeds down routinely. Record it, put the
     # credential back where it was, and leave the feeds alone.
-    credential.update!(state: previous_state, last_error: e.message)
+    credential.update!(state: fallback_state, last_error: e.message)
   end
 end

--- a/app/jobs/ai_credential_validation_job.rb
+++ b/app/jobs/ai_credential_validation_job.rb
@@ -7,12 +7,21 @@ class AiCredentialValidationJob < ApplicationJob
   queue_as :default
 
   def perform(credential)
+    previous_state = credential.state
     credential.validating!
 
     models = LlmClient.for(credential).available_models
     credential.update!(state: :active, available_models: models,
                        last_validated_at: Time.current, last_error: nil)
-  rescue LlmClient::Error => e
+  rescue LlmClient::AuthError => e
+    # A rejected key is dead, and a dead key cannot back a running feed.
+    # Matched before the provider error it descends from.
     credential.deactivate!(last_error: e.message)
+  rescue LlmClient::Error => e
+    # A timeout, a 429 or a provider fault says nothing about the key — and
+    # low-tier accounts are rate-limited often enough that treating one as a
+    # dead key would take a user's feeds down routinely. Record it, put the
+    # credential back where it was, and leave the feeds alone.
+    credential.update!(state: previous_state, last_error: e.message)
   end
 end

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -67,8 +67,7 @@ class LlmClient
            RubyLLM::InvalidRoleError,
            RubyLLM::InvalidToolChoiceError,
            RubyLLM::UnsupportedAttachmentError,
-           # Invalid JSON in tool-call arguments: a provider-communication
-           # failure like any other, and it must still write a usage row.
+           # Invalid JSON in tool-call arguments; still a billable call.
            JSON::ParserError => e
       Rails.error.report(e, context: error_context(ctx))
       write_usage(ctx, outcome: :provider_error, started_at: started_at, error_message: e.message)
@@ -133,10 +132,9 @@ class LlmClient
   # (metadata warnings, timestamps) is dropped. String keys so the shape
   # round-trips through jsonb unchanged.
   #
-  # Providers whose models aren't in the gem's registry get placeholder limits
-  # rather than real ones, and those would be persisted and rendered as fact
-  # (a 4,096-token context for Kimi). Keep only what the provider itself told
-  # us; the credential page already hides missing fields.
+  # Models outside the gem's registry come back with invented limits, so those
+  # providers keep only what the provider itself reported. The credential page
+  # already hides missing fields.
   def serialize_model(model)
     return { "id" => model.id, "name" => model.name } if credential.llm_provider.assume_model_exists?
 
@@ -178,10 +176,8 @@ class LlmClient
     )
   end
 
-  # A halted tool loop (ToolBudget) returns the halt notice rather than the
-  # model's message, which would throw away everything gathered before the
-  # budget ran out. Fall back to the last thing the model actually said; a
-  # degraded run that keeps its content beats an empty one.
+  # A halted tool loop returns the halt notice in place of the model's message.
+  # Recover what it had already gathered; a degraded run beats an empty one.
   def recover_halted(chat, response)
     return response unless response.is_a?(RubyLLM::Tool::Halt)
 

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -15,9 +15,7 @@ class LlmClient
   DetectionForbidden = Class.new(Error)
   CredentialMissing = Class.new(Error)
 
-  class RateLimited < Error
-    attr_accessor :retry_after
-  end
+  RateLimited = Class.new(Error)
 
   ProviderResponse = Data.define(:payload, :input_tokens, :output_tokens, :cache_write_tokens, :cache_read_tokens)
 
@@ -55,9 +53,7 @@ class LlmClient
       raise
     rescue RubyLLM::RateLimitError => e
       write_usage(ctx, outcome: :rate_limited, started_at: started_at, error_message: e.message)
-      raised = RateLimited.new(e.message)
-      raised.retry_after = e.try(:retry_after)
-      raise raised
+      raise RateLimited, e.message
     rescue Net::ReadTimeout, Net::OpenTimeout, Faraday::TimeoutError => e
       write_usage(ctx, outcome: :timeout, started_at: started_at, error_message: e.message)
       raise Timeout, e.message
@@ -70,7 +66,10 @@ class LlmClient
            RubyLLM::PromptNotFoundError,
            RubyLLM::InvalidRoleError,
            RubyLLM::InvalidToolChoiceError,
-           RubyLLM::UnsupportedAttachmentError => e
+           RubyLLM::UnsupportedAttachmentError,
+           # Invalid JSON in tool-call arguments: a provider-communication
+           # failure like any other, and it must still write a usage row.
+           JSON::ParserError => e
       Rails.error.report(e, context: error_context(ctx))
       write_usage(ctx, outcome: :provider_error, started_at: started_at, error_message: e.message)
       raise ProviderError, e.message
@@ -104,7 +103,7 @@ class LlmClient
     raise AuthError, e.message
   rescue Net::ReadTimeout, Net::OpenTimeout, Faraday::TimeoutError => e
     raise Timeout, e.message
-  rescue RubyLLM::Error, RubyLLM::ConfigurationError, Faraday::ConnectionFailed => e
+  rescue RubyLLM::Error, RubyLLM::ConfigurationError, Faraday::ConnectionFailed, OpenSSL::SSL::SSLError => e
     Rails.error.report(e, context: { credential_id: credential.id, provider: credential.provider })
     raise ProviderError, e.message
   end
@@ -133,7 +132,14 @@ class LlmClient
   # fields worth showing or selecting on later; provider-specific noise
   # (metadata warnings, timestamps) is dropped. String keys so the shape
   # round-trips through jsonb unchanged.
+  #
+  # Providers whose models aren't in the gem's registry get placeholder limits
+  # rather than real ones, and those would be persisted and rendered as fact
+  # (a 4,096-token context for Kimi). Keep only what the provider itself told
+  # us; the credential page already hides missing fields.
   def serialize_model(model)
+    return { "id" => model.id, "name" => model.name } if credential.llm_provider.assume_model_exists?
+
     {
       "id" => model.id,
       "name" => model.name,

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -165,10 +165,24 @@ class LlmClient
     end
 
     response = chat.ask(prompt)
+    answer = recover_halted(chat, response)
     ProviderResponse.new(
-      payload: output_schema.present? ? parse_payload(response) : response_text(response),
+      payload: output_schema.present? ? parse_payload(answer) : response_text(answer),
       **usage_totals(chat, response)
     )
+  end
+
+  # A halted tool loop (ToolBudget) returns the halt notice rather than the
+  # model's message, which would throw away everything gathered before the
+  # budget ran out. Fall back to the last thing the model actually said; a
+  # degraded run that keeps its content beats an empty one.
+  def recover_halted(chat, response)
+    return response unless response.is_a?(RubyLLM::Tool::Halt)
+
+    said = Array(chat.try(:messages)).reverse.find do |message|
+      message.try(:role) == :assistant && message.content.is_a?(String) && message.content.present?
+    end
+    said || response
   end
 
   # A web-enabled call is several billed completions — one per tool round —

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -11,17 +11,21 @@ class LlmClient
       # Every provider uses the same credential-backed search and fetch tools.
       # Adapters may still add provider-specific request params, but search never
       # delegates to a provider-hosted implementation.
+      #
+      # Both tools share one budget so the pair can't outspend it between them.
       def apply_web(chat, model, search_provider:, search_credential:, refresh_event: nil)
         params = web_params(model)
         chat.with_params(**params) if params.present?
+        budget = LlmClient::ToolBudget.new
         chat.with_tool(
           LlmClient::Tools::WebSearch.new(
             provider: search_provider,
             credential: search_credential,
-            refresh_event: refresh_event
+            refresh_event: refresh_event,
+            budget: budget
           )
         )
-        chat.with_tool(LlmClient::Tools::WebFetch)
+        chat.with_tool(LlmClient::Tools::WebFetch.new(budget: budget))
       end
 
       # True when one web+schema call returns grounded, schema-valid JSON; false

--- a/app/services/llm_client/adapter/moonshot.rb
+++ b/app/services/llm_client/adapter/moonshot.rb
@@ -1,9 +1,11 @@
 class LlmClient
   module Adapter
     # Moonshot (Kimi) returns structured output in markdown fences often enough
-    # that JSON must be unwrapped before parsing.
+    # that JSON must be unwrapped before parsing. The fence is matched wherever
+    # it appears and whatever its tag's case, since a model that adds a sentence
+    # of preamble or writes ```JSON is not a different failure.
     class Moonshot < Base
-      FENCE = /\A```[a-z]*\n?(.*?)\n?```\z/m
+      FENCE = /```[a-z]*\n?(.*?)\n?```/mi
 
       def unwrap_json(text)
         stripped = text.to_s.strip

--- a/app/services/llm_client/adapter/moonshot.rb
+++ b/app/services/llm_client/adapter/moonshot.rb
@@ -1,9 +1,8 @@
 class LlmClient
   module Adapter
     # Moonshot (Kimi) returns structured output in markdown fences often enough
-    # that JSON must be unwrapped before parsing. The fence is matched wherever
-    # it appears and whatever its tag's case, since a model that adds a sentence
-    # of preamble or writes ```JSON is not a different failure.
+    # that JSON must be unwrapped before parsing. Matched unanchored and
+    # case-insensitively: preamble prose and a ```JSON tag are the same failure.
     class Moonshot < Base
       FENCE = /```[a-z]*\n?(.*?)\n?```/mi
 

--- a/app/services/llm_client/tool_budget.rb
+++ b/app/services/llm_client/tool_budget.rb
@@ -28,7 +28,7 @@ class LlmClient
     def claim
       @spent += 1
       return nil if @spent <= @rounds
-      return { error: OVER_BUDGET } if @spent <= @rounds + @grace
+      return { error: OVER_BUDGET }.to_json if @spent <= @rounds + @grace
 
       RubyLLM::Tool::Halt.new(HALTED)
     end

--- a/app/services/llm_client/tool_budget.rb
+++ b/app/services/llm_client/tool_budget.rb
@@ -1,12 +1,9 @@
 class LlmClient
-  # Bounds one call's tool loop. Both web tools are billable — LLM rounds plus
-  # search-API calls — and RubyLLM satisfies tool calls for as long as the model
-  # keeps emitting them, so a model stuck searching spends without limit.
+  # Bounds one call's tool loop: RubyLLM satisfies tool calls for as long as the
+  # model emits them, and both web tools cost money every round.
   #
-  # Past the budget the tools stop doing paid work and say so. That alone is
-  # advisory: a model can ignore it and call again. So a couple of rounds later
-  # the loop is halted outright, which is what actually guarantees termination.
-  # The gathered content survives either way (see LlmClient#invoke_provider).
+  # Two stages, and both are needed. Telling the model to stop is advisory — it
+  # can call again — so the halt is what actually guarantees termination.
   class ToolBudget
     ROUNDS = 8
     GRACE = 2

--- a/app/services/llm_client/tool_budget.rb
+++ b/app/services/llm_client/tool_budget.rb
@@ -1,0 +1,36 @@
+class LlmClient
+  # Bounds one call's tool loop. Both web tools are billable — LLM rounds plus
+  # search-API calls — and RubyLLM satisfies tool calls for as long as the model
+  # keeps emitting them, so a model stuck searching spends without limit.
+  #
+  # Past the budget the tools stop doing paid work and say so. That alone is
+  # advisory: a model can ignore it and call again. So a couple of rounds later
+  # the loop is halted outright, which is what actually guarantees termination.
+  # The gathered content survives either way (see LlmClient#invoke_provider).
+  class ToolBudget
+    ROUNDS = 8
+    GRACE = 2
+
+    OVER_BUDGET = "Tool budget spent. Answer now using what you have already gathered, " \
+                  "and do not call any more tools.".freeze
+    HALTED = "Tool budget exceeded; the tool loop was stopped.".freeze
+
+    attr_reader :spent
+
+    def initialize(rounds: ROUNDS, grace: GRACE)
+      @rounds = rounds
+      @grace = grace
+      @spent = 0
+    end
+
+    # nil while the caller may do its paid work, otherwise the result the tool
+    # must return in its place.
+    def claim
+      @spent += 1
+      return nil if @spent <= @rounds
+      return { error: OVER_BUDGET } if @spent <= @rounds + @grace
+
+      RubyLLM::Tool::Halt.new(HALTED)
+    end
+  end
+end

--- a/app/services/llm_client/tools/web_fetch.rb
+++ b/app/services/llm_client/tools/web_fetch.rb
@@ -16,11 +16,12 @@ class LlmClient
         @budget = budget
       end
 
+      # Claimed before the URL is judged: a refused call still cost an LLM
+      # round, and a model looping on bad URLs has to reach the halt too.
       def execute(url:)
-        return { error: "Refused: pass one absolute public http(s) URL." }.to_json unless PublicUrl.safe?(url)
-
         over_budget = @budget&.claim
         return over_budget if over_budget
+        return { error: "Refused: pass one absolute public http(s) URL." }.to_json unless PublicUrl.safe?(url)
 
         # public-only so a redirect can't slip past the check above to an
         # internal address (SSRF; spec 005 §8).

--- a/app/services/llm_client/tools/web_fetch.rb
+++ b/app/services/llm_client/tools/web_fetch.rb
@@ -11,8 +11,16 @@ class LlmClient
       MAX_BYTES = 200_000
       MAX_TEXT = 8_000
 
+      def initialize(budget: nil)
+        super()
+        @budget = budget
+      end
+
       def execute(url:)
         return { error: "Refused: pass one absolute public http(s) URL." } unless PublicUrl.safe?(url)
+
+        over_budget = @budget&.claim
+        return over_budget if over_budget
 
         # public-only so a redirect can't slip past the check above to an
         # internal address (SSRF; spec 005 §8).
@@ -20,7 +28,7 @@ class LlmClient
                              .get(url.to_s.strip, options: { validate_url: PublicUrl.method(:safe?) })
         return { error: "HTTP #{response.status}" } unless response.success?
 
-        { content: readable_text(response.body) }
+        { content: readable_text(response.body) }.to_json
       rescue HttpClient::Error => e
         { error: e.message }
       end

--- a/app/services/llm_client/tools/web_fetch.rb
+++ b/app/services/llm_client/tools/web_fetch.rb
@@ -17,7 +17,7 @@ class LlmClient
       end
 
       def execute(url:)
-        return { error: "Refused: pass one absolute public http(s) URL." } unless PublicUrl.safe?(url)
+        return { error: "Refused: pass one absolute public http(s) URL." }.to_json unless PublicUrl.safe?(url)
 
         over_budget = @budget&.claim
         return over_budget if over_budget
@@ -26,11 +26,11 @@ class LlmClient
         # internal address (SSRF; spec 005 §8).
         response = HttpClient.build(max_redirects: MAX_REDIRECTS)
                              .get(url.to_s.strip, options: { validate_url: PublicUrl.method(:safe?) })
-        return { error: "HTTP #{response.status}" } unless response.success?
+        return { error: "HTTP #{response.status}" }.to_json unless response.success?
 
         { content: readable_text(response.body) }.to_json
       rescue HttpClient::Error => e
-        { error: e.message }
+        { error: e.message }.to_json
       end
 
       private

--- a/app/services/llm_client/tools/web_search.rb
+++ b/app/services/llm_client/tools/web_search.rb
@@ -22,7 +22,7 @@ class LlmClient
       end
 
       def execute(query:)
-        return { error: "Refused: query must not be blank." } if query.blank?
+        return { error: "Refused: query must not be blank." }.to_json if query.blank?
 
         over_budget = @budget&.claim
         return over_budget if over_budget
@@ -33,7 +33,7 @@ class LlmClient
       rescue ::WebSearchProvider::AuthError
         raise
       rescue ::WebSearchProvider::Error => e
-        { error: e.message }
+        { error: e.message }.to_json
       end
 
       private

--- a/app/services/llm_client/tools/web_search.rb
+++ b/app/services/llm_client/tools/web_search.rb
@@ -21,11 +21,12 @@ class LlmClient
         @budget = budget
       end
 
+      # Claimed before the argument is judged: a refused call still cost an LLM
+      # round, and a model looping on bad arguments has to reach the halt too.
       def execute(query:)
-        return { error: "Refused: query must not be blank." }.to_json if query.blank?
-
         over_budget = @budget&.claim
         return over_budget if over_budget
+        return { error: "Refused: query must not be blank." }.to_json if query.blank?
 
         record_usage
         results = @provider.search(query, max_results: MAX_RESULTS)

--- a/app/services/llm_client/tools/web_search.rb
+++ b/app/services/llm_client/tools/web_search.rb
@@ -13,19 +13,23 @@ class LlmClient
 
       MAX_RESULTS = 5
 
-      def initialize(provider:, credential:, refresh_event: nil)
+      def initialize(provider:, credential:, refresh_event: nil, budget: nil)
         super()
         @provider = provider
         @credential = credential
         @refresh_event = refresh_event
+        @budget = budget
       end
 
       def execute(query:)
         return { error: "Refused: query must not be blank." } if query.blank?
 
+        over_budget = @budget&.claim
+        return over_budget if over_budget
+
         record_usage
         results = @provider.search(query, max_results: MAX_RESULTS)
-        { results: results.map(&:to_h) }
+        { results: results.map(&:to_h) }.to_json
       rescue ::WebSearchProvider::AuthError
         raise
       rescue ::WebSearchProvider::Error => e

--- a/test/jobs/ai_credential_validation_job_test.rb
+++ b/test/jobs/ai_credential_validation_job_test.rb
@@ -41,10 +41,10 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
     assert_nil credential.last_error
   end
 
-  test "#perform should move credential to inactive and record the error on provider failure" do
+  test "#perform should deactivate the credential and its feeds when the key is rejected" do
     feed = create(:feed, :enabled, user: user, ai_credential: credential)
 
-    stub_available_models(LlmClient::ProviderError.new("invalid api key")) do
+    stub_available_models(LlmClient::AuthError.new("invalid api key")) do
       AiCredentialValidationJob.perform_now(credential)
     end
 
@@ -56,12 +56,30 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
     assert Event.exists?(subject: credential, type: "ai_credential_deactivated")
   end
 
-  test "#perform should move credential to inactive on rate-limit during validation" do
+  test "#perform should leave feeds running when the provider fails transiently" do
+    active = create(:ai_credential, user: user, state: :active)
+    feed = create(:feed, :enabled, user: user, ai_credential: active)
+
+    stub_available_models(LlmClient::ProviderError.new("500 upstream")) do
+      AiCredentialValidationJob.perform_now(active)
+    end
+
+    active.reload
+    assert_equal "active", active.state
+    assert_equal "500 upstream", active.last_error
+    assert_equal "enabled", feed.reload.state
+    assert_not Event.exists?(subject: active, type: "ai_credential_deactivated")
+  end
+
+  test "#perform should not deactivate on a rate limit during validation" do
+    feed = create(:feed, :enabled, user: user, ai_credential: credential)
+
     stub_available_models(LlmClient::RateLimited.new("429")) do
       AiCredentialValidationJob.perform_now(credential)
     end
 
-    assert_equal "inactive", credential.reload.state
+    assert_equal "pending", credential.reload.state
+    assert_equal "enabled", feed.reload.state
   end
 
   # No LlmClient stubbing: goes through the real client so an error the
@@ -73,7 +91,7 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
     end
 
     credential.reload
-    assert_equal "inactive", credential.state
+    assert_equal "pending", credential.state
     assert_match "unknown RubyLLM provider", credential.last_error
   end
 
@@ -85,7 +103,7 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
     AiCredentialValidationJob.perform_now(moonshot)
 
     moonshot.reload
-    assert_equal "inactive", moonshot.state
+    assert_equal "pending", moonshot.state
     assert_not_nil moonshot.last_error
   end
 end

--- a/test/jobs/ai_credential_validation_job_test.rb
+++ b/test/jobs/ai_credential_validation_job_test.rb
@@ -78,8 +78,20 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
       AiCredentialValidationJob.perform_now(credential)
     end
 
-    assert_equal "pending", credential.reload.state
     assert_equal "enabled", feed.reload.state
+    assert_not Event.exists?(subject: credential, type: "ai_credential_deactivated")
+  end
+
+  # The validation page polls silently while a credential is pending or
+  # validating, so a transient failure has to leave a state that settles.
+  test "#perform should settle a never-active credential rather than leave it polling" do
+    stub_available_models(LlmClient::ProviderError.new("500 upstream")) do
+      AiCredentialValidationJob.perform_now(credential)
+    end
+
+    credential.reload
+    assert_predicate credential, :inactive?
+    assert_equal "500 upstream", credential.last_error
   end
 
   # No LlmClient stubbing: goes through the real client so an error the
@@ -91,7 +103,7 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
     end
 
     credential.reload
-    assert_equal "pending", credential.state
+    assert_equal "inactive", credential.state
     assert_match "unknown RubyLLM provider", credential.last_error
   end
 
@@ -103,7 +115,7 @@ class AiCredentialValidationJobTest < ActiveJob::TestCase
     AiCredentialValidationJob.perform_now(moonshot)
 
     moonshot.reload
-    assert_equal "pending", moonshot.state
+    assert_equal "inactive", moonshot.state
     assert_not_nil moonshot.last_error
   end
 end

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -56,7 +56,11 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
       assert_same provider, search_tool.instance_variable_get(:@provider), name
       assert_same context[:search_credential], search_tool.instance_variable_get(:@credential), name
       assert_same context[:refresh_event], search_tool.instance_variable_get(:@refresh_event), name
-      assert_equal LlmClient::Tools::WebFetch, fetch_tool, name
+      assert_instance_of LlmClient::Tools::WebFetch, fetch_tool, name
+
+      budget = search_tool.instance_variable_get(:@budget)
+      assert_instance_of LlmClient::ToolBudget, budget, name
+      assert_same budget, fetch_tool.instance_variable_get(:@budget), name
     end
   end
 
@@ -104,6 +108,13 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_equal '{"a":1}', adapter.unwrap_json("```\n{\"a\":1}\n```")
     assert_equal '{"a":1}', adapter.unwrap_json('{"a":1}')
     assert_equal '{"a":1}', adapter.unwrap_json("  {\"a\":1}  ")
+  end
+
+  test "moonshot #unwrap_json should tolerate prose around the fence and an uppercase tag" do
+    adapter = LlmClient::Adapter::Moonshot.new
+
+    assert_equal '{"a":1}', adapter.unwrap_json("Here you go:\n```json\n{\"a\":1}\n```\nHope that helps.")
+    assert_equal '{"a":1}', adapter.unwrap_json("```JSON\n{\"a\":1}\n```")
   end
 
   test "base #unwrap_json should be identity" do

--- a/test/services/llm_client/tool_budget_test.rb
+++ b/test/services/llm_client/tool_budget_test.rb
@@ -38,6 +38,18 @@ class LlmClient::ToolBudgetTest < ActiveSupport::TestCase
 
     assert_nil shared.claim
     assert_instance_of RubyLLM::Tool::Halt, fetch.execute(url: "https://example.com/")
-    assert_match(/Refused/, JSON.parse(search.execute(query: ""))["error"])
+    assert_instance_of RubyLLM::Tool::Halt, search.execute(query: "anything")
+  end
+
+  # A refused call still costs an LLM round, so a model looping on bad
+  # arguments has to reach the halt like any other.
+  test "calls refused for bad arguments should still spend the budget" do
+    shared = LlmClient::ToolBudget.new(rounds: 1, grace: 0)
+    search = LlmClient::Tools::WebSearch.new(provider: nil, credential: nil, budget: shared)
+    fetch = LlmClient::Tools::WebFetch.new(budget: shared)
+
+    assert_match(/Refused/, JSON.parse(search.execute(query: "  "))["error"])
+    assert_instance_of RubyLLM::Tool::Halt, fetch.execute(url: "ftp://example.com")
+    assert_equal 2, shared.spent
   end
 end

--- a/test/services/llm_client/tool_budget_test.rb
+++ b/test/services/llm_client/tool_budget_test.rb
@@ -14,7 +14,7 @@ class LlmClient::ToolBudgetTest < ActiveSupport::TestCase
   test "#claim should tell the model to answer once the budget is spent" do
     2.times { budget.claim }
 
-    assert_equal({ error: LlmClient::ToolBudget::OVER_BUDGET }, budget.claim)
+    assert_equal LlmClient::ToolBudget::OVER_BUDGET, JSON.parse(budget.claim)["error"]
   end
 
   test "#claim should halt the loop when the model keeps calling past the grace" do
@@ -38,6 +38,6 @@ class LlmClient::ToolBudgetTest < ActiveSupport::TestCase
 
     assert_nil shared.claim
     assert_instance_of RubyLLM::Tool::Halt, fetch.execute(url: "https://example.com/")
-    assert_equal({ error: "Refused: query must not be blank." }, search.execute(query: ""))
+    assert_match(/Refused/, JSON.parse(search.execute(query: ""))["error"])
   end
 end

--- a/test/services/llm_client/tool_budget_test.rb
+++ b/test/services/llm_client/tool_budget_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class LlmClient::ToolBudgetTest < ActiveSupport::TestCase
+  def budget(rounds: 2, grace: 1)
+    @budget ||= LlmClient::ToolBudget.new(rounds: rounds, grace: grace)
+  end
+
+  test "#claim should allow work while the budget lasts" do
+    assert_nil budget.claim
+    assert_nil budget.claim
+    assert_equal 2, budget.spent
+  end
+
+  test "#claim should tell the model to answer once the budget is spent" do
+    2.times { budget.claim }
+
+    assert_equal({ error: LlmClient::ToolBudget::OVER_BUDGET }, budget.claim)
+  end
+
+  test "#claim should halt the loop when the model keeps calling past the grace" do
+    3.times { budget.claim }
+
+    halt = budget.claim
+    assert_instance_of RubyLLM::Tool::Halt, halt
+    assert_equal LlmClient::ToolBudget::HALTED, halt.content
+  end
+
+  test "#claim should keep halting once halted" do
+    5.times { budget.claim }
+
+    assert_instance_of RubyLLM::Tool::Halt, budget.claim
+  end
+
+  test "the shared budget should count both tools together" do
+    shared = LlmClient::ToolBudget.new(rounds: 1, grace: 0)
+    search = LlmClient::Tools::WebSearch.new(provider: nil, credential: nil, budget: shared)
+    fetch = LlmClient::Tools::WebFetch.new(budget: shared)
+
+    assert_nil shared.claim
+    assert_instance_of RubyLLM::Tool::Halt, fetch.execute(url: "https://example.com/")
+    assert_equal({ error: "Refused: query must not be blank." }, search.execute(query: ""))
+  end
+end

--- a/test/services/llm_client/tools/web_fetch_test.rb
+++ b/test/services/llm_client/tools/web_fetch_test.rb
@@ -30,8 +30,8 @@ class LlmClient::Tools::WebFetchTest < ActiveSupport::TestCase
 
   test "#execute should fetch a public URL and return stripped, capped text" do
     with_client(ok_response("<h1>Title</h1>  <p>Body   text</p>")) do
-      result = tool.execute(url: "https://example.com/post")
-      assert_equal "Title Body text", result[:content]
+      result = JSON.parse(tool.execute(url: "https://example.com/post"))
+      assert_equal "Title Body text", result["content"]
     end
   end
 

--- a/test/services/llm_client/tools/web_fetch_test.rb
+++ b/test/services/llm_client/tools/web_fetch_test.rb
@@ -37,8 +37,8 @@ class LlmClient::Tools::WebFetchTest < ActiveSupport::TestCase
 
   test "#execute should refuse non-http schemes without making a request" do
     with_client(ok_response) do |client|
-      assert_match(/Refused/, tool.execute(url: "ftp://example.com")[:error])
-      assert_match(/Refused/, tool.execute(url: "file:///etc/passwd")[:error])
+      assert_match(/Refused/, JSON.parse(tool.execute(url: "ftp://example.com"))["error"])
+      assert_match(/Refused/, JSON.parse(tool.execute(url: "file:///etc/passwd"))["error"])
       assert_empty client.requested
     end
   end
@@ -49,7 +49,7 @@ class LlmClient::Tools::WebFetchTest < ActiveSupport::TestCase
         http://localhost/x http://127.0.0.1/x http://10.1.2.3/ http://192.168.0.1/
         http://172.16.5.5/ http://169.254.169.254/latest/meta-data/ http://[::1]/
       ].each do |url|
-        assert_match(/Refused/, tool.execute(url: url)[:error], url)
+        assert_match(/Refused/, JSON.parse(tool.execute(url: url))["error"], url)
       end
       assert_empty client.requested
     end
@@ -57,14 +57,14 @@ class LlmClient::Tools::WebFetchTest < ActiveSupport::TestCase
 
   test "#execute should refuse a URL carrying credentials" do
     with_client(ok_response) do |client|
-      assert_match(/Refused/, tool.execute(url: "https://user:pass@example.com/")[:error])
+      assert_match(/Refused/, JSON.parse(tool.execute(url: "https://user:pass@example.com/"))["error"])
       assert_empty client.requested
     end
   end
 
   test "#execute should report a non-success HTTP status" do
     with_client(HttpClient::Response.new(status: 404, body: "")) do
-      assert_equal "HTTP 404", tool.execute(url: "https://example.com/missing")[:error]
+      assert_equal "HTTP 404", JSON.parse(tool.execute(url: "https://example.com/missing"))["error"]
     end
   end
 
@@ -73,7 +73,7 @@ class LlmClient::Tools::WebFetchTest < ActiveSupport::TestCase
     def raising.get(_url, **) = raise(HttpClient::TimeoutError, "timed out")
 
     HttpClient.stub(:build, ->(**) { raising }) do
-      assert_equal "timed out", tool.execute(url: "https://example.com/")[:error]
+      assert_equal "timed out", JSON.parse(tool.execute(url: "https://example.com/"))["error"]
     end
   end
 
@@ -81,9 +81,9 @@ class LlmClient::Tools::WebFetchTest < ActiveSupport::TestCase
     url = "https://example.com/page"
     stub_request(:get, url).to_return(status: 302, headers: { "Location" => "http://127.0.0.1/metadata" })
 
-    result = tool.execute(url: url)
+    result = JSON.parse(tool.execute(url: url))
 
-    assert result[:error].present?
+    assert result["error"].present?
     assert_not_requested :get, "http://127.0.0.1/metadata"
   end
 end

--- a/test/services/llm_client/tools/web_search_test.rb
+++ b/test/services/llm_client/tools/web_search_test.rb
@@ -40,12 +40,12 @@ class LlmClient::Tools::WebSearchTest < ActiveSupport::TestCase
     provider = FakeProvider.new(results: [result(1), result(2)])
 
     assert_difference("Event.where(type: WebSearchUsage::EVENT_TYPE).count", 1) do
-      payload = tool(provider).execute(query: "ruby feeds")
+      payload = JSON.parse(tool(provider).execute(query: "ruby feeds"))
 
       assert_equal [
-        { title: "T1", url: "https://1.example", snippet: "s1" },
-        { title: "T2", url: "https://2.example", snippet: "s2" }
-      ], payload[:results]
+        { "title" => "T1", "url" => "https://1.example", "snippet" => "s1" },
+        { "title" => "T2", "url" => "https://2.example", "snippet" => "s2" }
+      ], payload["results"]
     end
 
     event = Event.where(type: WebSearchUsage::EVENT_TYPE).order(:id).last
@@ -105,9 +105,9 @@ class LlmClient::Tools::WebSearchTest < ActiveSupport::TestCase
     failing = ->(**) { raise ActiveRecord::RecordInvalid }
 
     WebSearchUsage.stub(:record!, failing) do
-      payload = tool(provider).execute(query: "ruby feeds")
+      payload = JSON.parse(tool(provider).execute(query: "ruby feeds"))
 
-      assert_equal 1, payload[:results].size
+      assert_equal 1, payload["results"].size
     end
   end
 end

--- a/test/services/llm_client/tools/web_search_test.rb
+++ b/test/services/llm_client/tools/web_search_test.rb
@@ -69,7 +69,7 @@ class LlmClient::Tools::WebSearchTest < ActiveSupport::TestCase
     provider = FakeProvider.new
 
     assert_no_difference("Event.where(type: WebSearchUsage::EVENT_TYPE).count") do
-      assert_match(/Refused/, tool(provider).execute(query: "  ")[:error])
+      assert_match(/Refused/, JSON.parse(tool(provider).execute(query: "  "))["error"])
     end
     assert_empty provider.queries
   end
@@ -78,7 +78,7 @@ class LlmClient::Tools::WebSearchTest < ActiveSupport::TestCase
     provider = FakeProvider.new(error: WebSearchProvider::ConfigurationError.new("Serper API key missing"))
 
     assert_difference("Event.where(type: WebSearchUsage::EVENT_TYPE).count", 1) do
-      assert_equal "Serper API key missing", tool(provider).execute(query: "ruby feeds")[:error]
+      assert_equal "Serper API key missing", JSON.parse(tool(provider).execute(query: "ruby feeds"))["error"]
     end
   end
 
@@ -86,7 +86,7 @@ class LlmClient::Tools::WebSearchTest < ActiveSupport::TestCase
     provider = FakeProvider.new(error: WebSearchProvider::ProviderError.new("Serper: HTTP 429"))
 
     assert_difference("Event.where(type: WebSearchUsage::EVENT_TYPE).count", 1) do
-      assert_equal "Serper: HTTP 429", tool(provider).execute(query: "ruby feeds")[:error]
+      assert_equal "Serper: HTTP 429", JSON.parse(tool(provider).execute(query: "ruby feeds"))["error"]
     end
   end
 

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -381,6 +381,19 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal "provider_error", LlmUsage.last.outcome
   end
 
+  # Invalid JSON in tool-call arguments would otherwise escape the taxonomy and
+  # leave the call unbilled.
+  test "#call should map malformed tool-call arguments to ProviderError" do
+    client = LlmClient.new(credential)
+    stub_provider_to_raise(client, JSON::ParserError.new("unexpected token"))
+
+    assert_difference("LlmUsage.count", 1) do
+      assert_raises(LlmClient::ProviderError) { client.call(default_ctx, **call_opts) }
+    end
+
+    assert_equal "provider_error", LlmUsage.last.outcome
+  end
+
   # A chat double that records the system prompt and the asked user prompt, so we
   # can verify the system message travels via with_instructions and the user
   # prompt via #ask — the injection-defense channel separation (spec §8).
@@ -406,6 +419,49 @@ class LlmClientTest < ActiveSupport::TestCase
     def initialize(messages)
       @messages = messages
     end
+  end
+
+  # A halted tool loop: RubyLLM returns the halt notice itself rather than a
+  # message, with the model's earlier turns left on the chat.
+  class FakeHaltedChat < FakeChat
+    attr_reader :messages
+
+    def initialize(messages)
+      @messages = messages
+    end
+
+    def ask(prompt)
+      @asked = prompt
+      RubyLLM::Tool::Halt.new(LlmClient::ToolBudget::HALTED)
+    end
+  end
+
+  def assistant_message(content)
+    Data.define(:role, :content, :input_tokens, :output_tokens, :cache_write_tokens, :cache_read_tokens)
+        .new(role: :assistant, content: content, input_tokens: 1, output_tokens: 1,
+             cache_write_tokens: 0, cache_read_tokens: 0)
+  end
+
+  test "#invoke_provider should keep what the model gathered when the tool loop halts" do
+    client = LlmClient.new(credential)
+    chat = FakeHaltedChat.new([assistant_message("gathered so far"), assistant_message(nil)])
+
+    response = stub_chat(client, chat) do
+      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "p", output_schema: nil, web: false, system: nil)
+    end
+
+    assert_equal "gathered so far", response.payload
+  end
+
+  test "#invoke_provider should fall back to the halt notice when the model said nothing" do
+    client = LlmClient.new(credential)
+    chat = FakeHaltedChat.new([])
+
+    response = stub_chat(client, chat) do
+      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "p", output_schema: nil, web: false, system: nil)
+    end
+
+    assert_equal LlmClient::ToolBudget::HALTED, response.payload
   end
 
   # Returns a response carrying distinct cache counts, so a swap between the

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -221,6 +221,25 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal 0, LlmUsage.count
   end
 
+  # RubyLLM invents context/output limits for models it doesn't know, and those
+  # would be persisted and rendered as fact on the credential page.
+  test "#available_models should keep only provider-supplied fields for unregistered models" do
+    moonshot = create(:ai_credential, user: user, provider: "moonshot",
+                                      credential_data: { "api_key" => "sk-moon" })
+    client = LlmClient.new(moonshot)
+    model = fake_model(id: "kimi-k2.6", name: "Kimi K2.6", context_window: 4_096)
+    stub_provider_models(client) { [model] }
+
+    assert_equal [{ "id" => "kimi-k2.6", "name" => "Kimi K2.6" }], client.available_models
+  end
+
+  test "#available_models should map a TLS failure to a provider error" do
+    client = LlmClient.new(credential)
+    client.define_singleton_method(:fetch_provider_models) { raise OpenSSL::SSL::SSLError, "handshake failed" }
+
+    assert_raises(LlmClient::ProviderError) { client.available_models }
+  end
+
   test "#available_models should return an empty array when the provider lists no models" do
     client = LlmClient.new(credential)
     stub_provider_models(client) { [] }

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -221,8 +221,7 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal 0, LlmUsage.count
   end
 
-  # RubyLLM invents context/output limits for models it doesn't know, and those
-  # would be persisted and rendered as fact on the credential page.
+  # The invented limits would otherwise be persisted and rendered as fact.
   test "#available_models should keep only provider-supplied fields for unregistered models" do
     moonshot = create(:ai_credential, user: user, provider: "moonshot",
                                       credential_data: { "api_key" => "sk-moon" })
@@ -381,8 +380,6 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal "provider_error", LlmUsage.last.outcome
   end
 
-  # Invalid JSON in tool-call arguments would otherwise escape the taxonomy and
-  # leave the call unbilled.
   test "#call should map malformed tool-call arguments to ProviderError" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, JSON::ParserError.new("unexpected token"))
@@ -421,8 +418,8 @@ class LlmClientTest < ActiveSupport::TestCase
     end
   end
 
-  # A halted tool loop: RubyLLM returns the halt notice itself rather than a
-  # message, with the model's earlier turns left on the chat.
+  # RubyLLM returns the halt notice itself rather than a message, leaving the
+  # model's earlier turns on the chat.
   class FakeHaltedChat < FakeChat
     attr_reader :messages
 


### PR DESCRIPTION
Changes:

- Bound the tool-call loop with a per-call budget shared by both web tools
- Deactivate an AI credential only when the key is rejected; transient failures leave the user's feeds running
- Fence unwrapping tolerates preamble prose and an uppercase tag
- Malformed tool arguments and TLS failures join the error taxonomy
- Persist only provider-reported model fields for models outside the gem's registry
- Web tools return JSON rather than Ruby inspect output

Nothing bounded the tool loop, and both tools bill on every round. Past the budget they stop doing paid work and say so; that is advisory, so the loop halts outright two rounds later. A halt returns the notice in place of the model's message, so the client recovers what was gathered before it fired.

Validation treated every failure as a dead key, deactivating the credential and bulk-disabling every feed on it — a 429 is routine on low-tier accounts, and re-validating never re-enabled the feeds. Auth errors keep the full deactivation and are matched first, since they descend from the provider error.

References:

- Closes #1188
- Closes #1189
- Closes #1191
