### PR TITLE
Stop Kimi fence stripping from eating quoted fences

### DIFF
--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -53,6 +53,7 @@ module LlmCapabilityProbe
   def self.refusal?(text)
     text.to_s.match?(REFUSAL_MARKERS)
   end
+
   # Mirrors production's structuring stage: fixed text in, strict JSON out.
   STRUCTURE_PROMPT_PREFIX = "Convert the gathered web content below into the required JSON object. " \
                             "Use only what is present; do not invent items or fields.\n\nGATHERED CONTENT:\n"
@@ -91,8 +92,9 @@ module LlmCapabilityProbe
 
     def name = SEARCH_TOOL_NAME
 
+    # Serialized like the production tool, so the loop sees the same wire shape.
     def execute(query:)
-      { results: RESULTS }
+      { results: RESULTS }.to_json
     end
   end
 

--- a/app/services/llm_client/adapter/moonshot.rb
+++ b/app/services/llm_client/adapter/moonshot.rb
@@ -1,13 +1,19 @@
 class LlmClient
   module Adapter
     # Moonshot (Kimi) returns structured output in markdown fences often enough
-    # that JSON must be unwrapped before parsing. Matched unanchored and
-    # case-insensitively: preamble prose and a ```JSON tag are the same failure.
+    # that JSON must be unwrapped before parsing.
     class Moonshot < Base
-      FENCE = /```[a-z]*\n?(.*?)\n?```/mi
+      # Unanchored and case-insensitive, so preamble prose and a ```JSON tag are
+      # both absorbed. Greedy on purpose: the payload itself may quote a fenced
+      # code block, and the closing fence is the last one, not the first.
+      FENCE = /```[a-z]*\n?(.*)\n?```/mi
 
       def unwrap_json(text)
         stripped = text.to_s.strip
+        # Already-clean JSON is returned untouched — a fence quoted inside a
+        # string value is content, not a wrapper.
+        return stripped if stripped.start_with?("{", "[")
+
         match = stripped.match(FENCE)
         match ? match[1].strip : stripped
       end

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -255,9 +255,9 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   end
 
   test "canned web search should return fixed real URLs without touching a search provider" do
-    result = LlmCapabilityProbe::CannedWebSearch.new.execute(query: "anything")
+    result = JSON.parse(LlmCapabilityProbe::CannedWebSearch.new.execute(query: "anything"))
 
-    assert_equal ["https://example.com/"], result[:results].map { |r| r["url"] }
+    assert_equal ["https://example.com/"], result["results"].map { |r| r["url"] }
   end
 
   test "#run should attach the schema and both client tools to one chat for client_tools_schema" do

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -117,6 +117,21 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_equal '{"a":1}', adapter.unwrap_json("```JSON\n{\"a\":1}\n```")
   end
 
+  # A gathered post can quote a code block, so a fence inside the payload is
+  # content. Unwrapping it as if it were the wrapper corrupts valid JSON.
+  test "moonshot #unwrap_json should leave a fence quoted inside the payload alone" do
+    adapter = LlmClient::Adapter::Moonshot.new
+    payload = %q({"items":[{"body":"install it: ```ruby\ngem \"foo\"\n``` done"}]})
+
+    assert_equal payload, adapter.unwrap_json(payload)
+    assert_equal payload, adapter.unwrap_json("```json\n#{payload}\n```")
+    assert JSON.parse(adapter.unwrap_json("```json\n#{payload}\n```"))
+  end
+
+  test "moonshot #unwrap_json should pass a bare JSON array through" do
+    assert_equal '[{"a":1}]', LlmClient::Adapter::Moonshot.new.unwrap_json('[{"a":1}]')
+  end
+
   test "base #unwrap_json should be identity" do
     assert_equal "```json\n{}\n```", LlmClient::Adapter::Base.new.unwrap_json("```json\n{}\n```")
   end


### PR DESCRIPTION
Changes:

- Stop Kimi's fence stripping from unwrapping a code block quoted inside the JSON payload
- Make the capability probe's canned search return the same wire shape as the production search tool

Opening the fence match up to preamble prose also made it unanchored and lazy, so it began matching fences *inside* the payload rather than only one wrapping it. A gathered post that quotes a code block — ordinary content for a technical feed — corrupted the JSON before parsing and failed the run. Kimi is the only provider that de-fences, so this is Kimi-specific.

The probe change is fidelity, not a fix: the stand-in returned a Hash where the real tool returns a JSON string, which is exactly the divergence that stand-in exists to avoid.

References:

- Related PR: #1253
