### PR TITLE
Fail fast on empty deploy secrets

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,13 +52,30 @@ jobs:
 
       - name: Configure SSH
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_PRODUCTION }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan app-origin.fffeeder.com >> ~/.ssh/known_hosts
+
+          # net-ssh, which Kamal uses, silently skips a key it cannot load and
+          # falls back to password auth, failing far from the cause.
+          if ! ssh-keygen -y -f ~/.ssh/id_ed25519 </dev/null >/dev/null 2>&1; then
+            echo "::error::SSH_PRIVATE_KEY_PRODUCTION is not a usable private key: either malformed, or passphrase-protected (CI has no way to supply a passphrase)."
+            exit 1
+          fi
+
+          echo "Deploy key: $(ssh-keygen -y -f ~/.ssh/id_ed25519 | ssh-keygen -lf -)"
+
+          # BatchMode blocks that fallback, so a refused key reports as an auth
+          # failure rather than a prompt against a runner with no TTY.
+          if ! ssh -o BatchMode=yes -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 \
+                   root@app-origin.fffeeder.com true; then
+            echo "::error::app-origin.fffeeder.com rejected the deploy key. Compare the fingerprint above against 'ssh-keygen -lf ~/.ssh/authorized_keys' on the host."
+            exit 1
+          fi
 
       - name: Write Rails master key
         env:

--- a/.kamal/hooks/pre-connect
+++ b/.kamal/hooks/pre-connect
@@ -26,9 +26,11 @@ fail() {
   exit 1
 }
 
-# Both markers must stand on lines of their own, which is what separates a real
-# PEM from a one-line blob whose newlines were escaped away. Trailing whitespace
-# is tolerated so CRLF values still pass, as they do in kamal-proxy.
+# Structure first. This alone catches the realistic failure — an unset variable
+# resolving to an empty secret — and needs no tooling. Both markers must stand on
+# lines of their own, which is what separates a real PEM from a one-line blob
+# whose newlines were escaped away. Trailing whitespace is tolerated so CRLF
+# values still pass, as they do in kamal-proxy.
 pem_ok() {
   printf '%s\n' "$1" | grep -q "^-----BEGIN $2-----[[:space:]]*\$" &&
     printf '%s\n' "$1" | grep -q "^-----END $2-----[[:space:]]*\$"
@@ -39,3 +41,20 @@ pem_ok "$CERTIFICATE_PEM" "CERTIFICATE" ||
 
 pem_ok "$PRIVATE_KEY_PEM" "[A-Z ]*PRIVATE KEY" ||
   fail "PRIVATE_KEY_PEM is not a PEM private key: export CF_ORIGIN_KEY with the multi-line key itself, not a path or an escaped one-liner."
+
+# Then the contents. Well-formed wrappers around corrupt DER, and a cert and key
+# that don't belong together, both reach kamal-proxy and fail there just as
+# opaquely. Skipped rather than fatal without openssl: this is a tripwire, and
+# the structural check above already covers the common case.
+command -v openssl >/dev/null 2>&1 || exit 0
+
+cert_pubkey=$(printf '%s\n' "$CERTIFICATE_PEM" | openssl x509 -noout -pubkey 2>/dev/null)
+[ -n "$cert_pubkey" ] ||
+  fail "CERTIFICATE_PEM has PEM markers but openssl cannot read a certificate between them."
+
+key_pubkey=$(printf '%s\n' "$PRIVATE_KEY_PEM" | openssl pkey -pubout 2>/dev/null)
+[ -n "$key_pubkey" ] ||
+  fail "PRIVATE_KEY_PEM has PEM markers but openssl cannot read a private key between them."
+
+[ "$cert_pubkey" = "$key_pubkey" ] ||
+  fail "CERTIFICATE_PEM and PRIVATE_KEY_PEM are from different pairs: kamal-proxy needs the key that Cloudflare issued with this certificate."

--- a/.kamal/hooks/pre-connect
+++ b/.kamal/hooks/pre-connect
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Fail fast when the kamal-proxy TLS certificate secrets are missing or malformed.
+#
+# Kamal evaluates each `$(...)` in .kamal/secrets* with backticks and ignores the
+# exit status, so the `|| { echo ...; exit 1; }` guards there cannot abort a
+# deploy — they just yield an empty secret. Kamal then uploads an empty cert.pem
+# and the run dies minutes later inside kamal-proxy with nothing but
+# "Error: unable to load certificate". A failing hook does abort, so check here.
+#
+# Secrets are exported into the hook environment, so this sees the values exactly
+# as kamal-proxy will receive them. printf, not echo: dash's echo expands \n, which
+# would let a one-line blob with escaped newlines pass as a valid PEM.
+
+# Only the f2 app serves a custom certificate. imgproxy shares this hooks
+# directory and uses Let's Encrypt, so it has no such secrets.
+[ "$KAMAL_SERVICE" = "f2" ] || exit 0
+
+case "$KAMAL_COMMAND" in
+  setup | deploy | redeploy | rollback) ;;
+  *) exit 0 ;;
+esac
+
+fail() {
+  echo "$1 See docs/deployment-setup.md." >&2
+  exit 1
+}
+
+# Both markers must stand on lines of their own, which is what separates a real
+# PEM from a one-line blob whose newlines were escaped away. Trailing whitespace
+# is tolerated so CRLF values still pass, as they do in kamal-proxy.
+pem_ok() {
+  printf '%s\n' "$1" | grep -q "^-----BEGIN $2-----[[:space:]]*\$" &&
+    printf '%s\n' "$1" | grep -q "^-----END $2-----[[:space:]]*\$"
+}
+
+pem_ok "$CERTIFICATE_PEM" "CERTIFICATE" ||
+  fail "CERTIFICATE_PEM is not a PEM certificate: export CF_ORIGIN_CERT with the multi-line certificate itself, not a path or an escaped one-liner."
+
+pem_ok "$PRIVATE_KEY_PEM" "[A-Z ]*PRIVATE KEY" ||
+  fail "PRIVATE_KEY_PEM is not a PEM private key: export CF_ORIGIN_KEY with the multi-line key itself, not a path or an escaped one-liner."

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -203,6 +203,10 @@ config/credentials/production.key
 
 The `.key` files are gitignored. Store and share them through the team password manager.
 
