### PR TITLE
Require MAILER_FROM instead of defaulting

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,12 @@
 
 ACTION_MAILER_HOST=example.com
 
+# Sender address for all outgoing mail. Production and staging require it — the
+# app won't boot without it — and the address must be on a domain verified in
+# the Resend workspace, or every delivery is rejected. Development falls back to
+# noreply@localhost, since mail there is written to disk instead of sent.
+MAILER_FROM=noreply@example.com
+
 # Only consumed in production/staging for Rails host authorization.
 # Listed here so `bin/rails assets:precompile` and similar production-mode
 # tasks have a value locally. Do not add www. if it redirects to apex on edge.

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN bundle exec bootsnap precompile app/ lib/
 RUN SECRET_KEY_BASE_DUMMY=1 \
     HOSTS=example.com \
     ACTION_MAILER_HOST=example.com \
+    MAILER_FROM=noreply@example.com \
     ./bin/rails assets:precompile
 
 

--- a/app/controllers/development/system_status_controller.rb
+++ b/app/controllers/development/system_status_controller.rb
@@ -49,8 +49,6 @@ class Development::SystemStatusController < ApplicationController
     { key: "background_jobs", label: "Background jobs are processing", status: :error }
   end
 
-  # The effective sender, not the raw MAILER_FROM value: a mismatch between the
-  # two is exactly the kind of thing this page exists to surface.
   def configuration
     { mailer_from: ApplicationMailer.default_params[:from] }
   end

--- a/app/controllers/development/system_status_controller.rb
+++ b/app/controllers/development/system_status_controller.rb
@@ -3,6 +3,7 @@ class Development::SystemStatusController < ApplicationController
     authorize :access, :dev?
     @config_checks = config_checks
     @release_info = release_info
+    @configuration = configuration
     @disk_usage = Rails.cache.fetch("development/system_status/v5", expires_in: 5.minutes) do
       DiskUsageService.new.call
     end
@@ -46,6 +47,12 @@ class Development::SystemStatusController < ApplicationController
   rescue StandardError => e
     Rails.error.report(e)
     { key: "background_jobs", label: "Background jobs are processing", status: :error }
+  end
+
+  # The effective sender, not the raw MAILER_FROM value: a mismatch between the
+  # two is exactly the kind of thing this page exists to surface.
+  def configuration
+    { mailer_from: ApplicationMailer.default_params[:from] }
   end
 
   def release_info

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,3 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch("MAILER_FROM", "noreply@frf.im")
   layout "mailer"
 end

--- a/app/views/development/system_status/show.html.erb
+++ b/app/views/development/system_status/show.html.erb
@@ -16,7 +16,7 @@
   <% end %>
 
   <section class="space-y-4">
-    <h2 class="text-2xl font-semibold mb-3 text-heading">Configuration</h2>
+    <h2 class="text-2xl font-semibold mb-3 text-heading">Health Checks</h2>
     <ul class="space-y-2">
       <% @config_checks.each do |check| %>
         <li class="flex items-center gap-2" data-key="config.<%= check[:key] %>" data-status="<%= check[:status] %>">
@@ -44,6 +44,17 @@
         label: "Environment",
         value: environment_badge,
         key: "release.environment"
+      )) %>
+    <% end %>
+  </section>
+
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold mb-3 text-heading">Configuration</h2>
+    <%= render(DescriptionListComponent.new) do |list| %>
+      <% list.with_item(StatListItemComponent.new(
+        label: "From address",
+        value: @configuration[:mailer_from].present? ? tag.code(@configuration[:mailer_from]) : "—",
+        key: "configuration.mailer_from"
       )) %>
     <% end %>
   </section>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,6 +60,7 @@ Rails.application.configure do
   # config.generators.apply_rubocop_autocorrect_after_generate!
 
   config.action_mailer.default_url_options = { host: ENV.fetch("ACTION_MAILER_HOST", "localhost:3000") }
+  config.action_mailer.default_options = { from: ENV.fetch("MAILER_FROM", "noreply@localhost") }
   config.action_mailer.delivery_method = :file
   config.action_mailer.file_settings = {}
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,11 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: ENV.fetch("ACTION_MAILER_HOST") }
 
+  # No fallback on purpose. A sender on a domain Resend hasn't verified is
+  # rejected at send time, one delivery at a time, long after the bad config
+  # shipped. Boot loudly instead.
+  config.action_mailer.default_options = { from: ENV.fetch("MAILER_FROM") }
+
   # See resend initializer for configuration
   config.action_mailer.delivery_method = :resend
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,7 @@ Rails.application.configure do
   # Configure Action Mailer for testing
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_options = { from: "noreply@example.com" }
 
   # Use test adapter for jobs - runs jobs inline during tests
   config.active_job.queue_adapter = :test

--- a/docs/email-dev-emulation.md
+++ b/docs/email-dev-emulation.md
@@ -8,6 +8,15 @@ In development and test environments, the app does not send real emails. Outgoin
 - `config.email_storage_adapter = :file_system` persists captured messages via `EmailStorage::FileSystemStorage`.
 - Routes under `namespace :development` are mounted only when `Rails.env.development? || Rails.env.test?`.
 
+## Sender address
+
+`MAILER_FROM` sets the sender for all outgoing mail. Development falls back to
+`noreply@localhost` because nothing leaves the machine. Production and staging
+have no fallback and refuse to boot without it: the address has to be on a
+domain verified in the Resend workspace, and a wrong one is only rejected at
+send time, long after the deploy looked healthy. The effective value is shown
+under Configuration on `/development/system_status`.
+
 ## Viewing captured emails
 
 With the Rails server running, open `/development/sent_emails` in your browser to see the inbox of captured messages. Click any entry to read it. Use the "Purge All" button to clear the inbox when you want a clean slate.

