### PR TITLE
Read a spent AI key as a dead key, not backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
-## 2026-08-16
+## 2026-08-17
 
 - An AI key that's run out of credit now switches itself off with a clear reason, instead of retrying on every run.
+
+## 2026-08-16
+
 - OpenAI is now available for AI feeds. Add an OpenAI key on the credentials page and pick it when setting up a feed.
 - New FreeFeed tokens now ask for one extra permission so Feeder can read your target group's subscriber count. Tokens you added earlier keep publishing as usual — recreate one to get the count.
 - Edit, Delete, and Make default on credential and access token pages now live in a single … menu, so the page header stays tidy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-16
 
+- An AI key that's run out of credit now switches itself off with a clear reason, instead of retrying on every run.
 - OpenAI is now available for AI feeds. Add an OpenAI key on the credentials page and pick it when setting up a feed.
 - New FreeFeed tokens now ask for one extra permission so Feeder can read your target group's subscriber count. Tokens you added earlier keep publishing as usual — recreate one to get the count.
 - Edit, Delete, and Make default on credential and access token pages now live in a single … menu, so the page header stays tidy.

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -52,6 +52,13 @@ class LlmClient
       write_usage(ctx, outcome: :provider_error, started_at: started_at, error_message: e.message)
       raise
     rescue RubyLLM::RateLimitError => e
+      # A spent key arrives as a 429 from some providers and will not clear on
+      # retry, so it has to read as a dead key rather than as backpressure.
+      if adapter.dead_key?(e)
+        write_usage(ctx, outcome: :provider_error, started_at: started_at, error_message: e.message)
+        raise AuthError, e.message
+      end
+
       write_usage(ctx, outcome: :rate_limited, started_at: started_at, error_message: e.message)
       raise RateLimited, e.message
     rescue Net::ReadTimeout, Net::OpenTimeout, Faraday::TimeoutError => e
@@ -101,6 +108,11 @@ class LlmClient
     fetch_provider_models.map { |model| serialize_model(model) }
   rescue RubyLLM::UnauthorizedError, RubyLLM::ForbiddenError, RubyLLM::PaymentRequiredError => e
     raise AuthError, e.message
+  rescue RubyLLM::RateLimitError => e
+    raise AuthError, e.message if adapter.dead_key?(e)
+
+    Rails.error.report(e, context: { credential_id: credential.id, provider: credential.provider })
+    raise ProviderError, e.message
   rescue Net::ReadTimeout, Net::OpenTimeout, Faraday::TimeoutError => e
     raise Timeout, e.message
   rescue RubyLLM::Error, RubyLLM::ConfigurationError, Faraday::ConnectionFailed, OpenSSL::SSL::SSLError => e

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -46,10 +46,34 @@ class LlmClient
         true
       end
 
+      # Whether a failure means the key itself is finished — unfunded, overdue
+      # or expired — rather than a fault that may clear. RubyLLM maps every 429
+      # to a rate limit, but some vendors report a spent key that way, so
+      # providers refine this.
+      def dead_key?(_error)
+        false
+      end
+
       # Repairs structured-output text before JSON parsing. Default trusts clean
       # JSON; providers that wrap it (Moonshot fences) override.
       def unwrap_json(text)
         text
+      end
+
+      private
+
+      # The vendor's own identifier for a failure, read from the raw response
+      # body a RubyLLM error carries. Nil when the body is missing or not the
+      # shape the vendor documents.
+      def error_code(error)
+        body = error.try(:response).try(:body)
+        json = JSON.parse(body.to_s)
+        reported = json.is_a?(Hash) ? json["error"] : nil
+        return nil unless reported.is_a?(Hash)
+
+        reported["type"] || reported["code"]
+      rescue JSON::ParserError
+        nil
       end
     end
   end

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -62,18 +62,19 @@ class LlmClient
 
       private
 
-      # The vendor's own identifier for a failure, read from the raw response
-      # body a RubyLLM error carries. Nil when the body is missing or not the
-      # shape the vendor documents.
-      def error_code(error)
+      # The vendor's own identifiers for a failure, read from the raw response
+      # body a RubyLLM error carries. Vendors put the machine-readable name in
+      # `type` or in `code` and not consistently the same one, so both are
+      # returned rather than one being preferred.
+      def error_codes(error)
         body = error.try(:response).try(:body)
         json = JSON.parse(body.to_s)
         reported = json.is_a?(Hash) ? json["error"] : nil
