### PR TITLE
Hold the structuring call to the items envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-22
 
+- AI feeds fail less often on an off-format reply: Feeder now spells out the shape it needs and only asks providers that honor it.
 - The access token page now tells you when a token can't look up subscriber counts, and how to swap in one that can.
 - A token that's missing the permissions Feeder needs now says so, instead of being reported as expired or revoked.
 

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -167,6 +167,7 @@ module LlmCapabilityProbe
     def check_schema
       chat = @credential.chat(@model).with_schema(adapter.schema_payload(PROBE_SCHEMA))
       chat.with_instructions(PROBE_INSTRUCTIONS)
+      apply_params(chat, schema: true, web: false)
       response = chat.ask(STRUCTURE_PROMPT_PREFIX + SAMPLE_TEXT)
       validate_items(response, expect_null_source_url: true)
     end
@@ -206,12 +207,19 @@ module LlmCapabilityProbe
       chat = @credential.chat(@model)
       chat.with_instructions(PROBE_INSTRUCTIONS)
       chat.with_schema(adapter.schema_payload(schema)) if schema
-      params = adapter.web_params(@model)
-      chat.with_params(**params) if params.present?
+      apply_params(chat, schema: !schema.nil?, web: true)
       budget = LlmClient::ToolBudget.new
       chat.with_tool(CannedWebSearch.new(budget: budget))
       chat.with_tool(LlmClient::Tools::WebFetch.new(budget: budget))
       chat
+    end
+
+    # The params production sends for the shape being probed
+    # (LlmClient::Adapter::Base#params_for), so provider routing is qualified as
+    # it ships — a structuring call constrained the way the loader constrains it.
+    def apply_params(chat, schema:, web:)
+      params = adapter.params_for(@model, schema: schema, web: web)
+      chat.with_params(**params) if params.present?
     end
 
     def grounding_failure(answer)

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -214,9 +214,8 @@ module LlmCapabilityProbe
       chat
     end
 
-    # The params production sends for the shape being probed
-    # (LlmClient::Adapter::Base#params_for), so provider routing is qualified as
-    # it ships — a structuring call constrained the way the loader constrains it.
+    # The params production sends for the shape being probed, so a model is
+    # qualified on the request the loader actually makes.
     def apply_params(chat, schema:, web:)
       params = adapter.params_for(@model, schema: schema, web: web)
       chat.with_params(**params) if params.present?

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -185,9 +185,8 @@ class LlmClient
     )
   end
 
-  # The provider's routing and decoding params for this call. Applied whether or
-  # not tools come along: on the two-step path the schema travels on the call
-  # that has none, and that is the call a schema param has to reach.
+  # Sent with or without tools: the two-step path carries the schema on the
+  # call that has none, and its routing is what decides the reply's shape.
   def apply_params(chat, model, schema:, web:)
     params = adapter.params_for(model, schema: schema, web: web)
     chat.with_params(**params) if params.present?

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -168,10 +168,10 @@ class LlmClient
     # by #ask travels as a separate user-role message (spec §8).
     chat.with_instructions(system) if system.present?
     chat.with_schema(adapter.schema_payload(output_schema)) if output_schema.present?
+    apply_params(chat, model, schema: output_schema.present?, web: web)
     if web
       adapter.apply_web(
         chat,
-        model,
         search_provider: search_provider_for(ctx),
         search_credential: ctx.search_credential,
         refresh_event: ctx.refresh_event
@@ -183,6 +183,14 @@ class LlmClient
       payload: response_content(recover_halted(chat, response)),
       **usage_totals(chat, response)
     )
+  end
+
+  # The provider's routing and decoding params for this call. Applied whether or
+  # not tools come along: on the two-step path the schema travels on the call
+  # that has none, and that is the call a schema param has to reach.
+  def apply_params(chat, model, schema:, web:)
+    params = adapter.params_for(model, schema: schema, web: web)
+    chat.with_params(**params) if params.present?
   end
 
   # A halted tool loop returns the halt notice in place of the model's message.

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -8,14 +8,28 @@ class LlmClient
         {}
       end
 
