### PR TITLE
Add OpenAI as a native LLM provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-16
+
+- OpenAI is now available for AI feeds. Add an OpenAI key on the credentials page and pick it when setting up a feed.
+
 ## 2026-08-15
 
 - A search key that's been revoked or has run out of credit now switches itself off with a clear reason, instead of quietly failing on every run.

--- a/app/jobs/open_ai_capability_probe_job.rb
+++ b/app/jobs/open_ai_capability_probe_job.rb
@@ -1,0 +1,6 @@
+# Live-qualifies the OpenAI candidate on the provider's default model.
+# See LlmCapabilityProbeJob.
+class OpenAiCapabilityProbeJob < LlmCapabilityProbeJob
+  PROVIDER = "openai".freeze
+  MODEL = "gpt-5.4".freeze
+end

--- a/app/jobs/open_ai_capability_probe_job.rb
+++ b/app/jobs/open_ai_capability_probe_job.rb
@@ -1,6 +1,6 @@
-# Live-qualifies OpenAI on gpt-5-mini, cheap enough to re-run freely while the
-# pair is being iterated on. See LlmCapabilityProbeJob.
+# Live-qualifies OpenAI on gpt-5.6-luna, the provider's default. See
+# LlmCapabilityProbeJob.
 class OpenAiCapabilityProbeJob < LlmCapabilityProbeJob
   PROVIDER = "openai".freeze
-  MODEL = "gpt-5-mini".freeze
+  MODEL = "gpt-5.6-luna".freeze
 end

--- a/app/jobs/open_ai_capability_probe_job.rb
+++ b/app/jobs/open_ai_capability_probe_job.rb
@@ -1,4 +1,4 @@
-# Live-qualifies OpenAI on gpt-5.6-luna, the provider's default. See
+# Live-qualifies the OpenAI provider on its default model. See
 # LlmCapabilityProbeJob.
 class OpenAiCapabilityProbeJob < LlmCapabilityProbeJob
   PROVIDER = "openai".freeze

--- a/app/jobs/open_ai_capability_probe_job.rb
+++ b/app/jobs/open_ai_capability_probe_job.rb
@@ -1,6 +1,6 @@
-# Live-qualifies the OpenAI candidate on the provider's default model.
-# See LlmCapabilityProbeJob.
+# Live-qualifies OpenAI on gpt-5-mini, cheap enough to re-run freely while the
+# pair is being iterated on. See LlmCapabilityProbeJob.
 class OpenAiCapabilityProbeJob < LlmCapabilityProbeJob
   PROVIDER = "openai".freeze
-  MODEL = "gpt-5.4".freeze
+  MODEL = "gpt-5-mini".freeze
 end

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -4,6 +4,7 @@ class JobRun < ApplicationRecord
   RUNNABLE_JOBS = [
     AnthropicCapabilityProbeJob,
     KimiCapabilityProbeJob,
+    OpenAiCapabilityProbeJob,
     SerperCapabilityProbeJob,
     BraveCapabilityProbeJob,
     TavilyCapabilityProbeJob,

--- a/app/models/llm_model_capability.rb
+++ b/app/models/llm_model_capability.rb
@@ -16,7 +16,8 @@
 class LlmModelCapability
   ENTRIES = [
     { provider: "anthropic", model: "claude-sonnet-4-6" },
-    { provider: "moonshot", model: "kimi-k2.6" }
+    { provider: "moonshot", model: "kimi-k2.6" },
+    { provider: "openai", model: "gpt-5.6-luna" }
   ].freeze
 
   class << self

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -60,6 +60,12 @@ class LlmProvider
       ruby_llm_provider: :openrouter,
       default_model: "anthropic/claude-sonnet-4-6"
     ),