-        return nil unless reported.is_a?(Hash)
+        return [] unless reported.is_a?(Hash)
 
-        reported["type"] || reported["code"]
+        reported.values_at("type", "code").compact
       rescue JSON::ParserError
-        nil
+        []
       end
     end
   end

--- a/app/services/llm_client/adapter/moonshot.rb
+++ b/app/services/llm_client/adapter/moonshot.rb
@@ -12,10 +12,10 @@ class LlmClient
 
       # Moonshot reports an unfunded, overdue or expired account as a 429, the
       # same status it uses for throttling and for an overloaded engine.
-      SPENT_KEY_CODE = "exceeded_current_quota_error".freeze
+      SPENT_KEY_CODES = %w[exceeded_current_quota_error].freeze
 
       def dead_key?(error)
-        error_code(error) == SPENT_KEY_CODE
+        error_codes(error).intersect?(SPENT_KEY_CODES)
       end
 
       def unwrap_json(text)

--- a/app/services/llm_client/adapter/moonshot.rb
+++ b/app/services/llm_client/adapter/moonshot.rb
@@ -10,6 +10,14 @@ class LlmClient
 
       OPENERS = { "{" => "}", "[" => "]" }.freeze
 
+      # Moonshot reports an unfunded, overdue or expired account as a 429, the
+      # same status it uses for throttling and for an overloaded engine.
+      SPENT_KEY_CODE = "exceeded_current_quota_error".freeze
+
+      def dead_key?(error)
+        error_code(error) == SPENT_KEY_CODE
+      end
+
       def unwrap_json(text)
         stripped = text.to_s.strip
         # Already-clean JSON is returned untouched — a fence quoted inside a

--- a/app/services/llm_client/adapter/open_ai.rb
+++ b/app/services/llm_client/adapter/open_ai.rb
@@ -1,12 +1,20 @@
 class LlmClient
   module Adapter
     class OpenAi < Base
-      # OpenAI reports a key with no spend room left as a 429, the same status
-      # it uses for throughput throttling; only the body tells them apart.
-      SPENT_KEY_CODE = "insufficient_quota".freeze
+      # OpenAI reports every billing stop as a 429, the status it also uses for
+      # throughput throttling, so only the body separates them. Each of these
+      # needs someone to add credit or raise a cap; none clears on retry.
+      # `insufficient_quota` is the older name and is still served.
+      SPENT_KEY_CODES = %w[
+        credit_balance_exhausted
+        organization_spend_limit_exceeded
+        project_spend_limit_exceeded
+        organization_usage_limit_reached
+        insufficient_quota
+      ].freeze
 
       def dead_key?(error)
-        error_code(error) == SPENT_KEY_CODE
+        error_codes(error).intersect?(SPENT_KEY_CODES)
       end
 
       # OpenAI's reasoning models reason by default, and OpenAI rejects function

--- a/app/services/llm_client/adapter/open_ai.rb
+++ b/app/services/llm_client/adapter/open_ai.rb
@@ -1,6 +1,14 @@
 class LlmClient
   module Adapter
     class OpenAi < Base
+      # OpenAI reports a key with no spend room left as a 429, the same status
+      # it uses for throughput throttling; only the body tells them apart.
+      SPENT_KEY_CODE = "insufficient_quota".freeze
+
+      def dead_key?(error)
+        error_code(error) == SPENT_KEY_CODE
+      end
+
       # OpenAI's reasoning models reason by default, and OpenAI rejects function
       # tools alongside reasoning on the chat-completions endpoint RubyLLM
       # speaks. Scoped to tool-enabled calls, so structuring keeps its reasoning.

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -126,9 +126,22 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     )
   end
 
