### PR TITLE
Exclude test gems from production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,7 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y curl libjemalloc2 postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Set production environment. BUNDLE_WITHOUT excludes :test alongside
-# :development — the Rails default drops only development-only gems, leaving the
-# shared :development, :test group (and all of :test) in the image.
+# Set production environment
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,13 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y curl libjemalloc2 postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Set production environment
+# Set production environment. BUNDLE_WITHOUT excludes :test alongside
+# :development — the Rails default drops only development-only gems, leaving the
+# shared :development, :test group (and all of :test) in the image.
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
+    BUNDLE_WITHOUT="development:test"
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build


### PR DESCRIPTION
Changes:

- Exclude the `:test` gem group alongside `:development` when bundling the production image

`BUNDLE_WITHOUT="development"` drops only gems whose sole group is `:development`, so the shared `:development, :test` group and the `:test`-only group both survived the filter and got copied into the final stage — roughly 76 MB of gem sources nothing in production can require, plus their share of the bundle-install layer's build time.

Nothing in the image reaches for them: `test/` is already excluded by `.dockerignore`, and `assets:precompile` runs with `Rails.groups` of default + production. Verified by booting production and running `assets:precompile` with the narrowed group set. `Dockerfile.dev` still installs every group, so container dev and remote sessions keep their tooling.
