### PR TITLE
Persist token scopes and gate subscriber counts on them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-08-22
 
 - The access token page now tells you when a token can't look up subscriber counts, and how to swap in one that can.
+- A token that's missing the permissions Feeder needs now says so, instead of being reported as expired or revoked.
 
 ## 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-22
+
+- The access token page now tells you when a token can't look up subscriber counts, and how to swap in one that can.
+
 ## 2026-08-21
 
 - Podcast feeds get their own feed type: episodes come through with cover art, show notes, and a link to the audio.

--- a/app/jobs/token_validation_job.rb
+++ b/app/jobs/token_validation_job.rb
@@ -4,8 +4,8 @@ class TokenValidationJob < ApplicationJob
   queue_as :default
 
   def perform(access_token)
-    # Validation makes two GETs: whoami and managedGroups.
-    result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { get: 2 })
+    # Validation makes three GETs: whoami, managedGroups, and the token's scopes.
+    result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { get: 3 })
     return reschedule_for_rate_limit(result.retry_after) unless result.allowed?
 
     AccessTokenValidationService.new(access_token).call

--- a/app/jobs/token_validation_job.rb
+++ b/app/jobs/token_validation_job.rb
@@ -4,7 +4,8 @@ class TokenValidationJob < ApplicationJob
   queue_as :default
 
   def perform(access_token)
-    # Validation makes three GETs: whoami, managedGroups, and the token's scopes.
+    # Validation makes up to three GETs: the token's scopes, then whoami and
+    # managedGroups when the scopes allow them.
     result = RateLimit.acquire(:freefeed, subject: access_token.rate_limit_subject, cost: { get: 3 })
     return reschedule_for_rate_limit(result.retry_after) unless result.allowed?
 

--- a/app/jobs/update_feed_subscribers_count_job.rb
+++ b/app/jobs/update_feed_subscribers_count_job.rb
@@ -6,6 +6,11 @@ class UpdateFeedSubscribersCountJob < ApplicationJob
   def perform(feed)
     return unless feed.enabled? && feed.access_token&.active? && feed.target_group.present?
 
+    # Statistics sit behind read-users-info, and a token can never gain a scope
+    # it wasn't issued with. Without it the request can only ever be refused, so
+    # skip before spending any rate-limit budget on it.
+    return unless feed.access_token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
+
     result = RateLimit.acquire(:freefeed, subject: feed.access_token.rate_limit_subject, cost: { get: 1 })
     return reschedule_for_rate_limit(result.retry_after) unless result.allowed?
 

--- a/app/jobs/update_feed_subscribers_counts_job.rb
+++ b/app/jobs/update_feed_subscribers_counts_job.rb
@@ -2,7 +2,12 @@ class UpdateFeedSubscribersCountsJob < ApplicationJob
   queue_as :default
 
   def perform
-    Feed.enabled.where.not(access_token_id: nil).where.not(target_group: [nil, ""]).find_each do |feed|
+    # Feeds on a token without read-users-info are left out: the per-feed job
+    # would only skip them, so enqueuing is pure overhead.
+    Feed.enabled
+        .where.not(target_group: [nil, ""])
+        .where(access_token: AccessToken.allowing_scope(AccessToken::READ_USERS_INFO_SCOPE))
+        .find_each do |feed|
       UpdateFeedSubscribersCountJob.perform_later(feed)
     end
   end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -34,8 +34,7 @@ class AccessToken < ApplicationRecord
     "https://#{domain}/settings/app-tokens/create?scopes=#{TOKEN_SCOPES.join('%20')}"
   end
 
-  # Feeds whose token may hold the scope — both the granted case and the
-  # unknown one, matching #allows_scope?.
+  # SQL counterpart of #allows_scope?. Keep the two in step.
   scope :allowing_scope, ->(scope) {
     where("scopes IS NULL OR scopes @> ARRAY[?]::varchar[]", scope)
   }
@@ -87,16 +86,14 @@ class AccessToken < ApplicationRecord
     FreefeedClient.new(host: host, token: encrypted_token, rate_limit_subject: rate_limit_subject)
   end
 
-  # FreeFeed fixes an app token's scopes when it's issued and offers no way to
-  # widen them later, so a missing scope is permanent for this token. Unknown
-  # scopes (nil) stay ungated: the token predates this column or is a session
-  # token, which has unrestricted access.
+  # FreeFeed fixes an app token's scopes when it issues the token, so a missing
+  # scope is permanent. Unknown scopes (nil) stay ungated: those tokens either
+  # predate this column or are session tokens, which are unrestricted.
   def allows_scope?(scope)
     scopes.nil? || scopes.include?(scope)
   end
 
-  # Where the user goes to issue a replacement token on this token's instance,
-  # pre-asking for every scope Feeder uses.
+  # Points at this token's own instance rather than the default one.
   def token_creation_url
     self.class.token_url(host_domain)
   end
@@ -171,8 +168,8 @@ class AccessToken < ApplicationRecord
     RateLimit.forget(:freefeed, subject: subject)
   end
 
-  # `event_type` names why the token is being switched off, so the user sees a
-  # dead token and an under-permissioned one described differently.
+  # `event_type` carries the reason, so a dead token and an under-permissioned
+  # one read differently in the event log.
   def disable_token_and_feeds(event_type: "access_token_validation_failed")
     with_lock do
       inactive!

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -17,15 +17,24 @@ class AccessToken < ApplicationRecord
 
   attr_accessor :token
 