+      # Provider-specific request params a schema-bearing call needs. Separate
+      # from web_params because the two-step path splits gathering and
+      # structuring across two calls: the schema rides on the one without tools,
+      # so a param that serves structured output has to travel on its own.
+      def schema_params(_model)
+        {}
+      end
+
+      # Everything one call sends, merged into a single set — RubyLLM's
+      # `with_params` replaces rather than merges, so a combined call would
+      # otherwise keep only whichever set was applied last.
+      def params_for(model, schema:, web:)
+        params = schema ? schema_params(model) : {}
+        web ? params.deep_merge(web_params(model)) : params
+      end
+
       # Every provider uses the same credential-backed search and fetch tools.
-      # Adapters may still add provider-specific request params, but search never
-      # delegates to a provider-hosted implementation.
+      # Adapters may still add provider-specific request params (#params_for),
+      # but search never delegates to a provider-hosted implementation.
       #
       # Both tools share one budget so the pair can't outspend it between them.
-      def apply_web(chat, model, search_provider:, search_credential:, refresh_event: nil)
-        params = web_params(model)
-        chat.with_params(**params) if params.present?
+      def apply_web(chat, search_provider:, search_credential:, refresh_event: nil)
         budget = LlmClient::ToolBudget.new
         chat.with_tool(
           LlmClient::Tools::WebSearch.new(

--- a/app/services/llm_client/adapter/base.rb
+++ b/app/services/llm_client/adapter/base.rb
@@ -8,17 +8,14 @@ class LlmClient
         {}
       end
 
-      # Provider-specific request params a schema-bearing call needs. Separate
-      # from web_params because the two-step path splits gathering and
-      # structuring across two calls: the schema rides on the one without tools,
-      # so a param that serves structured output has to travel on its own.
+      # Request params a schema-bearing call needs. Kept apart from web_params
+      # because the two-step path sends the schema on the call without tools.
       def schema_params(_model)
         {}
       end
 
-      # Everything one call sends, merged into a single set — RubyLLM's
-      # `with_params` replaces rather than merges, so a combined call would
-      # otherwise keep only whichever set was applied last.
+      # All params for one call, merged. RubyLLM's `with_params` replaces the
+      # whole set, so both kinds have to be sent together.
       def params_for(model, schema:, web:)
         params = schema ? schema_params(model) : {}
         web ? params.deep_merge(web_params(model)) : params

--- a/app/services/llm_client/adapter/open_router.rb
+++ b/app/services/llm_client/adapter/open_router.rb
@@ -1,14 +1,12 @@
 class LlmClient
   module Adapter
     class OpenRouter < Base
-      # OpenRouter picks which upstream serves a model, and an upstream that
-      # doesn't implement a parameter drops it silently instead of failing. This
-      # narrows routing to upstreams that honor everything the request carries:
-      # the JSON schema when structuring, the client-side tools when gathering.
-      # Without it a structuring call can land where `response_format` is
-      # ignored and come back as prose or a bare list — a schema failure no
-      # payload repair can rescue. Web search and fetch are supplied by the
-      # shared client-side tools either way.
+      # OpenRouter picks the upstream, and one that doesn't implement a
+      # parameter drops it silently. This restricts routing to upstreams that
+      # honor what the request carries: the schema when structuring, the tools
+      # when gathering. Without it a structuring call can land where
+      # `response_format` is ignored and reply with prose. Web access still
+      # comes from the shared client-side tools, not an OpenRouter plugin.
       ROUTING = { provider: { require_parameters: true } }.freeze
 
       def web_params(_model)

--- a/app/services/llm_client/adapter/open_router.rb
+++ b/app/services/llm_client/adapter/open_router.rb
@@ -1,10 +1,22 @@
 class LlmClient
   module Adapter
     class OpenRouter < Base
-      # Route only to upstreams that honor structured-output parameters. Web
-      # search and fetch are supplied by the shared client-side tools.
+      # OpenRouter picks which upstream serves a model, and an upstream that
+      # doesn't implement a parameter drops it silently instead of failing. This
+      # narrows routing to upstreams that honor everything the request carries:
+      # the JSON schema when structuring, the client-side tools when gathering.
+      # Without it a structuring call can land where `response_format` is
+      # ignored and come back as prose or a bare list — a schema failure no
+      # payload repair can rescue. Web search and fetch are supplied by the
+      # shared client-side tools either way.
+      ROUTING = { provider: { require_parameters: true } }.freeze
+
       def web_params(_model)
-        { provider: { require_parameters: true } }
+        ROUTING
+      end
+
+      def schema_params(_model)
+        ROUTING
       end
     end
   end

--- a/app/services/loader/llm_prompts.rb
+++ b/app/services/loader/llm_prompts.rb
@@ -29,7 +29,16 @@ module Loader
     # The output contract, injected into the stages that emit the JSON schema
     # (the combined call and the two-step structure call). Field names match
     # FeedProfile::UNIVERSAL_OUTPUT_SCHEMA.
+    #
+    # The envelope is spelled out because the schema alone doesn't guarantee it:
+    # providers whose structured-output mode is advisory (Kimi, and whichever
+    # upstream OpenRouter picks) shape the reply from this text, and "return
+    # items" reads as a bare array to a model that never sees the schema.
     OUTPUT_CONTRACT = <<~TEXT.strip
+      Reply with a single JSON object whose only key is "items", holding the
+      array of items. A bare array, or any other shape at the top level, is not
+      a valid reply.
+
       Each item is an object with these fields:
       - body (required): the post text, plain and readable.
       - source_url (required): the post's own permalink. For a standing-query
@@ -78,7 +87,7 @@ module Loader
       #{OUTPUT_CONTRACT}
 
       Use only what is present in the gathered content; if it contains no posts,
-      return no items.
+      return the object with an empty items array.
 
       #{SAFEGUARDS}
     TEXT

--- a/app/services/loader/llm_prompts.rb
+++ b/app/services/loader/llm_prompts.rb
@@ -30,10 +30,9 @@ module Loader
     # (the combined call and the two-step structure call). Field names match
     # FeedProfile::UNIVERSAL_OUTPUT_SCHEMA.
     #
-    # The envelope is spelled out because the schema alone doesn't guarantee it:
-    # providers whose structured-output mode is advisory (Kimi, and whichever
-    # upstream OpenRouter picks) shape the reply from this text, and "return
-    # items" reads as a bare array to a model that never sees the schema.
+    # The envelope is stated here because the schema alone doesn't guarantee it.
+    # Providers whose structured-output mode is advisory (Kimi, and whichever
+    # upstream OpenRouter picks) shape the reply from this text.
     OUTPUT_CONTRACT = <<~TEXT.strip
       Reply with a single JSON object whose only key is "items", holding the
       array of items. A bare array, or any other shape at the top level, is not

--- a/app/services/loader/llm_prompts.rb
+++ b/app/services/loader/llm_prompts.rb
@@ -34,9 +34,13 @@ module Loader
     # Providers whose structured-output mode is advisory (Kimi, and whichever
     # upstream OpenRouter picks) shape the reply from this text.
     OUTPUT_CONTRACT = <<~TEXT.strip
-      Reply with a single JSON object whose only key is "items", holding the
-      array of items. A bare array, or any other shape at the top level, is not
-      a valid reply.
+      Reply with one JSON object and nothing else, shaped like this:
+
+      {"items": [ ... ]}
+
+      Any other top level shape is invalid, whatever it contains: a bare array,
+      a different key name, an object wrapped in quotes, JSON with prose around
+      it.
 
       Each item is an object with these fields:
       - body (required): the post text, plain and readable.

--- a/lib/tasks/ai_extraction_verify.rake
+++ b/lib/tasks/ai_extraction_verify.rake
@@ -36,9 +36,10 @@ namespace :ai do
       chat = ai_credential.chat(model)
       chat.with_instructions(Loader::LlmPrompts::COMBINED_SYSTEM)
       chat.with_schema(schema)
+      params = adapter.params_for(model, schema: true, web: true)
+      chat.with_params(**params) if params.present?
       adapter.apply_web(
         chat,
-        model,
         search_provider: search_credential.web_search_provider,
         search_credential: search_credential
       )

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -336,14 +336,26 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     assert_equal LlmCapabilityProbe::PROBE_INSTRUCTIONS, chat.instructions
   end
 
-  # The tool checks are the ones a provider-specific request param exists for,
-  # so a chat built without them probes a shape production never sends.
+  # A chat built without the provider's request params probes a shape production
+  # never sends.
   test "#run should carry the adapter's web params onto the tool chat" do
     credential = FakeCredential.new(grounded_payload, tool_rounds: full_tool_loop, provider: "openai")
     LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model",
                                    checks: ["client_tools"]).run
 
-    assert_equal LlmClient::Adapter::OpenAi.new.web_params("test-model"),
+    assert_equal LlmClient::Adapter::OpenAi.new.params_for("test-model", schema: false, web: true),
+                 credential.chats.first.params
+    assert_predicate credential.chats.first.params, :present?
+  end
+
+  # The structure check mirrors the loader's structuring call, params included:
+  # qualifying a model on an unconstrained call says nothing about the
+  # constrained one production sends.
+  test "#run should carry the adapter's schema params onto the structure chat" do
+    credential = FakeCredential.new(valid_payload, provider: "openrouter")
+    LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: ["schema"]).run
+
+    assert_equal LlmClient::Adapter::OpenRouter.new.params_for("test-model", schema: true, web: false),
                  credential.chats.first.params
     assert_predicate credential.chats.first.params, :present?
   end

