### PR TITLE
Send feed editor Cancel back to the feed page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-15
 
+- Canceling out of a feed's settings now takes you back to that feed instead of the feeds list.
 - A temporary hiccup while checking an AI credential no longer switches off your feeds — only a key the provider actually rejects does.
 - Fixed AI feeds failing when the model wrapped its answer in a code block or added a line of preamble.
 - Kimi feeds now use K2.6, since Moonshot is retiring K2.5 at the end of August. Feeds still set to the old model switch over on their own — no action needed.

--- a/app/components/feed_form_component.html.erb
+++ b/app/components/feed_form_component.html.erb
@@ -319,7 +319,7 @@
                    disabled: checking?,
                    class: submit_classes,
                    data: { turbo_submits_with: "Saving…" } %>
-      <%= link_to "Cancel", helpers.feeds_path, class: helpers.secondary_button_classes %>
+      <%= link_to "Cancel", cancel_path, class: helpers.secondary_button_classes %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/feed_form_component.rb
+++ b/app/components/feed_form_component.rb
@@ -71,9 +71,6 @@ class FeedFormComponent < ViewComponent::Base
     edit_mode? ? :patch : :post
   end
 
-  # Backing out of an edit returns to the feed's own page — including a draft's,
-  # which exists as soon as the feed is saved. Only an unsaved feed has no page
-  # to return to, so creation falls back to the list.
   def cancel_path
     edit_mode? ? helpers.feed_path(feed) : helpers.feeds_path
   end

--- a/app/components/feed_form_component.rb
+++ b/app/components/feed_form_component.rb
@@ -71,6 +71,13 @@ class FeedFormComponent < ViewComponent::Base
     edit_mode? ? :patch : :post
   end
 
+  # Backing out of an edit returns to the feed's own page — including a draft's,
+  # which exists as soon as the feed is saved. Only an unsaved feed has no page
+  # to return to, so creation falls back to the list.
+  def cancel_path
+    edit_mode? ? helpers.feed_path(feed) : helpers.feeds_path
+  end
+
   # feed_id is nil (and dropped from the URL) for an unpersisted feed.
   def form_data
     {

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -736,6 +736,25 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='form.source-locked-note']", count: 0
   end
 
+  test "#edit should point Cancel to the feed page" do
+    sign_in_as(user)
+    draft = create(:feed, :draft, user: user)
+
+    get edit_feed_url(draft)
+
+    assert_response :success
+    assert_select "a[href=?]", feed_path(draft), text: "Cancel"
+  end
+
+  test "#new should point Cancel to the feeds list" do
+    sign_in_as(user)
+
+    get new_feed_url
+
+    assert_response :success
+    assert_select "a[href=?]", feeds_path, text: "Cancel"
+  end
+
   test "#edit should show the editable prompt for a query-shaped AI feed" do
     sign_in_as(user)
     prompt_feed = create(:feed, user: user, feed_profile_key: "llm", params: { "prompt" => "cat pictures" })


### PR DESCRIPTION
Changes:

- Cancel in the feed editor returns to the feed's own page when the feed exists (drafts included), and to the feeds list only when creating a new one.
- Added tests for both cases.

Backing out of edits used to always land on the feeds list, which loses the context you were working in. A draft gets its own page as soon as it's saved, so there's a page to return to in every edit case.
