### PR TITLE
Name probe credentials after their job

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,7 +7,12 @@ class ApplicationJob < ActiveJob::Base
 
   # One line shown above the job's run history in the dev area, for what a
   # maintenance job needs before it can run. Nil when the name says enough.
+  # Rendered as HTML, so a description with markup composes it through `helpers`
+  # and every interpolated value stays escaped.
   def self.description = nil
+
+  # The view's tag builders, for descriptions that carry markup.
+  def self.helpers = ApplicationController.helpers
 
   # Arguments the dev area launches this job with. Jobs that act on behalf of
   # whoever pressed Run override it to receive them.

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,12 +7,8 @@ class ApplicationJob < ActiveJob::Base
 
   # One line shown above the job's run history in the dev area, for what a
   # maintenance job needs before it can run. Nil when the name says enough.
-  # Rendered as HTML, so a description with markup composes it through `helpers`
-  # and every interpolated value stays escaped.
+  # Rendered as HTML — DescribesWithMarkup covers the ones carrying markup.
   def self.description = nil
-
-  # The view's tag builders, for descriptions that carry markup.
-  def self.helpers = ApplicationController.helpers
 
   # Arguments the dev area launches this job with. Jobs that act on behalf of
   # whoever pressed Run override it to receive them.

--- a/app/jobs/describes_with_markup.rb
+++ b/app/jobs/describes_with_markup.rb
@@ -1,0 +1,15 @@
+# Lets a maintenance job's description carry markup — the dev area renders it as
+# HTML above the job's run history.
+#
+# Composing through these helpers is what keeps a description safe: the parts a
+# job interpolates are escaped, and only the tags it builds here are markup.
+module DescribesWithMarkup
+  extend ActiveSupport::Concern
+
+  class_methods do
+    private
+
+    # The view's tag builders, reachable from a job class.
+    def helpers = ApplicationController.helpers
+  end
+end

--- a/app/jobs/llm_capability_probe_job.rb
+++ b/app/jobs/llm_capability_probe_job.rb
@@ -3,7 +3,7 @@
 # lands in JobRun events: one event per check with full evidence, plus a
 # summary verdict — no files to chase afterwards.
 #
-# The key comes from an AiCredential named after the probe and owned by whoever
+# The key comes from an AiCredential named after the job and owned by whoever
 # launched the run. Without that record the run says which credential to create
 # and ends.
 class LlmCapabilityProbeJob < ApplicationJob
@@ -11,9 +11,27 @@ class LlmCapabilityProbeJob < ApplicationJob
 
   queue_as :default
 
+  # The credential wears the job's own class name, so what the dev area lists
+  # is what to type into the credential form — no second naming to look up.
+  def self.credential_name = name.delete_suffix("Job")
+
+  # Scoped to whoever launched the probe: a run spends that key, and display
+  # names are unique per user and provider, so the owner is what makes the name
+  # resolve to one credential.
+  def self.credential_for(user)
+    user.ai_credentials.find_by(provider: self::PROVIDER, display_name: credential_name)
+  end
+
+  # Says what to create, since the fix is always the same: one credential, this
+  # provider, this exact name.
+  def self.missing_credential_message
+    "no AI credential named #{credential_name.inspect} on your account — " \
+      "add a #{LlmProvider.find(self::PROVIDER).display_name} credential with that exact name to run this probe"
+  end
+
   def self.description
     "Runs the capability checks for #{self::MODEL} against the live #{self::PROVIDER} API. " \
-      "Needs an AI credential named “#{LlmCapabilityProbe.credential_name(self::PROVIDER)}” on your own account."
+      "Needs an AI credential named “#{credential_name}” on your own account."
   end
 
   def self.runnable_arguments(user) = [user]
@@ -21,13 +39,13 @@ class LlmCapabilityProbeJob < ApplicationJob
   def perform(user)
     provider_key = self.class::PROVIDER
     model = self.class::MODEL
-    credential = LlmCapabilityProbe.credential_for(provider_key, user: user)
+    credential = self.class.credential_for(user)
 
     if credential.nil?
       record_event(type: "job.llm_capability_probe.skipped",
-                   message: "#{provider_key}/#{model}: #{LlmCapabilityProbe.missing_credential_message(provider_key)}",
+                   message: "#{provider_key}/#{model}: #{self.class.missing_credential_message}",
                    level: :warning, provider: provider_key, model: model,
-                   expected_credential_name: LlmCapabilityProbe.credential_name(provider_key))
+                   expected_credential_name: self.class.credential_name)
       return
     end
 

