### PR TITLE
Exclude screenshots from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,6 +61,7 @@
 /Procfile.dev
 /REVIEW.yml
 /compose.yaml
+/screenshots
 /script
 
 # Ignore docs and design records. CHANGELOG.md must stay: the /changelog page


### PR DESCRIPTION
Changes:

- Add `/screenshots` to `.dockerignore`

The three tracked PNGs were landing in the `COPY . .` layer, so touching a screenshot invalidated the bootsnap precompile and `assets:precompile` steps that follow it — a minute or two of asset rebuild for files that never reach the image. Nothing in the app, docs, or build references them.