### PR TITLE
Derive imgproxy's Kamal version from Gemfile.lock

### DIFF
--- a/.github/workflows/deploy-imgproxy.yml
+++ b/.github/workflows/deploy-imgproxy.yml
@@ -21,14 +21,13 @@ jobs:
         uses: actions/checkout@v7
 
       # imgproxy needs no app code, so skip the bundle and install only Kamal.
-      # Pin to the version in Gemfile.lock.
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
 
       - name: Install Kamal
-        run: gem install kamal -v 2.11.0
+        run: bin/install-kamal
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/bin/install-kamal
+++ b/bin/install-kamal
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Installs the Kamal CLI standalone, at the version Gemfile.lock pins.
+#
+# For deploys that carry no app bundle, so there is no binstub to run: imgproxy
+# ships no Rails app and skips the bundle entirely. Reading the version here
+# keeps that install in step with the gem in the :development group, which the
+# hardcoded pin it replaces did not — that pin sat a version behind the lockfile.
+
+require "bundler"
+
+lockfile = File.expand_path("../Gemfile.lock", __dir__)
+spec = Bundler::LockfileParser.new(File.read(lockfile)).specs.find { |candidate| candidate.name == "kamal" }
+abort "bin/install-kamal: no kamal in Gemfile.lock" unless spec
+
+version = spec.version.to_s
+
+if system("gem", "list", "^kamal$", "-i", "--silent", "-v", version)
+  puts "kamal #{version} is already installed"
+  exit
+end
+
+puts "Installing kamal #{version}"
+system("gem", "install", "kamal", "-v", version, "--no-document", exception: true)


### PR DESCRIPTION
Changes:

- Read the Kamal version for the imgproxy deploy from `Gemfile.lock` instead of a hardcoded pin in the workflow

The imgproxy deploy installs Kamal standalone, since it ships no Rails app and needs no bundle. Its version was written into the workflow and had drifted a version behind the lockfile. `bin/install-kamal` derives it from the lockfile instead, so the two can't diverge again.
