### PR TITLE
Fail fast on unusable staging deploy key

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,6 +53,23 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan dev-origin.fffeeder.com >> ~/.ssh/known_hosts
 
+          # Kamal drives net-ssh, which skips an unusable key without comment and
+          # falls back to a password prompt. On a runner that surfaces minutes
+          # later as "Errno::ENOTTY", naming neither SSH nor the secret. Check the
+          # key here, while the cause is still legible.
+          if ! ssh-keygen -y -f ~/.ssh/id_ed25519 </dev/null >/dev/null 2>&1; then
+            echo "::error::SSH_PRIVATE_KEY_STAGING is not a usable private key: either malformed, or passphrase-protected (CI has no way to supply a passphrase)."
+            exit 1
+          fi
+
+          echo "Deploy key: $(ssh-keygen -y -f ~/.ssh/id_ed25519 | ssh-keygen -lf -)"
+
+          if ! ssh -o BatchMode=yes -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 \
+                   root@dev-origin.fffeeder.com true; then
+            echo "::error::dev-origin.fffeeder.com rejected the deploy key. Compare the fingerprint above against 'ssh-keygen -lf ~/.ssh/authorized_keys' on the host."
+            exit 1
+          fi
+
       - name: Write Rails master key
         env:
           RAILS_MASTER_KEY_STAGING: ${{ secrets.RAILS_MASTER_KEY_STAGING }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,10 +53,8 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan dev-origin.fffeeder.com >> ~/.ssh/known_hosts
 
-          # Kamal drives net-ssh, which skips an unusable key without comment and
-          # falls back to a password prompt. On a runner that surfaces minutes
-          # later as "Errno::ENOTTY", naming neither SSH nor the secret. Check the
-          # key here, while the cause is still legible.
+          # net-ssh, which Kamal uses, silently skips a key it cannot load and
+          # falls back to password auth, failing far from the cause.
           if ! ssh-keygen -y -f ~/.ssh/id_ed25519 </dev/null >/dev/null 2>&1; then
             echo "::error::SSH_PRIVATE_KEY_STAGING is not a usable private key: either malformed, or passphrase-protected (CI has no way to supply a passphrase)."
             exit 1
@@ -64,6 +62,8 @@ jobs:
 
           echo "Deploy key: $(ssh-keygen -y -f ~/.ssh/id_ed25519 | ssh-keygen -lf -)"
 
+          # BatchMode blocks that fallback, so a refused key reports as an auth
+          # failure rather than a prompt against a runner with no TTY.
           if ! ssh -o BatchMode=yes -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 \
                    root@dev-origin.fffeeder.com true; then
             echo "::error::dev-origin.fffeeder.com rejected the deploy key. Compare the fingerprint above against 'ssh-keygen -lf ~/.ssh/authorized_keys' on the host."


### PR DESCRIPTION
Changes:

- Validate the staging deploy key before the image build, failing with an error that names the secret
- Log the public fingerprint of the key, for comparison against the `authorized_keys` file on the host
- Verify SSH authentication with `BatchMode=yes`, so a rejected key reports as rejected

Kamal drives net-ssh, which skips a key it cannot load and quietly falls back to password auth. On a runner there is no TTY, so that surfaces minutes into the deploy as `Errno::ENOTTY` — an error naming neither SSH nor the secret it came from, and only after a full image build. Checking the key up front turns a two-and-a-half minute mystery into a twenty second answer, and separates an unloadable key from one the host refuses.

This improves diagnosis only; it does not itself fix a bad key.

References:

- Related PR: #1263
