### PR TITLE
Run the LLM capability probes on credential records

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,9 +20,6 @@ jobs:
       IMGPROXY_SALT: ${{ secrets.IMGPROXY_SALT }}
       CF_ORIGIN_CERT: ${{ secrets.CF_ORIGIN_CERT }}
       CF_ORIGIN_KEY: ${{ secrets.CF_ORIGIN_KEY }}
-      # Optional LLM provider keys for the capability probe job.
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
 
     steps:
       - name: Checkout code

--- a/.kamal/secrets.staging
+++ b/.kamal/secrets.staging
@@ -14,9 +14,3 @@ RAILS_MASTER_KEY=$(cat config/credentials/staging.key)
 # for manual deploys (e.g. export CF_ORIGIN_CERT="$(cat cf-origin.pem)").
 CERTIFICATE_PEM=$(printenv CF_ORIGIN_CERT | grep . || { echo "CF_ORIGIN_CERT is required and must be non-empty" >&2; exit 1; })
 PRIVATE_KEY_PEM=$(printenv CF_ORIGIN_KEY | grep . || { echo "CF_ORIGIN_KEY is required and must be non-empty" >&2; exit 1; })
-
-# LLM provider keys for the capability probe job (issue #913). Optional on
-# purpose: the probe skips providers without a key, so deploys must not fail
-# when these are absent from the deploying environment.
-ANTHROPIC_API_KEY=$(printenv ANTHROPIC_API_KEY)
-MOONSHOT_API_KEY=$(printenv MOONSHOT_API_KEY)

--- a/app/jobs/llm_capability_probe_job.rb
+++ b/app/jobs/llm_capability_probe_job.rb
@@ -1,8 +1,11 @@
-# Base for the per-provider capability probe jobs (spec 005 §5; issue #913).
-# Subclasses pin one (provider, model) pair via PROVIDER/MODEL. Everything the
-# research needs lands in JobRun events: one event per check with full
-# evidence, plus a summary verdict — no files to chase afterwards. If the
-# provider has no API key in the environment, the run records a skip and ends.
+# Base for the per-provider capability probe jobs. Subclasses pin one
+# (provider, model) pair via PROVIDER/MODEL. Everything the research needs
+# lands in JobRun events: one event per check with full evidence, plus a
+# summary verdict — no files to chase afterwards.
+#
+# The key comes from an AiCredential named after the probe and owned by whoever
+# launched the run. Without that record the run says which credential to create
+# and ends.
 class LlmCapabilityProbeJob < ApplicationJob
   include RecordsJobRun
 
@@ -10,40 +13,44 @@ class LlmCapabilityProbeJob < ApplicationJob
 
   def self.description
     "Runs the capability checks for #{self::MODEL} against the live #{self::PROVIDER} API. " \
-      "Needs #{LlmCapabilityProbe::Provider.env_key_for(self::PROVIDER)} in the environment."
+      "Needs an AI credential named “#{LlmCapabilityProbe.credential_name(self::PROVIDER)}” on your own account."
   end
 
-  def perform
+  def self.runnable_arguments(user) = [user]
+
+  def perform(user)
     provider_key = self.class::PROVIDER
     model = self.class::MODEL
+    credential = LlmCapabilityProbe.credential_for(provider_key, user: user)
 
-    unless LlmCapabilityProbe::Provider.configured?(provider_key)
+    if credential.nil?
       record_event(type: "job.llm_capability_probe.skipped",
-                   message: "#{provider_key}/#{model}: no API key in environment",
-                   level: :warning, provider: provider_key, model: model)
+                   message: "#{provider_key}/#{model}: #{LlmCapabilityProbe.missing_credential_message(provider_key)}",
+                   level: :warning, provider: provider_key, model: model,
+                   expected_credential_name: LlmCapabilityProbe.credential_name(provider_key))
       return
     end
 
-    probe(provider_key, model)
+    probe(provider_key, model, credential)
   end
 
   private
 
-  def probe(provider_key, model)
-    provider = LlmCapabilityProbe::Provider.build(provider_key)
-    outcome = LlmCapabilityProbe::Runner.new(provider: provider, model: model).run
+  def probe(provider_key, model, credential)
+    outcome = LlmCapabilityProbe::Runner.new(credential: credential, model: model).run
 
     outcome[:results].each do |result|
       record_event(type: "job.llm_capability_probe.check",
                    message: "#{result[:check]}: #{result[:status]} (#{result[:seconds]}s) — #{result[:note]}",
                    level: result[:status] == "FAIL" ? :warning : :info,
-                   provider: provider_key, model: model, **result)
+                   provider: provider_key, model: model, credential_id: credential.id, **result)
     end
 
     summary = outcome[:results].map { |r| "#{r[:check]}=#{r[:status]}" }.join(" ")
     record_event(type: "job.llm_capability_probe.completed",
                  message: "#{provider_key}/#{model}: #{summary}",
                  level: outcome[:passed] ? :info : :warning,
-                 provider: provider_key, model: model, passed: outcome[:passed])
+                 provider: provider_key, model: model, credential_id: credential.id,
+                 passed: outcome[:passed])
   end
 end

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -46,4 +46,15 @@ class AiCredential < ApplicationRecord
       llm_provider.configure(config, credential_data["api_key"])
     end
   end
