### PR TITLE
Point Solid Cache at the primary database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-22
 
+- Fixed an error that could stop you from signing in, signing up, or refreshing a feed by hand.
 - The access token page now tells you when a token can't look up subscriber counts, and how to swap in one that can.
 - A token that's missing the permissions Feeder needs now says so, instead of being reported as expired or revoked.
 

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -12,5 +12,7 @@ test:
   <<: *default
 
 production:
-  database: cache
+  <<: *default
+
+staging:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -77,34 +77,20 @@ test:
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #
+# Solid Cache, Solid Queue and Solid Cable live in this one database: their
+# tables are part of db/schema.rb. Splitting any of them onto a database of its
+# own needs a schema dump or migrations for it first, or db:prepare creates the
+# extra database empty and the store fails on a missing table.
 production:
-  primary: &primary_production
-    <<: *default
-    database: f2_production
-    username: f2
-    password: <%= ENV["POSTGRES_PASSWORD"] %>
-    host: f2-db
-  cache:
-    <<: *primary_production
-    database: f2_production_cache
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_production
-    database: f2_production_queue
-    migrations_paths: db/queue_migrate
+  <<: *default
+  database: f2_production
+  username: f2
+  password: <%= ENV["POSTGRES_PASSWORD"] %>
+  host: f2-db
 
 staging:
-  primary: &primary_staging
-    <<: *default
-    database: f2_staging
-    username: f2
-    password: <%= ENV["POSTGRES_PASSWORD"] %>
-    host: f2-db
-  cache:
-    <<: *primary_staging
-    database: f2_staging_cache
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_staging
-    database: f2_staging_queue
-    migrations_paths: db/queue_migrate
+  <<: *default
+  database: f2_staging
+  username: f2
+  password: <%= ENV["POSTGRES_PASSWORD"] %>
+  host: f2-db

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -245,6 +245,17 @@ The app connects through `config/database.yml` using:
 
 Do not put the database password in `DATABASE_URL`. Keep it in Kamal secrets.
 
+One database per destination holds everything, Solid Cache, Solid Queue and
+Solid Cable included, so a `pg_dump` of it is a complete backup. Hosts deployed
+before Solid Cache moved onto it also carry empty `f2_<env>_cache` and
+`f2_<env>_queue` databases from the old config. Nothing reads them; drop them:
+
+```bash
+bin/kamal accessory exec db --reuse \
+  "psql -U f2 -d f2_production -c 'DROP DATABASE IF EXISTS f2_production_cache' \
+                               -c 'DROP DATABASE IF EXISTS f2_production_queue'" -d production
+```
+
 ## Preflight
 
 Before deploying, verify the local environment and target host:

--- a/test/config/database_config_test.rb
+++ b/test/config/database_config_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+# The scaffolded database.yml gave production and staging their own `cache` and
+# `queue` databases pointing at migrations paths that were never created, so
+# db:prepare created them empty. Solid Cache connected to that empty database
+# and every rate-limited request — sign-in among them — died on a missing
+# solid_cache_entries table. The solid_* tables live in the primary schema.
+class DatabaseConfigTest < ActiveSupport::TestCase
+  DEPLOYED_ENVIRONMENTS = %w[production staging].freeze
+
+  test "every deployed database has a schema the deploy can load" do
+    DEPLOYED_ENVIRONMENTS.each do |env|
+      configs_for(env).each do |config|
+        assert schema_source?(config),
+          "#{env}/#{config.name} has no schema dump and no migrations, so db:prepare would create it empty"
+      end
+    end
+  end
+
+  test "solid cache uses a database whose schema defines solid_cache_entries" do
+    DEPLOYED_ENVIRONMENTS.each do |env|
+      name = Rails.application.config_for(:cache, env: env)[:database].presence || "primary"
+      config = configs_for(env).find { |candidate| candidate.name == name.to_s }
+
+      assert config, "#{env} points Solid Cache at a #{name} database that database.yml doesn't declare"
+      assert_includes schema_tables(config), "solid_cache_entries",
+        "#{env} points Solid Cache at the #{name} database, whose schema has no solid_cache_entries table"
+    end
+  end
+
+  private
+
+  def configs_for(env)
+    ActiveRecord::Base.configurations.configs_for(env_name: env)
+  end
+
+  def schema_source?(config)
+    return true if schema_dump(config)
+
+    Array(config.migrations_paths).any? { |path| Dir.glob(Rails.root.join(path, "*.rb")).any? }
+  end
+
+  def schema_dump(config)
+    path = ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(config)
+    path if path && File.exist?(path)
+  end
+
+  def schema_tables(config)
+    dump = schema_dump(config)
+    return [] unless dump
+
+    File.read(dump).scan(/create_table "([^"]+)"/).flatten
+  end
+end


### PR DESCRIPTION
Changes:

- Point Solid Cache at the primary database, where its table actually lives
- Drop the `cache` and `queue` database entries from production and staging
- Cover the config with tests, and note the leftover empty databases in the deployment doc

Production and staging declared separate `cache` and `queue` databases whose `migrations_paths` were never created, so `db:prepare` made them empty on every boot. `config/cache.yml` then pointed Solid Cache at that empty `cache` database, and every rate-limited request — sign-in, sign-up, manual feed refresh — raised `PG::UndefinedTable` on `solid_cache_entries`.

The `solid_*` tables are part of `db/schema.rb`, so all three Solid stores belong on the primary connection. Solid Queue and Solid Cable were already there, since neither names a database of its own.

Reproduced in the dev container by recreating the broken config: `db:prepare` creates the database with no relations, and the cache write then fails with the same exception at the same `solid_cache/entry.rb` frames as the report.
