### PR TITLE
Request the read-users-info scope for subscriber counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-16
+
+- New FreeFeed tokens now ask for one extra permission so Feeder can read your target group's subscriber count. Tokens you added earlier keep publishing as usual — recreate one to get the count.
+
 ## 2026-08-15
 
 - A search key that's been revoked or has run out of credit now switches itself off with a clear reason, instead of quietly failing on every run.

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -17,9 +17,11 @@ class AccessToken < ApplicationRecord
 
   attr_accessor :token
 
-  # read-users-info is what covers GET /vN/users/:username/statistics, the
-  # subscriber count endpoint.
-  TOKEN_SCOPES = %w[read-my-info read-users-info manage-posts].freeze
+  TOKEN_SCOPES = %w[
+    read-my-info
+    read-users-info
+    manage-posts
+  ].freeze
 
   def self.token_url(domain)
     "https://#{domain}/settings/app-tokens/create?scopes=#{TOKEN_SCOPES.join('%20')}"

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -17,6 +17,14 @@ class AccessToken < ApplicationRecord
 
   attr_accessor :token
 
+  # read-users-info is what covers GET /vN/users/:username/statistics, the
+  # subscriber count endpoint.
+  TOKEN_SCOPES = %w[read-my-info read-users-info manage-posts].freeze
+
+  def self.token_url(domain)
+    "https://#{domain}/settings/app-tokens/create?scopes=#{TOKEN_SCOPES.join('%20')}"
+  end
+
   # A user can create access token record associated with a known
   # FreeFeed instances only (see Settings::AccessTokensController).
   # Though the model allows to define any valid host URL.
@@ -25,19 +33,19 @@ class AccessToken < ApplicationRecord
       url: "https://freefeed.net",
       display_name: "freefeed.net (main)",
       domain: "freefeed.net",
-      token_url: "https://freefeed.net/settings/app-tokens/create?scopes=read-my-info%20manage-posts"
+      token_url: token_url("freefeed.net")
     },
     staging: {
       url: "https://candy.freefeed.net",
       display_name: "candy.freefeed.net (staging)",
       domain: "candy.freefeed.net",
-      token_url: "https://candy.freefeed.net/settings/app-tokens/create?scopes=read-my-info%20manage-posts"
+      token_url: token_url("candy.freefeed.net")
     },
     beta: {
       url: "https://beta.freefeed.net",
       display_name: "beta.freefeed.net (beta)",
       domain: "beta.freefeed.net",
-      token_url: "https://beta.freefeed.net/settings/app-tokens/create?scopes=read-my-info%20manage-posts"
+      token_url: token_url("beta.freefeed.net")
     }
   }.freeze
 

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -38,6 +38,7 @@
           <p>Why Feeder needs these permissions:</p>
           <ul class="list-none space-y-2">
             <li><strong><code>read-my-info</code></strong> - Allows Feeder to verify your identity and display which FreeFeed account is connected to this token.</li>
+            <li><strong><code>read-users-info</code></strong> - Lets Feeder check how many subscribers your target group has.</li>
             <li><strong><code>manage-posts</code></strong> - Allows Feeder to create new posts and reposts on your behalf when publishing feed content to FreeFeed.</li>
           </ul>
         <% end %>

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -374,6 +374,14 @@ class AccessTokenTest < ActiveSupport::TestCase
     end
   end
 
+  test "FREEFEED_HOSTS token URLs should request every scope Feeder needs" do
+    AccessToken::FREEFEED_HOSTS.each do |key, config|
+      AccessToken::TOKEN_SCOPES.each do |scope|
+        assert_includes config[:token_url], scope, "#{key} token URL should request the #{scope} scope"
+      end
+    end
+  end
+
   test "#disable_associated_feeds should disable all feeds and clear access_token_id" do
     user = create(:user)
     token = create(:access_token, :active, user: user)


### PR DESCRIPTION
Changes:

- Ask for the `read-users-info` scope in the token creation links

`GET /v2/users/:username/statistics` lives in FreeFeed's `read-users-info` scope, which the token links never requested, so the nightly subscriber count job failed for every feed. Tokens created before this change need to be recreated to get counts.