+
+  # The chat a run is made on: this key, its provider's RubyLLM key, and its
+  # model-existence rule. Shared so a probe cannot qualify a model on a
+  # configuration production doesn't use.
+  def chat(model)
+    ruby_llm_context.chat(
+      model: model,
+      provider: llm_provider.ruby_llm_provider,
+      assume_model_exists: llm_provider.assume_model_exists?
+    )
+  end
 end

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -6,8 +6,9 @@
 # (LlmClient::Adapter::Base#apply_web), so a hosted mechanism tells us nothing
 # about a feed run.
 #
-# Keys come from the environment rather than managed credentials, so a provider
-# can be qualified before it is wired into the app.
+# The key comes from an AiCredential named after the probe and owned by whoever
+# launched the run, so the checks are made on the same objects and the same
+# provider configuration a feed run uses.
 #
 # See docs/llm-provider-qualification.md.
 module LlmCapabilityProbe
@@ -95,81 +96,31 @@ module LlmCapabilityProbe
     end
   end
 
-  class Provider
-    attr_reader :key
-
-    def initialize(key)
-      @key = key
+  class << self
+    def credential_name(provider)
+      "#{LlmProvider.find(provider).display_name} Probe"
     end
 
-    def context
-      @context ||= RubyLLM.context { |config| configure(config) }
+    # Scoped to whoever launched the probe: a run spends that key, and display
+    # names are unique per user and provider, so the owner is what makes the
+    # name resolve to one credential.
+    def credential_for(provider, user:)
+      user.ai_credentials.find_by(provider: provider, display_name: credential_name(provider))
     end
 
-    def chat(model)
-      context.chat(model: model, provider: ruby_llm_provider, assume_model_exists: assume_model_exists?)
-    end
-
-    # Resolved the way LlmClient does it — registry names don't always match
-    # RubyLLM provider keys.
-    def list_models
-      RubyLLM::Provider.resolve(ruby_llm_provider).new(context.config).list_models
-    end
-
-    def assume_model_exists? = false
-
-    # Repairs structured output the way production does, so the probe doesn't
-    # fail a model on a quirk the app already absorbs (Kimi fences its JSON).
-    def unwrap_json(text)
-      LlmClient::Adapter.for(key).unwrap_json(text)
-    end
-
-    class Anthropic < Provider
-      def self.env_key = "ANTHROPIC_API_KEY"
-
-      def configure(config)
-        config.anthropic_api_key = ENV.fetch(self.class.env_key)
-      end
-
-      def ruby_llm_provider = :anthropic
-    end
-
-    class Moonshot < Provider
-      def self.env_key = "MOONSHOT_API_KEY"
-
-      def configure(config)
-        config.openai_api_key = ENV.fetch(self.class.env_key)
-        config.openai_api_base = ENV.fetch("MOONSHOT_API_BASE", "https://api.moonshot.ai/v1")
-        # Must match LlmProvider#configure or results won't transfer: Moonshot
-        # rejects the "developer" role RubyLLM sends by default.
-        config.openai_use_system_role = true
-      end
-
-      def ruby_llm_provider = :openai
-      def assume_model_exists? = true
-    end
-
-    REGISTRY = { "anthropic" => Anthropic, "moonshot" => Moonshot }.freeze
-
-    def self.build(key)
-      klass = REGISTRY.fetch(key) { raise ArgumentError, "Unknown provider '#{key}'. Known: #{REGISTRY.keys.join(', ')}" }
-      klass.new(key)
-    end
-
-    def self.env_key_for(key)
-      REGISTRY.fetch(key).env_key
-    end
-
-    def self.configured?(key)
-      REGISTRY.key?(key) && ENV[REGISTRY.fetch(key).env_key].present?
+    # Says what to create, since the fix is always the same: one credential,
+    # this provider, this exact name.
+    def missing_credential_message(provider)
+      "no AI credential named #{credential_name(provider).inspect} on your account — " \
+        "add a #{LlmProvider.find(provider).display_name} credential with that exact name to run this probe"
     end
   end
 
   class Runner
     CHECKS = %w[models plain system_prompt schema client_tools client_tools_schema].freeze
 
-    def initialize(provider:, model:, checks: CHECKS)
-      @provider = provider
+    def initialize(credential:, model:, checks: CHECKS)
+      @credential = credential
       @model = model
       @checks = checks
       @results = []
@@ -197,9 +148,10 @@ module LlmCapabilityProbe
     end
 
     # LlmModelCapability matches on exact string, so a near-miss id qualifies
