### PR TITLE
Add live probes for the web search providers

### DIFF
--- a/app/controllers/development/job_runs_controller.rb
+++ b/app/controllers/development/job_runs_controller.rb
@@ -18,7 +18,7 @@ class Development::JobRunsController < ApplicationController
 
     # Insert the run before enqueuing so the worker can't pick the job up before
     # its JobRun exists; job_id is assigned at instantiation, ahead of enqueue.
-    job = job_class.new
+    job = job_class.new(*job_class.runnable_arguments(current_user))
     JobRun.create!(job_class: job_class.name, job_id: job.job_id)
     job.enqueue
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -9,6 +9,10 @@ class ApplicationJob < ActiveJob::Base
   # maintenance job needs before it can run. Nil when the name says enough.
   def self.description = nil
 
+  # Arguments the dev area launches this job with. Jobs that act on behalf of
+  # whoever pressed Run override it to receive them.
+  def self.runnable_arguments(_user) = []
+
   # Count every job run by outcome. A run that deferred itself for rate limiting
   # (RateLimited#rate_limited?) is throttled, not a real failure — it returns
   # normally after rescheduling, so we read the flag rather than catch anything.

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -5,6 +5,10 @@ class ApplicationJob < ActiveJob::Base
   # Most jobs are safe to ignore if the underlying records are no longer available
   discard_on ActiveJob::DeserializationError
 
+  # One line shown above the job's run history in the dev area, for what a
+  # maintenance job needs before it can run. Nil when the name says enough.
+  def self.description = nil
+
   # Count every job run by outcome. A run that deferred itself for rate limiting
   # (RateLimited#rate_limited?) is throttled, not a real failure — it returns
   # normally after rescheduling, so we read the flag rather than catch anything.

--- a/app/jobs/brave_capability_probe_job.rb
+++ b/app/jobs/brave_capability_probe_job.rb
@@ -1,0 +1,5 @@
+# Probes the Brave integration against the Brave Search API. See
+# SearchCapabilityProbeJob.
+class BraveCapabilityProbeJob < SearchCapabilityProbeJob
+  PROVIDER = "brave".freeze
+end

--- a/app/jobs/llm_capability_probe_job.rb
+++ b/app/jobs/llm_capability_probe_job.rb
@@ -8,6 +8,11 @@ class LlmCapabilityProbeJob < ApplicationJob
 
   queue_as :default
 
+  def self.description
+    "Runs the capability checks for #{self::MODEL} against the live #{self::PROVIDER} API. " \
+      "Needs #{LlmCapabilityProbe::Provider.env_key_for(self::PROVIDER)} in the environment."
+  end
+
   def perform
     provider_key = self.class::PROVIDER
     model = self.class::MODEL

--- a/app/jobs/search_capability_probe_job.rb
+++ b/app/jobs/search_capability_probe_job.rb
@@ -2,9 +2,9 @@
 # via PROVIDER. Everything the diagnosis needs lands in JobRun events: one event
 # per check with its evidence, plus a summary verdict.
 #
-# The key comes from a SearchCredential named after the probe (see
-# SearchCapabilityProbe.credential_name). Without that record the run says which
-# credential to create and ends.
+# The key comes from a SearchCredential named after the probe and owned by
+# whoever launched the run, so a probe only ever spends its own operator's
+# queries. Without that record the run says which credential to create and ends.
 class SearchCapabilityProbeJob < ApplicationJob
   include RecordsJobRun
 
@@ -12,21 +12,19 @@ class SearchCapabilityProbeJob < ApplicationJob
 
   def self.description
     "Runs the search checks against the live #{WebSearchProvider.label_for(self::PROVIDER)} API. " \
-      "Needs a search credential named “#{SearchCapabilityProbe.credential_name(self::PROVIDER)}”, " \
-      "and spends two queries on it."
+      "Needs a search credential named “#{SearchCapabilityProbe.credential_name(self::PROVIDER)}” on " \
+      "your own account, and spends two queries on it."
   end
 
-  def perform
+  def self.runnable_arguments(user) = [user]
+
+  def perform(user)
     provider = self.class::PROVIDER
-    credentials = SearchCapabilityProbe.candidate_credentials(provider).to_a
+    credential = SearchCapabilityProbe.credential_for(provider, user: user)
 
-    return skip(provider, SearchCapabilityProbe.missing_credential_message(provider)) if credentials.empty?
+    return skip(provider, SearchCapabilityProbe.missing_credential_message(provider)) if credential.nil?
 
-    if credentials.many?
-      return skip(provider, SearchCapabilityProbe.ambiguous_credential_message(provider, credentials.size))
-    end
-
-    probe(provider, credentials.sole)
+    probe(provider, credential)
   end
 
   private

--- a/app/jobs/search_capability_probe_job.rb
+++ b/app/jobs/search_capability_probe_job.rb
@@ -1,0 +1,52 @@
+# Base for the per-provider web-search probe jobs. Subclasses pin one provider
+# via PROVIDER. Everything the diagnosis needs lands in JobRun events: one event
+# per check with its evidence, plus a summary verdict.
+#
+# The key comes from a SearchCredential named after the probe (see
+# SearchCapabilityProbe.credential_name). Without that record the run says which
+# credential to create and ends.
+class SearchCapabilityProbeJob < ApplicationJob
+  include RecordsJobRun
+
+  queue_as :default
+
+  def perform
+    provider = self.class::PROVIDER
+    credentials = SearchCapabilityProbe.candidate_credentials(provider).to_a
+
+    return skip(provider, SearchCapabilityProbe.missing_credential_message(provider)) if credentials.empty?
+
+    if credentials.many?
+      return skip(provider, SearchCapabilityProbe.ambiguous_credential_message(provider, credentials.size))
+    end
+
+    probe(provider, credentials.sole)
+  end
+
+  private
+
+  def skip(provider, reason)
+    record_event(type: "job.search_capability_probe.skipped",
+                 message: "#{provider}: #{reason}",
+                 level: :warning, provider: provider,
+                 expected_credential_name: SearchCapabilityProbe.credential_name(provider))
+  end
+
+  def probe(provider, credential)
+    outcome = SearchCapabilityProbe::Runner.new(credential: credential).run
+
+    outcome[:results].each do |result|
+      record_event(type: "job.search_capability_probe.check",
+                   message: "#{result[:check]}: #{result[:status]} (#{result[:seconds]}s) — #{result[:note]}",
+                   level: result[:status] == "FAIL" ? :warning : :info,
+                   provider: provider, credential_id: credential.id, **result)
+    end
+
+    summary = outcome[:results].map { |result| "#{result[:check]}=#{result[:status]}" }.join(" ")
+    record_event(type: "job.search_capability_probe.completed",
+                 message: "#{provider}: #{summary}",
+                 level: outcome[:passed] ? :info : :warning,
+                 provider: provider, credential_id: credential.id,
+                 credential_state: credential.state, passed: outcome[:passed])
+  end
+end