--- a/app/jobs/llm_capability_probe_job.rb
+++ b/app/jobs/llm_capability_probe_job.rb
@@ -8,6 +8,7 @@
 # and ends.
 class LlmCapabilityProbeJob < ApplicationJob
   include RecordsJobRun
+  include DescribesWithMarkup
 
   queue_as :default
 

--- a/app/jobs/llm_capability_probe_job.rb
+++ b/app/jobs/llm_capability_probe_job.rb
@@ -30,8 +30,12 @@ class LlmCapabilityProbeJob < ApplicationJob
   end
 
   def self.description
-    "Runs the capability checks for #{self::MODEL} against the live #{self::PROVIDER} API. " \
-      "Needs an AI credential named “#{credential_name}” on your own account."
+    helpers.safe_join([
+      "Runs the capability checks for #{self::MODEL} against the live #{self::PROVIDER} API. " \
+      "Needs an AI credential named ",
+      helpers.tag.code(credential_name),
+      " on your own account."
+    ])
   end
 
   def self.runnable_arguments(user) = [user]

--- a/app/jobs/search_capability_probe_job.rb
+++ b/app/jobs/search_capability_probe_job.rb
@@ -7,6 +7,7 @@
 # queries. Without that record the run says which credential to create and ends.
 class SearchCapabilityProbeJob < ApplicationJob
   include RecordsJobRun
+  include DescribesWithMarkup
 
   queue_as :default
 

--- a/app/jobs/search_capability_probe_job.rb
+++ b/app/jobs/search_capability_probe_job.rb
@@ -29,9 +29,12 @@ class SearchCapabilityProbeJob < ApplicationJob
   end
 
   def self.description
-    "Runs the search checks against the live #{WebSearchProvider.label_for(self::PROVIDER)} API. " \
-      "Needs a search credential named “#{credential_name}” on " \
-      "your own account, and spends two queries on it."
+    helpers.safe_join([
+      "Runs the search checks against the live #{WebSearchProvider.label_for(self::PROVIDER)} API. " \
+      "Needs a search credential named ",
+      helpers.tag.code(credential_name),
+      " on your own account, and spends two queries on it."
+    ])
   end
 
   def self.runnable_arguments(user) = [user]

--- a/app/jobs/search_capability_probe_job.rb
+++ b/app/jobs/search_capability_probe_job.rb
@@ -2,7 +2,7 @@
 # via PROVIDER. Everything the diagnosis needs lands in JobRun events: one event
 # per check with its evidence, plus a summary verdict.
 #
-# The key comes from a SearchCredential named after the probe and owned by
+# The key comes from a SearchCredential named after the job and owned by
 # whoever launched the run, so a probe only ever spends its own operator's
 # queries. Without that record the run says which credential to create and ends.
 class SearchCapabilityProbeJob < ApplicationJob
@@ -10,9 +10,27 @@ class SearchCapabilityProbeJob < ApplicationJob
 
   queue_as :default
 
+  # The credential wears the job's own class name, so what the dev area lists
+  # is what to type into the credential form — no second naming to look up.
+  def self.credential_name = name.delete_suffix("Job")
+
+  # Scoped to whoever launched the probe: each run spends billed queries, and
+  # display names are unique per user and provider, so the owner is what makes
+  # the name resolve to one key.
+  def self.credential_for(user)
+    user.search_credentials.find_by(provider: self::PROVIDER, display_name: credential_name)
+  end
+
+  # Says what to create, since the fix is always the same: one credential, this
+  # provider, this exact name.
+  def self.missing_credential_message
+    "no search credential named #{credential_name.inspect} on your account — " \
+      "add a #{WebSearchProvider.label_for(self::PROVIDER)} credential with that exact name to run this probe"
+  end
+
   def self.description
     "Runs the search checks against the live #{WebSearchProvider.label_for(self::PROVIDER)} API. " \
-      "Needs a search credential named “#{SearchCapabilityProbe.credential_name(self::PROVIDER)}” on " \
+      "Needs a search credential named “#{credential_name}” on " \
       "your own account, and spends two queries on it."
   end
 
@@ -20,9 +38,9 @@ class SearchCapabilityProbeJob < ApplicationJob
 
   def perform(user)
     provider = self.class::PROVIDER
-    credential = SearchCapabilityProbe.credential_for(provider, user: user)
+    credential = self.class.credential_for(user)
 
