### PR TITLE
Move Kamal gem to development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,8 @@ group :development do
   gem "web-console"
 
   # Deploy this application anywhere as a Docker container [https://kamal-deploy.org].
-  # Kamal runs from CI or a workstation, never inside the container it deploys, so
-  # the production image skips it and its SSH stack (Dockerfile: BUNDLE_WITHOUT).
+  # Runs from CI or a workstation, reaching the deploy host over SSH, so the
+  # production image excludes it and its SSH stack (Dockerfile: BUNDLE_WITHOUT).
   gem "kamal", require: false
 
   # Duplication and complexity report, driven by bin/critic. Local only — it is

--- a/Gemfile
+++ b/Gemfile
@@ -33,9 +33,6 @@ gem "solid_cable"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-# Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
-gem "kamal", require: false
-
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false
 
@@ -73,6 +70,11 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # Deploy this application anywhere as a Docker container [https://kamal-deploy.org].
+  # Kamal runs from CI or a workstation, never inside the container it deploys, so
+  # the production image skips it and its SSH stack (Dockerfile: BUNDLE_WITHOUT).
+  gem "kamal", require: false
 
   # Duplication and complexity report, driven by bin/critic. Local only — it is
   # advisory, not a gate, so CI does not run it. [https://github.com/whitesmith/rubycritic]


### PR DESCRIPTION
Changes:

- Move `kamal` out of the default Gemfile group into `development`

Kamal orchestrates deploys from CI or a workstation and never runs inside the container it deploys, but the default group put it in the production image: the Dockerfile installs with `BUNDLE_WITHOUT="development"`. Every uncached build compiled the `ed25519` and `bcrypt_pbkdf` native extensions and shipped sshkit, net-ssh/scp/sftp and dotenv into the runtime image.

Thruster stays in the default group — the container's CMD runs it — and `bcrypt` (`has_secure_password`) is a different gem from `bcrypt_pbkdf`, so it is unaffected.

Deploys keep working: `Gemfile.lock` records no group information, so it is unchanged and the frozen deployment-mode install still resolves, and the deploy workflows still get `bin/kamal` because ruby/setup-ruby reads `BUNDLE_WITHOUT` only for its cache key and never sets it, with no `.bundle/config` checked in.