--- a/app/jobs/search_capability_probe_job.rb
+++ b/app/jobs/search_capability_probe_job.rb
@@ -10,6 +10,12 @@ class SearchCapabilityProbeJob < ApplicationJob
 
   queue_as :default
 
+  def self.description
+    "Runs the search checks against the live #{WebSearchProvider.label_for(self::PROVIDER)} API. " \
+      "Needs a search credential named “#{SearchCapabilityProbe.credential_name(self::PROVIDER)}”, " \
+      "and spends two queries on it."
+  end
+
   def perform
     provider = self.class::PROVIDER
     credentials = SearchCapabilityProbe.candidate_credentials(provider).to_a

--- a/app/jobs/serper_capability_probe_job.rb
+++ b/app/jobs/serper_capability_probe_job.rb
@@ -1,0 +1,4 @@
+# Probes the Serper integration against serper.dev. See SearchCapabilityProbeJob.
+class SerperCapabilityProbeJob < SearchCapabilityProbeJob
+  PROVIDER = "serper".freeze
+end

--- a/app/jobs/tavily_capability_probe_job.rb
+++ b/app/jobs/tavily_capability_probe_job.rb
@@ -1,0 +1,4 @@
+# Probes the Tavily integration against tavily.com. See SearchCapabilityProbeJob.
+class TavilyCapabilityProbeJob < SearchCapabilityProbeJob
+  PROVIDER = "tavily".freeze
+end

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -4,6 +4,9 @@ class JobRun < ApplicationRecord
   RUNNABLE_JOBS = [
     AnthropicCapabilityProbeJob,
     KimiCapabilityProbeJob,
+    SerperCapabilityProbeJob,
+    BraveCapabilityProbeJob,
+    TavilyCapabilityProbeJob,
     PurgeExpiredEventsJob
   ].freeze
 

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -156,6 +156,10 @@ module LlmCapabilityProbe
       klass.new(key)
     end
 
+    def self.env_key_for(key)
+      REGISTRY.fetch(key).env_key
+    end
+
     def self.configured?(key)
       REGISTRY.key?(key) && ENV[REGISTRY.fetch(key).env_key].present?
     end

--- a/app/services/search_capability_probe.rb
+++ b/app/services/search_capability_probe.rb
@@ -10,17 +10,7 @@ module SearchCapabilityProbe
   # exactly what a user's key has to satisfy to go active.
   QUERY = SearchCredentialValidationJob::VALIDATION_QUERY
 