+    "openai" => new(
+      name: "openai",
+      display_name: "OpenAI",
+      ruby_llm_provider: :openai,
+      default_model: "gpt-5.4"
+    ),
     "moonshot" => new(
       name: "moonshot",
       display_name: "Moonshot (Kimi)",

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -9,19 +9,22 @@
 class LlmProvider
   attr_reader :name, :display_name, :ruby_llm_provider, :default_model, :api_base
 
+  # api_base            - the provider rides another's runtime at its own URL;
+  #                       native providers leave it nil.
+  # assume_model_exists - the provider's models aren't in RubyLLM's bundled
+  #                       registry, so a call asserts the id rather than looking
+  #                       it up, and the model snapshot keeps only what the
+  #                       provider itself reported.
+  # pin_system_role     - the provider rejects RubyLLM's default "developer"
+  #                       system role and needs "system".
   def initialize(name:, display_name:, ruby_llm_provider:, default_model:, api_base: nil,
                  assume_model_exists: false, pin_system_role: false)
     @name = name
     @display_name = display_name
     @ruby_llm_provider = ruby_llm_provider
     @default_model = default_model
-    # OpenAI-compatible providers (Moonshot) reuse RubyLLM's :openai provider
-    # pointed at their own base URL; native providers leave this nil.
     @api_base = api_base
-    # True when the provider's models aren't in RubyLLM's bundled registry, so
-    # a call must assert the model exists rather than look it up.
     @assume_model_exists = assume_model_exists
-    # True when the provider rejects RubyLLM's default "developer" system role.
     @pin_system_role = pin_system_role
     freeze
   end
@@ -40,10 +43,8 @@ class LlmProvider
   def configure(config, api_key)
     config.public_send("#{ruby_llm_provider}_api_key=", api_key)
     config.public_send("#{ruby_llm_provider}_api_base=", api_base) if api_base
-    # RubyLLM's :openai provider sends system prompts as role "developer".
-    # OpenAI itself accepts that role; OpenAI-compatible APIs like Moonshot
-    # reject it with a 400. Opted into per provider rather than for everything
-    # riding :openai, so a native provider keeps the runtime's own default.
+    # RubyLLM's :openai provider sends system prompts as role "developer", which
+    # OpenAI accepts but some OpenAI-compatible APIs reject with a 400.
     config.openai_use_system_role = true if pin_system_role?
   end
 

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -64,7 +64,8 @@ class LlmProvider
       name: "openai",
       display_name: "OpenAI",
       ruby_llm_provider: :openai,
-      default_model: "gpt-5.4"
+      default_model: "gpt-5.6-luna",
+      assume_model_exists: true
     ),
     "moonshot" => new(
       name: "moonshot",

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -9,14 +9,17 @@
 class LlmProvider
   attr_reader :name, :display_name, :ruby_llm_provider, :default_model, :api_base
 
-  # api_base            - the provider rides another's runtime at its own URL;
-  #                       native providers leave it nil.
-  # assume_model_exists - the provider's models aren't in RubyLLM's bundled
-  #                       registry, so a call asserts the id rather than looking
-  #                       it up, and the model snapshot keeps only what the
-  #                       provider itself reported.
-  # pin_system_role     - the provider rejects RubyLLM's default "developer"
-  #                       system role and needs "system".
+  # @param name [String]
+  # @param display_name [String]
+  # @param ruby_llm_provider [Symbol]
+  # @param default_model [String]
+  # @param api_base [String, nil] set when the provider rides another's runtime
+  #   at its own URL; native providers leave it nil
+  # @param assume_model_exists [Boolean] set when the provider's models aren't in
+  #   RubyLLM's bundled registry, so a call asserts the id rather than looking it
+  #   up, and the model snapshot keeps only what the provider itself reported
+  # @param pin_system_role [Boolean] set when the provider rejects RubyLLM's
+  #   default "developer" system role and needs "system"
   def initialize(name:, display_name:, ruby_llm_provider:, default_model:, api_base: nil,
                  assume_model_exists: false, pin_system_role: false)
     @name = name

--- a/app/models/llm_provider.rb
+++ b/app/models/llm_provider.rb
@@ -9,7 +9,8 @@
 class LlmProvider
   attr_reader :name, :display_name, :ruby_llm_provider, :default_model, :api_base
 
-  def initialize(name:, display_name:, ruby_llm_provider:, default_model:, api_base: nil, assume_model_exists: false)
+  def initialize(name:, display_name:, ruby_llm_provider:, default_model:, api_base: nil,
+                 assume_model_exists: false, pin_system_role: false)
     @name = name
     @display_name = display_name
     @ruby_llm_provider = ruby_llm_provider
@@ -20,11 +21,17 @@ class LlmProvider
     # True when the provider's models aren't in RubyLLM's bundled registry, so
     # a call must assert the model exists rather than look it up.
     @assume_model_exists = assume_model_exists
+    # True when the provider rejects RubyLLM's default "developer" system role.
+    @pin_system_role = pin_system_role
     freeze
   end
 
   def assume_model_exists?
     @assume_model_exists
+  end
+
+  def pin_system_role?
+    @pin_system_role
   end
 
   # Applies this provider's credentials to a RubyLLM config. Keyed on the
@@ -33,11 +40,11 @@ class LlmProvider
   def configure(config, api_key)
     config.public_send("#{ruby_llm_provider}_api_key=", api_key)
     config.public_send("#{ruby_llm_provider}_api_base=", api_base) if api_base
-    # RubyLLM's :openai provider sends system prompts as role "developer"
-    # unless this flag is set, and OpenAI-compatible APIs like Moonshot reject
-    # that role with a 400. Scoped per-provider, not set globally, because
-    # OpenRouter reads the same attribute and expects the default.
-    config.openai_use_system_role = true if ruby_llm_provider == :openai
+    # RubyLLM's :openai provider sends system prompts as role "developer".
+    # OpenAI itself accepts that role; OpenAI-compatible APIs like Moonshot
+    # reject it with a 400. Opted into per provider rather than for everything
+    # riding :openai, so a native provider keeps the runtime's own default.
+    config.openai_use_system_role = true if pin_system_role?
   end
 
   PROVIDERS = {
@@ -59,7 +66,8 @@ class LlmProvider
       ruby_llm_provider: :openai,
       default_model: "kimi-k2.6",
       api_base: "https://api.moonshot.ai/v1",
-      assume_model_exists: true
+      assume_model_exists: true,
+      pin_system_role: true
     )
   }.freeze
 

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -165,7 +165,7 @@ module LlmCapabilityProbe
     # reject the system role RubyLLM defaults to, which a schema-only call
     # never exercises.
     def check_schema
-      chat = @credential.chat(@model).with_schema(PROBE_SCHEMA)
+      chat = @credential.chat(@model).with_schema(adapter.schema_payload(PROBE_SCHEMA))
       chat.with_instructions(PROBE_INSTRUCTIONS)
       response = chat.ask(STRUCTURE_PROMPT_PREFIX + SAMPLE_TEXT)
       validate_items(response, expect_null_source_url: true)
@@ -205,7 +205,7 @@ module LlmCapabilityProbe
     def client_tools_chat(schema)
       chat = @credential.chat(@model)
       chat.with_instructions(PROBE_INSTRUCTIONS)
-      chat.with_schema(schema) if schema
+      chat.with_schema(adapter.schema_payload(schema)) if schema
       budget = LlmClient::ToolBudget.new
       chat.with_tool(CannedWebSearch.new(budget: budget))
       chat.with_tool(LlmClient::Tools::WebFetch.new(budget: budget))
@@ -284,7 +284,13 @@ module LlmCapabilityProbe
     # Repairs structured output the way production does, so the probe doesn't
     # fail a model on a quirk the app already absorbs (Kimi fences its JSON).
     def unwrap_json(text)
-      LlmClient::Adapter.for(@credential.provider).unwrap_json(text)
+      adapter.unwrap_json(text)
+    end
+
+    # The same adapter production builds its calls with, so schema strictness
+    # and response repair are probed as they ship.
+    def adapter
+      @adapter ||= LlmClient::Adapter.for(@credential.provider)
     end
 
     def pass(condition, fail_note, evidence)

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -206,6 +206,8 @@ module LlmCapabilityProbe
       chat = @credential.chat(@model)
       chat.with_instructions(PROBE_INSTRUCTIONS)
       chat.with_schema(adapter.schema_payload(schema)) if schema