-    return skip(provider, SearchCapabilityProbe.missing_credential_message(provider)) if credential.nil?
+    return skip(provider, self.class.missing_credential_message) if credential.nil?
 
     probe(provider, credential)
   end
@@ -33,7 +51,7 @@ class SearchCapabilityProbeJob < ApplicationJob
     record_event(type: "job.search_capability_probe.skipped",
                  message: "#{provider}: #{reason}",
                  level: :warning, provider: provider,
-                 expected_credential_name: SearchCapabilityProbe.credential_name(provider))
+                 expected_credential_name: self.class.credential_name)
   end
 
   def probe(provider, credential)

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -6,9 +6,9 @@
 # (LlmClient::Adapter::Base#apply_web), so a hosted mechanism tells us nothing
 # about a feed run.
 #
-# The key comes from an AiCredential named after the probe and owned by whoever
-# launched the run, so the checks are made on the same objects and the same
-# provider configuration a feed run uses.
+# The key comes from an AiCredential named after the probe job and owned by
+# whoever launched the run, so the checks are made on the same objects and the
+# same provider configuration a feed run uses.
 #
 # See docs/llm-provider-qualification.md.
 module LlmCapabilityProbe
@@ -93,26 +93,6 @@ module LlmCapabilityProbe
       return over_budget if over_budget
 
       { results: RESULTS }.to_json
-    end
-  end
-
-  class << self
-    def credential_name(provider)
-      "#{LlmProvider.find(provider).display_name} Probe"
-    end
-
-    # Scoped to whoever launched the probe: a run spends that key, and display
-    # names are unique per user and provider, so the owner is what makes the
-    # name resolve to one credential.
-    def credential_for(provider, user:)
-      user.ai_credentials.find_by(provider: provider, display_name: credential_name(provider))
-    end
-
-    # Says what to create, since the fix is always the same: one credential,
-    # this provider, this exact name.
-    def missing_credential_message(provider)
-      "no AI credential named #{credential_name(provider).inspect} on your account — " \
-        "add a #{LlmProvider.find(provider).display_name} credential with that exact name to run this probe"
     end
   end
 

--- a/app/services/search_capability_probe.rb
+++ b/app/services/search_capability_probe.rb
@@ -2,33 +2,13 @@
 # only confirm our reading of a vendor's docs; these checks confirm the vendor
 # still behaves that way.
 #
-# The key comes from a SearchCredential named after the probe, so the checks run
-# through the same objects a feed run uses. Two of the three spend a real query,
+# The key comes from a SearchCredential named after the probe job, so the checks
+# run through the same objects a feed run uses. Two of the three spend a real query,
 # billed to that credential and recorded as usage.
 module SearchCapabilityProbe
   # The query the credential validation job sends, so the minimal check asks for
   # exactly what a user's key has to satisfy to go active.
   QUERY = SearchCredentialValidationJob::VALIDATION_QUERY
-
-  class << self
-    def credential_name(provider)
-      "#{WebSearchProvider.label_for(provider)} Probe"
-    end
-
-    # Scoped to whoever launched the probe: each run spends billed queries, and
-    # display names are unique per user and provider, so the owner is what makes
-    # the name resolve to one key.
-    def credential_for(provider, user:)
-      user.search_credentials.find_by(provider: provider, display_name: credential_name(provider))
-    end
-
-    # Says what to create, since the fix is always the same: one credential,
-    # this provider, this exact name.
-    def missing_credential_message(provider)
-      "no search credential named #{credential_name(provider).inspect} on your account — " \
-        "add a #{WebSearchProvider.label_for(provider)} credential with that exact name to run this probe"
-    end
-  end
 
   class Runner
     CHECKS = %w[rejection search minimal].freeze

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -13,11 +13,11 @@ share.
 
 ## Running it
 
-The key comes from the `AiCredential` whose name matches the probe — **Anthropic
-Probe**, **Moonshot (Kimi) Probe** — on **your own account**. The dev area
-passes whoever pressed Run through to the job, so a probe only ever spends its
-own operator's tokens. Without that record the run records a skip saying which
-credential to create.
+The key comes from the `AiCredential` named after the probe job, minus the `Job`
+suffix — **AnthropicCapabilityProbe**, **KimiCapabilityProbe** — on **your own
+account**. The dev area passes whoever pressed Run through to the job, so a
+probe only ever spends its own operator's tokens. Without that record the run
+records a skip saying which credential to create.
 
 From the dev area — the usual path, and the one that keeps the evidence
 searchable afterwards:
@@ -34,8 +34,8 @@ For a one-off pair, or a subset of checks, use the CLI instead. It has no
 session to read an operator from, so name one:
 
 ```sh
-bundle exec ruby script/llm_capability_probe.rb --user me@example.com --provider moonshot --model kimi-k3
-bundle exec ruby script/llm_capability_probe.rb --user me@example.com --provider anthropic --model claude-sonnet-4-6 --checks models
+bundle exec ruby script/llm_capability_probe.rb --user me@example.com --job KimiCapabilityProbeJob --model kimi-k3
+bundle exec ruby script/llm_capability_probe.rb --user me@example.com --job AnthropicCapabilityProbeJob --checks models
 ```
 
 A provider must be in `LlmProvider`'s registry before it can be probed, since
@@ -99,8 +99,9 @@ Before a pair can be probed, the provider needs:
   extraction;
 - a probe job pinning the pair, subclassing `LlmCapabilityProbeJob` with
   `PROVIDER`/`MODEL` and registered in `JobRun::RUNNABLE_JOBS`;
-- an `AiCredential` for it, named `LlmCapabilityProbe.credential_name(provider)`,
-  on the account that will run the probe.
+- an `AiCredential` for it, named after the probe job without the `Job` suffix
+  (`LlmCapabilityProbeJob.credential_name`), on the account that will run the
+  probe.
 
 There is nothing to keep in sync: the probe reaches the provider through
 `AiCredential#chat`, so it is configured by the same `LlmProvider#configure`

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -99,9 +99,8 @@ Before a pair can be probed, the provider needs:
   extraction;
 - a probe job pinning the pair, subclassing `LlmCapabilityProbeJob` with
   `PROVIDER`/`MODEL` and registered in `JobRun::RUNNABLE_JOBS`;
-- an `AiCredential` for it, named after the probe job without the `Job` suffix
-  (`LlmCapabilityProbeJob.credential_name`), on the account that will run the
-  probe.
+- an `AiCredential` for it, named after that new job without the `Job` suffix
+  (`<TheNewProbeJob>.credential_name`), on the account that will run the probe.
 
 There is nothing to keep in sync: the probe reaches the provider through
 `AiCredential#chat`, so it is configured by the same `LlmProvider#configure`

--- a/docs/search-provider-verification.md
+++ b/docs/search-provider-verification.md
@@ -16,13 +16,14 @@ pick one, and run it. Each check writes one event with its evidence, plus a
 summary verdict, so the run page is the whole record.
 
 The key comes from a managed credential, not the environment: the probe uses the
-`SearchCredential` whose name matches the probe — **Serper Probe**, **Brave
-Probe**, **Tavily Probe** — with the matching provider, on **your own account**.
-The dev area passes whoever pressed Run through to the job, so a probe only ever
-spends its own operator's queries, and the per-user uniqueness of display names
-makes the name resolve to exactly one key. Without that record the run records a
-skip saying which credential to create. The credential does not have to be
-active; probing a rejected key is a legitimate thing to want.
+`SearchCredential` named after the probe job, minus the `Job` suffix —
+**SerperCapabilityProbe**, **BraveCapabilityProbe**, **TavilyCapabilityProbe** —
+with the matching provider, on **your own account**. The dev area passes whoever
+pressed Run through to the job, so a probe only ever spends its own operator's
+queries, and the per-user uniqueness of display names makes the name resolve to
+exactly one key. Without that record the run records a skip saying which
+credential to create. The credential does not have to be active; probing a
+rejected key is a legitimate thing to want.
 
 Two of the three checks spend a real query, billed to that credential and
 recorded as usage like any other search.

--- a/script/llm_capability_probe.rb
+++ b/script/llm_capability_probe.rb
@@ -5,35 +5,39 @@
 # the probe; this wrapper covers local one-off runs against a single pair.
 #
 # Usage:
-#   bundle exec ruby script/llm_capability_probe.rb --user me@example.com --provider anthropic --model claude-sonnet-4-6
-#   bundle exec ruby script/llm_capability_probe.rb --user me@example.com --provider moonshot --model kimi-k2.6 --checks models
+#   bundle exec ruby script/llm_capability_probe.rb --user me@example.com --job AnthropicCapabilityProbeJob
+#   bundle exec ruby script/llm_capability_probe.rb --user me@example.com --job KimiCapabilityProbeJob --model kimi-k3 --checks models
 #