--- a/test/services/llm_capability_probe_test.rb
+++ b/test/services/llm_capability_probe_test.rb
@@ -348,9 +348,7 @@ class LlmCapabilityProbeTest < ActiveSupport::TestCase
     assert_predicate credential.chats.first.params, :present?
   end
 
-  # The structure check mirrors the loader's structuring call, params included:
-  # qualifying a model on an unconstrained call says nothing about the
-  # constrained one production sends.
+  # The structure check mirrors the loader's structuring call, params included.
   test "#run should carry the adapter's schema params onto the structure chat" do
     credential = FakeCredential.new(valid_payload, provider: "openrouter")
     LlmCapabilityProbe::Runner.new(credential: credential, model: "test-model", checks: ["schema"]).run

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -60,7 +60,7 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
 
     LlmClient::Adapter::REGISTRY.each_key do |name|
       chat = fake_chat
-      LlmClient::Adapter.for(name).apply_web(chat, "model", search_provider: provider, **context)
+      LlmClient::Adapter.for(name).apply_web(chat, search_provider: provider, **context)
 
       search_tool, fetch_tool = chat.tools
       assert_instance_of LlmClient::Tools::WebSearch, search_tool, name
@@ -76,43 +76,59 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
   end
 
   test "Anthropic should not send provider-hosted web tools" do
