### PR TITLE
Add podcast feed profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-21
+
+- Podcast feeds get their own feed type: episodes come through with cover art, show notes, and a link to the audio.
+
 ## 2026-08-20
 
 - AI feeds now recover when the model returns its answer in a slightly off format, instead of failing the refresh.

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -84,6 +84,19 @@ class FeedProfile
       normalizer: { class: "Normalizer::JsonFeedNormalizer", config: {} },
       title_extractor: "TitleExtractor::JsonFeedTitleExtractor"
     },
+    "podcast" => {
+      display_name: "Podcast",
+      description: "Podcast episodes with cover art and show notes",
+      input_shape: :url,
+      depends_on_ai: false,
+      scheduled: true,
+      matcher: "ProfileMatcher::PodcastProfileMatcher",
+      parameter_schema: URL_PARAMETER_SCHEMA,
+      loader: { class: "Loader::HttpLoader", config: {} },
+      processor: { class: "Processor::PodcastProcessor", config: {} },
+      normalizer: { class: "Normalizer::PodcastNormalizer", config: {} },
+      title_extractor: "TitleExtractor::RssTitleExtractor"
+    },
     "reddit" => {
       display_name: "Reddit",
       description: "Posts from a subreddit or Reddit user page via RSS",

--- a/app/services/normalizer/podcast_normalizer.rb
+++ b/app/services/normalizer/podcast_normalizer.rb
@@ -1,0 +1,32 @@
+module Normalizer
+  class PodcastNormalizer < RssNormalizer
+    private
+
+    # Episode title as the post text with the audio link folded in; the
+    # (often long) show notes travel as a comment instead.
+    def normalize_content
+      title = raw_data.dig("title").to_s.strip
+      enclosure_url = raw_data.dig("enclosure_url").presence
+      return title if enclosure_url.blank? || enclosure_url == source_url
+
+      "#{title}\nListen: #{enclosure_url}"
+    end
+
+    # Some podcast feeds skip per-episode pages; the audio file is the only
+    # stable URL then, so it stands in as the permalink.
+    def original_url
+      @original_url ||= super.presence || raw_data.dig("enclosure_url").to_s
+    end
+
+    def normalize_attachment_urls
+      [raw_data.dig("itunes_image")].compact_blank
+    end
+
+    def normalize_comments
+      summary = raw_data.dig("summary").presence
+      return [] unless summary
+
+      [truncate_text(strip_html(summary), max_length: 1500)].compact_blank
+    end
+  end
+end

--- a/app/services/processor/podcast_processor.rb
+++ b/app/services/processor/podcast_processor.rb
@@ -1,0 +1,22 @@
+module Processor
+  class PodcastProcessor < RssProcessor
+    private
+
+    # Feedjira parses itunes-namespaced feeds with ITunesRSSItem, which lacks
+    # the enclosure collections patched onto RSSEntry, so the generic
+    # sanitizer would drop the audio enclosure and cover art. Capture them
+    # explicitly; episodes without their own artwork fall back to the
+    # channel-level cover.
+    def build_entries(feed_data)
+      @channel_image = feed_data.try(:itunes_image).presence
+      super
+    end
+
+    def sanitize_feedjira_entry(entry)
+      super.merge(
+        "itunes_image" => entry.try(:itunes_image).presence || @channel_image,
+        "enclosure_url" => entry.try(:enclosure_url).presence
+      )
+    end
+  end
+end

--- a/app/services/profile_matcher/podcast_profile_matcher.rb
+++ b/app/services/profile_matcher/podcast_profile_matcher.rb
@@ -1,0 +1,21 @@
+module ProfileMatcher
+  class PodcastProfileMatcher < Base
+    # Ranks above generic RSS (10): the itunes namespace declaration is a
+    # stronger signal than the RSS matcher's scan for XML-like text.
+    match_specificity 15
+
+    # Mirrors Feedjira's ITunesRSS detection (namespace declaration outside
+    # CDATA), so the profile claims exactly the feeds Feedjira will hand to
+    # its iTunes parser. The <rss> shell check keeps an Atom feed with a
+    # stray itunes attribute out — Feedjira parses those as Atom.
+    ITUNES_NS = %r{xmlns:itunes\s?=\s?["']http://www\.itunes\.com/dtds/podcast-1\.0\.dtd["']}i
+    CDATA = /<!\[CDATA\[.*?\]\]>/m
+
+    def match?
+      return false if fetched_body.blank?
+      return false unless fetched_body.match?(/<rss[\s>]/i)
+
+      fetched_body.gsub(CDATA, "").match?(ITUNES_NS)
+    end
+  end
+end

--- a/test/fixtures/files/feeds/podcast/feed.xml
+++ b/test/fixtures/files/feeds/podcast/feed.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+  <channel>
+    <atom:link href="https://signalpath.example.fm/feed.xml" rel="self" type="application/rss+xml"/>
+    <title>Signal Path</title>
+    <description>Conversations about engineering behind everyday infrastructure.</description>
+    <link>https://signalpath.example.fm</link>
+    <language>en</language>
+    <itunes:author>Signal Path Media</itunes:author>
+    <itunes:image href="https://signalpath.example.fm/art/cover.jpg"/>
+    <itunes:category text="Technology"/>
+    <item>
+      <title>Ep. 42: The Grid at Night</title>
+      <pubDate>Mon, 10 Aug 2026 06:00:00 +0000</pubDate>
+      <guid isPermaLink="false">sp-ep-42</guid>
+      <link>https://signalpath.example.fm/episodes/42</link>
+      <itunes:image href="https://signalpath.example.fm/art/ep42.jpg"/>
+      <enclosure url="https://cdn.example.fm/signalpath/ep42.mp3" length="52428800" type="audio/mpeg"/>
+      <itunes:duration>54:21</itunes:duration>
+      <description><![CDATA[What keeps a power grid stable when demand drops after midnight? We talk to a <a href="https://signalpath.example.fm/guests/marta">grid operator</a> about the quiet hours.]]></description>
+      <itunes:summary><![CDATA[What keeps a power grid stable when demand drops after midnight?]]></itunes:summary>
+    </item>
+    <item>
+      <title>Ep. 41: Water Hammer</title>
+      <pubDate>Mon, 03 Aug 2026 06:00:00 +0000</pubDate>
+      <guid isPermaLink="false">sp-ep-41</guid>
+      <link>https://signalpath.example.fm/episodes/41</link>
+      <enclosure url="https://cdn.example.fm/signalpath/ep41.mp3" length="48234496" type="audio/mpeg"/>
+      <itunes:duration>47:05</itunes:duration>
+      <description><![CDATA[Why pipes bang when you close a tap too fast, and how engineers keep it from bursting city mains.]]></description>
+    </item>
+    <item>
+      <title>Ep. 40: Elevator Algorithms</title>
+      <pubDate>Mon, 27 Jul 2026 06:00:00 +0000</pubDate>
+      <guid isPermaLink="false">sp-ep-40</guid>
+      <itunes:image href="https://signalpath.example.fm/art/ep40.jpg"/>
+      <enclosure url="https://cdn.example.fm/signalpath/ep40.mp3" length="41943040" type="audio/mpeg"/>
+      <itunes:duration>41:12</itunes:duration>
+      <description><![CDATA[How a bank of elevators decides which car answers your call.]]></description>
+    </item>
+  </channel>
+</rss>

--- a/test/fixtures/files/feeds/podcast/normalized.json
+++ b/test/fixtures/files/feeds/podcast/normalized.json
@@ -1,0 +1,14 @@
+{
+  "attachment_urls": [
+    "https://signalpath.example.fm/art/ep42.jpg"
+  ],
+  "comments": [
+    "What keeps a power grid stable when demand drops after midnight? We talk to a grid operator about the quiet hours."
+  ],
+  "content": "Ep. 42: The Grid at Night\nListen: https://cdn.example.fm/signalpath/ep42.mp3 - https://signalpath.example.fm/episodes/42",
+  "published_at": "2026-08-10T06:00:00.000Z",
+  "source_url": "https://signalpath.example.fm/episodes/42",
+  "status": "enqueued",
+  "uid": "sp-ep-42",
+  "validation_errors": []
+}

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -16,6 +16,7 @@ class FeedProfileTest < ActiveSupport::TestCase
       "nextbigfuture",
       "oglaf",
       "pluralistic",
+      "podcast",
       "reddit",
       "rss",
       "smbc",

--- a/test/services/normalizer/podcast_normalizer_test.rb
+++ b/test/services/normalizer/podcast_normalizer_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class Normalizer::PodcastNormalizerTest < ActiveSupport::TestCase
+  include FixtureFeedEntries
+
+  def fixture_dir
+    "feeds/podcast"
+  end
+
+  def processor_class
+    Processor::PodcastProcessor
+  end
+
+  test "#normalize should match the expected normalization result" do
+    entry = feed_entry(0)
+
+    post = Normalizer::PodcastNormalizer.new(entry).normalize
+
+    assert_matches_snapshot(post.normalized_attributes, snapshot: "#{fixture_dir}/normalized.json")
+  end
+
+  test "#normalize should include the audio link in content" do
+    entry = feed_entry(0)
+
+    post = Normalizer::PodcastNormalizer.new(entry).normalize
+
+    assert_includes post.content, "Listen: https://cdn.example.fm/signalpath/ep42.mp3"
+  end
+
+  test "#normalize should use the episode page as source_url" do
+    entry = feed_entry(0)
+
+    post = Normalizer::PodcastNormalizer.new(entry).normalize
+
+    assert_equal "https://signalpath.example.fm/episodes/42", post.source_url
+  end
+
+  test "#normalize should use itunes_image as attachment" do
+    entry = feed_entry(0)
+
+    post = Normalizer::PodcastNormalizer.new(entry).normalize
+
+    assert_equal ["https://signalpath.example.fm/art/ep42.jpg"], post.attachment_urls
+  end
+
+  test "#normalize should include stripped show notes as comment" do
+    entry = feed_entry(0)
+
+    post = Normalizer::PodcastNormalizer.new(entry).normalize
+
+    assert_equal 1, post.comments.size
+    assert_includes post.comments.first, "What keeps a power grid stable"
+    assert_not_includes post.comments.first, "<a href"
+  end
+
+  test "#normalize should fall back to the enclosure URL when the episode has no page link" do
+    entry = feed_entry(2)
+
+    post = Normalizer::PodcastNormalizer.new(entry).normalize
+
+    assert_equal "https://cdn.example.fm/signalpath/ep40.mp3", post.source_url
+    assert_empty post.validation_errors
+    assert_not_includes post.content, "Listen:"
+  end
+end

--- a/test/services/processor/podcast_processor_test.rb
+++ b/test/services/processor/podcast_processor_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Processor::PodcastProcessorTest < ActiveSupport::TestCase
+  def feed
+    @feed ||= create(:feed, feed_profile_key: "podcast")
+  end
+
+  def feed_xml
+    @feed_xml ||= file_fixture("feeds/podcast/feed.xml").read
+  end
+
+  def processor
+    Processor::PodcastProcessor.new(feed, feed_xml)
+  end
+
+  test "#process should parse feed and create FeedEntry objects" do
+    entries = processor.process.entries
+
+    assert_equal 3, entries.length
+    assert entries.all? { |e| e.is_a?(FeedEntry) }
+    assert entries.all? { |e| e.feed == feed }
+    assert entries.all? { |e| e.status == "pending" }
+  end
+
+  test "#process should extract itunes_image into raw_data" do
+    entry = processor.process.entries.first
+
+    assert_equal "https://signalpath.example.fm/art/ep42.jpg", entry.raw_data["itunes_image"]
+  end
+
+  test "#process should fall back to the channel cover when an episode has no image" do
+    entry = processor.process.entries.second
+
+    assert_equal "https://signalpath.example.fm/art/cover.jpg", entry.raw_data["itunes_image"]
+  end
+
+  test "#process should extract enclosure_url into raw_data" do
+    entry = processor.process.entries.first
+
+    assert_equal "https://cdn.example.fm/signalpath/ep42.mp3", entry.raw_data["enclosure_url"]
+  end
+
+  test "#process should leave itunes_image nil when neither episode nor channel has one" do
+    xml_without_images = feed_xml.gsub(/<itunes:image[^>]*\/>\n?\s*/, "")
+    entry = Processor::PodcastProcessor.new(feed, xml_without_images).process.entries.first
+
+    assert_nil entry.raw_data["itunes_image"]
+  end
+end

--- a/test/services/profile_matcher/podcast_profile_matcher_test.rb
+++ b/test/services/profile_matcher/podcast_profile_matcher_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class ProfileMatcher::PodcastProfileMatcherTest < ActiveSupport::TestCase
+  def matcher(body)
+    ProfileMatcher::PodcastProfileMatcher.new("https://example.com/feed.xml", body)
+  end
+
+  test ".match_specificity should be 15, above generic RSS" do
+    assert_equal 15, ProfileMatcher::PodcastProfileMatcher.match_specificity
+    assert_operator ProfileMatcher::PodcastProfileMatcher.match_specificity, :>,
+                    ProfileMatcher::RssProfileMatcher.match_specificity
+  end
+
+  test ".profile_key should be podcast" do
+    assert_equal "podcast", ProfileMatcher::PodcastProfileMatcher.profile_key
+  end
+
+  test "#match? should match an RSS feed declaring the itunes namespace" do
+    body = file_fixture("feeds/podcast/feed.xml").read
+
+    assert matcher(body).match?
+  end
+
+  test "#match? should match a single-quoted namespace declaration" do
+    body = "<rss xmlns:itunes='http://www.itunes.com/dtds/podcast-1.0.dtd' version=\"2.0\"><channel></channel></rss>"
+
+    assert matcher(body).match?
+  end
+
+  test "#match? should not match plain RSS without the itunes namespace" do
+    body = file_fixture("feeds/rss/feed.xml").read
+
+    assert_not matcher(body).match?
+  end
+
+  test "#match? should not match an Atom feed with an itunes declaration" do
+    # Feedjira parses Atom documents with its Atom parser, so the podcast
+    # profile must not claim them even when the namespace is declared.
+    body = '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"></feed>'
+
+    assert_not matcher(body).match?
+  end
+
+  test "#match? should not match when the namespace appears only inside CDATA" do
+    body = <<~XML
+      <rss version="2.0"><channel><item>
+        <description><![CDATA[xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"]]></description>
+      </item></channel></rss>
+    XML
+
+    assert_not matcher(body).match?
+  end
+
+  test "#match? should handle blank inputs" do
+    assert_not matcher("").match?
+    assert_not matcher(nil).match?
+  end
+end


### PR DESCRIPTION
Changes:

- New `podcast` feed profile for iTunes-namespaced RSS feeds, auto-detected during feed identification
- Podcast episodes post with cover art, show notes as a comment, and a link to the audio file
- Episodes without their own artwork fall back to the channel cover; episodes without a page link use the audio URL as the permalink

Podcast feeds already parsed through the generic RSS profile (Feedjira picks its iTunes parser on its own), but the pipeline dropped everything podcast-specific: `ITunesRSSItem` entries don't carry the enclosure collections our Feedjira initializer patches onto `RSSEntry`, so cover art and audio links were lost. The new profile captures those fields explicitly. Detection mirrors Feedjira's own parser selection (the `xmlns:itunes` declaration outside CDATA, plus an RSS shell), so the profile claims exactly the feeds Feedjira parses as iTunes RSS, ranking above generic RSS and below site-specific matchers.