-  TOKEN_SCOPES = %w[
-    read-my-info
-    read-users-info
-    manage-posts
+  # Lets Feeder read a group's subscriber count.
+  READ_USERS_INFO_SCOPE = "read-users-info".freeze
+
+  TOKEN_SCOPES = [
+    "read-my-info",
+    READ_USERS_INFO_SCOPE,
+    "manage-posts"
   ].freeze
 
   def self.token_url(domain)
     "https://#{domain}/settings/app-tokens/create?scopes=#{TOKEN_SCOPES.join('%20')}"
   end
+
+  # Feeds whose token may hold the scope — both the granted case and the
+  # unknown one, matching #allows_scope?.
+  scope :allowing_scope, ->(scope) {
+    where("scopes IS NULL OR scopes @> ARRAY[?]::varchar[]", scope)
+  }
 
   # A user can create access token record associated with a known
   # FreeFeed instances only (see Settings::AccessTokensController).
@@ -72,6 +81,20 @@ class AccessToken < ApplicationRecord
 
   def build_client
     FreefeedClient.new(host: host, token: encrypted_token, rate_limit_subject: rate_limit_subject)
+  end
+
+  # FreeFeed fixes an app token's scopes when it's issued and offers no way to
+  # widen them later, so a missing scope is permanent for this token. Unknown
+  # scopes (nil) stay ungated: the token predates this column or is a session
+  # token, which has unrestricted access.
+  def allows_scope?(scope)
+    scopes.nil? || scopes.include?(scope)
+  end
+
+  # Where the user goes to issue a replacement token on this token's instance,
+  # pre-asking for every scope Feeder uses.
+  def token_creation_url
+    self.class.token_url(host_domain)
   end
 
   # Cache of this token's postable group names, shared by the feed form's

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -39,7 +39,7 @@ class AccessToken < ApplicationRecord
 
   # SQL counterpart of #allows_scope?. Keep the two in step.
   scope :allowing_scope, ->(scope) {
-    where("scopes IS NULL OR scopes @> ARRAY[?]::varchar[]", scope)
+    where("scopes @> ARRAY[?]::varchar[]", scope)
   }
 
   # A user can create access token record associated with a known
@@ -90,10 +90,9 @@ class AccessToken < ApplicationRecord
   end
 
   # FreeFeed fixes an app token's scopes when it issues the token, so a missing
-  # scope is permanent. nil means a session token, which carries unrestricted
-  # access and so allows everything.
+  # scope is permanent.
   def allows_scope?(scope)
-    scopes.nil? || scopes.include?(scope)
+    scopes.include?(scope)
   end
 
   # Points at this token's own instance rather than the default one.

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -24,10 +24,13 @@ class AccessToken < ApplicationRecord
   # Lets Feeder read a group's subscriber count.
   READ_USERS_INFO_SCOPE = "read-users-info".freeze
 
+  # Lets Feeder publish posts and comments on the user's behalf.
+  MANAGE_POSTS_SCOPE = "manage-posts".freeze
+
   TOKEN_SCOPES = [
     READ_MY_INFO_SCOPE,
     READ_USERS_INFO_SCOPE,
-    "manage-posts"
+    MANAGE_POSTS_SCOPE
   ].freeze
 
   def self.token_url(domain)

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -17,11 +17,15 @@ class AccessToken < ApplicationRecord
 
   attr_accessor :token
 
+  # Lets Feeder identify the account behind the token, via whoami and
+  # managedGroups. Without it there is nothing to validate.
+  READ_MY_INFO_SCOPE = "read-my-info".freeze
+
   # Lets Feeder read a group's subscriber count.
   READ_USERS_INFO_SCOPE = "read-users-info".freeze
 
   TOKEN_SCOPES = [
-    "read-my-info",
+    READ_MY_INFO_SCOPE,
     READ_USERS_INFO_SCOPE,
     "manage-posts"
   ].freeze
@@ -167,7 +171,9 @@ class AccessToken < ApplicationRecord
     RateLimit.forget(:freefeed, subject: subject)
   end
 
-  def disable_token_and_feeds
+  # `event_type` names why the token is being switched off, so the user sees a
+  # dead token and an under-permissioned one described differently.
+  def disable_token_and_feeds(event_type: "access_token_validation_failed")
     with_lock do
       inactive!
 
@@ -176,15 +182,15 @@ class AccessToken < ApplicationRecord
 
       feed_ids = enabled_feeds.pluck(:id)
       disabled_count = enabled_feeds.update_all(state: :disabled)
-      create_validation_failed_event(feed_ids: feed_ids, disabled_count: disabled_count)
+      create_validation_failed_event(event_type: event_type, feed_ids: feed_ids, disabled_count: disabled_count)
     end
   end
 
   private
 
-  def create_validation_failed_event(feed_ids:, disabled_count:)
+  def create_validation_failed_event(event_type:, feed_ids:, disabled_count:)
     Event.create!(
-      type: "access_token_validation_failed",
+      type: event_type,
       user: user,
       subject: self,
       level: :warning,

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -90,8 +90,8 @@ class AccessToken < ApplicationRecord
   end
 
   # FreeFeed fixes an app token's scopes when it issues the token, so a missing
-  # scope is permanent. Unknown scopes (nil) stay ungated: those tokens either
-  # predate this column or are session tokens, which are unrestricted.
+  # scope is permanent. nil means a session token, which carries unrestricted
+  # access and so allows everything.
   def allows_scope?(scope)
     scopes.nil? || scopes.include?(scope)
   end

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -57,10 +57,9 @@ class AccessTokenValidationService
   end
 
   # whoami and managedGroups both sit behind read-my-info. Without it they can
-  # only be refused, so there is nothing to learn from asking. nil means a
-  # session token, which is unrestricted.
+  # only be refused, so there is nothing to learn from asking.
   def scopes_cover_validation?(scopes)
-    scopes.nil? || scopes.include?(AccessToken::READ_MY_INFO_SCOPE)
+    scopes.include?(AccessToken::READ_MY_INFO_SCOPE)
   end
 
   # Persist the scopes on the way down. They are what lets the token page say
@@ -84,10 +83,10 @@ class AccessTokenValidationService
   # rather than under-permissioned, and anything else is transient: validation
   # stays unfinished and the job retries.
   #
-  # nil is a real answer, not a gap. It comes only from a session token, which
-  # FreeFeed rejects on this app-token-only route and which holds unrestricted
-  # access.
+  # A session token has no scope list to report, and FreeFeed rejects it on this
+  # app-token-only route. It is unrestricted, so it gets everything Feeder asks
+  # for. Widening TOKEN_SCOPES later means re-reading these tokens.
   def fetch_scopes
-    freefeed_client.app_token_info&.fetch(:scopes)
+    freefeed_client.app_token_info&.fetch(:scopes) || AccessToken::TOKEN_SCOPES
   end
 end

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -8,8 +8,8 @@ class AccessTokenValidationService
   def call
     access_token.validating! unless access_token.validating?
 
-    # Scopes lead: FreeFeed always allows this route, so it answers for any live
-    # token and says up front whether the rest of the sequence can succeed.
+    # Scopes come first because that route is always allowed. It answers for any
+    # live token, and tells us whether the rest of the sequence can succeed.
     scopes = fetch_scopes
     return disable_for_missing_scope(scopes) unless scopes_cover_validation?(scopes)
 
@@ -37,8 +37,8 @@ class AccessTokenValidationService
       )
     end
   rescue FreefeedClient::UnauthorizedError, FreefeedClient::ForbiddenError
-    # Reaching here means the token is dead rather than under-permissioned: the
-    # scope check above already sent that case down its own path.
+    # The token is dead, not under-permissioned. The scope check above already
+    # routed that case elsewhere.
     access_token.disable_token_and_feeds
   rescue RateLimit::Throttled
     # Throttling is control flow, not a validation failure: let it propagate so
@@ -58,13 +58,14 @@ class AccessTokenValidationService
 
   # whoami and managedGroups both sit behind read-my-info. Without it they can
   # only be refused, so there is nothing to learn from asking. Unknown scopes
-  # (nil) still go ahead — a session token reports none and can do everything.
+  # (nil) still go ahead, since a session token reports none and can do
+  # everything.
   def scopes_cover_validation?(scopes)
     scopes.nil? || scopes.include?(AccessToken::READ_MY_INFO_SCOPE)
   end
 
-  # Record the scopes on the way down: they're what lets the token page explain
-  # that the token is alive but can't be used, rather than calling it expired.
+  # Persist the scopes on the way down. They are what lets the token page say
+  # the token is alive but unusable, instead of calling it expired.
   def disable_for_missing_scope(scopes)
     access_token.update!(scopes: scopes)
     access_token.disable_token_and_feeds(event_type: "access_token_missing_scope")
@@ -78,18 +79,18 @@ class AccessTokenValidationService
     freefeed_client.managed_groups
   end
 
-  # Scopes only gate optional calls, never publishing, so a failure here must
-  # not sink an otherwise good validation. Falling back to nil re-opens the
-  # gate: callers attempt the call and handle the rejection, which beats
-  # gating on a stale list after the token secret was swapped for a new one.
+  # A failure here must not sink an otherwise good validation. Falling back to
+  # nil reopens the gate, so callers attempt the call and handle any rejection.
+  # Keeping the previous list instead would gate wrongly once the token secret
+  # is replaced with one carrying different scopes.
   def fetch_scopes
     freefeed_client.app_token_info&.fetch(:scopes)
   rescue FreefeedClient::InvalidTokenError
-    # The one 401 that isn't a scope-lookup failure: FreeFeed raises this only
+    # The one 401 that is not a scope-lookup failure. FreeFeed raises it only
     # for "inactive or expired token", so let it reach the handler that disables
-    # the token. A token merely lacking the scope answers 401 too, but as a
-    # plain UnauthorizedError — swallowed below, or it would take down every
-    # feed on a token that publishes perfectly well.
+    # the token. A token merely lacking the scope also answers 401, but as a
+    # plain UnauthorizedError. That one stays swallowed below, or it would take
+    # down every feed on a token that publishes perfectly well.
     raise
   rescue FreefeedClient::Error => e
     Rails.error.report(e, context: { access_token_id: access_token.id })

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -65,6 +65,13 @@ class AccessTokenValidationService
   # gating on a stale list after the token secret was swapped for a new one.
   def fetch_scopes
     freefeed_client.app_token_info&.fetch(:scopes)
+  rescue FreefeedClient::InvalidTokenError
+    # The one 401 that isn't a scope-lookup failure: FreeFeed raises this only
+    # for "inactive or expired token", so let it reach the handler that disables
+    # the token. A token merely lacking the scope answers 401 too, but as a
+    # plain UnauthorizedError — swallowed below, or it would take down every
+    # feed on a token that publishes perfectly well.
+    raise
   rescue FreefeedClient::Error => e
     Rails.error.report(e, context: { access_token_id: access_token.id })
     nil

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -7,9 +7,14 @@ class AccessTokenValidationService
 
   def call
     access_token.validating! unless access_token.validating?
+
+    # Scopes lead: FreeFeed always allows this route, so it answers for any live
+    # token and says up front whether the rest of the sequence can succeed.
+    scopes = fetch_scopes
+    return disable_for_missing_scope(scopes) unless scopes_cover_validation?(scopes)
+
     user_info = fetch_user_info
     managed_groups = fetch_managed_groups
-    scopes = fetch_scopes
 
     access_token.with_lock do
       access_token.update!(
@@ -32,8 +37,8 @@ class AccessTokenValidationService
       )
     end
   rescue FreefeedClient::UnauthorizedError, FreefeedClient::ForbiddenError
-    # A 401/403 on whoami or managedGroups means the token can't even read its
-    # own account, so it's effectively dead — disable it and its feeds.
+    # Reaching here means the token is dead rather than under-permissioned: the
+    # scope check above already sent that case down its own path.
     access_token.disable_token_and_feeds
   rescue RateLimit::Throttled
     # Throttling is control flow, not a validation failure: let it propagate so
@@ -49,6 +54,20 @@ class AccessTokenValidationService
 
   def freefeed_client
     @freefeed_client ||= access_token.build_client
+  end
+
+  # whoami and managedGroups both sit behind read-my-info. Without it they can
+  # only be refused, so there is nothing to learn from asking. Unknown scopes
+  # (nil) still go ahead — a session token reports none and can do everything.
+  def scopes_cover_validation?(scopes)
+    scopes.nil? || scopes.include?(AccessToken::READ_MY_INFO_SCOPE)
+  end
+
+  # Record the scopes on the way down: they're what lets the token page explain
+  # that the token is alive but can't be used, rather than calling it expired.
+  def disable_for_missing_scope(scopes)
+    access_token.update!(scopes: scopes)
+    access_token.disable_token_and_feeds(event_type: "access_token_missing_scope")
   end
 
   def fetch_user_info

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -57,9 +57,8 @@ class AccessTokenValidationService
   end
 
   # whoami and managedGroups both sit behind read-my-info. Without it they can
-  # only be refused, so there is nothing to learn from asking. Unknown scopes
-  # (nil) still go ahead, since a session token reports none and can do
-  # everything.
+  # only be refused, so there is nothing to learn from asking. nil means a
+  # session token, which is unrestricted.
   def scopes_cover_validation?(scopes)
     scopes.nil? || scopes.include?(AccessToken::READ_MY_INFO_SCOPE)
   end
@@ -79,21 +78,16 @@ class AccessTokenValidationService
     freefeed_client.managed_groups
   end
 
-  # A failure here must not sink an otherwise good validation. Falling back to
-  # nil reopens the gate, so callers attempt the call and handle any rejection.
-  # Keeping the previous list instead would gate wrongly once the token secret
-  # is replaced with one carrying different scopes.
+  # Errors are left to #call. A failure here means we don't know what the token
+  # can do, and guessing would either gate a capable token or clear the gate for
+  # one that can't. The route needs no scopes, so a 401 means the token is dead
+  # rather than under-permissioned, and anything else is transient: validation
+  # stays unfinished and the job retries.
+  #
+  # nil is a real answer, not a gap. It comes only from a session token, which
+  # FreeFeed rejects on this app-token-only route and which holds unrestricted
+  # access.
   def fetch_scopes
     freefeed_client.app_token_info&.fetch(:scopes)
-  rescue FreefeedClient::InvalidTokenError
-    # The one 401 that is not a scope-lookup failure. FreeFeed raises it only
-    # for "inactive or expired token", so let it reach the handler that disables
-    # the token. A token merely lacking the scope also answers 401, but as a
-    # plain UnauthorizedError. That one stays swallowed below, or it would take
-    # down every feed on a token that publishes perfectly well.
-    raise
-  rescue FreefeedClient::Error => e
-    Rails.error.report(e, context: { access_token_id: access_token.id })
-    nil
   end
 end

--- a/app/services/access_token_validation_service.rb
+++ b/app/services/access_token_validation_service.rb
@@ -9,12 +9,14 @@ class AccessTokenValidationService
     access_token.validating! unless access_token.validating?
     user_info = fetch_user_info
     managed_groups = fetch_managed_groups
+    scopes = fetch_scopes
 
     access_token.with_lock do
       access_token.update!(
         status: :active,
         owner: user_info[:username],
         freefeed_user_id: user_info[:id],
+        scopes: scopes,
         last_used_at: Time.current
       )
 
@@ -55,5 +57,16 @@ class AccessTokenValidationService
 
   def fetch_managed_groups
     freefeed_client.managed_groups
+  end
+
+  # Scopes only gate optional calls, never publishing, so a failure here must
+  # not sink an otherwise good validation. Falling back to nil re-opens the
+  # gate: callers attempt the call and handle the rejection, which beats
+  # gating on a stale list after the token secret was swapped for a new one.
+  def fetch_scopes
+    freefeed_client.app_token_info&.fetch(:scopes)
+  rescue FreefeedClient::Error => e
+    Rails.error.report(e, context: { access_token_id: access_token.id })
+    nil
   end
 end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -95,7 +95,7 @@
     <% end %>
   <% else %>
     <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive", key: "access_token.missing-identity-permission" }) do %>
-      <p>This token works, but it can't tell Feeder which FreeFeed account it belongs to — so there's no way to publish with it.</p>
+      <p>This token works, but it can't tell Feeder which FreeFeed account it belongs to, so there's no way to publish with it.</p>
       <p>
         A token's permissions are fixed when it's created, so this one can't be updated.
         <%= link_to "Create a new token", access_token.token_creation_url,

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -45,6 +45,20 @@
     <span>Token is valid and ready to use</span>
   <% end %>
 
+  <% unless access_token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE) %>
+    <%= render AlertComponent.new(variant: :warning, icon: "triangle-alert", data: { key: "access_token.missing-subscriber-permission" }) do %>
+      <p>This token can't look up subscriber counts, so feeds using it won't show how many people follow their group. Everything else works as usual.</p>
+      <p>
+        A token's permissions are fixed when it's created, so this one can't be updated.
+        <%= link_to "Create a new token", access_token.token_creation_url,
+                    target: "_blank",
+                    rel: "noopener",
+                    class: "font-medium underline underline-offset-4" %>
+        and <%= link_to "paste it here", edit_access_token_path(access_token), class: "font-medium underline underline-offset-4" %> to fix this.
+      </p>
+    <% end %>
+  <% end %>
+
   <% if feed_id.present? %>
     <%= link_to "Continue setting up your feed",
                 edit_feed_path(feed_id),

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -89,8 +89,22 @@
     </div>
   <% end %>
 <% elsif access_token.inactive? %>
