### PR TITLE
Move credential and token actions into a header menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-16
+
+- Edit, Delete, and Make default on credential and access token pages now live in a single … menu, so the page header stays tidy.
+
 ## 2026-08-15
 
 - A search key that's been revoked or has run out of credit now switches itself off with a clear reason, instead of quietly failing on every run.

--- a/app/components/dropdown_menu_component.html.erb
+++ b/app/components/dropdown_menu_component.html.erb
@@ -15,7 +15,11 @@
        aria-labelledby="<%= menu_id %>-button">
     <ul class="py-1">
       <% items.each do |item| %>
-        <li><%= render_item(item) %></li>
+        <% if item[:separator] %>
+          <li role="separator" class="my-1 border-t border-border"></li>
+        <% else %>
+          <li><%= render_item(item) %></li>
+        <% end %>
       <% end %>
     </ul>
   </div>

--- a/app/components/dropdown_menu_component.rb
+++ b/app/components/dropdown_menu_component.rb
@@ -7,6 +7,9 @@
 # disable); the rest render as links. Supported keys:
 #
 #   { label:, href:, method:, params:, target:, rel:, data: }
+#
+# A `{ separator: true }` entry draws a rule between groups, keeping a
+# destructive action off the edge of the one above it.
 class DropdownMenuComponent < ViewComponent::Base
   ITEM_CLASS = "block px-4 py-2 text-sm text-heading transition hover:bg-surface-muted"
 

--- a/app/helpers/credential_helper.rb
+++ b/app/helpers/credential_helper.rb
@@ -1,0 +1,19 @@
+module CredentialHelper
+  # Header action menu for a credential's show page. Delete sits below a
+  # separator so a destructive click isn't adjacent to the routine actions.
+  def credential_actions_menu_items(credential, delete_confirm:)
+    key_prefix = credential.model_name.param_key
+    items = [{ label: "Edit", href: edit_polymorphic_path(credential), data: { key: "#{key_prefix}.edit" } }]
+
+    unless credential.default?
+      items << { label: "Make default", href: polymorphic_path([credential, :default]), method: :patch,
+                 data: { key: "#{key_prefix}.make-default" } }
+    end
+
+    items << { separator: true }
+    items << { label: "Delete…", href: polymorphic_path(credential), method: :delete,
+               data: { key: "#{key_prefix}.delete", turbo_confirm: delete_confirm } }
+
+    items
+  end
+end

--- a/app/helpers/credential_helper.rb
+++ b/app/helpers/credential_helper.rb
@@ -16,4 +16,16 @@ module CredentialHelper
 
     items
   end
+
+  # Access tokens have no default flag, and deletion goes through the
+  # confirmation modal rendered alongside the page rather than a prompt.
+  def access_token_actions_menu_items(access_token)
+    [
+      { label: "Edit", href: edit_access_token_path(access_token), data: { key: "access_token.edit" } },
+      { separator: true },
+      { label: "Delete…", href: "#",
+        data: { key: "access_token.delete", controller: "modal-trigger",
+                modal_trigger_modal_id_value: "delete-token-modal", action: "click->modal-trigger#open" } }
+    ]
+  end
 end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -9,14 +9,10 @@
 
   <% unless access_token.pending? || access_token.validating? %>
     <% header.with_action_button do %>
-      <%= link_to "Edit", edit_access_token_path(access_token), class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1" %>
-    <% end %>
-
-    <% header.with_action_button do %>
-      <%= link_to "Delete…",
-                  "#",
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",
-                  data: { controller: "modal-trigger", modal_trigger_modal_id_value: "delete-token-modal", action: "click->modal-trigger#open" } %>
+      <%= render HeaderMenuComponent.new(
+        menu_id: "access-token-header-menu-#{access_token.id}",
+        items: access_token_actions_menu_items(access_token)
+      ) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/ai_credentials/_show_content.html.erb
+++ b/app/views/ai_credentials/_show_content.html.erb
@@ -3,17 +3,10 @@
   <%= render PageHeaderComponent.new(title: ai_credential.display_name) do |header| %>
     <% header.with_breadcrumb(label: "AI credentials", url: ai_credentials_path) %>
     <% header.with_action_button do %>