-    chat = fake_chat
+    adapter = LlmClient::Adapter::Anthropic.new
 
-    LlmClient::Adapter::Anthropic.new.apply_web(
-      chat,
-      "claude-opus-4-8",
-      search_provider: Object.new,
-      **search_context
-    )
-
-    assert_equal({}, chat.params)
+    assert_equal({}, adapter.params_for("claude-opus-4-8", schema: true, web: true))
   end
 
   test "OpenRouter should require structured parameters without enabling its web plugin" do
-    chat = fake_chat
+    params = LlmClient::Adapter::OpenRouter.new.params_for("openai/gpt-4o", schema: false, web: true)
 
-    LlmClient::Adapter::OpenRouter.new.apply_web(
-      chat,
-      "openai/gpt-4o",
-      search_provider: Object.new,
-      **search_context
-    )
+    assert_equal({ provider: { require_parameters: true } }, params)
+    assert_not params.key?(:plugins)
+  end
 
-    assert_equal({ provider: { require_parameters: true } }, chat.params)
-    assert_not chat.params.key?(:plugins)
+  # The two-step path carries the schema on the call without web tools, and an
+  # OpenRouter upstream that doesn't implement `response_format` drops it
+  # silently — so the routing constraint has to travel with the schema, not with
+  # the tools.
+  test "OpenRouter should require structured parameters on a schema-only call" do
+    params = LlmClient::Adapter::OpenRouter.new.params_for("openai/gpt-4o", schema: true, web: false)
+
+    assert_equal({ provider: { require_parameters: true } }, params)
   end
 
   test "OpenAI should opt out of reasoning on tool-enabled calls" do
