### PR TITLE
Bill a call whose reply we cannot parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 - Fixed AI feeds failing when the model wrapped its answer in a code block or added a line of preamble.
 - Kimi feeds now use K2.6, since Moonshot is retiring K2.5 at the end of August. Feeds still set to the old model switch over on their own — no action needed.
 - Events in the log now start with what happened, so entries that used to show only raw technical output are readable at a glance.
+- AI usage totals now include calls where the model's answer came back unreadable, so a run's real cost isn't understated.
 
 ## 2026-08-12
 

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -77,7 +77,8 @@ class LlmClient
     finished_at = Time.current
 
     begin
-      validate_payload!(response.payload, output_schema)
+      payload = parse_payload(response.payload, output_schema)
+      validate_payload!(payload, output_schema)
     rescue SchemaError => e
       write_usage(ctx, outcome: :schema_error, started_at: started_at,
                   finished_at: finished_at, response: response, error_message: e.message)
@@ -87,7 +88,7 @@ class LlmClient
     usage = write_usage(ctx, outcome: :success, started_at: started_at,
                         finished_at: finished_at, response: response)
 
-    Result.new(payload: response.payload, usage_id: usage.id)
+    Result.new(payload: payload, usage_id: usage.id)
   end
 
   # The provider's available models, as an array of plain hashes ready to
@@ -169,9 +170,8 @@ class LlmClient
     end
 
     response = chat.ask(prompt)
-    answer = recover_halted(chat, response)
     ProviderResponse.new(
-      payload: output_schema.present? ? parse_payload(answer) : response_text(answer),
+      payload: response_content(recover_halted(chat, response)),
       **usage_totals(chat, response)
     )
   end
@@ -216,15 +216,18 @@ class LlmClient
     @adapter ||= Adapter.for(credential.provider)
   end
 
-  def response_text(response)
-    response.respond_to?(:content) ? response.content.to_s : response.to_s
+  # A Hash when the provider parsed structured output itself, text otherwise.
+  # Parsing is deliberately left to the caller: it happens after the response
+  # carries its token counts, so a reply we can't parse is still billed honestly.
+  def response_content(answer)
+    content = answer.respond_to?(:content) ? answer.content : answer
+    content.is_a?(Hash) ? content : content.to_s
   end
 
-  def parse_payload(response)
-    raw = response.respond_to?(:content) ? response.content : response.to_s
-    return raw if raw.is_a?(Hash)
+  def parse_payload(raw, output_schema)
+    return raw if output_schema.blank? || raw.is_a?(Hash)
 
-    JSON.parse(adapter.unwrap_json(raw.to_s))
+    JSON.parse(adapter.unwrap_json(raw))
   rescue JSON::ParserError => e
     raise SchemaError, "non-JSON response from provider: #{e.message}"
   end

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -380,6 +380,37 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal "provider_error", LlmUsage.last.outcome
   end
 
+  # Kimi answers a schema call in prose often enough that this is a live path,
+  # and the call is billed whether or not we can parse what came back.
+  test "#call should record usage when a schema call comes back as non-JSON" do
+    client = LlmClient.new(credential)
+    stub_provider_response(client, LlmClient::ProviderResponse.new(
+      payload: "I cannot browse the web.", input_tokens: 900, output_tokens: 40,
+      cache_write_tokens: 0, cache_read_tokens: 0
+    ))
+
+    assert_difference("LlmUsage.count", 1) do
+      assert_raises(LlmClient::SchemaError) { client.call(default_ctx, **call_opts) }
+    end
+
+    usage = LlmUsage.last
+    assert_equal "schema_error", usage.outcome
+    assert_equal 900, usage.input_tokens
+  end
+
+  test "#call should unwrap a fenced payload before validating it" do
+    client = LlmClient.new(create(:ai_credential, :active, user: user, provider: "moonshot"))
+    stub_provider_response(client, LlmClient::ProviderResponse.new(
+      payload: %(```json\n{"items":[{"title":"Post 1"}]}\n```), input_tokens: 10, output_tokens: 5,
+      cache_write_tokens: 0, cache_read_tokens: 0
+    ))
+
+    result = client.call(default_ctx, **call_opts)
+
+    assert_equal({ "items" => [{ "title" => "Post 1" }] }, result.payload)
+    assert_equal "success", LlmUsage.last.outcome
+  end
+
   test "#call should map malformed tool-call arguments to ProviderError" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, JSON::ParserError.new("unexpected token"))


### PR DESCRIPTION
Changes:

- Parse a structured reply after the response carries its token counts, so an unparseable one records a `schema_error` usage row instead of escaping unbilled
- Cover both paths with tests: a prose answer to a schema call, and a fenced payload unwrapped before validation
