### PR TITLE
Read vendor-specific dead-key statuses as auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-15
 
+- A search key that's been revoked or has run out of credit now switches itself off with a clear reason, instead of quietly failing on every run.
 - A temporary hiccup while checking an AI credential no longer switches off your feeds — only a key the provider actually rejects does.
 - Fixed AI feeds failing when the model wrapped its answer in a code block or added a line of preamble.
 - Kimi feeds now use K2.6, since Moonshot is retiring K2.5 at the end of August. Feeds still set to the old model switch over on their own — no action needed.

--- a/app/services/web_search_provider/base.rb
+++ b/app/services/web_search_provider/base.rb
@@ -36,10 +36,9 @@ module WebSearchProvider
 
     attr_reader :api_key
 
-    # Whether a failed response means the key itself is finished — rejected,
-    # revoked, or spent — as opposed to a transient fault worth retrying.
-    # Vendors disagree on how to say it, so providers refine this; the statuses
-    # here are the ones they all use the same way.
+    # Whether a failure means the key itself is finished — rejected, revoked or
+    # spent — rather than a fault that may clear. Vendors disagree on how they
+    # say it, so providers refine this; these statuses are the ones they share.
     def auth_error?(response)
       AUTH_STATUSES.include?(response.status)
     end

--- a/app/services/web_search_provider/base.rb
+++ b/app/services/web_search_provider/base.rb
@@ -19,7 +19,7 @@ module WebSearchProvider
       response = request(query, count)
 
       unless response.success?
-        error = AUTH_STATUSES.include?(response.status) ? AuthError : ProviderError
+        error = auth_error?(response) ? AuthError : ProviderError
         raise error, "#{provider_name}: HTTP #{response.status}"
       end
 
@@ -35,6 +35,14 @@ module WebSearchProvider
     private
 
     attr_reader :api_key
+
+    # Whether a failed response means the key itself is finished — rejected,
+    # revoked, or spent — as opposed to a transient fault worth retrying.
+    # Vendors disagree on how to say it, so providers refine this; the statuses
+    # here are the ones they all use the same way.
+    def auth_error?(response)
+      AUTH_STATUSES.include?(response.status)
+    end
 
     def request(query, count)
       raise NotImplementedError, "#{self.class} must implement #request"

--- a/app/services/web_search_provider/brave.rb
+++ b/app/services/web_search_provider/brave.rb
@@ -2,8 +2,32 @@ module WebSearchProvider
   # Brave Search API — independent web index.
   class Brave < Base
     ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+    # Brave answers a rejected subscription token with 422 — the same status
+    # it uses for an ordinary bad parameter — so only the body separates a
+    # dead key from a malformed query.
+    REJECTED_KEY_STATUS = 422
+    REJECTED_KEY_CODE = "SUBSCRIPTION_TOKEN_INVALID".freeze
+    AUTH_COMPONENT = "authentication".freeze
 
     private