+      params = adapter.web_params(@model)
+      chat.with_params(**params) if params.present?
       budget = LlmClient::ToolBudget.new
       chat.with_tool(CannedWebSearch.new(budget: budget))
       chat.with_tool(LlmClient::Tools::WebFetch.new(budget: budget))

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -155,7 +155,7 @@ class LlmClient
     # System prompt is the privileged instruction channel; the user prompt sent
     # by #ask travels as a separate user-role message (spec §8).
     chat.with_instructions(system) if system.present?
-    chat.with_schema(output_schema) if output_schema.present?
+    chat.with_schema(adapter.schema_payload(output_schema)) if output_schema.present?
     if web
       adapter.apply_web(
         chat,

--- a/app/services/llm_client/adapter.rb
+++ b/app/services/llm_client/adapter.rb
@@ -6,6 +6,7 @@ class LlmClient
     REGISTRY = {
       "anthropic" => "Anthropic",
       "openrouter" => "OpenRouter",
+      "openai" => "OpenAi",
       "moonshot" => "Moonshot"
     }.freeze
 

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -34,6 +34,19 @@ class LlmClient
         false
       end
 
+      # RubyLLM's schema argument. The wrapper form is what carries strictness;
+      # passing the bare schema would silently default it to on.
+      def schema_payload(schema)
+        { "schema" => schema, "strict" => schema_strict? }
+      end
+
+      # Constrained decoding where the provider's strict mode can express the
+      # output schema. Off for providers whose strict mode cannot represent an
+      # optional key, since they reject such a schema rather than relax it.
+      def schema_strict?
+        true
+      end
+
       # Repairs structured-output text before JSON parsing. Default trusts clean
       # JSON; providers that wrap it (Moonshot fences) override.
       def unwrap_json(text)

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -34,8 +34,7 @@ class LlmClient
         false
       end
 
-      # RubyLLM's schema argument. The wrapper form is what carries strictness;
-      # passing the bare schema would silently default it to on.
+      # RubyLLM's schema argument; the wrapper form is what carries strictness.
       def schema_payload(schema)
         { "schema" => schema, "strict" => schema_strict? }
       end

--- a/app/services/llm_client/adapter/open_ai.rb
+++ b/app/services/llm_client/adapter/open_ai.rb
@@ -6,6 +6,14 @@ class LlmClient
     # survive the same call is what the capability probe decides, so this stays
     # on Base's two-call fallback until a run says otherwise.
     class OpenAi < Base
+      # OpenAI's strict mode requires every key in `properties` to appear in
+      # `required`, recursively. FeedProfile::UNIVERSAL_OUTPUT_SCHEMA marks
+      # only `body` and `source_url` required, so a strict call is rejected
+      # outright; unconstrained, the schema still shapes the response and the
+      # normalizer still validates what comes back.
+      def schema_strict?
+        false
+      end
     end
   end
 end

--- a/app/services/llm_client/adapter/open_ai.rb
+++ b/app/services/llm_client/adapter/open_ai.rb
@@ -1,23 +1,16 @@
 class LlmClient
   module Adapter
-    # OpenAI needs neither the request tweaks nor the response repair the other
-    # providers do: structured outputs come back as clean JSON, and the shared
-    # client-side web tools need no extra params. Whether a schema and tools
-    # survive the same call is what the capability probe decides, so this stays
-    # on Base's two-call fallback until a run says otherwise.
     class OpenAi < Base
-      # gpt-5.6 reasons by default, and OpenAI rejects function tools alongside
-      # reasoning on /v1/chat/completions — the endpoint RubyLLM speaks — with
-      # a 400 naming this opt-out. Scoped to tool-enabled calls, so the
-      # structure step keeps the model's reasoning.
+      # OpenAI's reasoning models reason by default, and OpenAI rejects function
+      # tools alongside reasoning on the chat-completions endpoint RubyLLM
+      # speaks. Scoped to tool-enabled calls, so structuring keeps its reasoning.
       def web_params(_model)
         { reasoning_effort: "none" }
       end
 
       # OpenAI's strict mode requires every key in `properties` to appear in
-      # `required`, recursively. FeedProfile::UNIVERSAL_OUTPUT_SCHEMA marks
-      # only `body` and `source_url` required, so a strict call is rejected
-      # outright; unconstrained, the schema still shapes the response and the
+      # `required`, recursively; UNIVERSAL_OUTPUT_SCHEMA leaves most item keys
+      # optional. Unconstrained the schema still shapes the response, and the
       # normalizer still validates what comes back.
       def schema_strict?
         false

--- a/app/services/llm_client/adapter/open_ai.rb
+++ b/app/services/llm_client/adapter/open_ai.rb
@@ -6,6 +6,14 @@ class LlmClient
     # survive the same call is what the capability probe decides, so this stays
     # on Base's two-call fallback until a run says otherwise.
     class OpenAi < Base
+      # gpt-5.6 reasons by default, and OpenAI rejects function tools alongside
+      # reasoning on /v1/chat/completions — the endpoint RubyLLM speaks — with
+      # a 400 naming this opt-out. Scoped to tool-enabled calls, so the
+      # structure step keeps the model's reasoning.
+      def web_params(_model)
+        { reasoning_effort: "none" }
+      end
+
       # OpenAI's strict mode requires every key in `properties` to appear in
       # `required`, recursively. FeedProfile::UNIVERSAL_OUTPUT_SCHEMA marks
       # only `body` and `source_url` required, so a strict call is rejected

--- a/app/services/llm_client/adapter/open_ai.rb
+++ b/app/services/llm_client/adapter/open_ai.rb
@@ -8,6 +8,12 @@ class LlmClient
         { reasoning_effort: "none" }
       end
 
+      # OpenAI completes a structured extraction while driving function tools,
+      # so gathering and structuring stay in one call.
+      def combined_extraction?
+        true
+      end
+
       # OpenAI's strict mode requires every key in `properties` to appear in
       # `required`, recursively; UNIVERSAL_OUTPUT_SCHEMA leaves most item keys
       # optional. Unconstrained the schema still shapes the response, and the

--- a/app/services/llm_client/adapter/open_ai.rb
+++ b/app/services/llm_client/adapter/open_ai.rb
@@ -1,0 +1,11 @@
+class LlmClient
+  module Adapter
+    # OpenAI needs neither the request tweaks nor the response repair the other
+    # providers do: structured outputs come back as clean JSON, and the shared
+    # client-side web tools need no extra params. Whether a schema and tools
+    # survive the same call is what the capability probe decides, so this stays
+    # on Base's two-call fallback until a run says otherwise.
+    class OpenAi < Base
+    end
+  end
+end

--- a/config/llm_rates.yml
+++ b/config/llm_rates.yml
@@ -57,6 +57,10 @@ openai:
     input_per_million: 2.50
     output_per_million: 15.00
     cache_read_per_million: 0.25
+  gpt-5-mini:
+    input_per_million: 0.25
+    output_per_million: 2.00
+    cache_read_per_million: 0.025
 
 # Moonshot (Kimi). Verified 2026-08-15 against
 # platform.kimi.ai/docs/pricing/chat-k26.

--- a/config/llm_rates.yml
+++ b/config/llm_rates.yml
@@ -48,6 +48,15 @@ openrouter:
     input_per_million: 0.12
     output_per_million: 0.40
 
+# OpenAI. Verified 2026-08-15 against openai.com/api/pricing. Cached input
+# bills at 10% of the input rate and there is no separate cache-write charge,
+# so only cache_read is listed.
+openai:
+  gpt-5.4:
+    input_per_million: 2.75
+    output_per_million: 16.50
+    cache_read_per_million: 0.275
+
 # Moonshot (Kimi). Verified 2026-08-15 against
 # platform.kimi.ai/docs/pricing/chat-k26.
 moonshot:

--- a/config/llm_rates.yml
+++ b/config/llm_rates.yml
@@ -50,12 +50,13 @@ openrouter:
 
 # OpenAI. Verified 2026-08-15 against openai.com/api/pricing. Cached input
 # bills at 10% of the input rate and there is no separate cache-write charge,
-# so only cache_read is listed.
+# so only cache_read is listed. These are the standard-context rates; OpenAI
+# bills long-context requests higher, which this flat table cannot express.
 openai:
   gpt-5.4:
-    input_per_million: 2.75
-    output_per_million: 16.50
-    cache_read_per_million: 0.275
+    input_per_million: 2.50
+    output_per_million: 15.00
+    cache_read_per_million: 0.25
 
 # Moonshot (Kimi). Verified 2026-08-15 against
 # platform.kimi.ai/docs/pricing/chat-k26.

--- a/config/llm_rates.yml
+++ b/config/llm_rates.yml
@@ -48,11 +48,10 @@ openrouter:
     input_per_million: 0.12
     output_per_million: 0.40
 
-# OpenAI. Verified 2026-08-15 against openai.com/api/pricing. These are the
-# standard-context rates; OpenAI bills long-context requests higher, which this
-# flat table cannot express. cache_write is omitted deliberately: OpenAI does
-# charge for it, but RubyLLM's OpenAI adapter never reports a cache-write
-# count, so a rate here would price nothing.
+# OpenAI. Verified 2026-08-15 against openai.com/api/pricing. Standard-context
+# rates: OpenAI bills long context higher, which this flat table cannot
+# express. cache_write is omitted because RubyLLM never reports a cache-write
+# count for OpenAI, so a rate would price nothing.
 openai:
   gpt-5.6-luna:
     input_per_million: 0.20

--- a/config/llm_rates.yml
+++ b/config/llm_rates.yml
@@ -48,19 +48,16 @@ openrouter:
     input_per_million: 0.12
     output_per_million: 0.40
 
-# OpenAI. Verified 2026-08-15 against openai.com/api/pricing. Cached input
-# bills at 10% of the input rate and there is no separate cache-write charge,
-# so only cache_read is listed. These are the standard-context rates; OpenAI
-# bills long-context requests higher, which this flat table cannot express.
+# OpenAI. Verified 2026-08-15 against openai.com/api/pricing. These are the
+# standard-context rates; OpenAI bills long-context requests higher, which this
+# flat table cannot express. cache_write is omitted deliberately: OpenAI does
+# charge for it, but RubyLLM's OpenAI adapter never reports a cache-write
+# count, so a rate here would price nothing.
 openai:
-  gpt-5.4:
-    input_per_million: 2.50
-    output_per_million: 15.00
-    cache_read_per_million: 0.25
-  gpt-5-mini:
-    input_per_million: 0.25
-    output_per_million: 2.00
-    cache_read_per_million: 0.025
+  gpt-5.6-luna:
+    input_per_million: 0.20
+    output_per_million: 1.20
+    cache_read_per_million: 0.02
 
 # Moonshot (Kimi). Verified 2026-08-15 against
 # platform.kimi.ai/docs/pricing/chat-k26.

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -14,10 +14,11 @@ share.
 ## Running it
 
 The key comes from the `AiCredential` named after the probe job, minus the `Job`
-suffix — **AnthropicCapabilityProbe**, **KimiCapabilityProbe** — on **your own
-account**. The dev area passes whoever pressed Run through to the job, so a
-probe only ever spends its own operator's tokens. Without that record the run
-records a skip saying which credential to create.
+suffix — **AnthropicCapabilityProbe**, **KimiCapabilityProbe**,
+**OpenAiCapabilityProbe** — on **your own account**. The dev area passes
+whoever pressed Run through to the job, so a probe only ever spends its own
+operator's tokens. Without that record the run records a skip saying which
+credential to create.
 
 From the dev area — the usual path, and the one that keeps the evidence
 searchable afterwards:

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -97,10 +97,12 @@ Before a pair can be probed, the provider needs:
 
 - an `LlmProvider` entry (RubyLLM provider key, default model, API base if it
   rides another provider's adapter);
-- an `LlmClient::Adapter` subclass, if it needs response repair, one-call
-  extraction, or a strictness other than the default (OpenAI's strict mode
-  cannot express the optional keys `UNIVERSAL_OUTPUT_SCHEMA` carries, so it
-  sends the schema unconstrained);
+- an `LlmClient::Adapter::REGISTRY` entry, which a test requires for every
+  registered provider — `Adapter.for` raises `KeyError` without one, after the
+  provider has billed the call. Point it at `Base` unless the provider needs
+  response repair, one-call extraction, or a strictness other than the default
+  (OpenAI's strict mode cannot express the optional keys
+  `UNIVERSAL_OUTPUT_SCHEMA` carries, so it sends the schema unconstrained);
 - a probe job pinning the pair, subclassing `LlmCapabilityProbeJob` with
   `PROVIDER`/`MODEL` and registered in `JobRun::RUNNABLE_JOBS`;
 - an `AiCredential` for it, named after that new job without the `Job` suffix

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -24,8 +24,9 @@ From the dev area — the usual path, and the one that keeps the evidence
 searchable afterwards:
 
 1. Add an AI credential for the provider, named exactly as above.
-2. Open `/development/jobs`, run `KimiCapabilityProbeJob` or
-   `AnthropicCapabilityProbeJob`, and read the run under `job_runs`.
+2. Open `/development/jobs`, run the probe job for the pair
+   (`AnthropicCapabilityProbeJob`, `KimiCapabilityProbeJob`,
+   `OpenAiCapabilityProbeJob`), and read the run under `job_runs`.
 
 Each check writes one event with its full evidence — the models listing, the
 tool calls with their arguments and results, the returned payload — so there is

--- a/docs/llm-provider-qualification.md
+++ b/docs/llm-provider-qualification.md
@@ -60,7 +60,7 @@ own web search works tells us nothing about a feed.
 | `models` | The id is served verbatim by the provider's listing — the allowlist matches on exact string |
 | `plain` | Basic round trip, deliberately without a system prompt so it isolates reachability |
 | `system_prompt` | The system channel arrives and is obeyed; instructions contradict the obvious answer, so a dropped or rejected prompt fails |
-| `schema` | Strict-schema JSON under production's `UNIVERSAL_OUTPUT_SCHEMA`, repaired the way production repairs it (`Adapter#unwrap_json`). Fails unless an item comes back with `source_url` null — a digest feed depends on that branch |
+| `schema` | JSON under production's `UNIVERSAL_OUTPUT_SCHEMA`, sent at the provider's own strictness (`Adapter#schema_payload`) and repaired the way production repairs it (`Adapter#unwrap_json`). Fails unless an item comes back with `source_url` null — a digest feed depends on that branch |
 | `client_tools` | The model drives our search and fetch tools through a real multi-round loop and grounds its answer in fetched content — production's gather step |
 | `client_tools_schema` | Schema and tools survive the *same* call — production's combined shape |
 
@@ -96,8 +96,10 @@ Before a pair can be probed, the provider needs:
 
 - an `LlmProvider` entry (RubyLLM provider key, default model, API base if it
   rides another provider's adapter);
-- an `LlmClient::Adapter` subclass, if it needs response repair or one-call
-  extraction;
+- an `LlmClient::Adapter` subclass, if it needs response repair, one-call
+  extraction, or a strictness other than the default (OpenAI's strict mode
+  cannot express the optional keys `UNIVERSAL_OUTPUT_SCHEMA` carries, so it
+  sends the schema unconstrained);
 - a probe job pinning the pair, subclassing `LlmCapabilityProbeJob` with
   `PROVIDER`/`MODEL` and registered in `JobRun::RUNNABLE_JOBS`;
 - an `AiCredential` for it, named after that new job without the `Job` suffix

--- a/test/jobs/llm_capability_probe_job_test.rb
+++ b/test/jobs/llm_capability_probe_job_test.rb
@@ -17,20 +17,32 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
     @job_run ||= create(:job_run, job_class: "AnthropicCapabilityProbeJob", job_id: job.job_id)
   end
 
-  test "should register both provider probes as runnable jobs" do
+  test "should register every provider probe as a runnable job" do
     assert_includes JobRun::RUNNABLE_JOBS, AnthropicCapabilityProbeJob
     assert_includes JobRun::RUNNABLE_JOBS, KimiCapabilityProbeJob
+    assert_includes JobRun::RUNNABLE_JOBS, OpenAiCapabilityProbeJob
   end
 
   test "should pin one provider and model per job" do
     assert_equal %w[anthropic claude-sonnet-4-6],
                  [AnthropicCapabilityProbeJob::PROVIDER, AnthropicCapabilityProbeJob::MODEL]
     assert_equal %w[moonshot kimi-k2.6], [KimiCapabilityProbeJob::PROVIDER, KimiCapabilityProbeJob::MODEL]
+    assert_equal %w[openai gpt-5.4], [OpenAiCapabilityProbeJob::PROVIDER, OpenAiCapabilityProbeJob::MODEL]
+  end
+
+  test "every probe should pin a model its provider can actually be configured for" do
+    JobRun::RUNNABLE_JOBS.select { |job| job < LlmCapabilityProbeJob }.each do |job|
+      assert_includes LlmProvider.names, job::PROVIDER,
+                      "#{job.name} pins unregistered provider #{job::PROVIDER}"
+      assert LlmClient::RateTable.rate_for(provider: job::PROVIDER, model: job::MODEL),
+             "#{job.name} pins #{job::MODEL}, which has no rate entry to price a run"
+    end
   end
 
   test ".credential_name should name the credential after the job" do
     assert_equal "AnthropicCapabilityProbe", AnthropicCapabilityProbeJob.credential_name
     assert_equal "KimiCapabilityProbe", KimiCapabilityProbeJob.credential_name
+    assert_equal "OpenAiCapabilityProbe", OpenAiCapabilityProbeJob.credential_name
   end
 
   test ".credential_for should find the credential named after the job" do
@@ -53,6 +65,7 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
   test ".description should mark up the credential the probe needs" do
     assert_includes AnthropicCapabilityProbeJob.description, "<code>AnthropicCapabilityProbe</code>"
     assert_includes KimiCapabilityProbeJob.description, "<code>KimiCapabilityProbe</code>"
+    assert_includes OpenAiCapabilityProbeJob.description, "<code>OpenAiCapabilityProbe</code>"
     assert_predicate AnthropicCapabilityProbeJob.description, :html_safe?
   end
 

--- a/test/jobs/llm_capability_probe_job_test.rb
+++ b/test/jobs/llm_capability_probe_job_test.rb
@@ -27,7 +27,7 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
     assert_equal %w[anthropic claude-sonnet-4-6],
                  [AnthropicCapabilityProbeJob::PROVIDER, AnthropicCapabilityProbeJob::MODEL]
     assert_equal %w[moonshot kimi-k2.6], [KimiCapabilityProbeJob::PROVIDER, KimiCapabilityProbeJob::MODEL]
-    assert_equal %w[openai gpt-5.4], [OpenAiCapabilityProbeJob::PROVIDER, OpenAiCapabilityProbeJob::MODEL]
+    assert_equal %w[openai gpt-5-mini], [OpenAiCapabilityProbeJob::PROVIDER, OpenAiCapabilityProbeJob::MODEL]
   end
 
   test "every probe should pin a model its provider can actually be configured for" do

--- a/test/jobs/llm_capability_probe_job_test.rb
+++ b/test/jobs/llm_capability_probe_job_test.rb
@@ -27,7 +27,7 @@ class LlmCapabilityProbeJobTest < ActiveJob::TestCase
     assert_equal %w[anthropic claude-sonnet-4-6],
                  [AnthropicCapabilityProbeJob::PROVIDER, AnthropicCapabilityProbeJob::MODEL]
     assert_equal %w[moonshot kimi-k2.6], [KimiCapabilityProbeJob::PROVIDER, KimiCapabilityProbeJob::MODEL]
-    assert_equal %w[openai gpt-5-mini], [OpenAiCapabilityProbeJob::PROVIDER, OpenAiCapabilityProbeJob::MODEL]
+    assert_equal %w[openai gpt-5.6-luna], [OpenAiCapabilityProbeJob::PROVIDER, OpenAiCapabilityProbeJob::MODEL]
   end
 
   test "every probe should pin a model its provider can actually be configured for" do

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -12,6 +12,12 @@ class LlmProviderTest < ActiveSupport::TestCase
     assert_includes LlmProvider.names, "openrouter"
   end
 
+  # AiCredentialsController defaults the new-credential form to the first
+  # registered provider, so insertion order is user-visible.
+  test "#names should lead with anthropic" do
+    assert_equal "anthropic", LlmProvider.names.first
+  end
+
   test "#find should return the anthropic provider instance" do
     provider = LlmProvider.find("anthropic")
     assert_kind_of LlmProvider, provider

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -30,6 +30,17 @@ class LlmProviderTest < ActiveSupport::TestCase
     assert_equal "anthropic/claude-sonnet-4-6", provider.default_model
   end
 
+  test "#find should return the openai provider instance" do
+    provider = LlmProvider.find("openai")
+    assert_kind_of LlmProvider, provider
+    assert_equal "openai", provider.name
+    assert_equal "OpenAI", provider.display_name
+    assert_equal :openai, provider.ruby_llm_provider
+    assert_equal "gpt-5.4", provider.default_model
+    assert_nil provider.api_base
+    assert_not provider.assume_model_exists?
+  end
+
   test "#find should return the moonshot provider mapped to the openai runtime" do
     provider = LlmProvider.find("moonshot")
     assert_equal "moonshot", provider.name
@@ -66,7 +77,16 @@ class LlmProviderTest < ActiveSupport::TestCase
   test "#pin_system_role? should default to false" do
     assert_not LlmProvider.find("anthropic").pin_system_role?
     assert_not LlmProvider.find("openrouter").pin_system_role?
+    assert_not LlmProvider.find("openai").pin_system_role?
     assert LlmProvider.find("moonshot").pin_system_role?
+  end
+
+  test "#configure should leave native openai on the runtime's own system role and base" do
+    config = Struct.new(:openai_api_key, :openai_api_base, :openai_use_system_role).new
+    LlmProvider.find("openai").configure(config, "sk-openai-x")
+    assert_equal "sk-openai-x", config.openai_api_key
+    assert_nil config.openai_api_base
+    assert_nil config.openai_use_system_role
   end
 
   test "#configure should leave the system-role flag alone for other providers" do

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -42,9 +42,9 @@ class LlmProviderTest < ActiveSupport::TestCase
     assert_equal "openai", provider.name
     assert_equal "OpenAI", provider.display_name
     assert_equal :openai, provider.ruby_llm_provider
-    assert_equal "gpt-5.4", provider.default_model
+    assert_equal "gpt-5.6-luna", provider.default_model
     assert_nil provider.api_base
-    assert_not provider.assume_model_exists?
+    assert provider.assume_model_exists?
   end
 
   test "#find should return the moonshot provider mapped to the openai runtime" do

--- a/test/models/llm_provider_test.rb
+++ b/test/models/llm_provider_test.rb
@@ -57,10 +57,16 @@ class LlmProviderTest < ActiveSupport::TestCase
     assert_equal "https://api.moonshot.ai/v1", config.openai_api_base
   end
 
-  test "#configure should pin system prompts to role system for providers riding :openai" do
+  test "#configure should pin system prompts to role system for providers that declare it" do
     config = Struct.new(:openai_api_key, :openai_api_base, :openai_use_system_role).new
     LlmProvider.find("moonshot").configure(config, "sk-moon-x")
     assert config.openai_use_system_role
+  end
+
+  test "#pin_system_role? should default to false" do
+    assert_not LlmProvider.find("anthropic").pin_system_role?
+    assert_not LlmProvider.find("openrouter").pin_system_role?
+    assert LlmProvider.find("moonshot").pin_system_role?
   end
 
   test "#configure should leave the system-role flag alone for other providers" do

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -314,9 +314,17 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: ["client_tools_schema"]).run
     chat = credential.chats.first
 
-    assert_equal LlmCapabilityProbe::PROBE_SCHEMA, chat.schema
+    assert_equal LlmCapabilityProbe::PROBE_SCHEMA, chat.schema["schema"]
     assert_equal [LlmCapabilityProbe::CannedWebSearch, LlmClient::Tools::WebFetch], chat.tools.map(&:class)
     assert_equal LlmCapabilityProbe::PROBE_INSTRUCTIONS, chat.instructions
+  end
+
+  test "#run should send the schema through the provider's own adapter" do
+    credential = FakeCredential.new(valid_payload)
+    LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: ["schema"]).run
+
+    assert_equal LlmClient::Adapter.for(credential.provider).schema_payload(LlmCapabilityProbe::PROBE_SCHEMA),
+                 credential.chats.first.schema
   end
 
   # The probe drives a paid API, and an unqualified model is the likeliest to loop.

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -14,7 +14,7 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   end
 
   class FakeChat
-    attr_reader :instructions, :schema, :tools
+    attr_reader :instructions, :schema, :tools, :params
 
     def initialize(response, tool_rounds: [])
       @response = response
@@ -22,7 +22,10 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
       @tools = []
     end
 
-    def with_params(**) = self
+    def with_params(**params)
+      (@params ||= {}).merge!(params)
+      self
+    end
 
     def with_schema(schema)
       @schema = schema
@@ -58,11 +61,11 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
   class FakeCredential
     attr_reader :provider, :chats
 
-    def initialize(responses, tool_rounds: [])
+    def initialize(responses, tool_rounds: [], provider: "moonshot")
       @responses = responses.is_a?(Array) ? responses.dup : [responses]
       @tool_rounds = tool_rounds
       @chats = []
-      @provider = "moonshot"
+      @provider = provider
     end
 
     def chat(_model)
@@ -317,6 +320,18 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     assert_equal LlmCapabilityProbe::PROBE_SCHEMA, chat.schema["schema"]
     assert_equal [LlmCapabilityProbe::CannedWebSearch, LlmClient::Tools::WebFetch], chat.tools.map(&:class)
     assert_equal LlmCapabilityProbe::PROBE_INSTRUCTIONS, chat.instructions
+  end
+
+  # The tool checks are the ones a provider-specific request param exists for,
+  # so a chat built without them probes a shape production never sends.
+  test "#run should carry the adapter's web params onto the tool chat" do
+    credential = FakeCredential.new(grounded_payload, tool_rounds: full_tool_loop, provider: "openai")
+    LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model",
+                                   checks: ["client_tools"]).run
+
+    assert_equal LlmClient::Adapter::OpenAi.new.web_params("test-model"),
+                 credential.chats.first.params
+    assert_predicate credential.chats.first.params, :present?
   end
 
   test "#run should send the schema through the provider's own adapter" do

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -117,10 +117,10 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
 
   test "#combined_extraction? should be true only for providers verified for one-call web+schema" do
     assert LlmClient::Adapter::Anthropic.new.combined_extraction?
