### PR TITLE
Handle expected FreeFeed errors in subscribers count job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@
 # belong in git's global ignore instead:
 # `$XDG_CONFIG_HOME/git/ignore` or `~/.config/git/ignore`
 
-# Ignore bundler config.
+# Ignore bundler config and locally vendored gems.
 /.bundle
+/vendor/bundle
 
 # Ignore all environment files.
 /.env*

--- a/app/jobs/update_feed_subscribers_count_job.rb
+++ b/app/jobs/update_feed_subscribers_count_job.rb
@@ -13,5 +13,16 @@ class UpdateFeedSubscribersCountJob < ApplicationJob
     feed.update!(subscribers_count: count, subscribers_count_updated_at: Time.current)
   rescue RateLimit::Throttled => e
     reschedule_for_rate_limit(e.retry_after)
+  rescue FreefeedClient::InvalidTokenError
+    # A dead token can't publish either, and a dormant feed may never reach the
+    # publishing flow that would notice — send the token through validation,
+    # which owns disabling it and notifying the user.
+    feed.access_token.validate_token_async
+  rescue FreefeedClient::UnauthorizedError, FreefeedClient::ForbiddenError, FreefeedClient::NotFoundError => e
+    # Statistics can be out of a token's reach while publishing still works:
+    # scoped app tokens get 401 "token has no access to this API method", and a
+    # renamed or deleted group 404s. Expected external conditions — keep the
+    # stale count and leave token/feed fallout to the flows that own it.
+    Rails.logger.info("Skipping subscribers count for feed #{feed.id}: #{e.message}")
   end
 end

--- a/app/jobs/update_feed_subscribers_count_job.rb
+++ b/app/jobs/update_feed_subscribers_count_job.rb
@@ -15,9 +15,11 @@ class UpdateFeedSubscribersCountJob < ApplicationJob
     reschedule_for_rate_limit(e.retry_after)
   rescue FreefeedClient::InvalidTokenError
     # A dead token can't publish either, and a dormant feed may never reach the
-    # publishing flow that would notice — send the token through validation,
-    # which owns disabling it and notifying the user.
-    feed.access_token.validate_token_async
+    # publishing flow that would notice — enqueue validation, which owns
+    # disabling the token and notifying the user. Not validate_token_async: its
+    # eager flip to `validating` would make FreefeedPublisher reject queued
+    # posts as poison while the validation job waits to run.
+    TokenValidationJob.perform_later(feed.access_token)
   rescue FreefeedClient::UnauthorizedError, FreefeedClient::ForbiddenError, FreefeedClient::NotFoundError => e
     # Statistics can be out of a token's reach while publishing still works:
     # scoped app tokens get 401 "token has no access to this API method", and a

--- a/test/jobs/update_feed_subscribers_count_job_test.rb
+++ b/test/jobs/update_feed_subscribers_count_job_test.rb
@@ -92,7 +92,9 @@ class UpdateFeedSubscribersCountJobTest < ActiveJob::TestCase
     end
 
     assert_equal 7, feed.reload.subscribers_count
-    assert feed.access_token.reload.validating?
+    # The status must not change until validation actually runs, or queued
+    # publications would fail against a transiently non-active token.
+    assert feed.access_token.reload.active?
   end
 
   test "reschedules when FreeFeed responds with 429" do

--- a/test/jobs/update_feed_subscribers_count_job_test.rb
+++ b/test/jobs/update_feed_subscribers_count_job_test.rb
@@ -50,6 +50,51 @@ class UpdateFeedSubscribersCountJobTest < ActiveJob::TestCase
     assert_not_requested :get, /\/v2\/users\//
   end
 
+  test "#perform should keep the stale count when the token has no access to statistics" do
+    feed = feed_with_stale_count
+    stub_statistics_error(feed, status: 401, err: "token has no access to this API method")
+
+    assert_nothing_raised do
+      UpdateFeedSubscribersCountJob.perform_now(feed)
+    end
+
+    assert_skipped_without_fallout(feed)
+  end
+
+  test "#perform should keep the stale count when FreeFeed forbids reading statistics" do
+    feed = feed_with_stale_count
+    stub_statistics_error(feed, status: 403, err: "You cannot see this user's statistics")
+
+    assert_nothing_raised do
+      UpdateFeedSubscribersCountJob.perform_now(feed)
+    end
+
+    assert_skipped_without_fallout(feed)
+  end
+
+  test "#perform should keep the stale count when the target group is not found" do
+    feed = feed_with_stale_count
+    stub_statistics_error(feed, status: 404, err: "Account 'testgroup' was not found")
+
+    assert_nothing_raised do
+      UpdateFeedSubscribersCountJob.perform_now(feed)
+    end
+
+    assert_skipped_without_fallout(feed)
+  end
+
+  test "#perform should send a dead token to validation" do
+    feed = feed_with_stale_count
+    stub_statistics_error(feed, status: 401, err: "inactive or expired token")
+
+    assert_enqueued_with(job: TokenValidationJob, args: [feed.access_token]) do
+      UpdateFeedSubscribersCountJob.perform_now(feed)
+    end
+
+    assert_equal 7, feed.reload.subscribers_count
+    assert feed.access_token.reload.validating?
+  end
+
   test "reschedules when FreeFeed responds with 429" do
     feed = create(:feed, :enabled)
     stub_request(:get, "#{feed.access_token.host}/v2/users/#{feed.target_group}/statistics")
@@ -58,5 +103,27 @@ class UpdateFeedSubscribersCountJobTest < ActiveJob::TestCase
     assert_enqueued_with(job: UpdateFeedSubscribersCountJob) do
       UpdateFeedSubscribersCountJob.perform_now(feed)
     end
+  end
+
+  private
+
+  def feed_with_stale_count
+    create(:feed, :enabled).tap do |feed|
+      feed.update!(subscribers_count: 7, subscribers_count_updated_at: Time.parse("2026-08-19 03:00:00 UTC"))
+    end
+  end
+
+  def stub_statistics_error(feed, status:, err:)
+    stub_request(:get, "#{feed.access_token.host}/v2/users/#{feed.target_group}/statistics")
+      .to_return(status: status, body: { err: err }.to_json, headers: { "Content-Type" => "application/json" })
+  end
+
+  def assert_skipped_without_fallout(feed)
+    feed.reload
+    assert_equal 7, feed.subscribers_count
+    assert_equal Time.parse("2026-08-19 03:00:00 UTC"), feed.subscribers_count_updated_at
+    assert feed.enabled?
+    assert feed.access_token.reload.active?
+    assert_no_enqueued_jobs
   end
 end


### PR DESCRIPTION
Changes:

- Skip the nightly subscriber count update when the token can't read statistics, stats are forbidden, or the target group is gone — keep the stale count instead of raising
- Send genuinely dead tokens through async validation, which owns disabling them and notifying the user
- Cover each error path with tests
- Ignore locally vendored gems in `.gitignore`

Scoped FreeFeed app tokens can publish but answer 401 "token has no access to this API method" on the statistics endpoint, so the nightly job raised an unhandled error every night for such feeds (Honeybadger fault 133567444). These are expected external conditions, not app faults, and must not disable the token or feed. The dead-token case is routed to validation instead of being swallowed because a dormant feed may otherwise never notice its token expired.