### PR TITLE
Add bootstrap toggle to deploy workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,6 +4,11 @@ name: Deploy Production
 # Actions tab. No push trigger on purpose.
 on:
   workflow_dispatch:
+    inputs:
+      bootstrap:
+        description: "First-time bootstrap: run kamal setup instead of deploy"
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-production
@@ -63,5 +68,10 @@ jobs:
           printf '%s' "$RAILS_MASTER_KEY_PRODUCTION" > config/credentials/production.key
           chmod 600 config/credentials/production.key
 
+      - name: Bootstrap production
+        if: ${{ inputs.bootstrap }}
+        run: bin/kamal setup -d production
+
       - name: Deploy to production
+        if: ${{ !inputs.bootstrap }}
         run: bin/kamal deploy -d production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ staging ]
   workflow_dispatch:
+    inputs:
+      bootstrap:
+        description: "First-time bootstrap: run kamal setup instead of deploy"
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-staging
@@ -78,5 +83,10 @@ jobs:
           printf '%s' "$RAILS_MASTER_KEY_STAGING" > config/credentials/staging.key
           chmod 600 config/credentials/staging.key
 
+      - name: Bootstrap staging
+        if: ${{ inputs.bootstrap }}
+        run: bin/kamal setup -d staging
+
       - name: Deploy to staging
+        if: ${{ !inputs.bootstrap }}
         run: bin/kamal deploy -d staging


### PR DESCRIPTION
Changes:

- Add a "bootstrap" checkbox to the Deploy Production and Deploy Staging workflows that runs `bin/kamal setup` instead of `bin/kamal deploy` for the destination

This makes first-time server bootstrap possible entirely from the Actions tab — no workstation deploy environment needed. `kamal setup` is non-interactive and the workflows already carry all required secrets. Leave the checkbox unchecked for regular deploys; staging's push-triggered runs are unaffected (inputs default to false outside `workflow_dispatch`).

References:

- Related PR: #1173