+    assert LlmClient::Adapter::OpenAi.new.combined_extraction?
     assert_not LlmClient::Adapter::OpenRouter.new.combined_extraction?
     assert_not LlmClient::Adapter::Base.new.combined_extraction?
     assert_not LlmClient::Adapter::Moonshot.new.combined_extraction?
-    assert_not LlmClient::Adapter::OpenAi.new.combined_extraction?
   end
 
   test ".for should resolve the moonshot adapter" do

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -102,6 +102,19 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_not chat.params.key?(:plugins)
   end
 
+  test "OpenAI should opt out of reasoning on tool-enabled calls" do
+    chat = fake_chat
+
+    LlmClient::Adapter::OpenAi.new.apply_web(
+      chat,
+      "gpt-5.6-luna",
+      search_provider: Object.new,
+      **search_context
+    )
+
+    assert_equal({ reasoning_effort: "none" }, chat.params)
+  end
+
   test "#combined_extraction? should be true only for providers verified for one-call web+schema" do
     assert LlmClient::Adapter::Anthropic.new.combined_extraction?
     assert_not LlmClient::Adapter::OpenRouter.new.combined_extraction?

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -29,6 +29,10 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_instance_of LlmClient::Adapter::OpenRouter, LlmClient::Adapter.for("openrouter")
   end
 