-    # nothing. The listing is recorded as evidence.
+    # nothing. Goes through the listing the app itself calls, so a pass means
+    # the credential can also be validated. The listing is recorded as evidence.
     def check_models
-      ids = @provider.list_models.map(&:id)
+      ids = LlmClient.new(@credential).available_models.map { |model| model["id"] }
       evidence = { model_ids: ids }
       return { status: "FAIL", note: "models endpoint returned no models", evidence: evidence } if ids.empty?
 
@@ -209,13 +161,13 @@ module LlmCapabilityProbe
     end
 
     def check_plain
-      chat = @provider.chat(@model)
+      chat = @credential.chat(@model)
       text = chat.ask("Reply with the single word: pong").content.to_s
       pass(text.match?(/pong/i), "expected 'pong'", text) { "plain round trip" }
     end
 
     def check_system_prompt
-      chat = @provider.chat(@model)
+      chat = @credential.chat(@model)
       chat.with_instructions(SYSTEM_CHECK_INSTRUCTIONS)
       text = chat.ask(SYSTEM_CHECK_PROMPT).content.to_s
       pass(honors_system_prompt?(text), "system instructions not honored verbatim", text) { "system prompt honored" }
@@ -233,7 +185,7 @@ module LlmCapabilityProbe
     # reject the system role RubyLLM defaults to, which a schema-only call
     # never exercises.
     def check_schema
-      chat = @provider.chat(@model).with_schema(PROBE_SCHEMA)
+      chat = @credential.chat(@model).with_schema(PROBE_SCHEMA)
       chat.with_instructions(PROBE_INSTRUCTIONS)
       response = chat.ask(STRUCTURE_PROMPT_PREFIX + SAMPLE_TEXT)
       validate_items(response, expect_null_source_url: true)
@@ -271,7 +223,7 @@ module LlmCapabilityProbe
     # (LlmClient::Adapter::Base#apply_web): the probe drives a paid API, and an
     # unqualified model is the likeliest to loop on a tool.
     def client_tools_chat(schema)
-      chat = @provider.chat(@model)
+      chat = @credential.chat(@model)
       chat.with_instructions(PROBE_INSTRUCTIONS)
       chat.with_schema(schema) if schema
       budget = LlmClient::ToolBudget.new
@@ -326,7 +278,7 @@ module LlmCapabilityProbe
 
     def validate_items(response, expect_null_source_url: false)
       raw = response.content
-      payload = raw.is_a?(Hash) ? raw : JSON.parse(@provider.unwrap_json(raw.to_s))
+      payload = raw.is_a?(Hash) ? raw : JSON.parse(unwrap_json(raw.to_s))
       errors = JSONSchemer.schema(PROBE_SCHEMA).validate(payload).to_a
       items = payload.is_a?(Hash) ? Array(payload["items"]) : []
       evidence = { items: items.first(3) }
@@ -347,6 +299,12 @@ module LlmCapabilityProbe
       end
     rescue JSON::ParserError => e
       { status: "FAIL", note: "non-JSON response: #{e.message[0, 120]}", evidence: raw.to_s[0, 500] }
+    end
+
+    # Repairs structured output the way production does, so the probe doesn't
+    # fail a model on a quirk the app already absorbs (Kimi fences its JSON).
+    def unwrap_json(text)
+      LlmClient::Adapter.for(@credential.provider).unwrap_json(text)
     end
 
     def pass(condition, fail_note, evidence)

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -150,10 +150,7 @@ class LlmClient
 
   # Single seam tests stub. Returns a ProviderResponse.
   def invoke_provider(ctx: nil, model:, prompt:, output_schema:, web:, system: nil)
-    provider = credential.llm_provider
-    chat = credential.ruby_llm_context.chat(
-      model: model, provider: provider.ruby_llm_provider, assume_model_exists: provider.assume_model_exists?
-    )
+    chat = credential.chat(model)
     # System prompt is the privileged instruction channel; the user prompt sent
     # by #ask travels as a separate user-role message (spec §8).
     chat.with_instructions(system) if system.present?

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -124,7 +124,3 @@ env:
     - POSTGRES_PASSWORD
     - IMGPROXY_KEY
     - IMGPROXY_SALT
-    # LLM provider keys for the capability probe job; optional, see
-    # .kamal/secrets.staging.
-    - ANTHROPIC_API_KEY
-    - MOONSHOT_API_KEY

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -222,7 +222,6 @@ The workflows read these repository secrets:
 | `STAGING_SSH_PRIVATE_KEY` | staging | SSH key for `dev-origin.fffeeder.com` |
 | `PRODUCTION_SSH_PRIVATE_KEY` | production | SSH key for `app-origin.fffeeder.com` |
 | `CF_ORIGIN_CERT` / `CF_ORIGIN_KEY` | both | Cloudflare Origin Certificate for kamal-proxy |
