### PR TITLE
Rename root namespace to Feeder

### DIFF
--- a/app/helpers/system_status_helper.rb
+++ b/app/helpers/system_status_helper.rb
@@ -15,7 +15,7 @@ module SystemStatusHelper
   # doesn't block linking.
   def revision_commit_link(revision_short, revision)
     link_to tag.code(revision_short, title: revision),
-            "#{F2Rails::GITHUB_REPO_URL}/commit/#{revision.presence || revision_short}",
+            "#{Feeder::GITHUB_REPO_URL}/commit/#{revision.presence || revision_short}",
             target: "_blank", rel: "noopener",
             class: "text-brand underline underline-offset-4 transition hover:text-brand-hover"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ RubyLLM.configure do |config|
   config.use_new_acts_as = true
 end
 
-module F2Rails
+module Feeder
   GITHUB_REPO_URL = "https://github.com/dreikanter/f2".freeze
 
   class Application < Rails::Application

--- a/lib/tasks/honeybadger.rake
+++ b/lib/tasks/honeybadger.rake
@@ -3,7 +3,7 @@ namespace :honeybadger do
   task notify_deploy: :environment do
     if Honeybadger.config[:api_key].blank?
       puts "Honeybadger API key not configured; skipping deploy notification."
-    elsif Honeybadger.track_deployment(repository: F2Rails::GITHUB_REPO_URL)
+    elsif Honeybadger.track_deployment(repository: Feeder::GITHUB_REPO_URL)
       puts "Honeybadger notified of deploy (#{Honeybadger.config[:revision] || 'unknown revision'})."
     else
       warn "Honeybadger deploy notification failed."

--- a/test/controllers/development/system_status_controller_test.rb
+++ b/test/controllers/development/system_status_controller_test.rb
@@ -89,7 +89,7 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_select "[data-key='release.revision.value'] a[href='#{F2Rails::GITHUB_REPO_URL}/commit/0123456789abcdef'] code", text: "0123456"
+    assert_select "[data-key='release.revision.value'] a[href='#{Feeder::GITHUB_REPO_URL}/commit/0123456789abcdef'] code", text: "0123456"
     assert_select "[data-key='release.deployed_at.value'] code", text: /9 May 2026, 12:34/
     assert_select "[data-key='release.environment.value'] span", text: Rails.env
   end

--- a/test/helpers/system_status_helper_test.rb
+++ b/test/helpers/system_status_helper_test.rb
@@ -32,7 +32,7 @@ class SystemStatusHelperTest < ActionView::TestCase
   test "#revision_commit_link should link the short hash to the commit page" do
     result = revision_commit_link("0123456", "0123456789abcdef")
 
-    assert_includes result, "#{F2Rails::GITHUB_REPO_URL}/commit/0123456789abcdef"
+    assert_includes result, "#{Feeder::GITHUB_REPO_URL}/commit/0123456789abcdef"
     assert_includes result, "<code"
     assert_includes result, "0123456"
   end
@@ -40,6 +40,6 @@ class SystemStatusHelperTest < ActionView::TestCase
   test "#revision_commit_link should fall back to the short hash without a full revision" do
     result = revision_commit_link("0123456", nil)
 
-    assert_includes result, "#{F2Rails::GITHUB_REPO_URL}/commit/0123456"
+    assert_includes result, "#{Feeder::GITHUB_REPO_URL}/commit/0123456"
   end
 end

--- a/test/lib/tasks/admin_test.rb
+++ b/test/lib/tasks/admin_test.rb
@@ -3,7 +3,7 @@ require "rake"
 
 class AdminCreateTaskTest < ActiveSupport::TestCase
   setup do
-    F2Rails::Application.load_tasks unless Rake::Task.task_defined?("admin:create")
+    Feeder::Application.load_tasks unless Rake::Task.task_defined?("admin:create")
     @task = Rake::Task["admin:create"]
     @task.reenable
   end

--- a/test/lib/tasks/ai_extraction_verify_test.rb
+++ b/test/lib/tasks/ai_extraction_verify_test.rb
@@ -3,7 +3,7 @@ require "rake"
 
 class AiVerifyExtractionTest < ActiveSupport::TestCase
   setup do
-    F2Rails::Application.load_tasks unless Rake::Task.task_defined?("ai:verify_extraction")
+    Feeder::Application.load_tasks unless Rake::Task.task_defined?("ai:verify_extraction")
     @task = Rake::Task["ai:verify_extraction"]
     @task.reenable
   end

--- a/test/lib/tasks/honeybadger_test.rb
+++ b/test/lib/tasks/honeybadger_test.rb
@@ -3,7 +3,7 @@ require "rake"
 
 class HoneybadgerNotifyDeployTest < ActiveSupport::TestCase
   setup do
-    F2Rails::Application.load_tasks unless Rake::Task.task_defined?("honeybadger:notify_deploy")
+    Feeder::Application.load_tasks unless Rake::Task.task_defined?("honeybadger:notify_deploy")
     @task = Rake::Task["honeybadger:notify_deploy"]
     @task.reenable
   end


### PR DESCRIPTION
Changes:

- Rename the application namespace from `F2Rails` to `Feeder`

The `Rails` suffix was an accident of how the app was bootstrapped: `rails new` ran in a scratch directory named `tmp-rails` and derived `module TmpRails` from it, and an early commit replaced `Tmp` with `F2` while keeping the suffix. Nothing in Rails asks for it — there is no minimum length for an application name, and `rails new f2` would have produced `module F2`. Feeder is what the app is called everywhere else, so the constant now agrees.

Rails derives the default session cookie key from this constant, so it becomes `_feeder_session`. Authentication does not read that cookie — sessions resume from a separately signed `session_id` cookie backed by a `Session` record — so nobody is signed out. The renamed cookie only carries `return_to_after_authenticating` and in-flight flash. Database names and the Kamal service still use `f2`.