-  <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive" }) do %>
-    <span>Token is inactive and cannot be used to access FreeFeed API. This token failed validation. It may be expired, revoked, or incorrectly copied.</span>
+  <% if access_token.allows_scope?(AccessToken::READ_MY_INFO_SCOPE) %>
+    <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive" }) do %>
+      <span>Token is inactive and cannot be used to access FreeFeed API. This token failed validation. It may be expired, revoked, or incorrectly copied.</span>
+    <% end %>
+  <% else %>
+    <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive", key: "access_token.missing-identity-permission" }) do %>
+      <p>This token works, but it can't tell Feeder which FreeFeed account it belongs to — so there's no way to publish with it.</p>
+      <p>
+        A token's permissions are fixed when it's created, so this one can't be updated.
+        <%= link_to "Create a new token", access_token.token_creation_url,
+                    target: "_blank",
+                    rel: "noopener",
+                    class: "font-medium underline underline-offset-4" %>
+        and <%= link_to "paste it here", edit_access_token_path(access_token), class: "font-medium underline underline-offset-4" %> to fix this.
+      </p>
+    <% end %>
   <% end %>
 
   <%= render TokenDetailsComponent.new(access_token: access_token) %>

--- a/config/event_icons.yml
+++ b/config/event_icons.yml
@@ -18,6 +18,7 @@ feed_auto_disabled: circle-pause
 ai_credential_deactivated: sparkles
 search_credential_deactivated: search
 access_token_validation_failed: key
+access_token_missing_scope: key
 email_changed: mail
 user_suspended: circle-pause
 user_unsuspended: circle-play

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,9 @@ en:
     access_token_validation_failed:
       name: "Token validation failed"
       description_html: "FreeFeed token stopped working; disabled %{feed_links}"
