### PR TITLE
Repair malformed LLM responses instead of failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-20
+
+- AI feeds now recover when the model returns its answer in a slightly off format, instead of failing the refresh.
+
 ## 2026-08-17
 
 - An AI key that's run out of credit now switches itself off with a clear reason, instead of retrying on every run.

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -260,7 +260,7 @@ module LlmCapabilityProbe
 
     def validate_items(response, expect_null_source_url: false)
       raw = response.content
-      payload = raw.is_a?(Hash) ? raw : JSON.parse(unwrap_json(raw.to_s))
+      payload = raw.is_a?(Hash) ? raw : repair(JSON.parse(unwrap_json(raw.to_s)))
       errors = JSONSchemer.schema(PROBE_SCHEMA).validate(payload).to_a
       items = payload.is_a?(Hash) ? Array(payload["items"]) : []
       evidence = { items: items.first(3) }
@@ -287,6 +287,12 @@ module LlmCapabilityProbe
     # fail a model on a quirk the app already absorbs (Kimi fences its JSON).
     def unwrap_json(text)
       adapter.unwrap_json(text)
+    end
+
+    # Same root repairs production applies after parsing (a bare items array,
+    # a double-encoded payload), for the same reason as unwrap_json.
+    def repair(payload)
+      LlmClient::PayloadRepair.repair(payload, PROBE_SCHEMA)
     end
 
     # The same adapter production builds its calls with, so schema strictness

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -236,39 +236,9 @@ class LlmClient
   def parse_payload(raw, output_schema)
     return raw if output_schema.blank? || raw.is_a?(Hash)
 
-    repair_root(JSON.parse(adapter.unwrap_json(raw)), output_schema)
+    PayloadRepair.repair(JSON.parse(adapter.unwrap_json(raw)), output_schema)
   rescue JSON::ParserError => e
     raise SchemaError, "non-JSON response from provider: #{e.message}"
-  end
-
-  # Two non-object roots models emit often enough to absorb rather than fail:
-  # the whole payload JSON-encoded once more (a quoted string), and the
-  # envelope dropped (a bare array where the schema wraps it in one array
-  # property). Repairs still go through validate_payload!, so a wrong guess
-  # fails there instead of leaking a malformed payload.
-  def repair_root(payload, output_schema)
-    payload = unquote(payload) if payload.is_a?(String)
-    return payload unless payload.is_a?(Array)
-
-    key = envelope_key(output_schema)
-    key ? { key => payload } : payload
-  end
-
-  def unquote(payload)
-    JSON.parse(payload)
-  rescue JSON::ParserError
-    payload
-  end
-
-  # The array property a bare array can be re-wrapped under — only when the
-  # schema's object root has exactly one, so the repair is unambiguous.
-  def envelope_key(output_schema)
-    return nil unless output_schema.is_a?(Hash) && output_schema["type"] == "object"
-
-    array_keys = Hash(output_schema["properties"]).filter_map do |key, spec|
-      key if spec.is_a?(Hash) && spec["type"] == "array"
-    end
-    array_keys.size == 1 ? array_keys.first : nil
   end
 
   def validate_payload!(payload, output_schema)

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -236,9 +236,39 @@ class LlmClient
   def parse_payload(raw, output_schema)
     return raw if output_schema.blank? || raw.is_a?(Hash)
 
-    JSON.parse(adapter.unwrap_json(raw))
+    repair_root(JSON.parse(adapter.unwrap_json(raw)), output_schema)
   rescue JSON::ParserError => e
     raise SchemaError, "non-JSON response from provider: #{e.message}"
+  end
+
+  # Two non-object roots models emit often enough to absorb rather than fail:
+  # the whole payload JSON-encoded once more (a quoted string), and the
+  # envelope dropped (a bare array where the schema wraps it in one array
+  # property). Repairs still go through validate_payload!, so a wrong guess
+  # fails there instead of leaking a malformed payload.
+  def repair_root(payload, output_schema)
+    payload = unquote(payload) if payload.is_a?(String)
+    return payload unless payload.is_a?(Array)
+
+    key = envelope_key(output_schema)
+    key ? { key => payload } : payload
+  end
+
+  def unquote(payload)
+    JSON.parse(payload)
+  rescue JSON::ParserError
+    payload
+  end
+
+  # The array property a bare array can be re-wrapped under — only when the
+  # schema's object root has exactly one, so the repair is unambiguous.
+  def envelope_key(output_schema)
+    return nil unless output_schema.is_a?(Hash) && output_schema["type"] == "object"
+
+    array_keys = Hash(output_schema["properties"]).filter_map do |key, spec|
+      key if spec.is_a?(Hash) && spec["type"] == "array"
+    end
+    array_keys.size == 1 ? array_keys.first : nil
   end
 
   def validate_payload!(payload, output_schema)