-| `ANTHROPIC_API_KEY` / `MOONSHOT_API_KEY` | staging | optional LLM keys for the capability probe job (see [llm-provider-qualification.md](llm-provider-qualification.md)) |
 
 ## Database
 

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -6,21 +6,23 @@ probe run shows it works on the shape production actually calls. The model
 picker offers that list intersected with the credential's own model snapshot, so
 an unqualified model can never be selected and fail asynchronously mid-run.
 
-`LlmCapabilityProbe` is the gate. It runs against the real provider API, and
-takes its keys from the environment rather than managed credentials, so a
-provider can be qualified before it is wired into the app.
+`LlmCapabilityProbe` is the gate. It runs against the real provider API on a
+managed credential, through the same provider configuration a feed run uses
+(`AiCredential#chat`), so a pass cannot come from a setup production doesn't
+share.
 
 ## Running it
 
-Keys come from the environment: `ANTHROPIC_API_KEY`, `MOONSHOT_API_KEY`
-(`MOONSHOT_API_BASE` overrides the endpoint). Without a key the run records a
-skip event and ends.
+The key comes from the `AiCredential` whose name matches the probe — **Anthropic
+Probe**, **Moonshot (Kimi) Probe** — on **your own account**. The dev area
+passes whoever pressed Run through to the job, so a probe only ever spends its
+own operator's tokens. Without that record the run records a skip saying which
+credential to create.
 
 From the dev area — the usual path, and the one that keeps the evidence
 searchable afterwards:
 
-1. Set the key on the target environment (staging; see
-   [deployment-setup.md](deployment-setup.md)).
+1. Add an AI credential for the provider, named exactly as above.
 2. Open `/development/jobs`, run `KimiCapabilityProbeJob` or
    `AnthropicCapabilityProbeJob`, and read the run under `job_runs`.
 
@@ -28,12 +30,22 @@ Each check writes one event with its full evidence — the models listing, the
 tool calls with their arguments and results, the returned payload — so there is
 no separate transcript to chase.
 
-For a one-off pair, or a subset of checks, use the CLI instead:
+For a one-off pair, or a subset of checks, use the CLI instead. It has no
+session to read an operator from, so name one:
 
 ```sh
-bundle exec ruby script/llm_capability_probe.rb --provider moonshot --model kimi-k3
-bundle exec ruby script/llm_capability_probe.rb --provider anthropic --model claude-sonnet-4-6 --checks models,client_tools
+bundle exec ruby script/llm_capability_probe.rb --user me@example.com --provider moonshot --model kimi-k3
+bundle exec ruby script/llm_capability_probe.rb --user me@example.com --provider anthropic --model claude-sonnet-4-6 --checks models
 ```
+
+A provider must be in `LlmProvider`'s registry before it can be probed, since
+that is what a credential is created against. Registering one exposes nothing on
+its own: the model picker reads `LlmModelCapability`, which is what a passing
+probe run earns.
+
+Probe runs write no `LlmUsage` rows. Usage is feed-run accounting — its
+`purpose` enum has no probe value and its rows hang off a feed — so probe cost
+is reported in the run's own events instead of the credential's usage surface.
 
 ## What it checks, and why only these
 

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -97,8 +97,11 @@ Before a pair can be probed, the provider needs:
   rides another provider's adapter);
 - an `LlmClient::Adapter` subclass, if it needs response repair or one-call
   extraction;
-- a `LlmCapabilityProbe::Provider` subclass with `env_key`, `configure` and
-  `ruby_llm_provider`, registered in that class's `REGISTRY`.
+- a probe job pinning the pair, subclassing `LlmCapabilityProbeJob` with
+  `PROVIDER`/`MODEL` and registered in `JobRun::RUNNABLE_JOBS`;
+- an `AiCredential` for it, named `LlmCapabilityProbe.credential_name(provider)`,
+  on the account that will run the probe.
 
-The probe's `configure` must mirror production's `LlmProvider#configure`. If
-they drift, the probe qualifies a wire shape the app never sends.
+There is nothing to keep in sync: the probe reaches the provider through
+`AiCredential#chat`, so it is configured by the same `LlmProvider#configure`
+production uses.

--- a/lib/tasks/ai_extraction_verify.rake
+++ b/lib/tasks/ai_extraction_verify.rake
@@ -3,16 +3,17 @@ namespace :ai do
   # runs the combined system prompt + universal schema + web tools against a real
   # provider and a real source, then validates the structured result. Also a
   # smoke test of the transformation contract — the request asks for one-line
-  # summaries, so the returned bodies should be short. The search credential is
-  # selected explicitly so this task exercises the same managed-key path as a
-  # feed run.
+  # summaries, so the returned bodies should be short. Both credentials are
+  # selected explicitly by id, so this task exercises the same managed-key path
+  # as a feed run.
   desc "Verify AI extraction end-to-end with the production prompts against a live provider"
   task verify_extraction: :environment do
     provider_key = "anthropic"
     model = "claude-sonnet-4-6"
 