+  test ".for should return the OpenAI adapter" do
+    assert_instance_of LlmClient::Adapter::OpenAi, LlmClient::Adapter.for("openai")
+  end
+
   test ".for should accept a symbol provider" do
     assert_instance_of LlmClient::Adapter::Anthropic, LlmClient::Adapter.for(:anthropic)
   end
@@ -96,10 +100,18 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_not LlmClient::Adapter::OpenRouter.new.combined_extraction?
     assert_not LlmClient::Adapter::Base.new.combined_extraction?
     assert_not LlmClient::Adapter::Moonshot.new.combined_extraction?
+    assert_not LlmClient::Adapter::OpenAi.new.combined_extraction?
   end
 
   test ".for should resolve the moonshot adapter" do
     assert_instance_of LlmClient::Adapter::Moonshot, LlmClient::Adapter.for("moonshot")
+  end
+
+  test "openai #unwrap_json should pass provider JSON through untouched" do
+    adapter = LlmClient::Adapter::OpenAi.new
+
+    assert_equal '{"a":1}', adapter.unwrap_json('{"a":1}')
+    assert_equal "```\n{\"a\":1}\n```", adapter.unwrap_json("```\n{\"a\":1}\n```")
   end
 
   test "moonshot #unwrap_json should strip markdown fences and pass clean JSON through" do

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -41,6 +41,13 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_raises(KeyError) { LlmClient::Adapter.for("nope") }
   end
 
