### PR TITLE
Autofocus the first field on credential pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-23
+
+- Adding or editing an AI or search key now starts with the cursor already in the first field.
+
 ## 2026-08-22
 
 - Fixed an error that could stop you from signing in, signing up, or refreshing a feed by hand.

--- a/app/views/ai_credentials/edit.html.erb
+++ b/app/views/ai_credentials/edit.html.erb
@@ -30,6 +30,7 @@
           <%= f.label :display_name, "Name", class: "block font-semibold text-heading" %>
           <%= f.text_field :display_name,
                            placeholder: "Personal Anthropic key",
+                           autofocus: true,
                            class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
                            required: true,
                            data: { key: "ai_credentials.display-name" } %>

--- a/app/views/ai_credentials/new.html.erb
+++ b/app/views/ai_credentials/new.html.erb
@@ -23,6 +23,7 @@
           <%= f.select :provider,
                        LlmProvider.all.map { |provider| [provider.display_name, provider.name] },
                        {},
+                       autofocus: true,
                        class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
                        data: { key: "ai_credentials.provider" } %>
         </div>

--- a/app/views/search_credentials/edit.html.erb
+++ b/app/views/search_credentials/edit.html.erb
@@ -29,6 +29,7 @@
         <div class="space-y-2">
           <%= f.label :display_name, "Name", class: "block font-semibold text-heading" %>
           <%= f.text_field :display_name,
+                           autofocus: true,
                            class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
                            required: true,
                            data: { key: "search_credentials.display-name" } %>

--- a/app/views/search_credentials/new.html.erb
+++ b/app/views/search_credentials/new.html.erb
@@ -23,6 +23,7 @@
           <%= f.select :provider,
                        WebSearchProvider.options_for_select,
                        {},
+                       autofocus: true,
                        class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring",
                        data: { key: "search_credentials.provider" } %>
         </div>

--- a/test/integration/form_autofocus_test.rb
+++ b/test/integration/form_autofocus_test.rb
@@ -59,6 +59,30 @@ class FormAutofocusTest < ActionDispatch::IntegrationTest
     assert_autofocus_on_first_field "access_token_name"
   end
 
+  test "new AI credential form autofocuses the provider field" do
+    sign_in_as(user)
+    get new_ai_credential_path
+    assert_autofocus_on_first_field "ai_credential_provider"
+  end
+
+  test "edit AI credential form autofocuses the name field" do
+    sign_in_as(user)
+    get edit_ai_credential_path(create(:ai_credential, user: user))
+    assert_autofocus_on_first_field "ai_credential_display_name"
+  end
+
+  test "new search credential form autofocuses the provider field" do
+    sign_in_as(user)
+    get new_search_credential_path
+    assert_autofocus_on_first_field "search_credential_provider"
+  end
+
+  test "edit search credential form autofocuses the name field" do
+    sign_in_as(user)
+    get edit_search_credential_path(create(:search_credential, user: user))
+    assert_autofocus_on_first_field "search_credential_display_name"
+  end
+
   private
 
   def assert_autofocus_on_first_field(expected_id)

--- a/test/integration/form_autofocus_test.rb
+++ b/test/integration/form_autofocus_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+# Account and settings forms put the cursor in their first field on load,
+# which browsers do natively from the autofocus attribute. These lock the
+# markup in so a form can't quietly lose it.
+class FormAutofocusTest < ActionDispatch::IntegrationTest
+  UNFOCUSABLE_INPUT_TYPES = %w[hidden submit button image reset].freeze
+
+  def user
+    @user ||= create(:user)
+  end
+
+  test "sign in form autofocuses the email field" do
+    get new_session_path
+    assert_autofocus_on_first_field "email_address"
+  end
+
+  test "forgot password form autofocuses the email field" do
+    get new_password_path
+    assert_autofocus_on_first_field "email_address"
+  end
+
+  test "password reset form autofocuses the new password field" do
+    get edit_password_path(user.generate_token_for(:password_reset))
+    assert_autofocus_on_first_field "password"
+  end
+
+  test "registration form autofocuses the email field" do
+    get registration_path(code: create(:invite).id)
+    assert_autofocus_on_first_field "user_email_address"
+  end
+
+  test "resend confirmation form autofocuses the email field" do
+    get new_registration_confirmation_path
+    assert_autofocus_on_first_field "email_address"
+  end
+
+  test "change password form autofocuses the current password field" do
+    sign_in_as(user)
+    get edit_settings_password_update_path
+    assert_autofocus_on_first_field "user_current_password"
+  end
+
+  test "change email form autofocuses the new email field" do
+    sign_in_as(user)
+    get edit_settings_email_update_path
+    assert_autofocus_on_first_field "user_email_address"
+  end
+
+  test "new access token form autofocuses the instance field" do
+    sign_in_as(user)
+    get new_access_token_path
+    assert_autofocus_on_first_field "access_token_host"
+  end
+
+  test "edit access token form autofocuses the name field" do
+    sign_in_as(user)
+    get edit_access_token_path(create(:access_token, user: user))
+    assert_autofocus_on_first_field "access_token_name"
+  end
+
+  private
+
+  def assert_autofocus_on_first_field(expected_id)
+    assert_response :success
+
+    autofocused = Nokogiri::HTML(response.body).css("[autofocus]")
+    assert_equal 1, autofocused.size, "expected exactly one autofocused element on the page"
+    assert_equal expected_id, autofocused.first["id"], "autofocus is on an unexpected field"
+
+    form = autofocused.first.ancestors("form").first
+    assert_equal expected_id, first_field(form)&.[]("id"), "autofocus is not on the form's first field"
+  end
+
+  def first_field(form)
+    form.css("input, select, textarea").find do |field|
+      next false if field["disabled"]
+
+      field.name != "input" || UNFOCUSABLE_INPUT_TYPES.exclude?(field["type"])
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Autofocus the first field when adding or editing an AI or search credential — the only account forms that were missing it
- Cover first-field autofocus across the account and settings forms with an integration test
- Changelog entry

The prompt for this was the "Choose a new password" page not landing the cursor in the New password field. That page already carries `autofocus`, and it works — verified in a real browser on a direct load, after a failed-confirmation redirect, and with JavaScript switched off — so nothing changed there. Auditing the rest turned up the credential pages as the one real gap.

Focus stays native: the `autofocus` attribute alone, no JavaScript. The test asserts each page has exactly one autofocused element, that it's the expected field, and that it is the form's first focusable control, so a form can't quietly lose it or drift to the wrong field.
