### PR TITLE
Drop unused date-fns npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": "true",
   "dependencies": {
     "@tailwindcss/cli": "^4.3.3",
-    "date-fns": "^4.4.0",
     "flowbite": "^4.0.2",
     "nodemon": "^3.1.14",
     "tailwindcss": "^4.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,11 +370,6 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-date-fns@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.4.0.tgz#806539edf45c616b2b76b5f78b88c56ed3c7e036"
-  integrity sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==
-
 debug@^4:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"


### PR DESCRIPTION
Changes:

- Remove `date-fns` from `package.json` and its entry from `yarn.lock`

The browser loads `date-fns` from esm.sh through the importmap pin, so the npm copy was never reachable from the app: `node_modules` isn't on Propshaft's asset path, `vendor/javascript/` is empty, and no Tailwind content glob scans it. Nothing depends on it transitively either — flowbite's datepicker pulls in `flowbite-datepicker`, not `date-fns`.

The datepicker keeps working unchanged; its `import { format } from "date-fns"` always resolved through the CDN.

Verified the built stylesheet is byte-identical (69,022 B) before and after, with the full suite and RuboCop green.
