### PR TITLE
Adopt environment-suffix convention for env vars

### DIFF
--- a/.github/workflows/deploy-imgproxy.yml
+++ b/.github/workflows/deploy-imgproxy.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Configure SSH
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_STAGING }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Configure SSH
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_STAGING }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,27 @@ Local-only Rails credential keys.
 
 Not committed. Kamal reads the right key and passes it to the container as `RAILS_MASTER_KEY`.
 
+## Environment variable naming
+
+When a value differs per environment, the environment goes **last**, as a suffix:
+
+```text
+POSTGRES_PASSWORD_STAGING
+POSTGRES_PASSWORD_PRODUCTION
+RAILS_MASTER_KEY_STAGING
+SSH_PRIVATE_KEY_STAGING
+```
+
+The base name stays stable, so every variant of a value sorts and groups
+together and the environment reads as a qualifier rather than a namespace.
+Names with no suffix (`GHCR_TOKEN`, `IMGPROXY_KEY`) are shared by all
+environments.
+
+The suffix only exists where several environments' values sit side by side —
+GitHub Actions secrets and local shell exports. Inside a container the app sees
+the plain name: `.kamal/secrets.staging` maps `POSTGRES_PASSWORD_STAGING` to
+`POSTGRES_PASSWORD`.
+
 ## Why both Kamal secrets and Rails credentials?
 
 Kamal secrets answer: **where does deploy read secret values from?**

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -224,6 +224,11 @@ The workflows read these repository secrets. Per-environment values carry a
 | `PRODUCTION_SSH_PRIVATE_KEY` | production | SSH key for `app-origin.fffeeder.com` |
 | `CF_ORIGIN_CERT` / `CF_ORIGIN_KEY` | both | Cloudflare Origin Certificate for kamal-proxy |
 
+`PRODUCTION_SSH_PRIVATE_KEY` is the one holdout from the convention. It keeps
+the old prefix form until the renamed secret exists, so don't create
+`SSH_PRIVATE_KEY_PRODUCTION` and expect the production workflow to pick it up —
+rename the workflow reference and the secret together.
+
 ## Database
 
 Each destination runs a Kamal PostgreSQL accessory named `db`. PostgreSQL 18 stores versioned data under `/var/lib/postgresql`, so the accessory mounts `data:/var/lib/postgresql` instead of mounting the `data` subdirectory directly.

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -220,7 +220,7 @@ The workflows read these repository secrets. Per-environment values carry a
 | `POSTGRES_PASSWORD_PRODUCTION` | production | production database password |
 | `RAILS_MASTER_KEY_STAGING` | staging | written to `config/credentials/staging.key` |
 | `RAILS_MASTER_KEY_PRODUCTION` | production | written to `config/credentials/production.key` |
-| `STAGING_SSH_PRIVATE_KEY` | staging | SSH key for `dev-origin.fffeeder.com` |
+| `SSH_PRIVATE_KEY_STAGING` | staging | SSH key for `dev-origin.fffeeder.com` |
 | `PRODUCTION_SSH_PRIVATE_KEY` | production | SSH key for `app-origin.fffeeder.com` |
 | `CF_ORIGIN_CERT` / `CF_ORIGIN_KEY` | both | Cloudflare Origin Certificate for kamal-proxy |
 

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -209,7 +209,8 @@ Both destinations can be deployed from the Actions tab. **Deploy Staging** also
 runs on every push to the `staging` branch; **Deploy Production** is
 `workflow_dispatch` only, so production deploys are always deliberate.
 
-The workflows read these repository secrets:
+The workflows read these repository secrets. Per-environment values carry a
+`_STAGING` / `_PRODUCTION` suffix — see [Environment variable naming](configuration.md#environment-variable-naming).
 
 | Secret | Used by | Purpose |
 | --- | --- | --- |


### PR DESCRIPTION
Changes:

- Document the naming convention for environment-specific variables: the environment goes last, as a `_STAGING` / `_PRODUCTION` suffix
- Rename `STAGING_SSH_PRIVATE_KEY` to `SSH_PRIVATE_KEY_STAGING` in the staging and imgproxy deploy workflows and in the secrets table

Most per-environment variables already followed this shape (`POSTGRES_PASSWORD_STAGING`, `RAILS_MASTER_KEY_PRODUCTION`); the SSH keys were the outliers. Keeping the base name stable means every variant of a value groups together, and the environment reads as a qualifier rather than a namespace.

`PRODUCTION_SSH_PRIVATE_KEY` is left alone for now — the renamed secret doesn't exist yet, and renaming it here would break production deploys. It should follow once `SSH_PRIVATE_KEY_PRODUCTION` is added to the repository secrets.