-    chat = fake_chat
+    adapter = LlmClient::Adapter::OpenAi.new
 
-    LlmClient::Adapter::OpenAi.new.apply_web(
-      chat,
-      "gpt-5.6-luna",
-      search_provider: Object.new,
-      **search_context
-    )
+    assert_equal({ reasoning_effort: "none" }, adapter.params_for("gpt-5.6-luna", schema: false, web: true))
+  end
 
-    assert_equal({ reasoning_effort: "none" }, chat.params)
+  # Structuring is where reasoning earns its cost, and no tool is there to
+  # collide with it.
+  test "OpenAI should keep reasoning on a schema-only call" do
+    adapter = LlmClient::Adapter::OpenAi.new
+
+    assert_equal({}, adapter.params_for("gpt-5.6-luna", schema: true, web: false))
+  end
+
+  test "#params_for should send nothing when a call carries neither a schema nor tools" do
+    LlmClient::Adapter::REGISTRY.each_key do |name|
+      assert_equal({}, LlmClient::Adapter.for(name).params_for("model", schema: false, web: false), name)
+    end
+  end
+
+  # with_params replaces the whole set, so a combined call has to send one
+  # merged hash or lose whichever half was applied first.
+  test "#params_for should merge the schema and web params of a combined call" do
+    adapter = Class.new(LlmClient::Adapter::Base) do
+      def schema_params(_model) = { provider: { require_parameters: true }, response_format: "json" }
+      def web_params(_model) = { provider: { sort: "latency" }, reasoning_effort: "none" }
+    end.new
+
+    assert_equal({ provider: { require_parameters: true, sort: "latency" },
+                   response_format: "json", reasoning_effort: "none" },
+                 adapter.params_for("model", schema: true, web: true))
   end
 
   def rate_limit_error(body)

--- a/test/services/llm_client/adapter_test.rb
+++ b/test/services/llm_client/adapter_test.rb
@@ -88,10 +88,8 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_not params.key?(:plugins)
   end
 
-  # The two-step path carries the schema on the call without web tools, and an
-  # OpenRouter upstream that doesn't implement `response_format` drops it
-  # silently — so the routing constraint has to travel with the schema, not with
-  # the tools.
+  # An OpenRouter upstream that ignores `response_format` drops it silently, so
+  # the routing constraint has to travel with the schema, not with the tools.
   test "OpenRouter should require structured parameters on a schema-only call" do
     params = LlmClient::Adapter::OpenRouter.new.params_for("openai/gpt-4o", schema: true, web: false)
 
@@ -104,8 +102,7 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     assert_equal({ reasoning_effort: "none" }, adapter.params_for("gpt-5.6-luna", schema: false, web: true))
   end
 
-  # Structuring is where reasoning earns its cost, and no tool is there to
-  # collide with it.
+  # Structuring keeps its reasoning: no tool is there to collide with it.
   test "OpenAI should keep reasoning on a schema-only call" do
     adapter = LlmClient::Adapter::OpenAi.new
 