-    unless LlmCapabilityProbe::Provider.configured?(provider_key)
-      puts "[#{provider_key}/#{model}] SKIP: no AI provider API key in environment"
+    ai_credential = AiCredential.find_by(id: ENV["AI_CREDENTIAL_ID"], provider: provider_key)
+    unless ai_credential
+      puts "[#{provider_key}/#{model}] SKIP: set AI_CREDENTIAL_ID to a managed #{provider_key} credential"
       next
     end
 
@@ -32,7 +33,7 @@ namespace :ai do
     PROMPT
 
     begin
-      chat = LlmCapabilityProbe::Provider.build(provider_key).chat(model)
+      chat = ai_credential.chat(model)
       chat.with_instructions(Loader::LlmPrompts::COMBINED_SYSTEM)
       chat.with_schema(schema)
       adapter.apply_web(

--- a/script/llm_capability_probe.rb
+++ b/script/llm_capability_probe.rb
@@ -5,29 +5,35 @@
 # the probe; this wrapper covers local one-off runs against a single pair.
 #
 # Usage:
-#   bundle exec ruby script/llm_capability_probe.rb --provider anthropic --model claude-sonnet-4-6
-#   bundle exec ruby script/llm_capability_probe.rb --provider moonshot --model kimi-k2.6 --checks models,client_tools
+#   bundle exec ruby script/llm_capability_probe.rb --user me@example.com --provider anthropic --model claude-sonnet-4-6
+#   bundle exec ruby script/llm_capability_probe.rb --user me@example.com --provider moonshot --model kimi-k2.6 --checks models
 #
-# Keys via env: ANTHROPIC_API_KEY, MOONSHOT_API_KEY (MOONSHOT_API_BASE to override).
+# The key comes from that user's AI credential named after the probe (see
+# LlmCapabilityProbe.credential_name); --user is what the dev area gets from
+# the session and the CLI has to be told.
 
 require "optparse"
 require_relative "../config/environment"
 
 options = { checks: LlmCapabilityProbe::Runner::CHECKS }
 OptionParser.new do |parser|
-  parser.on("--provider KEY", "anthropic | moonshot") { |v| options[:provider] = v }
+  parser.on("--user EMAIL", "Owner of the probe credential") { |v| options[:user] = v }
+  parser.on("--provider KEY", "#{LlmProvider.names.join(' | ')}") { |v| options[:provider] = v }
   parser.on("--model ID", "Model id as the provider names it") { |v| options[:model] = v }
   parser.on("--checks LIST", "Comma-separated subset of: #{LlmCapabilityProbe::Runner::CHECKS.join(',')}") do |v|
     options[:checks] = v.split(",").map(&:strip) & LlmCapabilityProbe::Runner::CHECKS
   end
 end.parse!
-abort "Required: --provider and --model" unless options[:provider] && options[:model]
+abort "Required: --user, --provider and --model" unless options[:user] && options[:provider] && options[:model]
 
-provider = LlmCapabilityProbe::Provider.build(options[:provider])
-runner = LlmCapabilityProbe::Runner.new(provider: provider, model: options[:model], checks: options[:checks])
+user = User.find_by(email_address: options[:user]) || abort("No user with email #{options[:user]}")
+credential = LlmCapabilityProbe.credential_for(options[:provider], user: user) ||
+             abort("#{options[:user]}: #{LlmCapabilityProbe.missing_credential_message(options[:provider])}")
+
+runner = LlmCapabilityProbe::Runner.new(credential: credential, model: options[:model], checks: options[:checks])
 outcome = runner.run
 
-puts "\n#{provider.key} / #{options[:model]}"
+puts "\n#{credential.provider} / #{options[:model]} (#{credential.display_name})"
 outcome[:results].each { |r| puts format("  %-11s %-4s %5ss  %s", r[:check], r[:status], r[:seconds], r[:note]) }
 puts JSON.pretty_generate(outcome[:results])
 exit(outcome[:passed] ? 0 : 1)

--- a/test/jobs/llm_capability_probe_job_test.rb
+++ b/test/jobs/llm_capability_probe_job_test.rb
@@ -1,8 +1,16 @@
 require "test_helper"
 
 class LlmCapabilityProbeJobTest < ActiveJob::TestCase
+  def operator
+    @operator ||= create(:user, :dev)
+  end
+
   def job
-    @job ||= AnthropicCapabilityProbeJob.new
+    @job ||= AnthropicCapabilityProbeJob.new(operator)
+  end
+
+  def credential
+    @credential ||= create(:ai_credential, user: operator, provider: "anthropic", display_name: "Anthropic Probe")
   end
 
   def job_run
@@ -20,25 +28,39 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
     assert_equal %w[moonshot kimi-k2.6], [KimiCapabilityProbeJob::PROVIDER, KimiCapabilityProbeJob::MODEL]
   end
 
-  test ".description should name the environment key the probe needs" do
-    assert_match(/ANTHROPIC_API_KEY/, AnthropicCapabilityProbeJob.description)
-    assert_match(/MOONSHOT_API_KEY/, KimiCapabilityProbeJob.description)
+  test ".description should name the credential the probe needs" do
+    assert_match(/Anthropic Probe/, AnthropicCapabilityProbeJob.description)
+    assert_match(/Moonshot \(Kimi\) Probe/, KimiCapabilityProbeJob.description)
   end
 
-  test "#perform should record a skip event when the API key is not configured" do
-    job_run
+  test ".runnable_arguments should ask the dev area for the user who pressed Run" do
+    assert_equal [operator], AnthropicCapabilityProbeJob.runnable_arguments(operator)
+  end
 
-    LlmCapabilityProbe::Provider.stub(:configured?, false) do
+  test "#perform should record a skip naming the credential to create when it is missing" do
+    job_run
+    job.perform_now
+
+    event = Event.find_by(subject: job_run, type: "job.llm_capability_probe.skipped")
+    assert_predicate event, :warning?
+    assert_includes event.message, '"Anthropic Probe"'
+    assert_equal "Anthropic Probe", event.metadata["expected_credential_name"]
+  end
+
+  test "#perform should ignore a probe-named credential owned by someone else" do
+    job_run
+    create(:ai_credential, user: create(:user, :dev), provider: "anthropic", display_name: "Anthropic Probe")
+
+    LlmCapabilityProbe::Runner.stub(:new, ->(**) { raise "should not run" }) do
       job.perform_now
     end
 
-    events = Event.where(subject: job_run, type: "job.llm_capability_probe.skipped")
-    assert_equal 1, events.count
-    assert_predicate events.first, :warning?
+    assert Event.exists?(subject: job_run, type: "job.llm_capability_probe.skipped")
   end
 
   test "#perform should record one event per check with full evidence plus a summary" do
     job_run
+    credential
 
     outcome = {
       results: [
@@ -50,12 +72,8 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
     runner = Minitest::Mock.new
     runner.expect(:run, outcome)
 
-    LlmCapabilityProbe::Provider.stub(:configured?, true) do
-      LlmCapabilityProbe::Provider.stub(:build, ->(key) { key }) do
-        LlmCapabilityProbe::Runner.stub(:new, ->(**) { runner }) do
-          job.perform_now
-        end
-      end
+    LlmCapabilityProbe::Runner.stub(:new, ->(**) { runner }) do
+      job.perform_now
     end
 
     checks = Event.where(subject: job_run, type: "job.llm_capability_probe.check").order(:id)
@@ -67,6 +85,7 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
 
     summary = Event.find_by(subject: job_run, type: "job.llm_capability_probe.completed")
     assert_includes summary.message, "plain=PASS schema=FAIL"
+    assert_equal credential.id, summary.metadata["credential_id"]
     assert_equal false, summary.metadata["passed"]
     assert_predicate summary, :warning?
     runner.verify

--- a/test/lib/tasks/ai_extraction_verify_test.rb
+++ b/test/lib/tasks/ai_extraction_verify_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+require "rake"
+
+class AiVerifyExtractionTest < ActiveSupport::TestCase
+  setup do
+    F2Rails::Application.load_tasks unless Rake::Task.task_defined?("ai:verify_extraction")
+    @task = Rake::Task["ai:verify_extraction"]
+    @task.reenable
+  end
+
+  def with_env(values)
+    original = values.keys.index_with { |key| ENV.fetch(key, nil) }
+    values.each { |key, value| ENV[key] = value }
+    yield
+  ensure
+    original.each { |key, value| ENV[key] = value }
+  end
+
+  # The task drives a live provider, so the reachable behavior here is its
+  # refusal to start: an unset or unknown id must name what to set rather than
+  # fail somewhere inside the call.
+  test "ai:verify_extraction should skip when AI_CREDENTIAL_ID names no credential" do
+    with_env("AI_CREDENTIAL_ID" => nil, "SEARCH_CREDENTIAL_ID" => nil) do
+      out, = capture_io { @task.invoke }
+
+      assert_match(/SKIP: set AI_CREDENTIAL_ID/, out)
+    end
+  end
+
+  test "ai:verify_extraction should skip when the credential belongs to another provider" do
+    credential = create(:ai_credential, provider: "openrouter")
+
+    with_env("AI_CREDENTIAL_ID" => credential.id, "SEARCH_CREDENTIAL_ID" => nil) do
+      out, = capture_io { @task.invoke }
+
+      assert_match(/SKIP: set AI_CREDENTIAL_ID/, out)
+    end
+  end
+
+  test "ai:verify_extraction should skip when no active search credential is named" do
+    credential = create(:ai_credential, provider: "anthropic")
+
+    with_env("AI_CREDENTIAL_ID" => credential.id, "SEARCH_CREDENTIAL_ID" => nil) do
+      out, = capture_io { @task.invoke }
+
+      assert_match(/SKIP: set SEARCH_CREDENTIAL_ID/, out)
+    end
+  end
+end

--- a/test/models/ai_credential_test.rb
+++ b/test/models/ai_credential_test.rb
@@ -195,6 +195,17 @@ class AiCredentialTest < ActiveSupport::TestCase
     assert_equal user, event.user
   end
 
+  test "#chat should build the chat on the provider's RubyLLM key and model-existence rule" do
+    credential = create(:ai_credential, user: user, provider: "moonshot")
+    captured = nil
+    context = Object.new
+    context.define_singleton_method(:chat) { |**args| captured = args }
+
+    credential.stub(:ruby_llm_context, context) { credential.chat("kimi-k2.6") }
+
+    assert_equal({ model: "kimi-k2.6", provider: :openai, assume_model_exists: true }, captured)
+  end
+
   test "#deactivate! should disable feeds running on the credential" do
     credential = create(:ai_credential, :active, user: user)
     enabled = create(:feed, :enabled, user: user, ai_credential: credential)

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -53,29 +53,38 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     end
   end
 
-  FakeModel = Struct.new(:id)
+  # Stands in for the credential the runner is built on. Moonshot, so the
+  # adapter the runner resolves is one that repairs fenced JSON.
+  class FakeCredential
+    attr_reader :provider, :chats
 
-  class FakeProvider
-    attr_reader :key, :chats
-
-    def initialize(responses, models: [], tool_rounds: [])
+    def initialize(responses, tool_rounds: [])
       @responses = responses.is_a?(Array) ? responses.dup : [responses]
-      @models = models
       @tool_rounds = tool_rounds
       @chats = []
-      @key = "fake"
+      @provider = "moonshot"
     end
 
     def chat(_model)
       FakeChat.new(@responses.shift, tool_rounds: @tool_rounds).tap { |chat| @chats << chat }
     end
-    def list_models = @models.map { |id| FakeModel.new(id) }
-    def unwrap_json(text) = LlmClient::Adapter::Moonshot.new.unwrap_json(text)
+  end
+
+  # The models check reads the listing through LlmClient, the same call the
+  # credential validation job makes.
+  FakeClient = Struct.new(:models) do
+    def available_models = models.map { |id| { "id" => id } }
   end
 
   def run_checks(responses, checks, models: [], tool_rounds: [])
-    provider = FakeProvider.new(responses, models: models, tool_rounds: tool_rounds)
-    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: checks).run
+    credential = FakeCredential.new(responses, tool_rounds: tool_rounds)
+    LlmClient.stub(:new, ->(_) { FakeClient.new(models) }) do
+      LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: checks).run
+    end
+  end
+
+  def operator
+    @operator ||= create(:user, :dev)
   end
 
   FETCHED_PAGE = "Example Domain This domain is for use in illustrative examples in documents.".freeze
@@ -305,9 +314,9 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   end
 
   test "#run should attach the schema and both client tools to one chat for client_tools_schema" do
-    provider = FakeProvider.new(grounded_payload, tool_rounds: full_tool_loop)
-    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["client_tools_schema"]).run
-    chat = provider.chats.first
+    credential = FakeCredential.new(grounded_payload, tool_rounds: full_tool_loop)
+    LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: ["client_tools_schema"]).run
+    chat = credential.chats.first
 
     assert_equal LlmCapabilityProbe::PROBE_SCHEMA, chat.schema
     assert_equal [LlmCapabilityProbe::CannedWebSearch, LlmClient::Tools::WebFetch], chat.tools.map(&:class)
