### PR TITLE
Drop placeholder env vars from the asset build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,11 +59,7 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 \
-    HOSTS=example.com \
-    ACTION_MAILER_HOST=example.com \
-    MAILER_FROM=noreply@example.com \
-    ./bin/rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 
 RUN rm -rf node_modules

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,18 +60,25 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [:id]
 
+  # assets:precompile boots this environment during the image build, where no
+  # runtime configuration exists yet. SECRET_KEY_BASE_DUMMY is Rails' own marker
+  # for that boot, so the build supplies placeholders and a real boot still
+  # fails loudly on anything missing.
+  build = ENV["SECRET_KEY_BASE_DUMMY"].present?
+  required_env = ->(name) { build ? "build-placeholder" : ENV.fetch(name) }
+
   # Enable DNS rebinding protection and other `Host` header attacks.
-  config.hosts = ENV.fetch("HOSTS").split(",").map(&:strip).compact_blank
+  config.hosts = required_env.call("HOSTS").split(",").map(&:strip).compact_blank
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  config.action_mailer.default_url_options = { host: ENV.fetch("ACTION_MAILER_HOST") }
+  config.action_mailer.default_url_options = { host: required_env.call("ACTION_MAILER_HOST") }
 
   # No fallback on purpose. A sender on a domain Resend hasn't verified is
   # rejected at send time, one delivery at a time, long after the bad config
   # shipped. Boot loudly instead.
-  config.action_mailer.default_options = { from: ENV.fetch("MAILER_FROM") }
+  config.action_mailer.default_options = { from: required_env.call("MAILER_FROM") }
 
   # See resend initializer for configuration
   config.action_mailer.delivery_method = :resend

--- a/test/config/mailer_sender_test.rb
+++ b/test/config/mailer_sender_test.rb
@@ -12,6 +12,20 @@ class MailerSenderConfigTest < ActiveSupport::TestCase
     assert_includes output, "MAILER_FROM"
   end
 
+  # assets:precompile boots production during the image build with no runtime
+  # config. Without this the Dockerfile has to pass a placeholder for every
+  # fallback-free setting.
+  test "production boots without runtime config during an image build" do
+    output, status = boot_production(
+      "MAILER_FROM" => nil,
+      "HOSTS" => nil,
+      "ACTION_MAILER_HOST" => nil,
+      "SECRET_KEY_BASE_DUMMY" => "1"
+    )
+
+    assert status.success?, "image build boot failed: #{output}"
+  end
+
   test "production uses MAILER_FROM as the sender" do
     output, status = boot_production("MAILER_FROM" => "hello@example.com")
 


### PR DESCRIPTION
Changes:

- Key the production environment's fallback-free settings off `SECRET_KEY_BASE_DUMMY`, which Rails already sets for the image build
- Reduce the Dockerfile's precompile step to `RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile`
- Cover the build path with a test that boots production with `HOSTS`, `ACTION_MAILER_HOST`, and `MAILER_FROM` all unset

`assets:precompile` boots the production environment, so every setting without a
fallback had to be handed a fake value on the `RUN` line — three of them, none
with any relation to compiling assets, and the list grew with each new required
setting. `SECRET_KEY_BASE_DUMMY` was already on that line and already means
"this is a build, not a real boot", so it can carry the rest.

A real boot still fails loudly on anything missing, and future settings never
touch the Dockerfile.

References:

- Related PR: #1276