@@ -118,8 +115,7 @@ class LlmClient::AdapterTest < ActiveSupport::TestCase
     end
   end
 
-  # with_params replaces the whole set, so a combined call has to send one
-  # merged hash or lose whichever half was applied first.
+  # with_params replaces the whole set, so a combined call sends one merged hash.
   test "#params_for should merge the schema and web params of a combined call" do
     adapter = Class.new(LlmClient::Adapter::Base) do
       def schema_params(_model) = { provider: { require_parameters: true }, response_format: "json" }

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -728,9 +728,8 @@ class LlmClientTest < ActiveSupport::TestCase
                                       credential_data: { "api_key" => "sk-or-test" })
   end
 
-  # The structuring call of the two-step path carries the schema and no tools,
-  # and it is the one that has to be routed to an upstream honoring the schema —
-  # an upstream that ignores it answers with something no repair can fit.
+  # The structuring call carries the schema and no tools. Its routing decides
+  # whether the schema is honored at all.
   test "#invoke_provider should send the provider's params on a schema call without web tools" do
     client = LlmClient.new(openrouter_credential)
     chat = FakeChat.new

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -534,10 +534,19 @@ class LlmClientTest < ActiveSupport::TestCase
   # can verify the system message travels via with_instructions and the user
   # prompt via #ask — the injection-defense channel separation (spec §8).
   class FakeChat
-    attr_reader :instructions, :asked, :schema
+    attr_reader :instructions, :asked, :schema, :params
+
+    def initialize
+      @params = {}
+    end
 
     def with_instructions(text)
       @instructions = text
+      self
+    end
+
+    def with_params(**params)
+      @params.merge!(params)
       self
     end
 
@@ -558,6 +567,7 @@ class LlmClientTest < ActiveSupport::TestCase
     attr_reader :messages
 
     def initialize(messages)
+      super()
       @messages = messages
     end
   end
@@ -568,6 +578,7 @@ class LlmClientTest < ActiveSupport::TestCase
     attr_reader :messages
 
     def initialize(messages)
+      super()
       @messages = messages
     end
 
@@ -710,6 +721,38 @@ class LlmClientTest < ActiveSupport::TestCase
     assert_equal 7, response.output_tokens
     assert_equal 3, response.cache_write_tokens
     assert_equal 11, response.cache_read_tokens
+  end
+
+  def openrouter_credential
+    @openrouter_credential ||= create(:ai_credential, :active, user: user, provider: "openrouter",
+                                      credential_data: { "api_key" => "sk-or-test" })
+  end
+
+  # The structuring call of the two-step path carries the schema and no tools,
+  # and it is the one that has to be routed to an upstream honoring the schema —
+  # an upstream that ignores it answers with something no repair can fit.
+  test "#invoke_provider should send the provider's params on a schema call without web tools" do
+    client = LlmClient.new(openrouter_credential)
+    chat = FakeChat.new
+
+    stub_chat(client, chat) do
+      client.send(:invoke_provider, model: "anthropic/claude-sonnet-4-6", prompt: "p",
+                  output_schema: FeedProfile::UNIVERSAL_OUTPUT_SCHEMA, web: false, system: nil)
+    end
+
+    assert_equal({ provider: { require_parameters: true } }, chat.params)
+  end
+
+  test "#invoke_provider should send no params for a provider that asks for none" do
+    client = LlmClient.new(credential)
+    chat = FakeChat.new
+
+    stub_chat(client, chat) do
+      client.send(:invoke_provider, model: "claude-sonnet-4-6", prompt: "p",
+                  output_schema: FeedProfile::UNIVERSAL_OUTPUT_SCHEMA, web: false, system: nil)
+    end
+
+    assert_empty chat.params
   end
 
   test "#invoke_provider should not set instructions when no system prompt is given" do