--- a/test/config/email_storage_adapter_test.rb
+++ b/test/config/email_storage_adapter_test.rb
@@ -13,7 +13,8 @@ class EmailStorageAdapterConfigTest < ActiveSupport::TestCase
       "RAILS_ENV" => "production",
       "SECRET_KEY_BASE" => "dummy",
       "HOSTS" => "example.com",
-      "ACTION_MAILER_HOST" => "example.com"
+      "ACTION_MAILER_HOST" => "example.com",
+      "MAILER_FROM" => "noreply@example.com"
     }
 
     output = nil

--- a/test/config/mailer_sender_test.rb
+++ b/test/config/mailer_sender_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class MailerSenderConfigTest < ActiveSupport::TestCase
+  # ApplicationMailer used to default the sender to an address on a domain that
+  # was never verified in Resend, so a deploy missing MAILER_FROM looked healthy
+  # and failed one delivery at a time. Production now has no fallback; boot it in
+  # a subprocess to prove a missing sender stops the app instead.
+  test "production refuses to boot without MAILER_FROM" do
+    output, status = boot_production("MAILER_FROM" => nil)
+
+    assert_not status.success?, "production booted without a sender: #{output}"
+    assert_includes output, "MAILER_FROM"
+  end
+
+  test "production uses MAILER_FROM as the sender" do
+    output, status = boot_production("MAILER_FROM" => "hello@example.com")
+
+    assert status.success?, "production environment failed to boot"
+    assert_includes output, "FROM:hello@example.com"
+  end
+
+  private
+
+  # A marker isolates our value from any gem warnings printed to stdout.
+  SCRIPT = 'puts "FROM:#{ApplicationMailer.default_params[:from]}"'.freeze
+
+  def boot_production(overrides)
+    env = {
+      "RAILS_ENV" => "production",
+      "SECRET_KEY_BASE" => "dummy",
+      "HOSTS" => "example.com",
+      "ACTION_MAILER_HOST" => "example.com"
+    }.merge(overrides)
+
+    output = nil
+    Dir.chdir(Rails.root) do
+      output = IO.popen(env, ["bin/rails", "runner", SCRIPT], err: [:child, :out], &:read)
+    end
+
+    [output, $?]
+  end
+end

--- a/test/controllers/development/system_status_controller_test.rb
+++ b/test/controllers/development/system_status_controller_test.rb
@@ -32,6 +32,16 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should show the effective mail sender" do
+    sign_in_as(dev_user)
+
+    get development_system_status_path
+
+    assert_response :success
+    assert_select "[data-key='configuration.mailer_from.label']", text: "From address"
+    assert_select "[data-key='configuration.mailer_from.value'] code", text: "noreply@example.com"
+  end
+
   test "should show configuration checklist" do
     sign_in_as(dev_user)
 

--- a/test/mailers/passwords_mailer_test.rb
+++ b/test/mailers/passwords_mailer_test.rb
@@ -11,7 +11,7 @@ class PasswordsMailerTest < ActionMailer::TestCase
 
     assert_equal "Reset your password", message.subject
     assert_equal [user.email_address], message.to
-    assert_equal ["noreply@frf.im"], message.from
+    assert_equal ["noreply@example.com"], message.from
     assert_match "password reset", message.body.encoded.downcase
   end
 end

--- a/test/mailers/profile_mailer_test.rb
+++ b/test/mailers/profile_mailer_test.rb
@@ -10,7 +10,7 @@ class ProfileMailerTest < ActionMailer::TestCase
 
     assert_equal "Confirm your new email address", message.subject
     assert_equal [new_email], message.to
-    assert_equal ["noreply@frf.im"], message.from
+    assert_equal ["noreply@example.com"], message.from
   end
 
   test "#account_confirmation should build a confirmation email to the user" do
@@ -19,6 +19,6 @@ class ProfileMailerTest < ActionMailer::TestCase
 
     assert_equal "Confirm your email address", message.subject
     assert_equal [user.email_address], message.to
-    assert_equal ["noreply@frf.im"], message.from
+    assert_equal ["noreply@example.com"], message.from
   end
 end

--- a/test/mailers/test_mailer_test.rb
+++ b/test/mailers/test_mailer_test.rb
@@ -7,7 +7,7 @@ class TestMailerTest < ActionMailer::TestCase
 
     assert_equal "Test email from Feeder", mail.subject
     assert_equal [email_address], mail.to
-    assert_equal ["noreply@frf.im"], mail.from
+    assert_equal ["noreply@example.com"], mail.from
   end
 
   test "ping with different email address" do


### PR DESCRIPTION
Changes:

- Drop the `noreply@frf.im` sender fallback and move the sender to `config.action_mailer.default_options`
- Production and staging fetch `MAILER_FROM` with no default, so a missing value stops the boot; development falls back to a local address and test pins one
- Show the effective From address under a new Configuration section on the system status page
- Rename the existing checks section to Health Checks, since Configuration now names the new list

`ApplicationMailer` defaulted the sender to an address on a domain that isn't
verified in the Resend workspace. A deploy that never set `MAILER_FROM` looked
healthy and then rejected every delivery at send time, one message at a time,
long after the bad config shipped. Failing at boot turns that into a problem you
find during deploy, and surfacing the effective sender means the next mismatch
is visible before the first bounce rather than after.

The pattern mirrors how `ACTION_MAILER_HOST` is already handled. Fixing the
gaps that a required variable exposes: the image build's `assets:precompile`
step and the production-boot test both had to start passing it.

References:

- Related PR: #842