+    access_token_missing_scope:
+      name: "Token missing a permission"
+      description_html: "FreeFeed token is missing a permission Feeder needs; disabled %{feed_links}"
     group_purge_started:
       name: "Feed purge started"
       description_html: "Clearing out %{subject_link}"

--- a/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
+++ b/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
@@ -1,6 +1,6 @@
 class AddScopesToAccessTokens < ActiveRecord::Migration[8.0]
   def change
-    # Nullable with no default: NULL means "unknown"
+    # Nullable with no default: NULL means a session token, which is unrestricted
     add_column :access_tokens, :scopes, :string, array: true
   end
 end

--- a/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
+++ b/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
@@ -1,6 +1,17 @@
 class AddScopesToAccessTokens < ActiveRecord::Migration[8.0]
-  def change
-    # Nullable with no default: NULL means a session token, which is unrestricted
-    add_column :access_tokens, :scopes, :string, array: true
+  def up
+    add_column :access_tokens, :scopes, :string, array: true, null: false, default: []
+
+    # Existing tokens predate the column, so their real scopes are unknown until
+    # something re-reads them. Seed the set Feeder asks for: an empty list would
+    # gate every one of them, and disable them on their next validation.
+    execute <<~SQL
+      UPDATE access_tokens
+      SET scopes = ARRAY['read-my-info', 'read-users-info', 'manage-posts']::varchar[]
+    SQL
+  end
+
+  def down
+    remove_column :access_tokens, :scopes
   end
 end

--- a/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
+++ b/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
@@ -1,8 +1,6 @@
 class AddScopesToAccessTokens < ActiveRecord::Migration[8.0]
   def change
-    # Nullable with no default: NULL means "unknown" (validated before this
-    # column existed, or a session token, which has no scopes to speak of) and
-    # is deliberately distinct from an app token that holds none.
+    # Nullable with no default: NULL means "unknown"
     add_column :access_tokens, :scopes, :string, array: true
   end
 end

--- a/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
+++ b/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
@@ -1,0 +1,8 @@
+class AddScopesToAccessTokens < ActiveRecord::Migration[8.0]
+  def change
+    # Nullable with no default: NULL means "unknown" (validated before this
+    # column existed, or a session token, which has no scopes to speak of) and
+    # is deliberately distinct from an app token that holds none.
+    add_column :access_tokens, :scopes, :string, array: true
+  end
+end

--- a/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
+++ b/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
@@ -1,14 +1,18 @@
+# Existing tokens predate the column, so their real scopes are unknown until
+# something re-reads them. Seed the set Feeder asks for: an empty list would
+# gate every one of them, and disable them on their next validation.
+# 
+# execute <<~SQL
+#   UPDATE access_tokens
+#   SET scopes = ARRAY['read-my-info', 'read-users-info', 'manage-posts']::varchar[]
+# SQL
+# 
+# Alternatively re-validate each token record:
+# 
+# AccessToken.active.find_each { TokenValidationJob.perform_later(_1) }
 class AddScopesToAccessTokens < ActiveRecord::Migration[8.0]
   def up
     add_column :access_tokens, :scopes, :string, array: true, null: false, default: []
-
-    # Existing tokens predate the column, so their real scopes are unknown until
-    # something re-reads them. Seed the set Feeder asks for: an empty list would
-    # gate every one of them, and disable them on their next validation.
-    execute <<~SQL
-      UPDATE access_tokens
-      SET scopes = ARRAY['read-my-info', 'read-users-info', 'manage-posts']::varchar[]
-    SQL
   end
 
   def down

--- a/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
+++ b/db/migrate/20260822140000_add_scopes_to_access_tokens.rb
@@ -1,14 +1,14 @@
 # Existing tokens predate the column, so their real scopes are unknown until
 # something re-reads them. Seed the set Feeder asks for: an empty list would
 # gate every one of them, and disable them on their next validation.
-# 
+#
 # execute <<~SQL
 #   UPDATE access_tokens
 #   SET scopes = ARRAY['read-my-info', 'read-users-info', 'manage-posts']::varchar[]
 # SQL
-# 
+#
 # Alternatively re-validate each token record:
-# 
+#
 # AccessToken.active.find_each { TokenValidationJob.perform_later(_1) }
 class AddScopesToAccessTokens < ActiveRecord::Migration[8.0]
   def up

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,7 +38,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_22_140000) do
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false
     t.string "freefeed_user_id"
-    t.string "scopes", array: true
+    t.string "scopes", default: [], null: false, array: true
     t.index ["freefeed_user_id"], name: "index_access_tokens_on_freefeed_user_id"
     t.index ["user_id", "name"], name: "index_access_tokens_on_user_id_and_name", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_08_21_210000) do
+ActiveRecord::Schema[8.2].define(version: 2026_08_22_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_21_210000) do
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false
     t.string "freefeed_user_id"
+    t.string "scopes", array: true
     t.index ["freefeed_user_id"], name: "index_access_tokens_on_freefeed_user_id"
     t.index ["user_id", "name"], name: "index_access_tokens_on_user_id_and_name", unique: true
   end

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -11,6 +11,9 @@ class FreefeedClient
   # UnauthorizedError so callers don't mistake it for a dead token and disable it.
   class ForbiddenError < Error; end
   class NotFoundError < Error; end
+  # The server rejected the request itself (HTTP 400) — e.g. an app-token-only
+  # route called with a session token.
+  class BadRequestError < Error; end
   # The server rejected an upload for exceeding its size limit (HTTP 413).
   # The limit is server-configured, so callers detect it from the response
   # rather than pre-checking against a hardcoded size.
@@ -60,6 +63,20 @@ class FreefeedClient
     parse_managed_groups_response(response.body)
   rescue HttpClient::Error => e
     raise Error, "Failed to fetch managed groups: #{e.message}"
+  end
+
+  # Describe the app token this client authenticates with.
+  # FreeFeed always allows this route, so any live app token can read it
+  # regardless of the scopes it holds. Session tokens aren't app tokens and are
+  # rejected with 400 — they carry full access, reported here as nil.
+  # @return [Hash, nil] {scopes:, expires_at:}, or nil for a session token
+  def app_token_info
+    response = get("/v2/app-tokens/current")
+    parse_app_token_info_response(response.body)
+  rescue BadRequestError
+    nil
+  rescue HttpClient::Error => e
+    raise Error, "Failed to fetch app token info: #{e.message}"
   end
 
   # Create attachment
@@ -199,6 +216,8 @@ class FreefeedClient
       else
         raise UnauthorizedError, err || "Unauthorized"
       end
+    when 400
+      raise BadRequestError, parse_error(response) || "Bad request"
     when 404
       # Preserve the server's message ("Account '<name>' was not found") so the
       # caller can explain a vanished/renamed target group.
@@ -277,6 +296,22 @@ class FreefeedClient
         is_restricted: group["isRestricted"] == "1"
       }
     end
+  rescue JSON::ParserError => e
+    raise Error, "Invalid JSON response: #{e.message}"
+  end
+
+  def parse_app_token_info_response(body)
+    data = JSON.parse(body)
+    token = data["token"]
+
+    unless token.is_a?(Hash)
+      raise Error, "Invalid app token info response format"
+    end
+
+    {
+      scopes: Array(token["scopes"]),
+      expires_at: token["expiresAt"]
+    }
   rescue JSON::ParserError => e
     raise Error, "Invalid JSON response: #{e.message}"
   end

--- a/lib/freefeed_client.rb
+++ b/lib/freefeed_client.rb
@@ -11,8 +11,8 @@ class FreefeedClient
   # UnauthorizedError so callers don't mistake it for a dead token and disable it.
   class ForbiddenError < Error; end
   class NotFoundError < Error; end
-  # The server rejected the request itself (HTTP 400) — e.g. an app-token-only
-  # route called with a session token.
+  # Raised for HTTP 400. An app-token-only route answers this when it's called
+  # with a session token.
   class BadRequestError < Error; end
   # The server rejected an upload for exceeding its size limit (HTTP 413).
   # The limit is server-configured, so callers detect it from the response
@@ -65,10 +65,9 @@ class FreefeedClient
     raise Error, "Failed to fetch managed groups: #{e.message}"
   end
 