@@ -316,10 +325,10 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
 
   # The probe drives a paid API, and an unqualified model is the likeliest to loop.
   test "#run should bound the client tools loop with one budget shared by both tools" do
-    provider = FakeProvider.new("The main heading reads: Example Domain", tool_rounds: full_tool_loop)
-    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["client_tools"]).run
+    credential = FakeCredential.new("The main heading reads: Example Domain", tool_rounds: full_tool_loop)
+    LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: ["client_tools"]).run
 
-    budgets = provider.chats.first.tools.map { |tool| tool.instance_variable_get(:@budget) }
+    budgets = credential.chats.first.tools.map { |tool| tool.instance_variable_get(:@budget) }
 
     assert_instance_of LlmClient::ToolBudget, budgets.first
     assert_same budgets.first, budgets.last
@@ -336,24 +345,24 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   # The pairing is its own wire shape: a schema-only call never exercises the
   # system role a provider might reject.
   test "#run should send a system prompt alongside the schema" do
-    provider = FakeProvider.new(valid_payload)
-    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["schema"]).run
+    credential = FakeCredential.new(valid_payload)
+    LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: ["schema"]).run
 
-    assert_equal LlmCapabilityProbe::PROBE_INSTRUCTIONS, provider.chats.first.instructions
+    assert_equal LlmCapabilityProbe::PROBE_INSTRUCTIONS, credential.chats.first.instructions
   end
 
   test "#run should leave the plain check bare so it isolates the round trip" do