+  # Adapter.for raises KeyError for a provider it has no entry for, and that
+  # escapes LlmClient#call's rescue list — after the provider has already
+  # billed the round trip, and without writing the usage row.
+  test "every registered provider should have an adapter" do
+    assert_equal LlmProvider.names.sort, LlmClient::Adapter::REGISTRY.keys.sort
+  end
+
   test "every registered adapter should inherit from Base" do
     LlmClient::Adapter::REGISTRY.each_key do |provider|
       assert_kind_of LlmClient::Adapter::Base, LlmClient::Adapter.for(provider)

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -107,6 +107,35 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_instance_of LlmClient::Adapter::Moonshot, LlmClient::Adapter.for("moonshot")
   end
 
+  test "#schema_payload should carry strictness rather than leave it to the runtime default" do
+    payload = LlmClient::Adapter::Anthropic.new.schema_payload({ "type" => "object" })
+
+    assert_equal({ "schema" => { "type" => "object" }, "strict" => true }, payload)
+  end
+
+  test "#schema_strict? should be false only where strict mode cannot express the output schema" do
+    assert LlmClient::Adapter::Base.new.schema_strict?
+    assert LlmClient::Adapter::Anthropic.new.schema_strict?
+    assert LlmClient::Adapter::OpenRouter.new.schema_strict?
+    assert LlmClient::Adapter::Moonshot.new.schema_strict?
+    assert_not LlmClient::Adapter::OpenAi.new.schema_strict?
+  end
+
+  test "openai #schema_payload should turn strictness off" do
+    payload = LlmClient::Adapter::OpenAi.new.schema_payload(FeedProfile::UNIVERSAL_OUTPUT_SCHEMA)
+
+    assert_equal FeedProfile::UNIVERSAL_OUTPUT_SCHEMA, payload["schema"]
+    assert_equal false, payload["strict"]
+  end
+
+  # OpenAI rejects a strict schema whose properties are not all required, and
+  # the universal schema's are not — so this is the shape that would break.
+  test "the universal output schema should leave properties out of required" do
+    item = FeedProfile::UNIVERSAL_OUTPUT_SCHEMA.dig("properties", "items", "items")
+
+    assert_operator item["properties"].keys.size, :>, item["required"].size
+  end
+
   test "openai #unwrap_json should pass provider JSON through untouched" do
     adapter = LlmClient::Adapter::OpenAi.new
 

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -339,6 +339,24 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal ["kimi-k2.6"], models.map { |m| m["id"] }
   end
 