-  # Describe the app token this client authenticates with.
-  # FreeFeed always allows this route, so any live app token can read it
-  # regardless of the scopes it holds. Session tokens aren't app tokens and are
-  # rejected with 400 — they carry full access, reported here as nil.
+  # FreeFeed lists this route as always allowed, so it answers for any live app
+  # token whatever scopes that token holds. Session tokens are not app tokens
+  # and get a 400. They are unrestricted, so that case reports nil.
   # @return [Hash, nil] {scopes:, expires_at:}, or nil for a session token
   def app_token_info
     response = get("/v2/app-tokens/current")

--- a/test/controllers/access_tokens/validations_controller_test.rb
+++ b/test/controllers/access_tokens/validations_controller_test.rb
@@ -80,7 +80,7 @@ class AccessTokens::ValidationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show should show inactive state with data-status attribute" do
-    access_token.update!(status: :inactive)
+    access_token.update!(status: :inactive, scopes: AccessToken::TOKEN_SCOPES)
     sign_in_as user
     get access_token_validation_path(access_token)
 

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -117,16 +117,6 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='access_token.missing-subscriber-permission']", count: 0
   end
 
-  test "#show should not warn when the token's permissions are unknown" do
-    sign_in_as user
-    active = create(:access_token, :active, user: user, scopes: nil)
-
-    get access_token_path(active)
-
-    assert_response :success
-    assert_select "[data-key='access_token.missing-subscriber-permission']", count: 0
-  end
-
   test "#show should explain an inactive token that lacks the identity permission" do
     sign_in_as user
     token = create(:access_token, user: user, status: :inactive, scopes: ["manage-posts"])

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -94,6 +94,39 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     assert_select "header [role='menu']", count: 0
   end
 
+  test "#show should warn when the token can't look up subscriber counts" do
+    sign_in_as user
+    active = create(:access_token, :active, user: user, scopes: ["read-my-info", "manage-posts"])
+
+    get access_token_path(active)
+
+    assert_response :success
+    assert_select "[data-key='access_token.missing-subscriber-permission']" do
+      assert_select "a[href=?]", active.token_creation_url
+      assert_select "a[href=?]", edit_access_token_path(active)
+    end
+  end
+
+  test "#show should not warn when the token can look up subscriber counts" do
+    sign_in_as user
+    active = create(:access_token, :active, user: user, scopes: AccessToken::TOKEN_SCOPES)
+
+    get access_token_path(active)
+
+    assert_response :success
+    assert_select "[data-key='access_token.missing-subscriber-permission']", count: 0
+  end
+
+  test "#show should not warn when the token's permissions are unknown" do
+    sign_in_as user
+    active = create(:access_token, :active, user: user, scopes: nil)
+
+    get access_token_path(active)
+
+    assert_response :success
+    assert_select "[data-key='access_token.missing-subscriber-permission']", count: 0
+  end
+
   test "#show should render Associated Feeds section when token has feeds" do
     sign_in_as user
     active = create(:access_token, :active, user: user)

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -127,6 +127,30 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='access_token.missing-subscriber-permission']", count: 0
   end
 
+  test "#show should explain an inactive token that lacks the identity permission" do
+    sign_in_as user
+    token = create(:access_token, user: user, status: :inactive, scopes: ["manage-posts"])
+
+    get access_token_path(token)
+
+    assert_response :success
+    assert_select "[data-key='access_token.missing-identity-permission']" do
+      assert_select "a[href=?]", token.token_creation_url
+      assert_select "a[href=?]", edit_access_token_path(token)
+    end
+  end
+
+  test "#show should call an inactive token expired when it held the identity permission" do
+    sign_in_as user
+    token = create(:access_token, user: user, status: :inactive, scopes: AccessToken::TOKEN_SCOPES)
+
+    get access_token_path(token)
+
+    assert_response :success
+    assert_select "[data-key='access_token.missing-identity-permission']", count: 0
+    assert_select "[data-status='inactive']", text: /expired, revoked, or incorrectly copied/
+  end
+
   test "#show should render Associated Feeds section when token has feeds" do
     sign_in_as user
     active = create(:access_token, :active, user: user)

--- a/test/factories/access_tokens.rb
+++ b/test/factories/access_tokens.rb
@@ -20,6 +20,8 @@ FactoryBot.define do
       status { :active }
       owner { "testuser" }
       sequence(:freefeed_user_id) { |n| "ff-user-#{n}" }
+      # Validation records these, so an active token always carries them.
+      scopes { AccessToken::TOKEN_SCOPES }
     end
 
     trait :inactive do

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -9,13 +9,13 @@ class TokenValidationJobTest < ActiveJob::TestCase
     @access_token ||= create(:access_token, user: user)
   end
 
-  test ".perform_now should reserve two GETs and reschedule when throttled" do
+  test ".perform_now should reserve three GETs and reschedule when throttled" do
     subject = access_token.rate_limit_subject
 
     freeze_time do
-      # Leave one GET token — short of validation's cost of 2, so it throttles
-      # before either GET goes out.
-      drain_freefeed(subject, :get, remaining: 1)
+      # Leave two GET tokens — short of validation's cost of 3, so it throttles
+      # before any of the GETs goes out.
+      drain_freefeed(subject, :get, remaining: 2)
 
       assert_enqueued_with(job: TokenValidationJob) do
         TokenValidationJob.perform_now(access_token)
@@ -23,6 +23,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
     end
 
     assert_not_requested :get, "#{access_token.host}/v4/users/whoami"
+    assert_not_requested :get, "#{access_token.host}/v2/app-tokens/current"
   end
 
   test ".perform_now should reset token to pending when throttle retries are exhausted" do

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -146,6 +146,13 @@ class TokenValidationJobTest < ActiveJob::TestCase
         headers: { "Content-Type" => "application/json" }
       )
 