-      <%= link_to "Edit",
-                  edit_ai_credential_path(ai_credential),
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted",
-                  data: { key: "ai_credential.edit" } %>
-    <% end %>
-    <% header.with_action_button do %>
-      <%= button_to "Delete…",
-                    ai_credential_path(ai_credential),
-                    method: :delete,
-                    form: { data: { turbo_confirm: "Delete this AI credential? Feeds using it will be disabled." } },
-                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
+      <%= render HeaderMenuComponent.new(
+        menu_id: "ai-credential-header-menu-#{ai_credential.id}",
+        items: credential_actions_menu_items(ai_credential, delete_confirm: "Delete this AI credential? Feeds using it will be disabled.")
+      ) %>
     <% end %>
   <% end %>
 
@@ -51,26 +44,18 @@
     <%= render AiCredentialDetailsComponent.new(ai_credential: ai_credential) %>
   <% end %>
 
-  <% if feed_id.present? || !ai_credential.default? %>
+  <% if feed_id.present? %>
     <div class="flex flex-wrap gap-3">
-      <% if feed_id.present? %>
-        <% if ai_credential.active? %>
-          <%= link_to "Continue setting up your feed",
-                      edit_feed_path(feed_id),
-                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover",
-                      data: { key: "ai_credential.return-to" } %>
-        <% else %>
-          <%= link_to "Back to your feed",
-                      edit_feed_path(feed_id),
-                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted",
-                      data: { key: "ai_credential.return-to" } %>
-        <% end %>
-      <% end %>
-      <% unless ai_credential.default? %>
-        <%= button_to "Make default",
-                      ai_credential_default_path(ai_credential),
-                      method: :patch,
-                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
+      <% if ai_credential.active? %>
+        <%= link_to "Continue setting up your feed",
+                    edit_feed_path(feed_id),
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover",
+                    data: { key: "ai_credential.return-to" } %>
+      <% else %>
+        <%= link_to "Back to your feed",
+                    edit_feed_path(feed_id),
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted",
+                    data: { key: "ai_credential.return-to" } %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/search_credentials/_show_content.html.erb
+++ b/app/views/search_credentials/_show_content.html.erb
@@ -3,17 +3,10 @@
   <%= render PageHeaderComponent.new(title: search_credential.display_name) do |header| %>
     <% header.with_breadcrumb(label: "Search credentials", url: search_credentials_path) %>
     <% header.with_action_button do %>
-      <%= link_to "Edit",
-                  edit_search_credential_path(search_credential),
-                  class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted",
-                  data: { key: "search_credential.edit" } %>
-    <% end %>
-    <% header.with_action_button do %>
-      <%= button_to "Delete…",
-                    search_credential_path(search_credential),
-                    method: :delete,
-                    form: { data: { turbo_confirm: "Delete this search credential?" } },
-                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
+      <%= render HeaderMenuComponent.new(
+        menu_id: "search-credential-header-menu-#{search_credential.id}",
+        items: credential_actions_menu_items(search_credential, delete_confirm: "Delete this search credential?")
+      ) %>
     <% end %>
   <% end %>
 
@@ -52,26 +45,18 @@
     </section>
   <% end %>
 
-  <% if feed_id.present? || !search_credential.default? %>
+  <% if feed_id.present? %>
     <div class="flex flex-wrap gap-3">
-      <% if feed_id.present? %>
-        <% if search_credential.active? %>
-          <%= link_to "Continue setting up your feed",
-                      edit_feed_path(feed_id),
-                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover",
-                      data: { key: "search_credential.return-to" } %>
-        <% else %>
-          <%= link_to "Back to your feed",
-                      edit_feed_path(feed_id),
-                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted",
-                      data: { key: "search_credential.return-to" } %>
-        <% end %>
-      <% end %>
-      <% unless search_credential.default? %>
-        <%= button_to "Make default",
-                      search_credential_default_path(search_credential),
-                      method: :patch,
-                      class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:cursor-not-allowed disabled:opacity-50" %>
+      <% if search_credential.active? %>
+        <%= link_to "Continue setting up your feed",
+                    edit_feed_path(feed_id),
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md bg-brand px-4 py-2 text-base font-semibold text-on-brand shadow-sm transition hover:bg-brand-hover",
+                    data: { key: "search_credential.return-to" } %>
+      <% else %>
+        <%= link_to "Back to your feed",
+                    edit_feed_path(feed_id),
+                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-body shadow-sm transition hover:bg-surface-muted",
+                    data: { key: "search_credential.return-to" } %>
       <% end %>
     </div>
   <% end %>