-# The key comes from that user's AI credential named after the probe (see
-# LlmCapabilityProbe.credential_name); --user is what the dev area gets from
-# the session and the CLI has to be told.
+# The probe job is what names the credential and pins the pair, so the CLI takes
+# one and borrows both; --model overrides the pinned model for a one-off pair.
+# --user is what the dev area gets from the session and the CLI has to be told.
 
 require "optparse"
 require_relative "../config/environment"
 
+probe_jobs = JobRun::RUNNABLE_JOBS.select { |job| job < LlmCapabilityProbeJob }
+
 options = { checks: LlmCapabilityProbe::Runner::CHECKS }
 OptionParser.new do |parser|
   parser.on("--user EMAIL", "Owner of the probe credential") { |v| options[:user] = v }
-  parser.on("--provider KEY", "#{LlmProvider.names.join(' | ')}") { |v| options[:provider] = v }
-  parser.on("--model ID", "Model id as the provider names it") { |v| options[:model] = v }
+  parser.on("--job NAME", "#{probe_jobs.map(&:name).join(' | ')}") { |v| options[:job] = v }
+  parser.on("--model ID", "Model id as the provider names it; defaults to the job's") { |v| options[:model] = v }
   parser.on("--checks LIST", "Comma-separated subset of: #{LlmCapabilityProbe::Runner::CHECKS.join(',')}") do |v|
     options[:checks] = v.split(",").map(&:strip) & LlmCapabilityProbe::Runner::CHECKS
   end
 end.parse!
-abort "Required: --user, --provider and --model" unless options[:user] && options[:provider] && options[:model]
+abort "Required: --user and --job" unless options[:user] && options[:job]
 
+job_class = probe_jobs.find { |job| job.name == options[:job] } || abort("No probe job named #{options[:job]}")
+model = options[:model] || job_class::MODEL
 user = User.find_by(email_address: options[:user]) || abort("No user with email #{options[:user]}")
-credential = LlmCapabilityProbe.credential_for(options[:provider], user: user) ||
-             abort("#{options[:user]}: #{LlmCapabilityProbe.missing_credential_message(options[:provider])}")
+credential = job_class.credential_for(user) ||
+             abort("#{options[:user]}: #{job_class.missing_credential_message}")
 
-runner = LlmCapabilityProbe::Runner.new(credential: credential, model: options[:model], checks: options[:checks])
+runner = LlmCapabilityProbe::Runner.new(credential: credential, model: model, checks: options[:checks])
 outcome = runner.run
 
-puts "\n#{credential.provider} / #{options[:model]} (#{credential.display_name})"
+puts "\n#{credential.provider} / #{model} (#{credential.display_name})"
 outcome[:results].each { |r| puts format("  %-11s %-4s %5ss  %s", r[:check], r[:status], r[:seconds], r[:note]) }
 puts JSON.pretty_generate(outcome[:results])
 exit(outcome[:passed] ? 0 : 1)

--- a/test/components/page_header_component_test.rb
+++ b/test/components/page_header_component_test.rb
@@ -8,6 +8,16 @@ class PageHeaderComponentTest < ViewComponent::TestCase
     assert_equal "New Feed", result.at_css("h1").text
   end
 
+  test "#render should render markup in a context paragraph and escape plain text" do
+    result = render_inline(PageHeaderComponent.new(title: "New Feed")) do |component|
+      component.with_context_paragraph("Needs <code>Key</code>".html_safe)
+      component.with_context_paragraph("Plain <b>text</b>")
+    end
+
+    assert_equal "Key", result.at_css("p code").text
+    assert_equal "Plain <b>text</b>", result.css("p").last.text
+  end
+
   test "#render should render title icon inside the heading" do
     result = render_inline(PageHeaderComponent.new(title: "New Feed")) do |component|
       component.with_title_icon { "*" }

--- a/test/controllers/development/job_runs_controller_test.rb
+++ b/test/controllers/development/job_runs_controller_test.rb
@@ -40,7 +40,7 @@ class Development::JobRunsControllerTest < ActionDispatch::IntegrationTest
     get development_job_job_runs_path("SerperCapabilityProbeJob")
 
     assert_response :success
-    assert_select "p", text: /SerperCapabilityProbe/
+    assert_select "p code", text: "SerperCapabilityProbe"
   end
 
   test "#index should leave the header clean for a job that needs nothing" do