+    stub_request(:get, "https://custom.freefeed.com/v2/app-tokens/current")
+      .to_return(
+        status: 200,
+        body: { token: { id: "token-1", scopes: AccessToken::TOKEN_SCOPES } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
     TokenValidationJob.perform_now(custom_token)
 
     custom_token.reload
@@ -248,6 +255,13 @@ class TokenValidationJobTest < ActiveJob::TestCase
         headers: { "Content-Type" => "application/json" }
       )
 
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(
+        status: 200,
+        body: { token: { id: "token-1", scopes: AccessToken::TOKEN_SCOPES } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
     # First run raises — token stays validating
     assert_raises(StandardError) do
       TokenValidationJob.perform_now(access_token)
@@ -294,6 +308,13 @@ class TokenValidationJobTest < ActiveJob::TestCase
       .to_return(
         status: 200,
         body: [].to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(
+        status: 200,
+        body: { token: { id: "token-1", scopes: AccessToken::TOKEN_SCOPES } }.to_json,
         headers: { "Content-Type" => "application/json" }
       )
   end

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -46,6 +46,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should reschedule without failing when validation is throttled mid-call" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .to_return(status: 429, headers: { "Retry-After" => "30" })
 
@@ -84,6 +85,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should raise and not disable token on transient HTTP error" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .to_raise(StandardError.new("Connection failed"))
 
@@ -98,6 +100,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should raise and not disable token when JSON parsing fails" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -183,6 +186,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should raise and not disable token when response format is invalid" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -207,6 +211,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should raise and not disable token on timeout" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .to_timeout
 
@@ -229,6 +234,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
   end
 
   test ".perform_now should succeed on retry after transient failure" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .to_timeout.times(1)
       .then.to_return(
@@ -253,13 +259,6 @@ class TokenValidationJobTest < ActiveJob::TestCase
       .to_return(
         status: 200,
         body: [].to_json,
-        headers: { "Content-Type" => "application/json" }
-      )
-
-    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
-      .to_return(
-        status: 200,
-        body: { token: { id: "token-1", scopes: AccessToken::TOKEN_SCOPES } }.to_json,
         headers: { "Content-Type" => "application/json" }
       )
 
@@ -320,7 +319,17 @@ class TokenValidationJobTest < ActiveJob::TestCase
       )
   end
 
+  def stub_app_token_info(scopes: AccessToken::TOKEN_SCOPES)
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(
+        status: 200,
+        body: { token: { id: "token-1", scopes: scopes } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
   def stub_failed_freefeed_response
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {

--- a/test/jobs/token_validation_job_test.rb
+++ b/test/jobs/token_validation_job_test.rb
@@ -13,7 +13,7 @@ class TokenValidationJobTest < ActiveJob::TestCase
     subject = access_token.rate_limit_subject
 
     freeze_time do
-      # Leave two GET tokens — short of validation's cost of 3, so it throttles
+      # Two GET tokens is short of validation's cost of 3, so it throttles
       # before any of the GETs goes out.
       drain_freefeed(subject, :get, remaining: 2)
 

--- a/test/jobs/update_feed_subscribers_count_job_test.rb
+++ b/test/jobs/update_feed_subscribers_count_job_test.rb
@@ -39,6 +39,41 @@ class UpdateFeedSubscribersCountJobTest < ActiveJob::TestCase
     assert_not_requested :get, /\/v2\/users\//
   end
 
+  test "#perform should do nothing when the token lacks read-users-info" do
+    feed = feed_with_stale_count
+    feed.access_token.update!(scopes: ["read-my-info", "manage-posts"])
+
+    UpdateFeedSubscribersCountJob.perform_now(feed)
+
+    assert_not_requested :get, /\/v2\/users\//
+    assert_skipped_without_fallout(feed)
+  end
+
+  test "#perform should not spend rate-limit budget when the token lacks read-users-info" do
+    feed = create(:feed, :enabled)
+    feed.access_token.update!(scopes: ["manage-posts"])
+    subject = feed.access_token.rate_limit_subject
+
+    UpdateFeedSubscribersCountJob.perform_now(feed)
+
+    assert_equal RateLimit.capacity(:freefeed, :get), freefeed_tokens_left(subject, :get)
+  end
+
+  test "#perform should fetch the count when the token holds read-users-info" do
+    feed = create(:feed, :enabled)
+    feed.access_token.update!(scopes: AccessToken::TOKEN_SCOPES)
+    stub_request(:get, "#{feed.access_token.host}/v2/users/#{feed.target_group}/statistics")
+      .to_return(
+        status: 200,
+        body: { statistics: { subscribers: "42" } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    UpdateFeedSubscribersCountJob.perform_now(feed)
+
+    assert_equal 42, feed.reload.subscribers_count
+  end
+
   test "reschedules when the local rate limit is exhausted" do
     feed = create(:feed, :enabled)
     drain_freefeed(feed.access_token.rate_limit_subject, :get, remaining: 0)

--- a/test/jobs/update_feed_subscribers_counts_job_test.rb
+++ b/test/jobs/update_feed_subscribers_counts_job_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class UpdateFeedSubscribersCountsJobTest < ActiveJob::TestCase
+  def user
+    @user ||= create(:user)
+  end
+
+  def token_with_scopes(scopes)
+    create(:access_token, :active, user: user, scopes: scopes)
+  end
+
+  def enqueued_feeds
+    enqueued_jobs
+      .select { |job| job["job_class"] == "UpdateFeedSubscribersCountJob" }
+      .map { |job| ActiveJob::Arguments.deserialize(job["arguments"]).first }
+  end
+
+  test "#perform should enqueue a job per eligible feed" do
+    feed = create(:feed, :enabled, user: user, access_token: token_with_scopes(AccessToken::TOKEN_SCOPES))
+
+    UpdateFeedSubscribersCountsJob.perform_now
+
+    assert_equal [feed], enqueued_feeds
+  end
+
+  test "#perform should enqueue feeds on a token with unknown scopes" do
+    feed = create(:feed, :enabled, user: user, access_token: token_with_scopes(nil))
+
+    UpdateFeedSubscribersCountsJob.perform_now
+
+    assert_equal [feed], enqueued_feeds
+  end
+
+  test "#perform should skip feeds on a token without read-users-info" do
+    create(:feed, :enabled, user: user, access_token: token_with_scopes(["read-my-info", "manage-posts"]))
+
+    UpdateFeedSubscribersCountsJob.perform_now
+
+    assert_empty enqueued_feeds
+  end
+
+  test "#perform should skip feeds that are not enabled" do
+    create(:feed, :disabled, user: user, access_token: token_with_scopes(AccessToken::TOKEN_SCOPES))
+
+    UpdateFeedSubscribersCountsJob.perform_now
+
+    assert_empty enqueued_feeds
+  end
+
+  test "#perform should skip draft feeds" do
+    create(:feed, :draft, user: user, access_token: token_with_scopes(AccessToken::TOKEN_SCOPES))
+
+    UpdateFeedSubscribersCountsJob.perform_now
+
+    assert_empty enqueued_feeds
+  end
+end

--- a/test/jobs/update_feed_subscribers_counts_job_test.rb
+++ b/test/jobs/update_feed_subscribers_counts_job_test.rb
@@ -23,14 +23,6 @@ class UpdateFeedSubscribersCountsJobTest < ActiveJob::TestCase
     assert_equal [feed], enqueued_feeds
   end
 
-  test "#perform should enqueue feeds on a token with unknown scopes" do
-    feed = create(:feed, :enabled, user: user, access_token: token_with_scopes(nil))
-
-    UpdateFeedSubscribersCountsJob.perform_now
-
-    assert_equal [feed], enqueued_feeds
-  end
-
   test "#perform should skip feeds on a token without read-users-info" do
     create(:feed, :enabled, user: user, access_token: token_with_scopes(["read-my-info", "manage-posts"]))
 

--- a/test/lib/freefeed_client_test.rb
+++ b/test/lib/freefeed_client_test.rb
@@ -255,6 +255,98 @@ class FreefeedClientTest < ActiveSupport::TestCase
     assert_includes error.message, "Connection failed"
   end
 
+  # app_token_info method tests
+  test "#app_token_info should return scopes and expiry on success" do
+    response_body = {
+      "token" => {
+        "id" => "token-1",
+        "issue" => 1,
+        "scopes" => ["read-my-info", "read-users-info", "manage-posts"],
+        "expiresAt" => "2027-01-01T00:00:00.000Z"
+      }
+    }.to_json
+
+    stub_request(:get, "#{@host}/v2/app-tokens/current")
+      .with(
+        headers: {
+          "Authorization" => "Bearer #{@token}",
+          "Accept" => "application/json"
+        }
+      )
+      .to_return(status: 200, body: response_body)
+
+    result = @client.app_token_info
+
+    assert_equal ["read-my-info", "read-users-info", "manage-posts"], result[:scopes]
+    assert_equal "2027-01-01T00:00:00.000Z", result[:expires_at]
+  end
+
+  test "#app_token_info should report an empty scope list as such" do
+    stub_request(:get, "#{@host}/v2/app-tokens/current")
+      .to_return(status: 200, body: { "token" => { "id" => "token-1", "scopes" => [] } }.to_json)
+
+    assert_equal [], @client.app_token_info[:scopes]
+  end
+
+  test "#app_token_info should treat a missing scopes key as no scopes" do
+    stub_request(:get, "#{@host}/v2/app-tokens/current")
+      .to_return(status: 200, body: { "token" => { "id" => "token-1" } }.to_json)
+
+    result = @client.app_token_info
+
+    assert_equal [], result[:scopes]
+    assert_nil result[:expires_at]
+  end
+
+  test "#app_token_info should return nil for a session token" do
+    stub_request(:get, "#{@host}/v2/app-tokens/current")
+      .to_return(
+        status: 400,
+        body: { err: "This method is only available with the application token" }.to_json
+      )
+
+    assert_nil @client.app_token_info
+  end
+
+  test "#app_token_info should raise InvalidTokenError on a dead token" do
+    stub_request(:get, "#{@host}/v2/app-tokens/current")
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
+
+    assert_raises(FreefeedClient::InvalidTokenError) do
+      @client.app_token_info
+    end
+  end
+
+  test "#app_token_info should raise Error on invalid JSON" do
+    stub_request(:get, "#{@host}/v2/app-tokens/current")
+      .to_return(status: 200, body: "invalid json")
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.app_token_info
+    end
+    assert_includes error.message, "Invalid JSON response"
+  end
+
+  test "#app_token_info should raise Error on an unexpected response shape" do
+    stub_request(:get, "#{@host}/v2/app-tokens/current")
+      .to_return(status: 200, body: '{"invalid": "format"}')
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.app_token_info
+    end
+    assert_includes error.message, "Invalid app token info response format"
+  end
+
+  test "#app_token_info should raise Error on HTTP client errors" do
+    stub_request(:get, "#{@host}/v2/app-tokens/current")
+      .to_raise(HttpClient::ConnectionError.new("Connection failed"))
+
+    error = assert_raises(FreefeedClient::Error) do
+      @client.app_token_info
+    end
+    assert_includes error.message, "Failed to fetch app token info"
+  end
+
   # Edge cases
   test "handles empty managed groups response" do
     stub_request(:get, "#{@host}/v4/managedGroups")

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -419,4 +419,51 @@ class AccessTokenTest < ActiveSupport::TestCase
 
     assert_nil token.group_url("testgroup")
   end
+
+  test "#allows_scope? should be true when the token holds the scope" do
+    token = build(:access_token, scopes: AccessToken::TOKEN_SCOPES)
+
+    assert token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
+  end
+
+  test "#allows_scope? should be false when the token lacks the scope" do
+    token = build(:access_token, scopes: ["read-my-info", "manage-posts"])
+
+    assert_not token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
+  end
+
+  test "#allows_scope? should be false for a token with no scopes at all" do
+    token = build(:access_token, scopes: [])
+
+    assert_not token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
+  end
+
+  test "#allows_scope? should be true when scopes are unknown" do
+    token = build(:access_token, scopes: nil)
+
+    assert token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
+  end
+
+  test ".allowing_scope should match the tokens #allows_scope? accepts" do
+    granted = create(:access_token, scopes: AccessToken::TOKEN_SCOPES)
+    unknown = create(:access_token, scopes: nil)
+    lacking = create(:access_token, scopes: ["read-my-info", "manage-posts"])
+    empty = create(:access_token, scopes: [])
+
+    matched = AccessToken.allowing_scope(AccessToken::READ_USERS_INFO_SCOPE)
+
+    assert_includes matched, granted
+    assert_includes matched, unknown
+    assert_not_includes matched, lacking
+    assert_not_includes matched, empty
+  end
+
+  test "#token_creation_url should request every scope on the token's own instance" do
+    token = build(:access_token, host: "https://candy.freefeed.net")
+
+    assert_equal AccessToken.token_url("candy.freefeed.net"), token.token_creation_url
+    AccessToken::TOKEN_SCOPES.each do |scope|
+      assert_includes token.token_creation_url, scope
+    end
+  end
 end

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -441,24 +441,23 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert_not token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
   end
 
-  test "#allows_scope? should be true when scopes are unknown" do
-    token = build(:access_token, scopes: nil)
-
-    assert token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
+  test "#allows_scope? should default to no scopes" do
+    assert_equal [], build(:access_token).scopes
   end
 
   test ".allowing_scope should match the tokens #allows_scope? accepts" do
     granted = create(:access_token, scopes: AccessToken::TOKEN_SCOPES)
-    unknown = create(:access_token, scopes: nil)
-    lacking = create(:access_token, scopes: ["read-my-info", "manage-posts"])
+    lacking = create(:access_token, scopes: [AccessToken::READ_MY_INFO_SCOPE, AccessToken::MANAGE_POSTS_SCOPE])
     empty = create(:access_token, scopes: [])
 
     matched = AccessToken.allowing_scope(AccessToken::READ_USERS_INFO_SCOPE)
 
     assert_includes matched, granted
-    assert_includes matched, unknown
     assert_not_includes matched, lacking
     assert_not_includes matched, empty
+    [granted, lacking, empty].each do |token|
+      assert_equal matched.include?(token), token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
+    end
   end
 
   test "#token_creation_url should request every scope on the token's own instance" do

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -296,6 +296,9 @@ class AccessTokenTest < ActiveSupport::TestCase
     disabled_feed = create(:feed, user: user, access_token: access_token, state: :disabled)
     access_token.update!(status: :validating)
 
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(status: 200, body: { token: { id: "t", scopes: AccessToken::TOKEN_SCOPES } }.to_json)
+
     # Stub HTTP request to return 401 Unauthorized, triggering the rescue block
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(

--- a/test/services/access_token_validation_service_test.rb
+++ b/test/services/access_token_validation_service_test.rb
@@ -9,6 +9,18 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     @access_token ||= create(:access_token, user: user, status: :validating)
   end
 
+  def stub_app_token_info(scopes: AccessToken::TOKEN_SCOPES)
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(status: 200, body: { token: { id: "token-1", scopes: scopes } }.to_json)
+  end
+
+  def stub_successful_account_calls
+    stub_request(:get, "#{access_token.host}/v4/users/whoami")
+      .to_return(status: 200, body: { users: { id: "user123", username: "testuser" } }.to_json)
+    stub_request(:get, "#{access_token.host}/v4/managedGroups")
+      .to_return(status: 200, body: [].to_json)
+  end
+
   test "#call should activate token on successful validation" do
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
@@ -44,12 +56,15 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
         ].to_json
       )
 
+    stub_app_token_info
+
     service = AccessTokenValidationService.new(access_token)
     service.call
 
     assert_equal "active", access_token.reload.status
     assert_equal "testuser", access_token.owner
     assert_equal "user123", access_token.freefeed_user_id
+    assert_equal AccessToken::TOKEN_SCOPES, access_token.scopes
     assert_not_nil access_token.last_used_at
   end
 
@@ -86,6 +101,8 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
           { id: "group1", username: "group1", screenName: "Group 1" }
         ].to_json
       )
+
+    stub_app_token_info
 
     service = AccessTokenValidationService.new(access_token)
     assert_nil access_token.access_token_detail
@@ -133,6 +150,8 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
         body: [].to_json
       )
 
+    stub_app_token_info
+
     service = AccessTokenValidationService.new(access_token)
     service.call
 
@@ -149,6 +168,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
       .to_return(status: 200, body: { users: { id: "user123", username: "testuser" } }.to_json)
     stub_request(:get, "#{access_token.host}/v4/managedGroups")
       .to_return(status: 200, body: [].to_json)
+    stub_app_token_info
 
     AccessTokenValidationService.new(access_token).call
 
@@ -165,10 +185,60 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
       .to_return(status: 200, body: { users: { id: "user123", username: "testuser" } }.to_json)
     stub_request(:get, "#{access_token.host}/v4/managedGroups")
       .to_return(status: 200, body: [].to_json)
+    stub_app_token_info
 
     AccessTokenValidationService.new(access_token).call
 
     assert_not detail.reload.groups_refresh_failed?
+  end
+
+  test "#call should persist a partial scope list" do
+    stub_successful_account_calls
+    stub_app_token_info(scopes: ["read-my-info", "manage-posts"])
+
+    AccessTokenValidationService.new(access_token).call
+
+    assert_equal ["read-my-info", "manage-posts"], access_token.reload.scopes
+    assert_not access_token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
+  end
+
+  test "#call should leave scopes unknown for a session token" do
+    stub_successful_account_calls
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(
+        status: 400,
+        body: { err: "This method is only available with the application token" }.to_json
+      )
+
+    AccessTokenValidationService.new(access_token).call
+
+    access_token.reload
+    assert access_token.active?
+    assert_nil access_token.scopes
+    assert access_token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
+  end
+
+  test "#call should activate the token when the scopes request fails" do
+    stub_successful_account_calls
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    AccessTokenValidationService.new(access_token).call
+
+    access_token.reload
+    assert access_token.active?
+    assert_nil access_token.scopes
+  end
+
+  test "#call should reopen the gate when a revalidation can't read scopes" do
+    access_token.update!(scopes: ["read-my-info"])
+    stub_successful_account_calls
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    AccessTokenValidationService.new(access_token).call
+
+    assert_nil access_token.reload.scopes
   end
 
   test "#call should deactivate token on invalid token error" do

--- a/test/services/access_token_validation_service_test.rb
+++ b/test/services/access_token_validation_service_test.rb
@@ -230,6 +230,54 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     assert_nil access_token.scopes
   end
 
+  test "#call should skip the account calls when the token lacks read-my-info" do
+    stub_app_token_info(scopes: ["manage-posts"])
+
+    AccessTokenValidationService.new(access_token).call
+
+    assert_not_requested :get, "#{access_token.host}/v4/users/whoami"
+    assert_not_requested :get, "#{access_token.host}/v4/managedGroups"
+  end
+
+  test "#call should record the scopes it disabled an under-permissioned token for" do
+    stub_app_token_info(scopes: ["manage-posts"])
+
+    AccessTokenValidationService.new(access_token).call
+
+    access_token.reload
+    assert access_token.inactive?
+    assert_equal ["manage-posts"], access_token.scopes
+    assert_not access_token.allows_scope?(AccessToken::READ_MY_INFO_SCOPE)
+  end
+
+  test "#call should report a missing identity permission as its own event" do
+    access_token.update!(status: :active)
+    feed = create(:feed, user: user, access_token: access_token, state: :enabled)
+    access_token.update!(status: :validating)
+    stub_app_token_info(scopes: ["manage-posts"])
+
+    AccessTokenValidationService.new(access_token).call
+
+    assert_equal "disabled", feed.reload.state
+    event = Event.find_by!(subject: access_token)
+    assert_equal "access_token_missing_scope", event.type
+    assert_equal [feed.id], event.metadata["disabled_feed_ids"]
+  end
+
+  test "#call should still validate a token whose scopes are unknown" do
+    stub_successful_account_calls
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(
+        status: 400,
+        body: { err: "This method is only available with the application token" }.to_json
+      )
+
+    AccessTokenValidationService.new(access_token).call
+
+    assert access_token.reload.active?
+    assert_requested :get, "#{access_token.host}/v4/users/whoami"
+  end
+
   test "#call should disable the token when the scopes request reports it dead" do
     access_token.update!(status: :active)
     feed = create(:feed, user: user, access_token: access_token, state: :enabled)
@@ -268,6 +316,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
   end
 
   test "#call should deactivate token on invalid token error" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -284,6 +333,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
   end
 
   test "#call should deactivate token on forbidden error" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .to_return(status: 403, body: { err: "invalid JWT payload format" }.to_json)
 
@@ -294,6 +344,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
   end
 
   test "#call should not disable token on transient errors" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -321,6 +372,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     feed3 = create(:feed, user: user, access_token: access_token, state: :disabled)
     access_token.update!(status: :validating)
 
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -354,6 +406,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
   test "#call should not create event when no enabled feeds exist" do
     create(:feed, user: user, access_token: access_token, state: :disabled)
 
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {
@@ -373,6 +426,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
   end
 
   test "#call should deactivate token when managed_groups returns invalid token error" do
+    stub_app_token_info
     stub_request(:get, "#{access_token.host}/v4/users/whoami")
       .with(
         headers: {

--- a/test/services/access_token_validation_service_test.rb
+++ b/test/services/access_token_validation_service_test.rb
@@ -230,6 +230,32 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     assert_nil access_token.scopes
   end
 
+  test "#call should disable the token when the scopes request reports it dead" do
+    access_token.update!(status: :active)
+    feed = create(:feed, user: user, access_token: access_token, state: :enabled)
+    access_token.update!(status: :validating)
+    stub_successful_account_calls
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(status: 401, body: { err: "inactive or expired token" }.to_json)
+
+    AccessTokenValidationService.new(access_token).call
+
+    assert access_token.reload.inactive?
+    assert_equal "disabled", feed.reload.state
+  end
+
+  test "#call should keep the token active when it just can't read its own scopes" do
+    stub_successful_account_calls
+    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
+      .to_return(status: 401, body: { err: "token has no access to this API method" }.to_json)
+
+    AccessTokenValidationService.new(access_token).call
+
+    access_token.reload
+    assert access_token.active?
+    assert_nil access_token.scopes
+  end
+
   test "#call should reopen the gate when a revalidation can't read scopes" do
     access_token.update!(scopes: ["read-my-info"])
     stub_successful_account_calls

--- a/test/services/access_token_validation_service_test.rb
+++ b/test/services/access_token_validation_service_test.rb
@@ -202,7 +202,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     assert_not access_token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
   end
 
-  test "#call should leave scopes unknown for a session token" do
+  test "#call should record a session token as unrestricted" do
     stub_successful_account_calls
     stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
       .to_return(
@@ -218,16 +218,18 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     assert access_token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
   end
 
-  test "#call should activate the token when the scopes request fails" do
+  test "#call should leave validation unfinished when the scopes request fails" do
     stub_successful_account_calls
     stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
       .to_return(status: 500, body: "Internal Server Error")
 
-    AccessTokenValidationService.new(access_token).call
+    assert_raises(FreefeedClient::Error) do
+      AccessTokenValidationService.new(access_token).call
+    end
 
     access_token.reload
-    assert access_token.active?
-    assert_nil access_token.scopes
+    assert access_token.validating?, "the job retries; the token must not settle"
+    assert_not_requested :get, "#{access_token.host}/v4/users/whoami"
   end
 
   test "#call should skip the account calls when the token lacks read-my-info" do
@@ -292,27 +294,17 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
     assert_equal "disabled", feed.reload.state
   end
 
-  test "#call should keep the token active when it just can't read its own scopes" do
-    stub_successful_account_calls
-    stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
-      .to_return(status: 401, body: { err: "token has no access to this API method" }.to_json)
-
-    AccessTokenValidationService.new(access_token).call
-
-    access_token.reload
-    assert access_token.active?
-    assert_nil access_token.scopes
-  end
-
-  test "#call should reopen the gate when a revalidation can't read scopes" do
-    access_token.update!(scopes: ["read-my-info"])
+  test "#call should keep the recorded scopes when a revalidation can't read them" do
+    access_token.update!(scopes: [AccessToken::READ_MY_INFO_SCOPE])
     stub_successful_account_calls
     stub_request(:get, "#{access_token.host}/v2/app-tokens/current")
       .to_return(status: 500, body: "Internal Server Error")
 
-    AccessTokenValidationService.new(access_token).call
+    assert_raises(FreefeedClient::Error) do
+      AccessTokenValidationService.new(access_token).call
+    end
 
-    assert_nil access_token.reload.scopes
+    assert_equal [AccessToken::READ_MY_INFO_SCOPE], access_token.reload.scopes
   end
 
   test "#call should deactivate token on invalid token error" do

--- a/test/services/access_token_validation_service_test.rb
+++ b/test/services/access_token_validation_service_test.rb
@@ -214,7 +214,7 @@ class AccessTokenValidationServiceTest < ActiveSupport::TestCase
 
     access_token.reload
     assert access_token.active?
-    assert_nil access_token.scopes
+    assert_equal AccessToken::TOKEN_SCOPES, access_token.scopes
     assert access_token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE)
   end
 


### PR DESCRIPTION
Changes:

- Record an app token's scopes in a new `access_tokens.scopes` column, read once at validation
- Validate scopes first, and skip the calls that cannot succeed without them
- Skip the daily subscriber count fetch for feeds whose token lacks `read-users-info`
- Say when a token is missing a permission Feeder needs, instead of reporting it as expired

FreeFeed fixes an app token's scopes when it issues the token and offers no way to widen them later. That makes a missing scope permanent, so a call the token cannot make will fail on every future attempt. The daily subscriber count job was making one such call per feed, forever.

`GET /v2/app-tokens/current` is one of FreeFeed's always-allowed routes, so it answers for any live token whatever scopes it holds. That makes it safe to ask first. `whoami` and `managedGroups` both sit behind `read-my-info`, so without that scope there is nothing to validate and the calls are skipped.

The column is `NOT NULL` with an empty default, so it always holds a real list and never needs reading alongside `status`. A session token has no scope list to report and is unrestricted, so it records everything Feeder asks for. `AccessToken#allows_scope?` and the `allowing_scope` SQL scope both test membership, and have to stay in step.

A failed lookup is not recorded at all. Validation stays unfinished and the job retries, rather than writing a guess.

Deploying: existing rows are seeded with the scopes Feeder asks for, since an empty list would gate every one of them and disable them on their next validation. Replace the seeds with the real ones from a console:

```ruby
AccessToken.active.find_each do |token|
  token.update!(scopes: token.build_client.app_token_info&.fetch(:scopes) || AccessToken::TOKEN_SCOPES)
  sleep 1
rescue StandardError => e
  warn "#{token.id} #{token.owner}: #{e.class}: #{e.message}"
end
```

References:

- Closes #1291
- Related PR: #1285
- Related PR: #1266