--- a/test/components/dropdown_menu_component_test.rb
+++ b/test/components/dropdown_menu_component_test.rb
@@ -58,6 +58,19 @@ class DropdownMenuComponentTest < ViewComponent::TestCase
     assert_equal "Sure?", button["data-turbo-confirm"]
   end
 
+  test "#render should draw a rule for a separator item" do
+    result = render_inline(DropdownMenuComponent.new(menu_id: "m", items: [
+      { label: "Edit", href: "/feeds/1" },
+      { separator: true },
+      { label: "Delete…", href: "/feeds/1" }
+    ]))
+
+    separator = result.at_css("li[role='separator']")
+    assert_not_nil separator
+    assert_includes separator["class"], "border-t"
+    assert_equal 0, separator.css("a, button").size
+  end
+
   test "#render should drop nil items" do
     result = render_inline(DropdownMenuComponent.new(menu_id: "m", items: [
       { label: "Details", href: "#" },

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -71,6 +71,29 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", access_token.name
   end
 
+  test "#show should place the token actions in the header menu" do
+    sign_in_as user
+    active = create(:access_token, :active, user: user)
+
+    get access_token_path(active)
+
+    assert_response :success
+    assert_select "header [role='menu']" do
+      assert_select "[data-key='access_token.edit']"
+      assert_select "li[role='separator']"
+      assert_select "[data-key='access_token.delete']", text: /Delete/
+    end
+  end
+
+  test "#show should hide the header menu while the token is validating" do
+    sign_in_as user
+
+    get access_token_path(access_token)
+
+    assert_response :success
+    assert_select "header [role='menu']", count: 0
+  end
+
   test "#show should render Associated Feeds section when token has feeds" do
     sign_in_as user
     active = create(:access_token, :active, user: user)

--- a/test/controllers/ai_credentials_controller_test.rb
+++ b/test/controllers/ai_credentials_controller_test.rb
@@ -187,15 +187,27 @@ class AiCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='ai_credential.show']"
   end
 
-  test "#show should place edit and delete actions in the header" do
+  test "#show should place the credential actions in the header menu" do
     sign_in_as(user)
     get ai_credential_url(credential)
 
     assert_response :success
-    assert_select "header [data-key='ai_credential.edit']"
-    assert_select "header form[action=?]", ai_credential_path(credential) do
-      assert_select "button", text: /Delete/
+    assert_select "header [role='menu']" do
+      assert_select "[data-key='ai_credential.edit']"
+      assert_select "[data-key='ai_credential.make-default']"
+      assert_select "li[role='separator']"
+      assert_select "[data-key='ai_credential.delete']", text: /Delete/
     end
+  end
+
+  test "#show should omit make default from the header menu for the default credential" do
+    sign_in_as(user)
+    default_credential = create(:ai_credential, :default, user: user)
+
+    get ai_credential_url(default_credential)
+
+    assert_response :success
+    assert_select "[data-key='ai_credential.make-default']", count: 0
   end
 
   test "#show should render the polling shell for a pending credential" do

--- a/test/controllers/search_credentials_controller_test.rb
+++ b/test/controllers/search_credentials_controller_test.rb
@@ -120,16 +120,28 @@ class SearchCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='search_credential.show']"
   end
 
-  test "#show should place edit and delete actions in the header" do
+  test "#show should place the credential actions in the header menu" do
     sign_in_as(user)
 
     get search_credential_url(credential)
 
     assert_response :success
-    assert_select "header [data-key='search_credential.edit']"
-    assert_select "header form[action=?]", search_credential_path(credential) do
-      assert_select "button", text: /Delete/
+    assert_select "header [role='menu']" do
+      assert_select "[data-key='search_credential.edit']"
+      assert_select "[data-key='search_credential.make-default']"
+      assert_select "li[role='separator']"
+      assert_select "[data-key='search_credential.delete']", text: /Delete/
     end
+  end
+
+  test "#show should omit make default from the header menu for the default credential" do
+    sign_in_as(user)
+    default_credential = create(:search_credential, :default, user: user)
+
+    get search_credential_url(default_credential)
+
+    assert_response :success
+    assert_select "[data-key='search_credential.make-default']", count: 0
   end
 
   test "#show should render the pending state with polling" do

--- a/test/helpers/credential_helper_test.rb
+++ b/test/helpers/credential_helper_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class CredentialHelperTest < ActionView::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  test "#credential_actions_menu_items should list edit, make default, and delete" do
+    credential = create(:ai_credential, user: user)
+
+    labels = credential_actions_menu_items(credential, delete_confirm: "Sure?").map { _1[:label] }
+
+    assert_equal ["Edit", "Make default", nil, "Delete…"], labels
+  end
+
+  test "#credential_actions_menu_items should omit make default for the default credential" do
+    credential = create(:ai_credential, :default, user: user)
+
+    labels = credential_actions_menu_items(credential, delete_confirm: "Sure?").map { _1[:label] }
+
+    assert_equal ["Edit", nil, "Delete…"], labels
+  end
+
+  test "#credential_actions_menu_items should separate delete from the actions above it" do
+    credential = create(:ai_credential, user: user)
+
+    items = credential_actions_menu_items(credential, delete_confirm: "Sure?")
+
+    assert items[-2][:separator]
+    assert_equal "Delete…", items.last[:label]
+  end
+
+  test "#credential_actions_menu_items should wire the actions to their routes" do
+    credential = create(:search_credential, user: user)
+
+    items = credential_actions_menu_items(credential, delete_confirm: "Delete this search credential?")
+              .reject { _1[:separator] }.index_by { _1[:label] }
+
+    assert_equal edit_search_credential_path(credential), items["Edit"][:href]
+    assert_equal search_credential_default_path(credential), items["Make default"][:href]
+    assert_equal :patch, items["Make default"][:method]
+    assert_equal search_credential_path(credential), items["Delete…"][:href]
+    assert_equal :delete, items["Delete…"][:method]
+    assert_equal "Delete this search credential?", items["Delete…"].dig(:data, :turbo_confirm)
+  end
+
+  test "#credential_actions_menu_items should namespace test hooks by credential type" do
+    credential = create(:search_credential, user: user)
+
+    keys = credential_actions_menu_items(credential, delete_confirm: "Sure?").map { _1.dig(:data, :key) }
+
+    assert_equal ["search_credential.edit", "search_credential.make-default", nil, "search_credential.delete"], keys
+  end
+end

--- a/test/helpers/credential_helper_test.rb
+++ b/test/helpers/credential_helper_test.rb
@@ -51,4 +51,23 @@ class CredentialHelperTest < ActionView::TestCase
 
     assert_equal ["search_credential.edit", "search_credential.make-default", nil, "search_credential.delete"], keys
   end
+
+  test "#access_token_actions_menu_items should list edit and delete around a separator" do
+    access_token = create(:access_token, user: user)
+
+    items = access_token_actions_menu_items(access_token)
+
+    assert_equal ["Edit", nil, "Delete…"], items.map { _1[:label] }
+    assert items[1][:separator]
+    assert_equal edit_access_token_path(access_token), items.first[:href]
+  end
+
+  test "#access_token_actions_menu_items should open the delete confirmation modal" do
+    access_token = create(:access_token, user: user)
+
+    delete_item = access_token_actions_menu_items(access_token).last
+
+    assert_equal "delete-token-modal", delete_item.dig(:data, :modal_trigger_modal_id_value)
+    assert_equal "click->modal-trigger#open", delete_item.dig(:data, :action)
+  end
 end


### PR DESCRIPTION
Changes:

- Tuck Edit, Make default, and Delete into a `[…]` header menu on the AI credential, search credential, and access token pages, matching the feed page
- Set Delete apart from the routine actions with a separator rule
- Teach `DropdownMenuComponent` to render separator items

The credential pages had grown a row of header buttons plus a stray "Make
default" button below the content. Collecting them under one menu keeps the
header quiet and puts the destructive action where a stray click won't land
on it.

<img width="1200" height="900" alt="shotai" src="https://github.com/user-attachments/assets/b6292e33-8264-4350-a035-3836cfe1e6bd" />
<img width="1200" height="900" alt="shottoken" src="https://github.com/user-attachments/assets/c3fc7a58-793c-4753-b503-a10a56608bd0" />