--- a/test/controllers/development/job_runs_controller_test.rb
+++ b/test/controllers/development/job_runs_controller_test.rb
@@ -40,7 +40,7 @@ class Development::JobRunsControllerTest < ActionDispatch::IntegrationTest
     get development_job_job_runs_path("SerperCapabilityProbeJob")
 
     assert_response :success
-    assert_select "p", text: /Serper Probe/
+    assert_select "p", text: /SerperCapabilityProbe/
   end
 
   test "#index should leave the header clean for a job that needs nothing" do

--- a/test/jobs/llm_capability_probe_job_test.rb
+++ b/test/jobs/llm_capability_probe_job_test.rb
@@ -10,7 +10,7 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
   end
 
   def credential
-    @credential ||= create(:ai_credential, user: operator, provider: "anthropic", display_name: "Anthropic Probe")
+    @credential ||= create(:ai_credential, user: operator, provider: "anthropic", display_name: "AnthropicCapabilityProbe")
   end
 
   def job_run
@@ -28,9 +28,31 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
     assert_equal %w[moonshot kimi-k2.6], [KimiCapabilityProbeJob::PROVIDER, KimiCapabilityProbeJob::MODEL]
   end
 
+  test ".credential_name should name the credential after the job" do
+    assert_equal "AnthropicCapabilityProbe", AnthropicCapabilityProbeJob.credential_name
+    assert_equal "KimiCapabilityProbe", KimiCapabilityProbeJob.credential_name
+  end
+
+  test ".credential_for should find the credential named after the job" do
+    assert_equal credential, AnthropicCapabilityProbeJob.credential_for(operator)
+  end
+
+  test ".credential_for should ignore a credential of another provider with the same name" do
+    create(:ai_credential, user: operator, provider: "openrouter", display_name: "AnthropicCapabilityProbe")
+
+    assert_nil AnthropicCapabilityProbeJob.credential_for(operator)
+  end
+
+  test ".missing_credential_message should name the exact credential to create" do
+    message = AnthropicCapabilityProbeJob.missing_credential_message
+
+    assert_match(/"AnthropicCapabilityProbe"/, message)
+    assert_match(/Anthropic credential/, message)
+  end
+
   test ".description should name the credential the probe needs" do
-    assert_match(/Anthropic Probe/, AnthropicCapabilityProbeJob.description)
-    assert_match(/Moonshot \(Kimi\) Probe/, KimiCapabilityProbeJob.description)
+    assert_match(/AnthropicCapabilityProbe/, AnthropicCapabilityProbeJob.description)
+    assert_match(/KimiCapabilityProbe/, KimiCapabilityProbeJob.description)
   end
 
   test ".runnable_arguments should ask the dev area for the user who pressed Run" do
@@ -43,13 +65,13 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
 
     event = Event.find_by(subject: job_run, type: "job.llm_capability_probe.skipped")
     assert_predicate event, :warning?
-    assert_includes event.message, '"Anthropic Probe"'
-    assert_equal "Anthropic Probe", event.metadata["expected_credential_name"]
+    assert_includes event.message, '"AnthropicCapabilityProbe"'
+    assert_equal "AnthropicCapabilityProbe", event.metadata["expected_credential_name"]
   end
 
   test "#perform should ignore a probe-named credential owned by someone else" do
     job_run
-    create(:ai_credential, user: create(:user, :dev), provider: "anthropic", display_name: "Anthropic Probe")
+    create(:ai_credential, user: create(:user, :dev), provider: "anthropic", display_name: "AnthropicCapabilityProbe")
 
     LlmCapabilityProbe::Runner.stub(:new, ->(**) { raise "should not run" }) do
       job.perform_now

--- a/test/jobs/llm_capability_probe_job_test.rb
+++ b/test/jobs/llm_capability_probe_job_test.rb
@@ -50,9 +50,10 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
     assert_match(/Anthropic credential/, message)
   end
 
-  test ".description should name the credential the probe needs" do
-    assert_match(/AnthropicCapabilityProbe/, AnthropicCapabilityProbeJob.description)
-    assert_match(/KimiCapabilityProbe/, KimiCapabilityProbeJob.description)
+  test ".description should mark up the credential the probe needs" do
+    assert_includes AnthropicCapabilityProbeJob.description, "<code>AnthropicCapabilityProbe</code>"
+    assert_includes KimiCapabilityProbeJob.description, "<code>KimiCapabilityProbe</code>"
+    assert_predicate AnthropicCapabilityProbeJob.description, :html_safe?
   end
 
   test ".runnable_arguments should ask the dev area for the user who pressed Run" do

