### PR TITLE
Align email preview card icon to first title line

### DIFF
--- a/app/views/development/email_previews/index.html.erb
+++ b/app/views/development/email_previews/index.html.erb
@@ -9,8 +9,9 @@
     <% @previews.each do |preview| %>
       <%= render LinkedCardComponent.new(href: development_email_preview_path(preview[:id])) do %>
         <div class="space-y-4">
-          <h2 class="flex items-center gap-2 text-lg font-semibold text-heading">
-            <%= icon("mail", css_class: "size-5") %>
+          <h2 class="flex items-start gap-2 text-lg font-semibold text-heading">
+            <%# mt-1 centers the 1.25rem icon on the 1.75rem first line %>
+            <%= icon("mail", css_class: "mt-1 size-5") %>
             <span><%= preview[:label] %></span>
           </h2>
           <p class="text-body"><%= preview[:description] %></p>

--- a/app/views/development/email_previews/index.html.erb
+++ b/app/views/development/email_previews/index.html.erb
@@ -10,7 +10,6 @@
       <%= render LinkedCardComponent.new(href: development_email_preview_path(preview[:id])) do %>
         <div class="space-y-4">
           <h2 class="flex items-start gap-2 text-lg font-semibold text-heading">
-            <%# mt-1 centers the 1.25rem icon on the 1.75rem first line %>
             <%= icon("mail", css_class: "mt-1 size-5") %>
             <span><%= preview[:label] %></span>
           </h2>


### PR DESCRIPTION
Changes:

- Keep the envelope icon on the first line of the card title instead of centering it against the whole heading

On the email previews page, long titles wrap to two lines, which left the icon floating in the middle of the block. It now sits on the first line regardless of how the title wraps.