+  test "#available_models should list native openai models from OpenAI's own host" do
+    openai = create(:ai_credential, :active, user: user, provider: "openai",
+                    credential_data: { "api_key" => "sk-openai-test" })
+    client = LlmClient.new(openai)
+
+    stub_request(:get, "https://api.openai.com/v1/models")
+      .with(headers: { "Authorization" => "Bearer sk-openai-test" })
+      .to_return(
+        status: 200,
+        body: { data: [{ id: "gpt-5.4", object: "model", owned_by: "openai" }] }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    models = client.available_models
+
+    assert_equal ["gpt-5.4"], models.map { |m| m["id"] }
+  end
+
   test "#call should raise AuthError for RubyLLM::UnauthorizedError" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, RubyLLM::UnauthorizedError.new("401"))
@@ -426,10 +444,15 @@ class LlmClientTest < ActiveSupport::TestCase
   # can verify the system message travels via with_instructions and the user
   # prompt via #ask — the injection-defense channel separation (spec §8).
   class FakeChat
-    attr_reader :instructions, :asked
+    attr_reader :instructions, :asked, :schema
 
     def with_instructions(text)
       @instructions = text
+      self
+    end
+
+    def with_schema(schema)
+      @schema = schema
       self
     end
 
@@ -513,6 +536,33 @@ class LlmClientTest < ActiveSupport::TestCase
     context = Object.new
     context.define_singleton_method(:chat) { |**_| chat }
     client.credential.stub(:ruby_llm_context, context) { yield }
