### PR TITLE
Opt into RubyLLM's new acts_as API

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,15 @@ Bundler.require(*Rails.groups)
 # (see test/test_helper.rb).
 require_relative "../lib/boot/config"
 
+# RubyLLM reads this when ActiveRecord loads, which happens before
+# config/initializers run — hence the placement here. It opts into the
+# association-based acts_as API that replaces the legacy one in RubyLLM 2.0.
+# This app talks to the SDK directly and has no acts_as models, so the flag
+# only silences the legacy deprecation warning.
+RubyLLM.configure do |config|
+  config.use_new_acts_as = true
+end
+
 module F2Rails
   GITHUB_REPO_URL = "https://github.com/dreikanter/f2".freeze
 


### PR DESCRIPTION
Changes:

- Opt into RubyLLM's new `acts_as` API so the legacy deprecation warning stops firing on every boot

RubyLLM warns that the legacy `acts_as` API is deprecated and goes away in 2.0. The warning fires whenever `use_new_acts_as` is unset, regardless of whether an app uses the Rails integration at all — this one doesn't, it drives the SDK directly through `LlmClient`.

The flag lives in `application.rb` rather than an initializer because RubyLLM reads it when ActiveRecord loads, which happens before initializers run. No migration is needed here: the v1.7 generator exists to move `acts_as` models onto the DB-backed model registry, and there are no such models in this app.
