### PR TITLE
Cache deploy builds in a GHCR registry cache

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -51,6 +51,12 @@ asset_path: /rails/public/assets
 builder:
   arch: amd64
 
+  # See docs/deployment-ghcr.md.
+  cache:
+    type: registry
+    image: dreikanter/f2-build-cache
+    options: mode=max
+
   # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
   # remote: ssh://docker@docker-builder-server
   #

--- a/docs/deployment-configuration.md
+++ b/docs/deployment-configuration.md
@@ -29,7 +29,7 @@ bin/kamal
 - **Committed:** yes
 - **Format:** YAML
 - **Purpose:** Base Kamal config shared by all destinations.
-- **Contains:** service name, image name, GHCR registry settings, shared secret names, builder architecture, aliases.
+- **Contains:** service name, image name, GHCR registry settings, shared secret names, builder architecture and build cache, aliases.
 - **Used when:** any Kamal deploy/build/config command runs.
 
 ### `config/deploy.staging.yml`

--- a/docs/deployment-ghcr.md
+++ b/docs/deployment-ghcr.md
@@ -24,6 +24,32 @@ ghcr.io/dreikanter/f2
 
 Kamal tags each build and pushes it to that image repository.
 
+## Build cache
+
+Deploys run on fresh GitHub Actions runners with an empty Docker layer cache. A
+cold build compiles Node from source, clones `rails/rails` during
+`bundle install` (the Gemfile tracks edge Rails from git), and installs yarn
+packages. `config/deploy.yml` sets a registry cache so those layers survive
+between runs:
+
+```text
+ghcr.io/dreikanter/f2-build-cache
+```
+
+That is a second GHCR package next to the app image, under the same owner. The
+`write:packages` token used to push images already covers it, so the cache needs
+no extra credentials.
+
+`mode=max` is required: it caches the Dockerfile's throwaway build stage, where
+the slow work happens.
+
+Staging and production build the same `ghcr.io/dreikanter/f2` image, so both
+workflows share one cache. A deploy that touches only application code re-runs
+nothing before `COPY . .`.
+
+When the cache package is missing, buildx warns about the failed import, builds
+normally, and populates it.
+
 ## Credentials
 
 Kamal reads the registry password from `KAMAL_REGISTRY_PASSWORD`. In this repo, `.kamal/secrets-common` maps it to the local `GHCR_TOKEN` environment variable:


### PR DESCRIPTION
Changes:

- Point Kamal's builder at a registry build cache in GHCR
- Document it in `docs/deployment-ghcr.md`

Deploy workflows run on fresh runners with an empty Docker layer cache, so every deploy compiled Node from source, cloned `rails/rails` for the edge Rails gem, and reinstalled yarn packages. With the cache, a code-only deploy re-runs nothing before `COPY . .`.

`mode=max` is required. The slow work happens in the Dockerfile's throwaway build stage, which the default `min` mode does not cache.

Staging and production build the same image, so they share one cache. No workflow or credential changes needed: the cache package sits under the same GHCR owner as the app image, covered by the existing `write:packages` token.

Kamal 2.12.0 resolves the config identically for both destinations:

```
--cache-to   type=registry,ref=ghcr.io/dreikanter/f2-build-cache,mode=max
--cache-from type=registry,ref=ghcr.io/dreikanter/f2-build-cache
```