-    provider = FakeProvider.new("pong")
-    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["plain"]).run
+    credential = FakeCredential.new("pong")
+    LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: ["plain"]).run
 
-    assert_nil provider.chats.first.instructions
+    assert_nil credential.chats.first.instructions
   end
 
   test "#run should leave the plain client tools check unstructured" do
-    provider = FakeProvider.new("The main heading reads: Example Domain", tool_rounds: full_tool_loop)
-    LlmCapabilityProbe::Runner.new(provider: provider, model: "test-model", checks: ["client_tools"]).run
+    credential = FakeCredential.new("The main heading reads: Example Domain", tool_rounds: full_tool_loop)
+    LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: ["client_tools"]).run
 
-    assert_nil provider.chats.first.schema
+    assert_nil credential.chats.first.schema
   end
 
   test "#run should pass client_tools_schema on a grounded schema-valid payload" do
@@ -395,42 +404,38 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     assert_match(/RuntimeError: boom/, outcome[:results].first[:note])
   end
 
-  test ".build should raise on an unknown provider" do
-    error = assert_raises(ArgumentError) { LlmCapabilityProbe::Provider.build("nope") }
-    assert_match(/Unknown provider/, error.message)
-  end
-
-  test ".configured? should reflect presence of the provider env key" do
-    original = ENV.fetch("MOONSHOT_API_KEY", nil)
-    ENV["MOONSHOT_API_KEY"] = nil
-    assert_not LlmCapabilityProbe::Provider.configured?("moonshot")
-
-    ENV["MOONSHOT_API_KEY"] = "k"
-    assert LlmCapabilityProbe::Provider.configured?("moonshot")
-    assert_not LlmCapabilityProbe::Provider.configured?("nope")
-  ensure
-    ENV["MOONSHOT_API_KEY"] = original
-  end
-
   test "checks should cover only what production calls" do
     assert_equal %w[models plain system_prompt schema client_tools client_tools_schema],
                  LlmCapabilityProbe::Runner::CHECKS
   end
 