+
+    def auth_error?(response)
+      return true if super
+      return false unless response.status == REJECTED_KEY_STATUS
+
+      rejected_key?(response.body)
+    end
+
+    # Matches the documented code, and any other failure Brave attributes to
+    # authentication, so a renamed token error still reads as a dead key.
+    def rejected_key?(body)
+      error = JSON.parse(body.to_s)["error"]
+      return false unless error.is_a?(Hash)
+
+      error["code"] == REJECTED_KEY_CODE || error.dig("meta", "component") == AUTH_COMPONENT
+    rescue JSON::ParserError
+      false
+    end
 
     def request(query, count)
       http.get(

--- a/app/services/web_search_provider/brave.rb
+++ b/app/services/web_search_provider/brave.rb
@@ -2,9 +2,8 @@ module WebSearchProvider
   # Brave Search API — independent web index.
   class Brave < Base
     ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
-    # Brave answers a rejected subscription token with 422 — the same status
-    # it uses for an ordinary bad parameter — so only the body separates a
-    # dead key from a malformed query.
+    # Brave rejects a subscription token with 422, the same status it uses for
+    # a bad parameter, so only the body tells a dead key from a bad query.
     REJECTED_KEY_STATUS = 422
     REJECTED_KEY_CODE = "SUBSCRIPTION_TOKEN_INVALID".freeze
     AUTH_COMPONENT = "authentication".freeze
@@ -18,10 +17,11 @@ module WebSearchProvider
       rejected_key?(response.body)
     end
 
-    # Matches the documented code, and any other failure Brave attributes to
-    # authentication, so a renamed token error still reads as a dead key.
+    # Also accepts any failure Brave attributes to authentication, so a renamed
+    # token error still reads as a dead key.
     def rejected_key?(body)
-      error = JSON.parse(body.to_s)["error"]
+      json = JSON.parse(body.to_s)
+      error = json.is_a?(Hash) ? json["error"] : nil
       return false unless error.is_a?(Hash)
 
       error["code"] == REJECTED_KEY_CODE || error.dig("meta", "component") == AUTH_COMPONENT

--- a/app/services/web_search_provider/tavily.rb
+++ b/app/services/web_search_provider/tavily.rb
@@ -2,8 +2,8 @@ module WebSearchProvider
   # tavily.com — LLM-oriented search with content snippets.
   class Tavily < Base
     ENDPOINT = "https://api.tavily.com/search"
-    # Tavily reports an exhausted key with its own statuses: 432 for the plan
-    # limit, 433 for the pay-as-you-go limit. Neither clears on a retry.
+    # An exhausted key gets Tavily's own statuses: 432 plan limit, 433
+    # pay-as-you-go limit. Neither clears on a retry.
     SPENT_KEY_STATUSES = [432, 433].freeze
 
     private

--- a/app/services/web_search_provider/tavily.rb
+++ b/app/services/web_search_provider/tavily.rb
@@ -2,8 +2,15 @@ module WebSearchProvider
   # tavily.com — LLM-oriented search with content snippets.
   class Tavily < Base
     ENDPOINT = "https://api.tavily.com/search"
+    # Tavily reports an exhausted key with its own statuses: 432 for the plan
+    # limit, 433 for the pay-as-you-go limit. Neither clears on a retry.
+    SPENT_KEY_STATUSES = [432, 433].freeze
 
     private
+
+    def auth_error?(response)
+      super || SPENT_KEY_STATUSES.include?(response.status)
+    end
 
     def request(query, count)
       http.post(

--- a/test/services/web_search_provider_test.rb
+++ b/test/services/web_search_provider_test.rb
@@ -141,7 +141,67 @@ class WebSearchProviderTest < ActiveSupport::TestCase
     end
   end
 
-  test "#search should not raise AuthError for a server error status" do
+  test "brave #search should raise AuthError when 422 reports a rejected subscription token" do
+  body = { type: "ErrorResponse", error: { code: "SUBSCRIPTION_TOKEN_INVALID", status: 422 } }.to_json
+
+  with_client(HttpClient::Response.new(status: 422, body: body)) do
+    assert_raises(WebSearchProvider::AuthError) do
+      WebSearchProvider::Brave.new(api_key: "key").search("query")
+    end
+  end
+end
+
+test "brave #search should raise AuthError when 422 blames the authentication component" do
+  body = { error: { code: "SOME_FUTURE_TOKEN_ERROR", meta: { component: "authentication" } } }.to_json
+
+  with_client(HttpClient::Response.new(status: 422, body: body)) do
+    assert_raises(WebSearchProvider::AuthError) do
+      WebSearchProvider::Brave.new(api_key: "key").search("query")
+    end
+  end
+end
+
+test "brave #search should raise a plain ProviderError when 422 is a parameter complaint" do
+  body = { error: { code: "VALIDATION", meta: { component: "query" } } }.to_json
+
+  with_client(HttpClient::Response.new(status: 422, body: body)) do
+    error = assert_raises(WebSearchProvider::ProviderError) do
+      WebSearchProvider::Brave.new(api_key: "key").search("query")
+    end
+    assert_not_kind_of WebSearchProvider::AuthError, error
+  end
+end
+
+test "brave #search should raise a plain ProviderError when a 422 body is unreadable" do
+  with_client(HttpClient::Response.new(status: 422, body: "<html>nope</html>")) do
+    error = assert_raises(WebSearchProvider::ProviderError) do
+      WebSearchProvider::Brave.new(api_key: "key").search("query")
+    end
+    assert_not_kind_of WebSearchProvider::AuthError, error
+  end
+end
+
+test "tavily #search should raise AuthError on its plan and pay-as-you-go limit statuses" do
+  [432, 433].each do |status|
+    with_client(HttpClient::Response.new(status: status, body: "")) do
+      error = assert_raises(WebSearchProvider::AuthError) do
+        WebSearchProvider::Tavily.new(api_key: "key").search("query")
+      end
+      assert_equal "Tavily: HTTP #{status}", error.message
+    end
+  end
+end
+
+test "#search should keep vendor-specific auth statuses out of the shared contract" do
+  with_client(HttpClient::Response.new(status: 432, body: "")) do
+    error = assert_raises(WebSearchProvider::ProviderError) do
+      WebSearchProvider::Serper.new(api_key: "key").search("query")
+    end
+    assert_not_kind_of WebSearchProvider::AuthError, error
+  end
+end
+
+test "#search should not raise AuthError for a server error status" do
     with_client(HttpClient::Response.new(status: 500, body: "")) do
       error = assert_raises(WebSearchProvider::ProviderError) do
         WebSearchProvider::Serper.new(api_key: "key").search("query")

--- a/test/services/web_search_provider_test.rb
+++ b/test/services/web_search_provider_test.rb
@@ -142,66 +142,77 @@ class WebSearchProviderTest < ActiveSupport::TestCase
   end
 
   test "brave #search should raise AuthError when 422 reports a rejected subscription token" do
-  body = { type: "ErrorResponse", error: { code: "SUBSCRIPTION_TOKEN_INVALID", status: 422 } }.to_json
+    body = { type: "ErrorResponse", error: { code: "SUBSCRIPTION_TOKEN_INVALID", status: 422 } }.to_json
 
-  with_client(HttpClient::Response.new(status: 422, body: body)) do
-    assert_raises(WebSearchProvider::AuthError) do
-      WebSearchProvider::Brave.new(api_key: "key").search("query")
-    end
-  end
-end
-
-test "brave #search should raise AuthError when 422 blames the authentication component" do
-  body = { error: { code: "SOME_FUTURE_TOKEN_ERROR", meta: { component: "authentication" } } }.to_json
-
-  with_client(HttpClient::Response.new(status: 422, body: body)) do
-    assert_raises(WebSearchProvider::AuthError) do
-      WebSearchProvider::Brave.new(api_key: "key").search("query")
-    end
-  end
-end
-
-test "brave #search should raise a plain ProviderError when 422 is a parameter complaint" do
-  body = { error: { code: "VALIDATION", meta: { component: "query" } } }.to_json
-
-  with_client(HttpClient::Response.new(status: 422, body: body)) do
-    error = assert_raises(WebSearchProvider::ProviderError) do
-      WebSearchProvider::Brave.new(api_key: "key").search("query")
-    end
-    assert_not_kind_of WebSearchProvider::AuthError, error
-  end
-end
-
-test "brave #search should raise a plain ProviderError when a 422 body is unreadable" do
-  with_client(HttpClient::Response.new(status: 422, body: "<html>nope</html>")) do
-    error = assert_raises(WebSearchProvider::ProviderError) do
-      WebSearchProvider::Brave.new(api_key: "key").search("query")
-    end
-    assert_not_kind_of WebSearchProvider::AuthError, error
-  end
-end
-
-test "tavily #search should raise AuthError on its plan and pay-as-you-go limit statuses" do
-  [432, 433].each do |status|
-    with_client(HttpClient::Response.new(status: status, body: "")) do
-      error = assert_raises(WebSearchProvider::AuthError) do
-        WebSearchProvider::Tavily.new(api_key: "key").search("query")
+    with_client(HttpClient::Response.new(status: 422, body: body)) do
+      assert_raises(WebSearchProvider::AuthError) do
+        WebSearchProvider::Brave.new(api_key: "key").search("query")
       end
-      assert_equal "Tavily: HTTP #{status}", error.message
     end
   end
-end
 
-test "#search should keep vendor-specific auth statuses out of the shared contract" do
-  with_client(HttpClient::Response.new(status: 432, body: "")) do
-    error = assert_raises(WebSearchProvider::ProviderError) do
-      WebSearchProvider::Serper.new(api_key: "key").search("query")
+  test "brave #search should raise AuthError when 422 blames the authentication component" do
+    body = { error: { code: "SOME_FUTURE_TOKEN_ERROR", meta: { component: "authentication" } } }.to_json
+
+    with_client(HttpClient::Response.new(status: 422, body: body)) do
+      assert_raises(WebSearchProvider::AuthError) do
+        WebSearchProvider::Brave.new(api_key: "key").search("query")
+      end
     end
-    assert_not_kind_of WebSearchProvider::AuthError, error
   end
-end
 
-test "#search should not raise AuthError for a server error status" do
+  test "brave #search should raise a plain ProviderError when 422 is a parameter complaint" do
+    body = { error: { code: "VALIDATION", meta: { component: "query" } } }.to_json
+
+    with_client(HttpClient::Response.new(status: 422, body: body)) do
+      error = assert_raises(WebSearchProvider::ProviderError) do
+        WebSearchProvider::Brave.new(api_key: "key").search("query")
+      end
+      assert_not_kind_of WebSearchProvider::AuthError, error
+    end
+  end
+
+  test "brave #search should raise a plain ProviderError when a 422 body is unreadable" do
+    with_client(HttpClient::Response.new(status: 422, body: "<html>nope</html>")) do
+      error = assert_raises(WebSearchProvider::ProviderError) do
+        WebSearchProvider::Brave.new(api_key: "key").search("query")
+      end
+      assert_not_kind_of WebSearchProvider::AuthError, error
+    end
+  end
+
+  test "brave #search should raise a plain ProviderError when a 422 body is valid JSON but not an object" do
+    ["null", "[]", "42"].each do |body|
+      with_client(HttpClient::Response.new(status: 422, body: body)) do
+        error = assert_raises(WebSearchProvider::ProviderError) do
+          WebSearchProvider::Brave.new(api_key: "key").search("query")
+        end
+        assert_not_kind_of WebSearchProvider::AuthError, error
+      end
+    end
+  end
+
+  test "tavily #search should raise AuthError on its plan and pay-as-you-go limit statuses" do
+    [432, 433].each do |status|
+      with_client(HttpClient::Response.new(status: status, body: "")) do
+        error = assert_raises(WebSearchProvider::AuthError) do
+          WebSearchProvider::Tavily.new(api_key: "key").search("query")
+        end
+        assert_equal "Tavily: HTTP #{status}", error.message
+      end
+    end
+  end
+
+  test "#search should keep vendor-specific auth statuses out of the shared contract" do
+    with_client(HttpClient::Response.new(status: 432, body: "")) do
+      error = assert_raises(WebSearchProvider::ProviderError) do
+        WebSearchProvider::Serper.new(api_key: "key").search("query")
+      end
+      assert_not_kind_of WebSearchProvider::AuthError, error
+    end
+  end
+
+  test "#search should not raise AuthError for a server error status" do
     with_client(HttpClient::Response.new(status: 500, body: "")) do
       error = assert_raises(WebSearchProvider::ProviderError) do
         WebSearchProvider::Serper.new(api_key: "key").search("query")


### PR DESCRIPTION
Changes:

- Move auth classification behind an `auth_error?` seam on `WebSearchProvider::Base`, so each provider can speak for its own vendor instead of sharing one status list
- Treat Brave's 422 `SUBSCRIPTION_TOKEN_INVALID` as a dead key, keyed on the error body since Brave reuses 422 for ordinary parameter complaints
- Treat Tavily's 432 (plan limit) and 433 (pay-as-you-go limit) as a spent key