--- a/test/services/loader/llm_prompts_test.rb
+++ b/test/services/loader/llm_prompts_test.rb
@@ -32,8 +32,8 @@ class Loader::LlmPromptsTest < ActiveSupport::TestCase
   test "the output contract should require the items envelope" do
     contract = Loader::LlmPrompts::OUTPUT_CONTRACT
 
-    assert_match(/single JSON object whose only key is "items"/, contract)
-    assert_match(/bare array/, contract)
+    assert_match(/\{"items": \[ \.\.\. \]\}/, contract)
+    assert_match(/Any other top level shape is invalid/, contract)
   end
 
   # A model that never sees the schema needs the empty result named as a shape.

--- a/test/services/loader/llm_prompts_test.rb
+++ b/test/services/loader/llm_prompts_test.rb
@@ -28,8 +28,7 @@ class Loader::LlmPromptsTest < ActiveSupport::TestCase
   end
 
   # Structured-output modes are advisory on some providers, so the envelope has
-  # to be stated in the prompt too — a model that only reads this text otherwise
-  # replies with a bare array, which fails schema validation.
+  # to be stated in the prompt too.
   test "the output contract should require the items envelope" do
     contract = Loader::LlmPrompts::OUTPUT_CONTRACT
 
@@ -37,8 +36,7 @@ class Loader::LlmPromptsTest < ActiveSupport::TestCase
     assert_match(/bare array/, contract)
   end
 
-  # "Return no items" reads as "reply with nothing structured" to a model that
-  # never sees the schema; the empty envelope is the shape that validates.
+  # A model that never sees the schema needs the empty result named as a shape.
   test "the structure prompt should ask for an empty items array when nothing was gathered" do
     assert_match(/return the object with an empty items array/, Loader::LlmPrompts::STRUCTURE_SYSTEM)
   end

--- a/test/services/loader/llm_prompts_test.rb
+++ b/test/services/loader/llm_prompts_test.rb
@@ -27,6 +27,22 @@ class Loader::LlmPromptsTest < ActiveSupport::TestCase
     assert_not_includes Loader::LlmPrompts::GATHER_SYSTEM, Loader::LlmPrompts::OUTPUT_CONTRACT
   end
 
+  # Structured-output modes are advisory on some providers, so the envelope has
+  # to be stated in the prompt too — a model that only reads this text otherwise
+  # replies with a bare array, which fails schema validation.
+  test "the output contract should require the items envelope" do
+    contract = Loader::LlmPrompts::OUTPUT_CONTRACT
+
+    assert_match(/single JSON object whose only key is "items"/, contract)
+    assert_match(/bare array/, contract)
+  end
+
+  # "Return no items" reads as "reply with nothing structured" to a model that
+  # never sees the schema; the empty envelope is the shape that validates.
+  test "the structure prompt should ask for an empty items array when nothing was gathered" do
+    assert_match(/return the object with an empty items array/, Loader::LlmPrompts::STRUCTURE_SYSTEM)
+  end
+
   test "the output contract should describe the digest null-source regime and forbid uids" do
     contract = Loader::LlmPrompts::OUTPUT_CONTRACT
 


### PR DESCRIPTION
Changes:

- Require the `items` envelope in the AI extraction output contract
- Add `schema_params` to the adapter seam, merged with `web_params` by `params_for`
- Send OpenRouter's `require_parameters` on schema-bearing calls
- Probe models with the params production sends

Fixes `LlmClient::SchemaError` ("value at root is not an object") on scheduled AI refreshes.

Structured output is advisory on the two-step providers. Kimi shapes its reply from the prompt, and OpenRouter may route to an upstream that ignores `response_format`. The contract described each item but never the object wrapping them, so a bare array was a fair reading of it.

`require_parameters` restricts OpenRouter to upstreams that honor what the request carries. It rode along with the web tools, but the two-step path sends the schema on the call that has none, so it never reached the call that needed it.

References:

- Follows up on #1286