--- a/test/jobs/search_capability_probe_job_test.rb
+++ b/test/jobs/search_capability_probe_job_test.rb
@@ -67,9 +67,10 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
     assert_match(/Brave credential/, message)
   end
 
-  test ".description should name the credential the probe needs" do
-    assert_match(/SerperCapabilityProbe/, SerperCapabilityProbeJob.description)
-    assert_match(/TavilyCapabilityProbe/, TavilyCapabilityProbeJob.description)
+  test ".description should mark up the credential the probe needs" do
+    assert_includes SerperCapabilityProbeJob.description, "<code>SerperCapabilityProbe</code>"
+    assert_includes TavilyCapabilityProbeJob.description, "<code>TavilyCapabilityProbe</code>"
+    assert_predicate SerperCapabilityProbeJob.description, :html_safe?
   end
 
   test "#perform should record a skip naming the credential to create when it is missing" do

--- a/test/jobs/search_capability_probe_job_test.rb
+++ b/test/jobs/search_capability_probe_job_test.rb
@@ -14,7 +14,7 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
   end
 
   def credential
-    @credential ||= create(:search_credential, user: operator, provider: "serper", display_name: "Serper Probe")
+    @credential ||= create(:search_credential, user: operator, provider: "serper", display_name: "SerperCapabilityProbe")
   end
 
   def outcome
@@ -49,9 +49,27 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
     assert_empty PurgeExpiredEventsJob.runnable_arguments(operator)
   end
 
+  test ".credential_name should name the credential after the job" do
+    assert_equal "SerperCapabilityProbe", SerperCapabilityProbeJob.credential_name
+    assert_equal "TavilyCapabilityProbe", TavilyCapabilityProbeJob.credential_name
+  end
+
+  test ".credential_for should ignore a credential of another provider with the same name" do
+    create(:search_credential, user: operator, provider: "brave", display_name: "SerperCapabilityProbe")
+
+    assert_nil SerperCapabilityProbeJob.credential_for(operator)
+  end
+
+  test ".missing_credential_message should name the exact credential to create" do
+    message = BraveCapabilityProbeJob.missing_credential_message
+
+    assert_match(/"BraveCapabilityProbe"/, message)
+    assert_match(/Brave credential/, message)
+  end
+
   test ".description should name the credential the probe needs" do
-    assert_match(/Serper Probe/, SerperCapabilityProbeJob.description)
-    assert_match(/Tavily Probe/, TavilyCapabilityProbeJob.description)
+    assert_match(/SerperCapabilityProbe/, SerperCapabilityProbeJob.description)
+    assert_match(/TavilyCapabilityProbe/, TavilyCapabilityProbeJob.description)
   end
 
   test "#perform should record a skip naming the credential to create when it is missing" do
@@ -60,8 +78,8 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
 
     event = Event.find_by(subject: job_run, type: "job.search_capability_probe.skipped")
     assert_predicate event, :warning?
-    assert_includes event.message, '"Serper Probe"'
-    assert_equal "Serper Probe", event.metadata["expected_credential_name"]
+    assert_includes event.message, '"SerperCapabilityProbe"'
+    assert_equal "SerperCapabilityProbe", event.metadata["expected_credential_name"]
   end
 
   test "#perform should not run checks when the credential is missing" do
@@ -75,7 +93,7 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
 
   test "#perform should ignore a probe-named credential owned by someone else" do
     job_run
-    create(:search_credential, user: create(:user, :dev), provider: "serper", display_name: "Serper Probe")
+    create(:search_credential, user: create(:user, :dev), provider: "serper", display_name: "SerperCapabilityProbe")
 
     SearchCapabilityProbe::Runner.stub(:new, ->(**) { raise "should not run" }) do
       job.perform_now
@@ -87,7 +105,7 @@ class SearchCapabilityProbeJobTest < ActiveJob::TestCase
   test "#perform should probe the launching user's own credential" do
     job_run
     credential
-    create(:search_credential, user: create(:user, :dev), provider: "serper", display_name: "Serper Probe")
+    create(:search_credential, user: create(:user, :dev), provider: "serper", display_name: "SerperCapabilityProbe")
 
     stub_runner(outcome) { job.perform_now }
 

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -83,10 +83,6 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     end
   end
 
-  def operator
-    @operator ||= create(:user, :dev)
-  end
-
   FETCHED_PAGE = "Example Domain This domain is for use in illustrative examples in documents.".freeze
 
   def full_tool_loop(fetch_result: FETCHED_PAGE)