-  RESULT_URL = %r{\Ahttps?://}
-
   class << self
-    # Not a key any vendor issued, generated per run so nothing key-shaped is
-    # committed. What matters is not that the search fails but how: unless the
-    # refusal reaches us as AuthError, a spent credential stays in service and
-    # every later run keeps calling it.
-    def rejected_api_key
-      "f2-probe-#{SecureRandom.hex(8)}"
-    end
-
     def credential_name(provider)
       "#{WebSearchProvider.label_for(provider)} Probe"
     end
@@ -42,6 +32,7 @@ module SearchCapabilityProbe
 
   class Runner
     CHECKS = %w[rejection search minimal].freeze
+    RESULT_URL = %r{\Ahttps?://}
 
     def initialize(credential:, checks: CHECKS)
       @credential = credential
@@ -73,7 +64,7 @@ module SearchCapabilityProbe
     # itself how it turns a dead key away. A ProviderError here means a revoked
     # or exhausted key would read as a passing fault and stay in service.
     def check_rejection
-      WebSearchProvider.for(@credential.provider, api_key: SearchCapabilityProbe.rejected_api_key).search(QUERY, max_results: 1)
+      rejected_provider.search(QUERY, max_results: 1)
       { status: "FAIL", note: "an invalid key was accepted", evidence: nil }
     rescue WebSearchProvider::AuthError => e
       { status: "PASS", note: "invalid key rejected as AuthError", evidence: { error: e.message } }
@@ -87,17 +78,23 @@ module SearchCapabilityProbe
     # which looks exactly like a query with no matches.
     def check_search
       results = search(max_results: 3)
-      evidence = { results: results.first(3).map(&:to_h) }
+      evidence = { results: results.map(&:to_h) }
       return { status: "FAIL", note: "no results for #{QUERY.inspect}", evidence: evidence } if results.empty?
 
-      unmapped = results.reject { |result| mapped?(result) }
-      if unmapped.any?
-        return { status: "FAIL",
-                 note: "#{unmapped.size}/#{results.size} results missing mapped fields — check the response shape",
+      unlinked = results.reject { |result| result.url.match?(RESULT_URL) }
+      if unlinked.any?
+        return { status: "FAIL", note: "#{unlinked.size}/#{results.size} results have no usable URL",
                  evidence: evidence }
       end
 
-      { status: "PASS", note: "#{results.size} results, all fields mapped", evidence: evidence }
+      # A renamed response field blanks that field on every result, while one
+      # sparse result is ordinary — so only a field that never arrives is a
+      # mapping failure.
+      missing = %i[title snippet].select { |field| results.all? { |result| result.public_send(field).blank? } }
+      return { status: "PASS", note: "#{results.size} results, all fields mapped", evidence: evidence } if missing.empty?
+
+      { status: "FAIL", note: "#{missing.join(' and ')} never populated — check the response shape",
+        evidence: evidence }
     end
 
     # The shape SearchCredentialValidationJob sends, down to the one-result cap:
@@ -110,8 +107,12 @@ module SearchCapabilityProbe
       { status: "PASS", note: "one-result query accepted", evidence: evidence }
     end
 
-    def mapped?(result)
-      result.title.present? && result.snippet.present? && result.url.match?(RESULT_URL)
+    # Not a key any vendor issued, generated per run so nothing key-shaped is
+    # committed. What matters is not that the search fails but how: unless the
+    # refusal reaches us as AuthError, a spent credential stays in service and
+    # every later run keeps calling it.
+    def rejected_provider
+      WebSearchProvider.for(@credential.provider, api_key: "f2-probe-#{SecureRandom.hex(8)}")
     end
 
     # Recorded like any other search: an unaccounted call would make the

--- a/app/services/search_capability_probe.rb
+++ b/app/services/search_capability_probe.rb
@@ -1,0 +1,132 @@
+# Checks a web-search integration against the vendor's live API. Fixtures can
+# only confirm our reading of a vendor's docs; these checks confirm the vendor
+# still behaves that way.
+#
+# The key comes from a SearchCredential named after the probe, so the checks run
+# through the same objects a feed run uses. Two of the three spend a real query,
+# billed to that credential and recorded as usage.
+module SearchCapabilityProbe
+  # The query the credential validation job sends, so the minimal check asks for
+  # exactly what a user's key has to satisfy to go active.
+  QUERY = SearchCredentialValidationJob::VALIDATION_QUERY
+
+  RESULT_URL = %r{\Ahttps?://}
+
+  class << self
+    # Not a key any vendor issued, generated per run so nothing key-shaped is
+    # committed. What matters is not that the search fails but how: unless the
+    # refusal reaches us as AuthError, a spent credential stays in service and
+    # every later run keeps calling it.
+    def rejected_api_key
+      "f2-probe-#{SecureRandom.hex(8)}"
+    end
+
+    def credential_name(provider)
+      "#{WebSearchProvider.label_for(provider)} Probe"
+    end
+
+    # Scoped to dev users, since display names are only unique per user and the
+    # probe spends real queries: an unscoped lookup could bill a stranger's key.
+    def candidate_credentials(provider)
+      SearchCredential
+        .where(provider: provider, display_name: credential_name(provider))
+        .where(user: User.joins(:permissions).where(permissions: { name: Permission::DEV }))
+    end
+
+    # Says what to create, since the fix is always the same: one credential,
+    # this provider, this exact name.
+    def missing_credential_message(provider)
+      "no search credential named #{credential_name(provider).inspect} — " \
+        "add a #{WebSearchProvider.label_for(provider)} credential with that exact name to run this probe"
+    end
+
+    # Refused rather than guessed: picking one would spend a query on whichever
+    # dev the database happened to return first.
+    def ambiguous_credential_message(provider, count)
+      "#{count} dev users hold a search credential named #{credential_name(provider).inspect} — " \
+        "rename all but one so the probe knows whose key to spend"
+    end
+  end
+
+  class Runner
+    CHECKS = %w[rejection search minimal].freeze
+
+    def initialize(credential:, checks: CHECKS)
+      @credential = credential
+      @checks = checks
+      @results = []
+    end
+
+    # Returns { results:, passed: }. Failures are recorded rather than raised:
+    # the job is to report what a vendor does, not to stop at the first
+    # surprise.
+    def run
+      @checks.each { |check| record(check) { send("check_#{check}") } }
+      { results: @results, passed: @results.none? { |result| result[:status] == "FAIL" } }
+    end
+
+    private
+
+    def record(check)
+      started = Time.current
+      outcome = yield
+      @results << { check: check, status: outcome[:status], note: outcome[:note],
+                    evidence: outcome[:evidence], seconds: (Time.current - started).round(1) }
+    rescue StandardError => e
+      @results << { check: check, status: "FAIL", note: "#{e.class}: #{e.message.to_s[0, 300]}",
+                    evidence: nil, seconds: (Time.current - started).round(1) }
+    end
+
+    # Free, and the check fixtures cannot stand in for: it asks the vendor
+    # itself how it turns a dead key away. A ProviderError here means a revoked
+    # or exhausted key would read as a passing fault and stay in service.
+    def check_rejection
+      WebSearchProvider.for(@credential.provider, api_key: SearchCapabilityProbe.rejected_api_key).search(QUERY, max_results: 1)
+      { status: "FAIL", note: "an invalid key was accepted", evidence: nil }
+    rescue WebSearchProvider::AuthError => e
+      { status: "PASS", note: "invalid key rejected as AuthError", evidence: { error: e.message } }
+    rescue WebSearchProvider::Error => e
+      { status: "FAIL",
+        note: "invalid key raised #{e.class.name.demodulize}, not AuthError — a dead key would read as transient",
+        evidence: { error: e.message } }
+    end
+
+    # A vendor renaming a response field leaves a working key returning nothing,
+    # which looks exactly like a query with no matches.
+    def check_search
+      results = search(max_results: 3)
+      evidence = { results: results.first(3).map(&:to_h) }
+      return { status: "FAIL", note: "no results for #{QUERY.inspect}", evidence: evidence } if results.empty?
+
+      unmapped = results.reject { |result| mapped?(result) }
+      if unmapped.any?
+        return { status: "FAIL",
+                 note: "#{unmapped.size}/#{results.size} results missing mapped fields — check the response shape",
+                 evidence: evidence }
+      end
+
+      { status: "PASS", note: "#{results.size} results, all fields mapped", evidence: evidence }
+    end
+
+    # The shape SearchCredentialValidationJob sends, down to the one-result cap:
+    # a vendor that rejects it can never let a user's credential go active.
+    def check_minimal
+      results = search(max_results: 1)
+      evidence = { results: results.map(&:to_h) }
+      return { status: "FAIL", note: "one-result query returned nothing", evidence: evidence } if results.empty?
+
+      { status: "PASS", note: "one-result query accepted", evidence: evidence }
+    end
+
+    def mapped?(result)
+      result.title.present? && result.snippet.present? && result.url.match?(RESULT_URL)
+    end
+
+    # Recorded like any other search: an unaccounted call would make the
+    # credential's cost surface lie.
+    def search(max_results:)
+      WebSearchUsage.record!(credential: @credential)
+      @credential.web_search_provider.search(QUERY, max_results: max_results)
+    end
+  end
+end

--- a/app/services/search_capability_probe.rb
+++ b/app/services/search_capability_probe.rb
@@ -25,26 +25,18 @@ module SearchCapabilityProbe
       "#{WebSearchProvider.label_for(provider)} Probe"
     end
 
-    # Scoped to dev users, since display names are only unique per user and the
-    # probe spends real queries: an unscoped lookup could bill a stranger's key.
-    def candidate_credentials(provider)
-      SearchCredential
-        .where(provider: provider, display_name: credential_name(provider))
-        .where(user: User.joins(:permissions).where(permissions: { name: Permission::DEV }))
+    # Scoped to whoever launched the probe: each run spends billed queries, and
+    # display names are unique per user and provider, so the owner is what makes
+    # the name resolve to one key.
+    def credential_for(provider, user:)
+      user.search_credentials.find_by(provider: provider, display_name: credential_name(provider))
     end
 
     # Says what to create, since the fix is always the same: one credential,
     # this provider, this exact name.
     def missing_credential_message(provider)
-      "no search credential named #{credential_name(provider).inspect} — " \
+      "no search credential named #{credential_name(provider).inspect} on your account — " \
         "add a #{WebSearchProvider.label_for(provider)} credential with that exact name to run this probe"
-    end
-
-    # Refused rather than guessed: picking one would spend a query on whichever
-    # dev the database happened to return first.
-    def ambiguous_credential_message(provider, count)
-      "#{count} dev users hold a search credential named #{credential_name(provider).inspect} — " \
-        "rename all but one so the probe knows whose key to spend"
     end
   end
 

--- a/app/views/development/job_runs/index.html.erb
+++ b/app/views/development/job_runs/index.html.erb
@@ -3,6 +3,9 @@
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: @job_class.name) do |header| %>
     <% header.with_breadcrumb(label: "Maintenance Jobs", url: development_jobs_path) %>
+    <% if @job_class.description.present? %>
+      <% header.with_context_paragraph(@job_class.description) %>
+    <% end %>
     <% header.with_action_button do %>
       <%= button_to "Run", development_job_job_runs_path(@job_class.name),
             class: "inline-flex items-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 cursor-pointer",

--- a/docs/search-provider-verification.md
+++ b/docs/search-provider-verification.md
@@ -17,11 +17,12 @@ summary verdict, so the run page is the whole record.
 
 The key comes from a managed credential, not the environment: the probe uses the
 `SearchCredential` whose name matches the probe — **Serper Probe**, **Brave
-Probe**, **Tavily Probe** — with the matching provider, owned by a user with the
-`dev` permission. Without that record the run records a skip saying which
-credential to create; if two dev users hold the same probe name, it refuses
-rather than pick one. The credential does not have to be active; probing a
-rejected key is a legitimate thing to want.
+Probe**, **Tavily Probe** — with the matching provider, on **your own account**.
+The dev area passes whoever pressed Run through to the job, so a probe only ever
+spends its own operator's queries, and the per-user uniqueness of display names
+makes the name resolve to exactly one key. Without that record the run records a
+skip saying which credential to create. The credential does not have to be
+active; probing a rejected key is a legitimate thing to want.
 
 Two of the three checks spend a real query, billed to that credential and
 recorded as usage like any other search.

--- a/docs/search-provider-verification.md
+++ b/docs/search-provider-verification.md
@@ -1,0 +1,49 @@
+# Verifying a web search provider
+
+`WebSearchProvider` turns three vendor APIs into one normalized interface. Its
+unit tests run against fixtures, which can only confirm our reading of a
+vendor's docs — not that the vendor still behaves that way. `SearchCapabilityProbe`
+closes that gap by talking to the live API.
+
+Run it before trusting a new provider, and again when a vendor announces API
+changes or when search starts failing in a way the logs don't explain.
+
+## Running it
+
+Each provider has its own job: `SerperCapabilityProbeJob`,
+`BraveCapabilityProbeJob`, `TavilyCapabilityProbeJob`. Open `/development/jobs`,
+pick one, and run it. Each check writes one event with its evidence, plus a
+summary verdict, so the run page is the whole record.
+
+The key comes from a managed credential, not the environment: the probe uses the
+`SearchCredential` whose name matches the probe — **Serper Probe**, **Brave
+Probe**, **Tavily Probe** — with the matching provider, owned by a user with the
+`dev` permission. Without that record the run records a skip saying which
+credential to create; if two dev users hold the same probe name, it refuses
+rather than pick one. The credential does not have to be active; probing a
+rejected key is a legitimate thing to want.
+
+Two of the three checks spend a real query, billed to that credential and
+recorded as usage like any other search.
+
+## What it checks, and why only these
+
+| Check | What it proves |
+| --- | --- |
+| `rejection` | An invalid key comes back as `AuthError`. Free, and the one check fixtures can't stand in for |
+| `search` | A live query returns results that still map to populated `Result` fields |
+| `minimal` | The one-result query `SearchCredentialValidationJob` sends is accepted |
+
+`rejection` is the check worth understanding. Classification is per-vendor
+(`Base#auth_error?`): Serper rejects a key with 403, Brave with 422 plus an
+error code in the body, Tavily reports an exhausted key with 432/433. Get it
+wrong and a dead key reads as a passing fault — the credential stays active, the
+feed stays enabled, and every refresh keeps calling a key that can never work.
+That failure is invisible to fixtures, because the fixtures encode the same
+assumption the code does.
+
+A `FAIL` on `search` with a live key usually means the vendor renamed a response
+field: the mapping in `map_results` silently produces nothing, which in
+production looks identical to a query with no matches. The event's evidence
+carries the results as mapped, so the fix is normally visible in the diff
+between that and the vendor's current response shape.

--- a/test/controllers/development/job_runs_controller_test.rb
+++ b/test/controllers/development/job_runs_controller_test.rb
@@ -35,6 +35,22 @@ class Development::JobRunsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "#index should show what a job needs before it can run" do
+    sign_in_as(dev_user)
+    get development_job_job_runs_path("SerperCapabilityProbeJob")
+
+    assert_response :success
+    assert_select "p", text: /Serper Probe/
+  end
+
+  test "#index should leave the header clean for a job that needs nothing" do
+    sign_in_as(dev_user)
+    get development_job_job_runs_path("PurgeExpiredEventsJob")
+
+    assert_response :success
+    assert_nil PurgeExpiredEventsJob.description
+  end
+
   test "#index should return not found for an unregistered job" do
     sign_in_as(dev_user)
     get development_job_job_runs_path("SomeOtherJob")

--- a/test/controllers/development/job_runs_controller_test.rb
+++ b/test/controllers/development/job_runs_controller_test.rb
@@ -73,6 +73,14 @@ class Development::JobRunsControllerTest < ActionDispatch::IntegrationTest
     assert run.job_id.present?
   end
 
+  test "#create should enqueue a user-scoped job on behalf of whoever pressed Run" do
+    sign_in_as(dev_user)
+
+    assert_enqueued_with(job: SerperCapabilityProbeJob, args: [dev_user]) do
+      post development_job_job_runs_path("SerperCapabilityProbeJob")
+    end
+  end
+
   test "#create should enqueue a job that finds its run by job_id" do
     sign_in_as(dev_user)
 

--- a/test/jobs/llm_capability_probe_job_test.rb
+++ b/test/jobs/llm_capability_probe_job_test.rb
@@ -20,6 +20,11 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
     assert_equal %w[moonshot kimi-k2.6], [KimiCapabilityProbeJob::PROVIDER, KimiCapabilityProbeJob::MODEL]
   end
 
+  test ".description should name the environment key the probe needs" do
+    assert_match(/ANTHROPIC_API_KEY/, AnthropicCapabilityProbeJob.description)
+    assert_match(/MOONSHOT_API_KEY/, KimiCapabilityProbeJob.description)
+  end
+
   test "#perform should record a skip event when the API key is not configured" do
     job_run
 

--- a/test/jobs/search_capability_probe_job_test.rb
+++ b/test/jobs/search_capability_probe_job_test.rb
@@ -1,20 +1,20 @@
 require "test_helper"
 
 class SearchCapabilityProbeJobTest < ActiveJob::TestCase
+  def operator
+    @operator ||= create(:user, :dev)
+  end
+
   def job
-    @job ||= SerperCapabilityProbeJob.new
+    @job ||= SerperCapabilityProbeJob.new(operator)
   end
 
   def job_run
     @job_run ||= create(:job_run, job_class: "SerperCapabilityProbeJob", job_id: job.job_id)
   end
 
-  def dev_user
-    @dev_user ||= create(:user, :dev)
-  end
-
   def credential
-    @credential ||= create(:search_credential, user: dev_user, provider: "serper", display_name: "Serper Probe")
+    @credential ||= create(:search_credential, user: operator, provider: "serper", display_name: "Serper Probe")
   end
 
   def outcome
@@ -44,6 +44,11 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
     assert_equal WebSearchProvider::REGISTRY.keys.sort, pinned.sort
   end
 
+  test ".runnable_arguments should ask the dev area for the user who pressed Run" do
+    assert_equal [operator], SerperCapabilityProbeJob.runnable_arguments(operator)
+    assert_empty PurgeExpiredEventsJob.runnable_arguments(operator)
+  end
+
   test ".description should name the credential the probe needs" do
     assert_match(/Serper Probe/, SerperCapabilityProbeJob.description)
     assert_match(/Tavily Probe/, TavilyCapabilityProbeJob.description)
@@ -68,18 +73,26 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
     assert_empty Event.where(subject: job_run, type: "job.search_capability_probe.check")
   end
 
-  test "#perform should refuse to guess when two dev users hold the probe name" do
+  test "#perform should ignore a probe-named credential owned by someone else" do
     job_run
-    credential
     create(:search_credential, user: create(:user, :dev), provider: "serper", display_name: "Serper Probe")
 
     SearchCapabilityProbe::Runner.stub(:new, ->(**) { raise "should not run" }) do
       job.perform_now
     end
 
-    event = Event.find_by(subject: job_run, type: "job.search_capability_probe.skipped")
-    assert_includes event.message, "2 dev users"
-    assert_empty Event.where(subject: job_run, type: "job.search_capability_probe.check")
+    assert Event.exists?(subject: job_run, type: "job.search_capability_probe.skipped")
+  end
+
+  test "#perform should probe the launching user's own credential" do
+    job_run
+    credential
+    create(:search_credential, user: create(:user, :dev), provider: "serper", display_name: "Serper Probe")
+
+    stub_runner(outcome) { job.perform_now }
+
+    summary = Event.find_by(subject: job_run, type: "job.search_capability_probe.completed")
+    assert_equal credential.id, summary.metadata["credential_id"]
   end
 
   test "#perform should record one event per check plus a summary" do
@@ -104,7 +117,7 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
 
   test "#perform should use whichever credential carries the probe name" do
     job_run
-    create(:search_credential, user: dev_user, provider: "serper", display_name: "Some Other Key")
+    create(:search_credential, user: operator, provider: "serper", display_name: "Some Other Key")
     credential
 
     stub_runner(outcome.merge(passed: true, results: [])) { job.perform_now }

--- a/test/jobs/search_capability_probe_job_test.rb
+++ b/test/jobs/search_capability_probe_job_test.rb
@@ -1,0 +1,110 @@
+require "test_helper"
+
+class SearchCapabilityProbeJobTest < ActiveJob::TestCase
+  def job
+    @job ||= SerperCapabilityProbeJob.new
+  end
+
+  def job_run
+    @job_run ||= create(:job_run, job_class: "SerperCapabilityProbeJob", job_id: job.job_id)
+  end
+
+  def dev_user
+    @dev_user ||= create(:user, :dev)
+  end
+
+  def credential
+    @credential ||= create(:search_credential, user: dev_user, provider: "serper", display_name: "Serper Probe")
+  end
+
+  def outcome
+    {
+      results: [
+        { check: "rejection", status: "PASS", note: "invalid key rejected as AuthError",
+          evidence: { error: "Serper: HTTP 403" }, seconds: 0.1 },
+        { check: "search", status: "FAIL", note: "no results", evidence: { results: [] }, seconds: 0.2 }
+      ],
+      passed: false
+    }
+  end
+
+  def stub_runner(result)
+    runner = Minitest::Mock.new
+    runner.expect(:run, result)
+    SearchCapabilityProbe::Runner.stub(:new, ->(**) { runner }) { yield }
+    runner.verify
+  end
+
+  test "should register a probe per registered provider" do
+    [SerperCapabilityProbeJob, BraveCapabilityProbeJob, TavilyCapabilityProbeJob].each do |klass|
+      assert_includes JobRun::RUNNABLE_JOBS, klass
+    end
+
+    pinned = [SerperCapabilityProbeJob, BraveCapabilityProbeJob, TavilyCapabilityProbeJob].map { |k| k::PROVIDER }
+    assert_equal WebSearchProvider::REGISTRY.keys.sort, pinned.sort
+  end
+
+  test "#perform should record a skip naming the credential to create when it is missing" do
+    job_run
+    job.perform_now
+
+    event = Event.find_by(subject: job_run, type: "job.search_capability_probe.skipped")
+    assert_predicate event, :warning?
+    assert_includes event.message, '"Serper Probe"'
+    assert_equal "Serper Probe", event.metadata["expected_credential_name"]
+  end
+
+  test "#perform should not run checks when the credential is missing" do
+    job_run
+    SearchCapabilityProbe::Runner.stub(:new, ->(**) { raise "should not run" }) do
+      job.perform_now
+    end
+
+    assert_empty Event.where(subject: job_run, type: "job.search_capability_probe.check")
+  end
+
+  test "#perform should refuse to guess when two dev users hold the probe name" do
+    job_run
+    credential
+    create(:search_credential, user: create(:user, :dev), provider: "serper", display_name: "Serper Probe")
+
+    SearchCapabilityProbe::Runner.stub(:new, ->(**) { raise "should not run" }) do
+      job.perform_now
+    end
+
+    event = Event.find_by(subject: job_run, type: "job.search_capability_probe.skipped")
+    assert_includes event.message, "2 dev users"
+    assert_empty Event.where(subject: job_run, type: "job.search_capability_probe.check")
+  end
+
+  test "#perform should record one event per check plus a summary" do
+    job_run
+    credential
+
+    stub_runner(outcome) { job.perform_now }
+
+    checks = Event.where(subject: job_run, type: "job.search_capability_probe.check").order(:id)
+    assert_equal 2, checks.count
+    assert_predicate checks.first, :info?
+    assert_equal "Serper: HTTP 403", checks.first.metadata.dig("evidence", "error")
+    assert_predicate checks.second, :warning?
+    assert_includes checks.second.message, "search: FAIL"
+
+    summary = Event.find_by(subject: job_run, type: "job.search_capability_probe.completed")
+    assert_includes summary.message, "rejection=PASS search=FAIL"
+    assert_equal false, summary.metadata["passed"]
+    assert_equal credential.id, summary.metadata["credential_id"]
+    assert_predicate summary, :warning?
+  end
+
+  test "#perform should use whichever credential carries the probe name" do
+    job_run
+    create(:search_credential, user: dev_user, provider: "serper", display_name: "Some Other Key")
+    credential
+
+    stub_runner(outcome.merge(passed: true, results: [])) { job.perform_now }
+
+    summary = Event.find_by(subject: job_run, type: "job.search_capability_probe.completed")
+    assert_equal credential.id, summary.metadata["credential_id"]
+  end
+end

--- a/test/jobs/search_capability_probe_job_test.rb
+++ b/test/jobs/search_capability_probe_job_test.rb
@@ -44,6 +44,11 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
     assert_equal WebSearchProvider::REGISTRY.keys.sort, pinned.sort
   end
 
+  test ".description should name the credential the probe needs" do
+    assert_match(/Serper Probe/, SerperCapabilityProbeJob.description)
+    assert_match(/Tavily Probe/, TavilyCapabilityProbeJob.description)
+  end
+
   test "#perform should record a skip naming the credential to create when it is missing" do
     job_run
     job.perform_now

--- a/test/services/search_capability_probe_test.rb
+++ b/test/services/search_capability_probe_test.rb
@@ -115,14 +115,24 @@ class SearchCapabilityProbeTest < ActiveSupport::TestCase
     end
   end
 
-  test "#run should fail the search check when mapped fields are blank" do
+  test "#run should fail the search check when a field never arrives" do
     rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
-    live = [[result, result(snippet: "")], [result]]
+    live = [[result(snippet: ""), result(snippet: "")], [result]]
 
     run_probe(live: live, rejected: rejected) do |outcome|
       failure = check(outcome, "search")
       assert_equal "FAIL", failure[:status]
-      assert_match(%r{1/2 results missing mapped fields}, failure[:note])
+      assert_match(/snippet never populated/, failure[:note])
+    end
+  end
+
+  test "#run should pass the search check when only one result is sparse" do
+    rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
+    live = [[result, result(snippet: "")], [result]]
+
+    run_probe(live: live, rejected: rejected) do |outcome|
+      assert outcome[:passed]
+      assert_equal "PASS", check(outcome, "search")[:status]
     end
   end
 
@@ -131,7 +141,9 @@ class SearchCapabilityProbeTest < ActiveSupport::TestCase
     live = [[result(url: "not-a-url")], [result]]
 
     run_probe(live: live, rejected: rejected) do |outcome|
-      assert_equal "FAIL", check(outcome, "search")[:status]
+      failure = check(outcome, "search")
+      assert_equal "FAIL", failure[:status]
+      assert_match(%r{1/1 results have no usable URL}, failure[:note])
     end
   end
 

--- a/test/services/search_capability_probe_test.rb
+++ b/test/services/search_capability_probe_test.rb
@@ -1,0 +1,180 @@
+require "test_helper"
+
+class SearchCapabilityProbeTest < ActiveSupport::TestCase
+  # Answers each provider call from a queue, so a run's checks can be given
+  # different vendor responses without touching the network.
+  class ScriptedProvider
+    attr_reader :keys, :queries
+
+    def initialize(outcomes)
+      @outcomes = outcomes
+      @keys = []
+      @queries = []
+    end
+
+    def search(query, max_results: 5)
+      @queries << { query: query, max_results: max_results }
+      outcome = @outcomes.shift
+      raise outcome if outcome.is_a?(StandardError)
+
+      outcome
+    end
+  end
+
+  def result(title: "Ruby", url: "https://ruby-lang.org", snippet: "A dynamic language")
+    WebSearchProvider::Result.new(title: title, url: url, snippet: snippet)
+  end
+
+  def dev_user
+    @dev_user ||= create(:user, :dev)
+  end
+
+  def credential
+    @credential ||= create(:search_credential, user: dev_user, provider: "serper", display_name: "Serper Probe")
+  end
+
+  # Stubs the two seams a run uses: the credential's own provider (live key) and
+  # the registry (rejected key).
+  def run_probe(live:, rejected:, checks: SearchCapabilityProbe::Runner::CHECKS)
+    live_provider = ScriptedProvider.new(live)
+    rejected_provider = ScriptedProvider.new(rejected)
+
+    credential.stub(:web_search_provider, live_provider) do
+      WebSearchProvider.stub(:for, ->(_name, api_key:) { rejected_provider }) do
+        outcome = SearchCapabilityProbe::Runner.new(credential: credential, checks: checks).run
+        yield outcome, live_provider, rejected_provider
+      end
+    end
+  end
+
+  def check(outcome, name)
+    outcome[:results].find { |entry| entry[:check] == name }
+  end
+
+  test ".credential_name should name the credential after the provider label" do
+    assert_equal "Serper Probe", SearchCapabilityProbe.credential_name("serper")
+    assert_equal "Tavily Probe", SearchCapabilityProbe.credential_name("tavily")
+  end
+
+  test ".candidate_credentials should find the credential named after the probe" do
+    credential
+    assert_equal [credential], SearchCapabilityProbe.candidate_credentials("serper").to_a
+  end
+
+  test ".candidate_credentials should ignore a credential of another provider with the same name" do
+    create(:search_credential, user: dev_user, provider: "brave", display_name: "Serper Probe")
+    assert_empty SearchCapabilityProbe.candidate_credentials("serper")
+  end
+
+  test ".candidate_credentials should ignore a probe-named credential owned by a non-dev user" do
+    create(:search_credential, user: create(:user), provider: "serper", display_name: "Serper Probe")
+    assert_empty SearchCapabilityProbe.candidate_credentials("serper")
+  end
+
+  test ".ambiguous_credential_message should say which name to free up" do
+    message = SearchCapabilityProbe.ambiguous_credential_message("serper", 2)
+    assert_match(/2 dev users/, message)
+    assert_match(/"Serper Probe"/, message)
+  end
+
+  test ".missing_credential_message should name the exact credential to create" do
+    message = SearchCapabilityProbe.missing_credential_message("brave")
+    assert_match(/"Brave Probe"/, message)
+    assert_match(/Brave credential/, message)
+  end
+
+  test "#run should pass every check when the vendor behaves" do
+    rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
+    live = [[result, result], [result]]
+
+    run_probe(live: live, rejected: rejected) do |outcome|
+      assert outcome[:passed]
+      assert_equal %w[PASS PASS PASS], outcome[:results].map { |entry| entry[:status] }
+    end
+  end
+
+  test "#run should fail the rejection check when a dead key reads as transient" do
+    rejected = [WebSearchProvider::ProviderError.new("Brave: HTTP 422")]
+
+    run_probe(live: [[result], [result]], rejected: rejected) do |outcome|
+      assert_not outcome[:passed]
+      failure = check(outcome, "rejection")
+      assert_equal "FAIL", failure[:status]
+      assert_match(/not AuthError/, failure[:note])
+      assert_equal "Brave: HTTP 422", failure[:evidence][:error]
+    end
+  end
+
+  test "#run should fail the rejection check when an invalid key is accepted" do
+    run_probe(live: [[result], [result]], rejected: [[result]]) do |outcome|
+      assert_equal "FAIL", check(outcome, "rejection")[:status]
+      assert_match(/invalid key was accepted/, check(outcome, "rejection")[:note])
+    end
+  end
+
+  test "#run should fail the search check when the response maps to nothing" do
+    rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
+
+    run_probe(live: [[], [result]], rejected: rejected) do |outcome|
+      assert_not outcome[:passed]
+      assert_match(/no results/, check(outcome, "search")[:note])
+    end
+  end
+
+  test "#run should fail the search check when mapped fields are blank" do
+    rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
+    live = [[result, result(snippet: "")], [result]]
+
+    run_probe(live: live, rejected: rejected) do |outcome|
+      failure = check(outcome, "search")
+      assert_equal "FAIL", failure[:status]
+      assert_match(%r{1/2 results missing mapped fields}, failure[:note])
+    end
+  end
+
+  test "#run should fail the search check when a result url is not a url" do
+    rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
+    live = [[result(url: "not-a-url")], [result]]
+
+    run_probe(live: live, rejected: rejected) do |outcome|
+      assert_equal "FAIL", check(outcome, "search")[:status]
+    end
+  end
+
+  test "#run should send the validation job's own query and cap on the minimal check" do
+    rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
+
+    run_probe(live: [[result], [result]], rejected: rejected) do |outcome, live_provider|
+      assert_equal "PASS", check(outcome, "minimal")[:status]
+      assert_equal({ query: SearchCredentialValidationJob::VALIDATION_QUERY, max_results: 1 },
+                   live_provider.queries.last)
+    end
+  end
+
+  test "#run should record usage for the billed checks only" do
+    rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
+
+    assert_difference -> { WebSearchUsage.for_credential(credential).count }, 2 do
+      run_probe(live: [[result], [result]], rejected: rejected) { |outcome| assert outcome[:passed] }
+    end
+  end
+
+  test "#run should record a failure rather than raise when a check blows up" do
+    rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
+    live = [RuntimeError.new("boom"), [result]]
+
+    run_probe(live: live, rejected: rejected) do |outcome|
+      assert_not outcome[:passed]
+      assert_equal "FAIL", check(outcome, "search")[:status]
+      assert_match(/RuntimeError: boom/, check(outcome, "search")[:note])
+    end
+  end
+
+  test "#run should time each check" do
+    rejected = [WebSearchProvider::AuthError.new("Serper: HTTP 403")]
+
+    run_probe(live: [[result], [result]], rejected: rejected) do |outcome|
+      assert(outcome[:results].all? { |entry| entry[:seconds].is_a?(Numeric) })
+    end
+  end
+end

--- a/test/services/search_capability_probe_test.rb
+++ b/test/services/search_capability_probe_test.rb
@@ -25,12 +25,12 @@ class SearchCapabilityProbeTest < ActiveSupport::TestCase
     WebSearchProvider::Result.new(title: title, url: url, snippet: snippet)
   end
 
-  def dev_user
-    @dev_user ||= create(:user, :dev)
+  def operator
+    @operator ||= create(:user, :dev)
   end
 
   def credential
-    @credential ||= create(:search_credential, user: dev_user, provider: "serper", display_name: "Serper Probe")
+    @credential ||= create(:search_credential, user: operator, provider: "serper", display_name: "Serper Probe")
   end
 
   # Stubs the two seams a run uses: the credential's own provider (live key) and
@@ -56,25 +56,19 @@ class SearchCapabilityProbeTest < ActiveSupport::TestCase
     assert_equal "Tavily Probe", SearchCapabilityProbe.credential_name("tavily")
   end
 
-  test ".candidate_credentials should find the credential named after the probe" do
+  test ".credential_for should find the credential named after the probe" do
     credential
-    assert_equal [credential], SearchCapabilityProbe.candidate_credentials("serper").to_a
+    assert_equal credential, SearchCapabilityProbe.credential_for("serper", user: operator)
   end
 
-  test ".candidate_credentials should ignore a credential of another provider with the same name" do
-    create(:search_credential, user: dev_user, provider: "brave", display_name: "Serper Probe")
-    assert_empty SearchCapabilityProbe.candidate_credentials("serper")
+  test ".credential_for should ignore a credential of another provider with the same name" do
+    create(:search_credential, user: operator, provider: "brave", display_name: "Serper Probe")
+    assert_nil SearchCapabilityProbe.credential_for("serper", user: operator)
   end
 
-  test ".candidate_credentials should ignore a probe-named credential owned by a non-dev user" do
-    create(:search_credential, user: create(:user), provider: "serper", display_name: "Serper Probe")
-    assert_empty SearchCapabilityProbe.candidate_credentials("serper")
-  end
-
-  test ".ambiguous_credential_message should say which name to free up" do
-    message = SearchCapabilityProbe.ambiguous_credential_message("serper", 2)
-    assert_match(/2 dev users/, message)
-    assert_match(/"Serper Probe"/, message)
+  test ".credential_for should ignore a probe-named credential belonging to someone else" do
+    create(:search_credential, user: create(:user, :dev), provider: "serper", display_name: "Serper Probe")
+    assert_nil SearchCapabilityProbe.credential_for("serper", user: operator)
   end
 
   test ".missing_credential_message should name the exact credential to create" do


### PR DESCRIPTION
Changes:

- Add `SearchCapabilityProbe` and a probe job per provider (`SerperCapabilityProbeJob`, `BraveCapabilityProbeJob`, `TavilyCapabilityProbeJob`), runnable from `/development/jobs` and reporting like the LLM probes — one event per check with its evidence, plus a summary verdict
- Take the key from a `SearchCredential` named after the probe (**Serper Probe**, **Brave Probe**, **Tavily Probe**) on the account of whoever pressed Run; a missing record is reported by name
- Show what a maintenance job needs in its page header, for the search probes and the LLM ones alike
- Document the checks and how to read a failure in `docs/search-provider-verification.md`

`WebSearchProvider`'s unit tests run against fixtures, so they can only confirm
our reading of a vendor's docs — not that the vendor still behaves that way. The
two bugs fixed in #1257 were invisible to a green suite for exactly that reason:
the fixtures encoded the same wrong assumption as the code.

The checks:

| Check | What it proves |
| --- | --- |
| `rejection` | An invalid key comes back as `AuthError`. Free, needs no live quota, and the one check fixtures can't stand in for |
| `search` | A live query still maps to populated `Result` fields. Only a field blank on *every* result fails it — a renamed vendor field blanks the field everywhere, while one sparse result is ordinary |
| `minimal` | The one-result query `SearchCredentialValidationJob` sends is accepted |

Keys come from managed credentials rather than the environment, since that is
how search runs — so the checks go through the same objects a feed run uses. The
dev area passes the authenticated user to jobs that ask for it
(`ApplicationJob.runnable_arguments`), and since `display_name` is unique per
`[user_id, provider]`, the probe name resolves to exactly one credential by
construction; a run can only ever spend its own operator's queries.

The credential does not have to be active — probing a rejected key is a
legitimate thing to want. `search` and `minimal` spend a real query each, billed
to that credential and recorded as usage like any other search.

References:

- Follows: #1257