--- a/app/services/llm_client/payload_repair.rb
+++ b/app/services/llm_client/payload_repair.rb
@@ -1,0 +1,37 @@
+class LlmClient
+  # Repairs two non-object roots models emit often enough to absorb rather
+  # than fail: the whole payload JSON-encoded once more (a quoted string),
+  # and the envelope dropped (a bare array where the schema wraps it in one
+  # array property). Repaired output still goes through schema validation,
+  # so a wrong guess fails there instead of leaking a malformed payload.
+  # Shared with LlmCapabilityProbe so a model qualifies under exactly the
+  # repairs production applies.
+  module PayloadRepair
+    module_function
+
+    def repair(payload, output_schema)
+      payload = unquote(payload) if payload.is_a?(String)
+      return payload unless payload.is_a?(Array)
+
+      key = envelope_key(output_schema)
+      key ? { key => payload } : payload
+    end
+
+    def unquote(payload)
+      JSON.parse(payload)
+    rescue JSON::ParserError
+      payload
+    end
+
+    # The array property a bare array can be re-wrapped under — only when the
+    # schema's object root has exactly one, so the repair is unambiguous.
+    def envelope_key(output_schema)
+      return nil unless output_schema.is_a?(Hash) && output_schema["type"] == "object"
+
+      array_keys = Hash(output_schema["properties"]).filter_map do |key, spec|
+        key if spec.is_a?(Hash) && spec["type"] == "array"
+      end
+      array_keys.size == 1 ? array_keys.first : nil
+    end
+  end
+end

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -22,6 +22,11 @@ module Loader
       raise StandardError, "LlmLoader payload missing 'items' array" unless payload.is_a?(Hash) && payload["items"].is_a?(Array)
 
       payload["items"]
+    rescue LlmClient::SchemaError => e
+      # A reply that won't fit the schema is the source misbehaving, same as an
+      # HTTP loader's bad status: an expected failure per the LlmClient
+      # contract, already billed and recorded on the feed — not a crash.
+      raise Loader::Error, e.message
     end
 
     private

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -25,7 +25,10 @@ module Loader
     rescue LlmClient::SchemaError => e
       # A reply that won't fit the schema is the source misbehaving, same as an
       # HTTP loader's bad status: an expected failure per the LlmClient
-      # contract, already billed and recorded on the feed — not a crash.
+      # contract, already billed and recorded on the feed — not a crash. The
+      # report keeps it visible as a handled error once it's wrapped, since
+      # FeedRefreshJob deliberately swallows Loader::Error.
+      Rails.error.report(e, context: { feed_id: feed.id, profile_key: feed.feed_profile_key })
       raise Loader::Error, e.message
     end
 

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -242,6 +242,20 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     assert_equal "PASS", outcome[:results].first[:status]
   end
 
+  # The probe must qualify a model under exactly the root repairs production
+  # applies (LlmClient::PayloadRepair), or a usable model gets blocked.
+  test "#run should pass the schema check on a bare items array the app repairs" do
+    outcome = run_checks(JSON.generate(valid_payload["items"]), ["schema"])
+
+    assert_equal "PASS", outcome[:results].first[:status]
+  end
+
+  test "#run should pass the schema check on a double-encoded payload the app repairs" do
+    outcome = run_checks(JSON.generate(JSON.generate(valid_payload)), ["schema"])
+
+    assert_equal "PASS", outcome[:results].first[:status]
+  end
+
   test "#run should fail the schema check when schema-valid items are a refusal" do
     payload = { "items" => [{ "uid" => "u1", "source_url" => "https://example.com/",
                               "body" => "I cannot browse the live web, so I am unable to retrieve the posts." }] }

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -465,6 +465,60 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal "success", LlmUsage.last.outcome
   end
 
+  # A model on the two-call structure path drops the {"items": ...} envelope
+  # often enough that the bare array is repaired rather than failed.
+  test "#call should wrap a bare array under the schema's envelope property" do
+    client = LlmClient.new(credential)
+    stub_provider_response(client, LlmClient::ProviderResponse.new(
+      payload: '[{"title":"Post 1"}]', input_tokens: 10, output_tokens: 5,
+      cache_write_tokens: 0, cache_read_tokens: 0
+    ))
+
+    result = client.call(default_ctx, **call_opts)
+
+    assert_equal({ "items" => [{ "title" => "Post 1" }] }, result.payload)
+    assert_equal "success", LlmUsage.last.outcome
+  end
+
+  test "#call should re-parse a double-encoded JSON payload" do
+    client = LlmClient.new(credential)
+    stub_provider_response(client, LlmClient::ProviderResponse.new(
+      payload: JSON.generate('{"items":[{"title":"Post 1"}]}'), input_tokens: 10, output_tokens: 5,
+      cache_write_tokens: 0, cache_read_tokens: 0
+    ))
+
+    result = client.call(default_ctx, **call_opts)
+
+    assert_equal({ "items" => [{ "title" => "Post 1" }] }, result.payload)
+    assert_equal "success", LlmUsage.last.outcome
+  end
+
+  test "#call should raise SchemaError when a quoted reply holds no JSON" do
+    client = LlmClient.new(credential)
+    stub_provider_response(client, LlmClient::ProviderResponse.new(
+      payload: '"I cannot browse the web."', input_tokens: 10, output_tokens: 5,
+      cache_write_tokens: 0, cache_read_tokens: 0
+    ))
+
+    assert_raises(LlmClient::SchemaError) { client.call(default_ctx, **call_opts) }
+    assert_equal "schema_error", LlmUsage.last.outcome
+  end
+
+  # A repair never bypasses validation — a wrapped array of malformed items
+  # must still fail the full schema.
+  test "#call should still validate a repaired payload against the schema" do
+    client = LlmClient.new(credential)
+    stub_provider_response(client, LlmClient::ProviderResponse.new(
+      payload: '[{"title":"no body or source_url"}]', input_tokens: 10, output_tokens: 5,
+      cache_write_tokens: 0, cache_read_tokens: 0
+    ))
+
+    assert_raises(LlmClient::SchemaError) do
+      client.call(default_ctx, prompt: "Extract posts", output_schema: FeedProfile::UNIVERSAL_OUTPUT_SCHEMA)
+    end
+    assert_equal "schema_error", LlmUsage.last.outcome
+  end
+
   test "#call should map malformed tool-call arguments to ProviderError" do
     client = LlmClient.new(credential)
     stub_provider_to_raise(client, JSON::ParserError.new("unexpected token"))