@@ -407,35 +403,5 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   test "checks should cover only what production calls" do
     assert_equal %w[models plain system_prompt schema client_tools client_tools_schema],
                  LlmCapabilityProbe::Runner::CHECKS
-  end
-
-  test ".credential_name should name the credential after the provider" do
-    assert_equal "Anthropic Probe", LlmCapabilityProbe.credential_name("anthropic")
-    assert_equal "Moonshot (Kimi) Probe", LlmCapabilityProbe.credential_name("moonshot")
-  end
-
-  test ".credential_for should find the credential named after the probe" do
-    credential = create(:ai_credential, user: operator, provider: "anthropic", display_name: "Anthropic Probe")
-
-    assert_equal credential, LlmCapabilityProbe.credential_for("anthropic", user: operator)
-  end
-
-  test ".credential_for should ignore a credential of another provider with the same name" do
-    create(:ai_credential, user: operator, provider: "openrouter", display_name: "Anthropic Probe")
-
-    assert_nil LlmCapabilityProbe.credential_for("anthropic", user: operator)
-  end
-
-  test ".credential_for should ignore a probe-named credential belonging to someone else" do
-    create(:ai_credential, user: create(:user, :dev), provider: "anthropic", display_name: "Anthropic Probe")
-
-    assert_nil LlmCapabilityProbe.credential_for("anthropic", user: operator)
-  end
-
-  test ".missing_credential_message should name the exact credential to create" do
-    message = LlmCapabilityProbe.missing_credential_message("anthropic")
-
-    assert_match(/"Anthropic Probe"/, message)
-    assert_match(/Anthropic credential/, message)
   end
 end

--- a/test/services/search_capability_probe_test.rb
+++ b/test/services/search_capability_probe_test.rb
@@ -30,7 +30,7 @@ class SearchCapabilityProbeTest < ActiveSupport::TestCase
   end
 
   def credential
-    @credential ||= create(:search_credential, user: operator, provider: "serper", display_name: "Serper Probe")
+    @credential ||= create(:search_credential, user: operator, provider: "serper", display_name: "SerperCapabilityProbe")
   end
 
   # Stubs the two seams a run uses: the credential's own provider (live key) and
@@ -49,32 +49,6 @@ class SearchCapabilityProbeTest < ActiveSupport::TestCase
 
   def check(outcome, name)
     outcome[:results].find { |entry| entry[:check] == name }
-  end
-
-  test ".credential_name should name the credential after the provider label" do
-    assert_equal "Serper Probe", SearchCapabilityProbe.credential_name("serper")
-    assert_equal "Tavily Probe", SearchCapabilityProbe.credential_name("tavily")
-  end
-
-  test ".credential_for should find the credential named after the probe" do
-    credential
-    assert_equal credential, SearchCapabilityProbe.credential_for("serper", user: operator)
-  end
-
-  test ".credential_for should ignore a credential of another provider with the same name" do
-    create(:search_credential, user: operator, provider: "brave", display_name: "Serper Probe")
-    assert_nil SearchCapabilityProbe.credential_for("serper", user: operator)
-  end
-
-  test ".credential_for should ignore a probe-named credential belonging to someone else" do
-    create(:search_credential, user: create(:user, :dev), provider: "serper", display_name: "Serper Probe")
-    assert_nil SearchCapabilityProbe.credential_for("serper", user: operator)
-  end
-
-  test ".missing_credential_message should name the exact credential to create" do
-    message = SearchCapabilityProbe.missing_credential_message("brave")
-    assert_match(/"Brave Probe"/, message)
-    assert_match(/Brave credential/, message)
   end
 
   test "#run should pass every check when the vendor behaves" do


### PR DESCRIPTION
Changes:

- Name the probe credentials after the job that spends them, minus the `Job` suffix — `AnthropicCapabilityProbe` rather than `Anthropic Probe`
- Show that name as `<code>` in the job's description on its run-history page
- Take a `--job` instead of a `--provider` in the probe CLI

The name a probe expects and the name the dev area lists are now the same
string, so there is nothing to translate between the page and the credential
form. That moves credential lookup from the probe services onto the jobs — the
name follows the job, not the provider label, and only the job knows it.

Descriptions are composed through the view helpers rather than marked safe
after the fact, so their interpolated values stay escaped. The page header
already rendered HTML-safe slot content correctly; that behavior is now covered
by a test.