+  end
+
+  test "#invoke_provider should send the schema at the provider's own strictness" do
+    openai = create(:ai_credential, :active, user: user, provider: "openai",
+                    credential_data: { "api_key" => "sk-openai-test" })
+    client = LlmClient.new(openai)
+    chat = FakeChat.new
+
+    stub_chat(client, chat) do
+      client.send(:invoke_provider, model: "gpt-5.4", prompt: "p",
+                  output_schema: FeedProfile::UNIVERSAL_OUTPUT_SCHEMA, web: false, system: nil)
+    end
+
+    assert_equal FeedProfile::UNIVERSAL_OUTPUT_SCHEMA, chat.schema["schema"]
+    assert_equal false, chat.schema["strict"]
+  end
+
+  test "#invoke_provider should keep strictness on for providers whose strict mode fits the schema" do
+    client = LlmClient.new(credential)
+    chat = FakeChat.new
+
+    stub_chat(client, chat) do
+      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "p",
+                  output_schema: FeedProfile::UNIVERSAL_OUTPUT_SCHEMA, web: false, system: nil)
+    end
+
+    assert_equal true, chat.schema["strict"]
   end
 
   test "#invoke_provider should set the system prompt as instructions and ask the user prompt" do

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -348,13 +348,16 @@ class LlmClientTest < ActiveSupport::TestCase
       .with(headers: { "Authorization" => "Bearer sk-openai-test" })
       .to_return(
         status: 200,
-        body: { data: [{ id: "gpt-5.4", object: "model", owned_by: "openai" }] }.to_json,
+        body: { data: [{ id: "gpt-5.6-luna", object: "model", owned_by: "openai" }] }.to_json,
         headers: { "Content-Type" => "application/json" }
       )
 
     models = client.available_models
 
-    assert_equal ["gpt-5.4"], models.map { |m| m["id"] }
+    assert_equal ["gpt-5.6-luna"], models.map { |m| m["id"] }
+    # openai asserts model existence, so the snapshot keeps only what the
+    # provider itself reported rather than RubyLLM's registry limits.
+    assert_equal %w[id name], models.first.keys
   end
 
   test "#call should raise AuthError for RubyLLM::UnauthorizedError" do
@@ -545,7 +548,7 @@ class LlmClientTest < ActiveSupport::TestCase
     chat = FakeChat.new
 
     stub_chat(client, chat) do
-      client.send(:invoke_provider, model: "gpt-5.4", prompt: "p",
+      client.send(:invoke_provider, model: "gpt-5.6-luna", prompt: "p",
                   output_schema: FeedProfile::UNIVERSAL_OUTPUT_SCHEMA, web: false, system: nil)
     end
 


### PR DESCRIPTION
Changes:

- Add OpenAI as a native LLM provider, qualified for AI feeds on gpt-5.6-luna
- Move structured-output strictness and the `openai_use_system_role` override onto per-provider settings, so providers riding RubyLLM's `:openai` runtime don't inherit each other's workarounds
- Require an adapter registry entry for every registered provider, and apply the adapter's request params in the capability probe

Two OpenAI constraints shape the adapter. Its strict mode requires every key in `properties` to appear in `required`, which `UNIVERSAL_OUTPUT_SCHEMA` does not satisfy, so schemas are sent unconstrained. Its reasoning models reject function tools alongside reasoning on the chat-completions endpoint RubyLLM speaks, so tool-enabled calls opt out of reasoning while structuring keeps it.

A capability probe run passed all six checks, including schema and tools in the same call, so extraction is single-call as it is for Anthropic.