--- a/test/services/loader/llm_loader_test.rb
+++ b/test/services/loader/llm_loader_test.rb
@@ -140,6 +140,27 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
     assert_equal [:scheduled_run], client.calls.map { |c| c[:purpose] }
   end
 
+  # Same contract as HTTP loaders wrapping a bad status: the source (here, the
+  # model) misbehaving is an expected loader failure, not a crash.
+  test "#load should raise Loader::Error when the model reply fails the schema" do
+    failing_client = Class.new do
+      attr_reader :credential
+
+      def initialize(credential)
+        @credential = credential
+      end
+
+      def call(*, **)
+        raise LlmClient::SchemaError, "response did not match schema: value at root is not an object"
+      end
+    end.new(credential)
+
+    error = assert_raises(Loader::Error) do
+      Loader::LlmLoader.new(feed, llm_client: failing_client).load
+    end
+    assert_match(/did not match schema/, error.message)
+  end
+
   test "#load should raise when the structured payload is missing the items key" do
     loader = Loader::LlmLoader.new(feed, llm_client: fake_client(structured: { "wrong" => "shape" }))
 

--- a/test/services/loader/llm_loader_test.rb
+++ b/test/services/loader/llm_loader_test.rb
@@ -140,10 +140,8 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
     assert_equal [:scheduled_run], client.calls.map { |c| c[:purpose] }
   end
 
-  # Same contract as HTTP loaders wrapping a bad status: the source (here, the
-  # model) misbehaving is an expected loader failure, not a crash.
-  test "#load should raise Loader::Error when the model reply fails the schema" do
-    failing_client = Class.new do
+  def schema_failing_client
+    Class.new do
       attr_reader :credential
 
       def initialize(credential)
@@ -154,11 +152,31 @@ class Loader::LlmLoaderTest < ActiveSupport::TestCase
         raise LlmClient::SchemaError, "response did not match schema: value at root is not an object"
       end
     end.new(credential)
+  end
 
+  # Same contract as HTTP loaders wrapping a bad status: the source (here, the
+  # model) misbehaving is an expected loader failure, not a crash.
+  test "#load should raise Loader::Error when the model reply fails the schema" do
     error = assert_raises(Loader::Error) do
-      Loader::LlmLoader.new(feed, llm_client: failing_client).load
+      Loader::LlmLoader.new(feed, llm_client: schema_failing_client).load
     end
     assert_match(/did not match schema/, error.message)
+  end
+
+  # FeedRefreshJob swallows Loader::Error, so the wrap must not lose the
+  # failure from central error reporting.
+  test "#load should report the schema failure via Rails.error before wrapping it" do
+    reported = []
+    Rails.error.stub(:report, ->(err, **kwargs) { reported << [err, kwargs] }) do
+      assert_raises(Loader::Error) do
+        Loader::LlmLoader.new(feed, llm_client: schema_failing_client).load
+      end
+    end
+
+    assert_equal 1, reported.size
+    error, kwargs = reported.first
+    assert_kind_of LlmClient::SchemaError, error
+    assert_equal feed.id, kwargs.dig(:context, :feed_id)
   end
 
   test "#load should raise when the structured payload is missing the items key" do


### PR DESCRIPTION
Changes:

- Repair two recoverable LLM response shapes before schema validation: a bare items array missing the `{"items": ...}` envelope, and a payload JSON-encoded once more
- Treat an unrecoverable schema mismatch as an expected loader failure instead of a crash

Fixes a recurring staging fault from AI feed refreshes (`LlmClient::SchemaError: response did not match schema: value at root is not an object`). Models on the gather→structure path occasionally drop the envelope object or double-encode their JSON; both shapes are now repaired, and every repair still passes schema validation, so a wrong guess fails exactly as before. When the reply genuinely can't fit the schema, `LlmLoader` now raises `Loader::Error` — already logged, metered, and recorded on the feed as a failed refresh — matching the LlmClient contract that a schema violation is an expected failure, not error-tracker noise.