-  test "moonshot provider should configure the same system-role flag as production" do
-    original = ENV.fetch("MOONSHOT_API_KEY", nil)
-    ENV["MOONSHOT_API_KEY"] = "k"
-    config = Struct.new(:openai_api_key, :openai_api_base, :openai_use_system_role).new
-
-    LlmCapabilityProbe::Provider.build("moonshot").configure(config)
-
-    assert config.openai_use_system_role
-  ensure
-    ENV["MOONSHOT_API_KEY"] = original
+  test ".credential_name should name the credential after the provider" do
+    assert_equal "Anthropic Probe", LlmCapabilityProbe.credential_name("anthropic")
+    assert_equal "Moonshot (Kimi) Probe", LlmCapabilityProbe.credential_name("moonshot")
   end
 
-  test "probe providers should unwrap structured output the way production does" do
-    assert_equal '{"a":1}', LlmCapabilityProbe::Provider.build("moonshot").unwrap_json("```json\n{\"a\":1}\n```")
-    assert_equal '{"a":1}', LlmCapabilityProbe::Provider.build("anthropic").unwrap_json('{"a":1}')
+  test ".credential_for should find the credential named after the probe" do
+    credential = create(:ai_credential, user: operator, provider: "anthropic", display_name: "Anthropic Probe")
+
+    assert_equal credential, LlmCapabilityProbe.credential_for("anthropic", user: operator)
+  end
+
+  test ".credential_for should ignore a credential of another provider with the same name" do
+    create(:ai_credential, user: operator, provider: "openrouter", display_name: "Anthropic Probe")
+
+    assert_nil LlmCapabilityProbe.credential_for("anthropic", user: operator)
+  end
+
+  test ".credential_for should ignore a probe-named credential belonging to someone else" do
+    create(:ai_credential, user: create(:user, :dev), provider: "anthropic", display_name: "Anthropic Probe")
+
+    assert_nil LlmCapabilityProbe.credential_for("anthropic", user: operator)
+  end
+
+  test ".missing_credential_message should name the exact credential to create" do
+    message = LlmCapabilityProbe.missing_credential_message("anthropic")
+
+    assert_match(/"Anthropic Probe"/, message)
+    assert_match(/Anthropic credential/, message)
   end
 end


### PR DESCRIPTION
Changes:

- Move chat construction onto `AiCredential#chat`, so `LlmClient` and the probe reach a provider the same way
- Resolve the probe's key from an `AiCredential` named after it (**Anthropic Probe**, **Moonshot (Kimi) Probe**) on the launching user's own account, and delete `LlmCapabilityProbe::Provider` with its env-key registry
- Read the models check through `LlmClient#available_models`, the call the credential validation job makes
- Point `ai:verify_extraction` at `AI_CREDENTIAL_ID`, matching how it already selects its search credential
- Remove `ANTHROPIC_API_KEY` / `MOONSHOT_API_KEY` from the Kamal secrets, the staging workflow and the docs