-  test "#dead_key? should read the vendor's own spent-key identifier" do
-    assert LlmClient::Adapter::OpenAi.new.dead_key?(
-      rate_limit_error({ error: { type: "insufficient_quota", code: "insufficient_quota" } }.to_json)
+  test "#dead_key? should cover every billing stop OpenAI reports as a 429" do
+    adapter = LlmClient::Adapter::OpenAi.new
+
+    LlmClient::Adapter::OpenAi::SPENT_KEY_CODES.each do |code|
+      assert adapter.dead_key?(rate_limit_error({ error: { code: code } }.to_json)),
+             "#{code} should read as a spent key"
+    end
+  end
+
+  # The machine-readable name arrives under `code` for some failures and `type`
+  # for others, so neither field can be preferred over the other.
+  test "#dead_key? should read the identifier from either body field" do
+    adapter = LlmClient::Adapter::OpenAi.new
+
+    assert adapter.dead_key?(
+      rate_limit_error({ error: { type: "rate_limit_error", code: "project_spend_limit_exceeded" } }.to_json)
     )
     assert LlmClient::Adapter::Moonshot.new.dead_key?(
       rate_limit_error({ error: { type: "exceeded_current_quota_error" } }.to_json)

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -115,6 +115,34 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_equal({ reasoning_effort: "none" }, chat.params)
   end
 
+  def rate_limit_error(body)
+    RubyLLM::RateLimitError.new(Struct.new(:body).new(body), "429")
+  end
+
+  test "#dead_key? should be false where a 429 only ever means throttling" do
+    assert_not LlmClient::Adapter::Base.new.dead_key?(rate_limit_error(""))
+    assert_not LlmClient::Adapter::Anthropic.new.dead_key?(
+      rate_limit_error({ error: { type: "insufficient_quota" } }.to_json)
+    )
+  end
+
+  test "#dead_key? should read the vendor's own spent-key identifier" do
+    assert LlmClient::Adapter::OpenAi.new.dead_key?(
+      rate_limit_error({ error: { type: "insufficient_quota", code: "insufficient_quota" } }.to_json)
+    )
+    assert LlmClient::Adapter::Moonshot.new.dead_key?(
+      rate_limit_error({ error: { type: "exceeded_current_quota_error" } }.to_json)
+    )
+  end
+
+  test "#dead_key? should be false for a throttling 429 from the same provider" do
+    adapter = LlmClient::Adapter::OpenAi.new
+
+    assert_not adapter.dead_key?(rate_limit_error({ error: { type: "rate_limit_exceeded" } }.to_json))
+    assert_not adapter.dead_key?(rate_limit_error("<html>502</html>"))
+    assert_not adapter.dead_key?(RubyLLM::RateLimitError.new("429"))
+  end
+
   test "#combined_extraction? should be true only for providers verified for one-call web+schema" do
     assert LlmClient::Adapter::Anthropic.new.combined_extraction?
     assert LlmClient::Adapter::OpenAi.new.combined_extraction?

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -148,6 +148,39 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal 5, usage.output_tokens
   end
 
+  def spent_key_error
+    body = { error: { type: "insufficient_quota", code: "insufficient_quota" } }.to_json
+    RubyLLM::RateLimitError.new(Struct.new(:body).new(body), "quota exhausted")
+  end
+
+  def openai_credential
+    @openai_credential ||= create(:ai_credential, :active, user: user, provider: "openai",
+                                  credential_data: { "api_key" => "sk-openai-test" })
+  end
+
+  test "#call should map a spent key to AuthError rather than backpressure" do
+    client = LlmClient.new(openai_credential)
+    stub_provider_to_raise(client, spent_key_error)
+
+    assert_raises(LlmClient::AuthError) { client.call(default_ctx, **call_opts) }
+    assert_equal "provider_error", LlmUsage.last.outcome
+  end
+
+  test "#available_models should map a spent key to AuthError so validation disables the credential" do
+    client = LlmClient.new(openai_credential)
+    error = spent_key_error
+    stub_provider_models(client) { |*| raise error }
+
+    assert_raises(LlmClient::AuthError) { client.available_models }
+  end
+
+  test "#available_models should keep a throttling rate limit a provider error" do
+    client = LlmClient.new(openai_credential)
+    stub_provider_models(client) { |*| raise RubyLLM::RateLimitError.new("slow down") }
+
+    assert_raises(LlmClient::ProviderError) { client.available_models }
+  end
+
   test "#call should map a rate-limit error to RateLimited and record the failure" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, RubyLLM::RateLimitError.new("rate limit exceeded"))


### PR DESCRIPTION
Changes:

- Read the vendor's own error identifier off a 429 body through the adapter, so a key with no balance left disables the credential instead of retrying on every run
- Apply it on both paths: feed runs and the validation fetch that actually deactivates

OpenAI and Moonshot both report an unfunded, overdue or expired account with the same status they use for throughput throttling, so only the body separates a dead key from backpressure. Anthropic signals it as 402 and already mapped to an auth error.

Producing a spent key for a live check, without spending credit: on OpenAI set a project's hard spend limit to $0 and use a key scoped to that project — limits are per project, so the organization keeps its balance. Moonshot has no per-key cap, so it needs a key from an account that has never been topped up.

References:

- Follow-up to #1270
- Extends the dead-key handling added for search providers in #1257