+`.kamal/hooks/pre-connect` checks that `CERTIFICATE_PEM` and `PRIVATE_KEY_PEM`
+resolved to real PEM blobs before a `setup`, `deploy`, `redeploy`, or `rollback`
+starts, so a missing export fails in seconds instead of minutes into the run.
+
 ## Deploying from GitHub Actions
 
 Both destinations can be deployed from the Actions tab. **Deploy Staging** also
@@ -371,52 +375,45 @@ INFO First web container is unhealthy on app-origin.fffeeder.com, not booting an
 ERROR (SSHKit::Command::Failed): docker stderr: Error: unable to load certificate
 ```
 
-The container is fine — this is the `kamal-proxy deploy` step failing after the
-health check passes, so the app never gets registered for its host and the
-public domain serves kamal-proxy's own blue 404 page. (Ours is white; a blue
-404 means no target is registered.)
+The container is fine. This is `kamal-proxy deploy` failing *after* the health
+check passes, so the app never gets registered for its host and the public
+domain serves kamal-proxy's own blue 404 page. (Ours is white — a blue 404
+means no target is registered.)
 
 kamal-proxy collapses every certificate problem into that one message, but logs
-the real reason inside its own container:
+the real reason in its own container:
 
 ```bash
 bin/kamal proxy logs -d production --grep "TLS certificate"
 ```
 
-That prints, for example, `open /home/kamal-proxy/.apps-config/...: permission
-denied` or `tls: private key does not match public key`. Causes, in the order
-worth checking:
+| Logged error | Cause |
+| --- | --- |
+| `failed to find any PEM data in certificate input` | `cert.pem` is empty or isn't PEM |
+| `...did find a private key; PEM inputs may have been switched` | cert and key are swapped |
+| `private key does not match public key` | cert and key are from different pairs |
+| `no such file or directory` / `permission denied` | the proxy can't read the uploaded file |
 
-1. **`CERTIFICATE_PEM` and `PRIVATE_KEY_PEM` are not the same pair.** Cloudflare
-   shows the private key only once, and offers both RSA and ECC keys, so it's
-   easy to end up with a cert from one and a key from another. Verify before
-   deploying:
+Check what actually landed on the host, and what the proxy sees through its
+mount:
 
-   ```bash
-   diff <(openssl x509 -noout -pubkey <<<"$CF_ORIGIN_CERT") \
-        <(openssl pkey -pubout <<<"$CF_ORIGIN_KEY") && echo "pair matches"
-   ```
+```bash
+ssh root@app-origin.fffeeder.com \
+  'wc -c /root/.kamal/proxy/apps-config/f2-production/tls/web/*.pem'
+ssh root@app-origin.fffeeder.com \
+  'docker exec kamal-proxy ls -l /home/kamal-proxy/.apps-config/f2-production/tls/web/'
+```
 
-2. **The PEM lost its line breaks.** `printenv CF_ORIGIN_CERT | head -1` must be
-   exactly `-----BEGIN CERTIFICATE-----`, and the value must span many lines. A
-   one-line blob with literal `\n` is not a PEM. (A *missing trailing* newline
-   is fine.)
+A zero-byte `cert.pem` means `CF_ORIGIN_CERT` was empty in the shell that ran
+the deploy. The `|| { echo ...; exit 1; }` guards in `.kamal/secrets*` do **not**
+prevent this: Kamal evaluates each `$(...)` with backticks and ignores the exit
+status, so a failed guard yields an empty secret and the deploy carries on,
+uploading an empty certificate. `.kamal/hooks/pre-connect` now catches that
+before the build starts. If the host has the files but the container doesn't,
+the proxy is missing its apps-config mount — `bin/kamal proxy reboot -d production`.
 
-3. **kamal-proxy can't see the files.** Kamal uploads them to the host and
-   points the proxy at the mounted copy:
-
-   ```bash
-   ssh root@app-origin.fffeeder.com \
-     'ls -l /root/.kamal/proxy/apps-config/f2-production/tls/web/'
-   ssh root@app-origin.fffeeder.com \
-     'docker exec kamal-proxy ls -l /home/kamal-proxy/.apps-config/f2-production/tls/web/'
-   ```
-
-   If the host has them but the container doesn't, the proxy is missing the
-   apps-config mount: `bin/kamal proxy reboot -d production`.
-
-Fix the cert, then re-run `bin/kamal deploy -d production`. Accessories and the
-database survive the failed run, so a full `setup` isn't needed.
+Fix the secrets, then re-run `bin/kamal deploy -d production`. Accessories and
+the database survive the failed run, so a full `setup` isn't needed.
 
 ## Useful commands
 

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -225,13 +225,12 @@ The workflows read these repository secrets. Per-environment values carry a
 | `RAILS_MASTER_KEY_STAGING` | staging | written to `config/credentials/staging.key` |
 | `RAILS_MASTER_KEY_PRODUCTION` | production | written to `config/credentials/production.key` |
 | `SSH_PRIVATE_KEY_STAGING` | staging | SSH key for `dev-origin.fffeeder.com` |
-| `PRODUCTION_SSH_PRIVATE_KEY` | production | SSH key for `app-origin.fffeeder.com` |
+| `SSH_PRIVATE_KEY_PRODUCTION` | production | SSH key for `app-origin.fffeeder.com` |
 | `CF_ORIGIN_CERT` / `CF_ORIGIN_KEY` | both | Cloudflare Origin Certificate for kamal-proxy |
 
-`PRODUCTION_SSH_PRIVATE_KEY` is the one holdout from the convention. It keeps
-the old prefix form until the renamed secret exists, so don't create
-`SSH_PRIVATE_KEY_PRODUCTION` and expect the production workflow to pick it up —
-rename the workflow reference and the secret together.
+Both SSH secrets now follow the `_STAGING` / `_PRODUCTION` convention. The old
+prefix-form names (`STAGING_SSH_PRIVATE_KEY`, `PRODUCTION_SSH_PRIVATE_KEY`) are
+no longer read by any workflow and can be deleted from the repository secrets.
 
 ## Database
 

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -361,6 +361,62 @@ Common issues:
 - PostgreSQL 18 complains about `/var/lib/postgresql/data` — recreate the accessory after pulling the config that mounts `data:/var/lib/postgresql`.
 - `/up` returns `403` with `Blocked hosts` — Rails host authorization is blocking the health check; `/up` should be excluded in production config.
 - platform mismatch — confirm the server is `x86_64` and `builder.arch` is `amd64`.
+- `unable to load certificate` — see below.
+
+### `unable to load certificate`
+
+```text
+ERROR Failed to boot web on app-origin.fffeeder.com
+INFO First web container is unhealthy on app-origin.fffeeder.com, not booting any other roles
+ERROR (SSHKit::Command::Failed): docker stderr: Error: unable to load certificate
+```
+
+The container is fine — this is the `kamal-proxy deploy` step failing after the
+health check passes, so the app never gets registered for its host and the
+public domain serves kamal-proxy's own blue 404 page. (Ours is white; a blue
+404 means no target is registered.)
+
+kamal-proxy collapses every certificate problem into that one message, but logs
+the real reason inside its own container:
+
+```bash
+bin/kamal proxy logs -d production --grep "TLS certificate"
+```
+
+That prints, for example, `open /home/kamal-proxy/.apps-config/...: permission
+denied` or `tls: private key does not match public key`. Causes, in the order
+worth checking:
+
+1. **`CERTIFICATE_PEM` and `PRIVATE_KEY_PEM` are not the same pair.** Cloudflare
+   shows the private key only once, and offers both RSA and ECC keys, so it's
+   easy to end up with a cert from one and a key from another. Verify before
+   deploying:
+
+   ```bash
+   diff <(openssl x509 -noout -pubkey <<<"$CF_ORIGIN_CERT") \
+        <(openssl pkey -pubout <<<"$CF_ORIGIN_KEY") && echo "pair matches"
+   ```
+
+2. **The PEM lost its line breaks.** `printenv CF_ORIGIN_CERT | head -1` must be
+   exactly `-----BEGIN CERTIFICATE-----`, and the value must span many lines. A
+   one-line blob with literal `\n` is not a PEM. (A *missing trailing* newline
+   is fine.)
+
+3. **kamal-proxy can't see the files.** Kamal uploads them to the host and
+   points the proxy at the mounted copy:
+
+   ```bash
+   ssh root@app-origin.fffeeder.com \
+     'ls -l /root/.kamal/proxy/apps-config/f2-production/tls/web/'
+   ssh root@app-origin.fffeeder.com \
+     'docker exec kamal-proxy ls -l /home/kamal-proxy/.apps-config/f2-production/tls/web/'
+   ```
+
+   If the host has them but the container doesn't, the proxy is missing the
+   apps-config mount: `bin/kamal proxy reboot -d production`.
+
+Fix the cert, then re-run `bin/kamal deploy -d production`. Accessories and the
+database survive the failed run, so a full `setup` isn't needed.
 
 ## Useful commands
 


### PR DESCRIPTION
Changes:

- Validate the resolved TLS certificate secrets in a new `.kamal/hooks/pre-connect`, so a bad value aborts before the build rather than minutes into the deploy
- Point the production workflow at the SSH secret that actually exists, and give it the same key checks staging already has
- Document the `unable to load certificate` failure and how to trace it back to a cause

Two deploy secrets fail the same way: an undefined value expands to an empty string and surfaces far from its cause. An empty `CF_ORIGIN_CERT` becomes a zero-byte `cert.pem` that kamal-proxy rejects long after the app has booted — and the `|| exit 1` guards in `.kamal/secrets*` cannot prevent it, because Kamal evaluates those commands with backticks and discards the exit status. An undefined `PRODUCTION_SSH_PRIVATE_KEY`, which is the workflow's name for a secret stored as `SSH_PRIVATE_KEY_PRODUCTION`, becomes an empty key file. Both now fail immediately, with a message naming the secret at fault.

#1173 follow-up.