### PR TITLE
Show token and credential status as a badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-23
 
+- Token and credential pages now sum the status up with a small badge next to the name, instead of a banner repeating what the page already says.
 - Adding or editing an AI or search key now starts with the cursor already in the first field.
 - While a token or credential is being checked, the rest of the page stays clickable — you can head back to the list instead of waiting for the check to finish.
 - Tokens and credentials that haven't been checked yet now show a question mark in the list, instead of a spinner that never spun.

--- a/app/components/badge_component.rb
+++ b/app/components/badge_component.rb
@@ -7,10 +7,11 @@ class BadgeComponent < ViewComponent::Base
     danger: "bg-danger-subtle text-danger-strong ring-danger/20"
   }.freeze
 
-  def initialize(text:, color: :neutral, key: nil)
+  def initialize(text:, color: :neutral, key: nil, data: {})
     @text = text
     @color = color
     @key = key
+    @data = data
   end
 
   def call
@@ -27,6 +28,8 @@ class BadgeComponent < ViewComponent::Base
   end
 
   def data_attributes
-    @key ? { key: @key } : nil
+    attributes = @data.dup
+    attributes[:key] = @key if @key
+    attributes.presence
   end
 end

--- a/app/helpers/credential_helper.rb
+++ b/app/helpers/credential_helper.rb
@@ -1,4 +1,20 @@
 module CredentialHelper
+  # Access tokens and credentials share the pending/validating/active/inactive
+  # lifecycle, so they share one badge vocabulary.
+  STATUS_BADGES = {
+    "active" => { text: "Valid", color: :success },
+    "inactive" => { text: "Inactive", color: :danger }
+  }.freeze
+
+  def access_token_status_badge(access_token)
+    status_badge(access_token.status, key: "access_token.status_badge", data: { status: access_token.status })
+  end
+
+  def credential_status_badge(credential)
+    status_badge(credential.state, key: "#{credential.model_name.param_key}.status_badge",
+                                   data: { credential_state: credential.state })
+  end
+
   # Header action menu for a credential's show page. Delete sits below a
   # separator so a destructive click isn't adjacent to the routine actions.
   def credential_actions_menu_items(credential, delete_confirm:)
@@ -27,5 +43,17 @@ module CredentialHelper
         data: { key: "access_token.delete", controller: "modal-trigger",
                 modal_trigger_modal_id_value: "delete-token-modal", action: "click->modal-trigger#open" } }
     ]
+  end
+
+  private
+
+  # Only a settled state gets a badge: the show pages poll until the state data
+  # attribute turns up, so rendering one mid-check would stop the poller before
+  # there is a verdict to show.
+  def status_badge(state, key:, data:)
+    badge = STATUS_BADGES[state.to_s]
+    return if badge.nil?
+
+    BadgeComponent.new(text: badge[:text], color: badge[:color], key: key, data: data)
   end
 end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -8,6 +8,10 @@
   <% end %>
 
   <% unless access_token.pending? || access_token.validating? %>
+    <% header.with_context_paragraph do %>
+      <%= render access_token_status_badge(access_token) %>
+    <% end %>
+
     <% header.with_action_button do %>
       <%= render HeaderMenuComponent.new(
         menu_id: "access-token-header-menu-#{access_token.id}",
@@ -43,10 +47,6 @@
     </div>
   <% end %>
 <% elsif access_token.active? %>
-  <%= render AlertComponent.new(variant: :success, icon: "circle-check", data: { status: "active" }) do %>
-    <span>Token is valid and ready to use</span>
-  <% end %>
-
   <% unless access_token.allows_scope?(AccessToken::READ_USERS_INFO_SCOPE) %>
     <%= render AlertComponent.new(variant: :warning, icon: "triangle-alert", data: { key: "access_token.missing-subscriber-permission" }) do %>
       <p>This token can't look up subscriber counts, so feeds using it won't show how many people follow their group. Everything else works as usual.</p>
@@ -95,25 +95,25 @@
       that the token is short a permission — only a scope list we actually read
       can accuse it of that. %>
   <% if access_token.scopes.any? && !access_token.allows_scope?(AccessToken::READ_MY_INFO_SCOPE) %>
-    <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive", key: "access_token.missing-identity-permission" }) do %>
+    <div class="max-w-2xl space-y-2 text-body" data-key="access_token.missing-identity-permission">
       <p>This token works, but it can't tell Feeder which FreeFeed account it belongs to, so there's no way to publish with it.</p>
       <p>
         A token's permissions are fixed when it's created, so this one can't be updated.
         <%= link_to "Create a new token", access_token.token_creation_url,
                     target: "_blank",
                     rel: "noopener",
-                    class: "font-medium underline underline-offset-4" %>
-        and <%= link_to "paste it here", edit_access_token_path(access_token), class: "font-medium underline underline-offset-4" %> to fix this.
+                    class: "text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
+        and <%= link_to "paste it here", edit_access_token_path(access_token), class: "text-brand underline underline-offset-4 transition hover:text-brand-hover" %> to fix this.
       </p>
-    <% end %>
+    </div>
   <% else %>
-    <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive" }) do %>
-      <p>Feeder couldn't confirm this token, so it's inactive and feeds can't publish with it.</p>
+    <div class="max-w-2xl space-y-2 text-body" data-key="access_token.inactive-hint">
+      <p>Feeder couldn't confirm this token, so feeds can't publish with it.</p>
       <p>
         It may be expired, revoked, or incorrectly copied — or the check didn't get through.
-        <%= link_to "Paste the token again", edit_access_token_path(access_token), class: "font-medium underline underline-offset-4" %> to try once more.
+        <%= link_to "Paste the token again", edit_access_token_path(access_token), class: "text-brand underline underline-offset-4 transition hover:text-brand-hover" %> to try once more.
       </p>
-    <% end %>
+    </div>
   <% end %>
 
   <%= render TokenDetailsComponent.new(access_token: access_token) %>

--- a/app/views/admin/access_tokens/show.html.erb
+++ b/app/views/admin/access_tokens/show.html.erb
@@ -3,6 +3,11 @@
 <div id="access-token-show" class="space-y-8" data-key="admin.access_token.show">
   <%= render PageHeaderComponent.new(title: @access_token.name) do |header| %>
     <% header.with_breadcrumb(label: "Admin Panel", url: admin_path) %>
+    <% unless @access_token.pending? || @access_token.validating? %>
+      <% header.with_context_paragraph do %>
+        <%= render access_token_status_badge(@access_token) %>
+      <% end %>
+    <% end %>
     <% header.with_context_paragraph do %>
       Owner:
       <%= link_to @access_token.user.email_address, admin_user_path(@access_token.user), class: "text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
@@ -19,10 +24,6 @@
       </div>
     <% end %>
   <% elsif @access_token.active? %>
-    <%= render AlertComponent.new(variant: :success, icon: "circle-check", data: { status: "active" }) do %>
-      <span>Token is valid and ready to use</span>
-    <% end %>
-
     <%= render TokenDetailsComponent.new(access_token: @access_token) %>
 
     <% if @access_token.access_token_detail.present? %>
@@ -64,9 +65,9 @@
       <% end %>
     </div>
   <% elsif @access_token.inactive? %>
-    <%= render AlertComponent.new(variant: :error, icon: "circle-x", data: { status: "inactive" }) do %>
-      <span>Token is inactive and cannot be used to access FreeFeed API. This token failed validation. It may be expired, revoked, or incorrectly copied.</span>
-    <% end %>
+    <p class="max-w-2xl text-body" data-key="access_token.inactive-hint">
+      This token failed validation, so feeds can't publish with it. It may be expired, revoked, or incorrectly copied.
+    </p>
 
     <%= render TokenDetailsComponent.new(access_token: @access_token) %>
   <% end %>

--- a/app/views/admin/ai_credentials/show.html.erb
+++ b/app/views/admin/ai_credentials/show.html.erb
@@ -3,6 +3,11 @@
 <div id="ai-credential-show" class="space-y-6" data-key="admin.ai_credential.show">
   <%= render PageHeaderComponent.new(title: @ai_credential.display_name) do |header| %>
     <% header.with_breadcrumb(label: "Admin Panel", url: admin_path) %>
+    <% unless @ai_credential.pending? || @ai_credential.validating? %>
+      <% header.with_context_paragraph do %>
+        <%= render credential_status_badge(@ai_credential) %>
+      <% end %>
+    <% end %>
     <% header.with_context_paragraph do %>
       Owner:
       <%= link_to @ai_credential.user.email_address, admin_user_path(@ai_credential.user), class: "text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
@@ -22,23 +27,17 @@
       </div>
     </div>
   <% when "active" %>
-    <%= render AlertComponent.new(variant: :success, icon: "circle-check",
-                                  data: { credential_state: "active", key: "ai_credential.active" }) do %>
-      <span>Credential is active</span>
-    <% end %>
-
     <%= render AiCredentialDetailsComponent.new(ai_credential: @ai_credential) %>
 
     <%= render AiCredentialModelsComponent.new(ai_credential: @ai_credential) %>
   <% when "inactive" %>
-    <%= render AlertComponent.new(variant: :error, icon: "circle-x",
-                                  data: { credential_state: "inactive", key: "ai_credential.inactive" }) do %>
+    <p class="max-w-2xl text-body" data-key="ai_credential.inactive">
       <% if @ai_credential.last_error.present? %>
-        <span><%= @ai_credential.last_error %></span>
+        <%= @ai_credential.last_error %>
       <% else %>
-        <span>This key didn't pass validation.</span>
+        This key didn't pass validation.
       <% end %>
-    <% end %>
+    </p>
 
     <%= render AiCredentialDetailsComponent.new(ai_credential: @ai_credential) %>
   <% end %>

--- a/app/views/admin/search_credentials/show.html.erb
+++ b/app/views/admin/search_credentials/show.html.erb
@@ -3,6 +3,11 @@
 <div id="search-credential-show" class="space-y-6" data-key="admin.search_credential.show">
   <%= render PageHeaderComponent.new(title: @search_credential.display_name) do |header| %>
     <% header.with_breadcrumb(label: "Admin Panel", url: admin_path) %>
+    <% unless @search_credential.pending? || @search_credential.validating? %>
+      <% header.with_context_paragraph do %>
+        <%= render credential_status_badge(@search_credential) %>
+      <% end %>
+    <% end %>
     <% header.with_context_paragraph do %>
       Owner:
       <%= link_to @search_credential.user.email_address, admin_user_path(@search_credential.user), class: "text-brand underline underline-offset-4 transition hover:text-brand-hover" %>
@@ -20,20 +25,15 @@
       </div>
     </div>
   <% when "active" %>
-    <%= render AlertComponent.new(variant: :success, icon: "circle-check",
-                                  data: { credential_state: "active", key: "search_credential.active" }) do %>
-      <span>Credential is active</span>
-    <% end %>
     <%= render SearchCredentialDetailsComponent.new(search_credential: @search_credential) %>
   <% when "inactive" %>
-    <%= render AlertComponent.new(variant: :error, icon: "circle-x",
-                                  data: { credential_state: "inactive", key: "search_credential.inactive" }) do %>
+    <p class="max-w-2xl text-body" data-key="search_credential.inactive">
       <% if @search_credential.last_error.present? %>
-        <span><%= @search_credential.last_error %></span>
+        <%= @search_credential.last_error %>
       <% else %>
-        <span>This key didn't pass validation.</span>
+        This key didn't pass validation.
       <% end %>
-    <% end %>
+    </p>
     <%= render SearchCredentialDetailsComponent.new(search_credential: @search_credential) %>
   <% end %>
 

--- a/app/views/ai_credentials/_show_content.html.erb
+++ b/app/views/ai_credentials/_show_content.html.erb
@@ -2,6 +2,11 @@
 <div class="space-y-6" data-key="ai_credential.show">
   <%= render PageHeaderComponent.new(title: ai_credential.display_name) do |header| %>
     <% header.with_breadcrumb(label: "AI credentials", url: ai_credentials_path) %>
+    <% unless ai_credential.pending? || ai_credential.validating? %>
+      <% header.with_context_paragraph do %>
+        <%= render credential_status_badge(ai_credential) %>
+      <% end %>
+    <% end %>
     <% header.with_action_button do %>
       <%= render HeaderMenuComponent.new(
         menu_id: "ai-credential-header-menu-#{ai_credential.id}",
@@ -25,23 +30,17 @@
       </div>
     </div>
   <% when "active" %>
-    <%= render AlertComponent.new(variant: :success, icon: "circle-check",
-                                  data: { credential_state: "active", key: "ai_credential.active" }) do %>
-      <span>Credential is active</span>
-    <% end %>
-
     <%= render AiCredentialDetailsComponent.new(ai_credential: ai_credential) %>
 
     <%= render AiCredentialModelsComponent.new(ai_credential: ai_credential) %>
   <% when "inactive" %>
-    <%= render AlertComponent.new(variant: :error, icon: "circle-x",
-                                  data: { credential_state: "inactive", key: "ai_credential.inactive" }) do %>
+    <p class="max-w-2xl text-body" data-key="ai_credential.inactive">
       <% if ai_credential.last_error.present? %>
-        <span><%= ai_credential.last_error %></span>
+        <%= ai_credential.last_error %>
       <% else %>
-        <span>This key didn't work. Grab a fresh key from your provider's dashboard and add it again.</span>
+        This key didn't work. Grab a fresh key from your provider's dashboard and add it again.
       <% end %>
-    <% end %>
+    </p>
 
     <%= render AiCredentialDetailsComponent.new(ai_credential: ai_credential) %>
   <% end %>

--- a/app/views/search_credentials/_show_content.html.erb
+++ b/app/views/search_credentials/_show_content.html.erb
@@ -2,6 +2,11 @@
 <div class="space-y-6" data-key="search_credential.show">
   <%= render PageHeaderComponent.new(title: search_credential.display_name) do |header| %>
     <% header.with_breadcrumb(label: "Search credentials", url: search_credentials_path) %>
+    <% unless search_credential.pending? || search_credential.validating? %>
+      <% header.with_context_paragraph do %>
+        <%= render credential_status_badge(search_credential) %>
+      <% end %>
+    <% end %>
     <% header.with_action_button do %>
       <%= render HeaderMenuComponent.new(
         menu_id: "search-credential-header-menu-#{search_credential.id}",
@@ -23,20 +28,15 @@
       </div>
     </div>
   <% when "active" %>
-    <%= render AlertComponent.new(variant: :success, icon: "circle-check",
-                                  data: { credential_state: "active", key: "search_credential.active" }) do %>
-      <span>Credential is active</span>
-    <% end %>
     <%= render SearchCredentialDetailsComponent.new(search_credential: search_credential) %>
   <% when "inactive" %>
-    <%= render AlertComponent.new(variant: :error, icon: "circle-x",
-                                  data: { credential_state: "inactive", key: "search_credential.inactive" }) do %>
+    <p class="max-w-2xl text-body" data-key="search_credential.inactive">
       <% if search_credential.last_error.present? %>
-        <span><%= search_credential.last_error %></span>
+        <%= search_credential.last_error %>
       <% else %>
-        <span>This key didn't work. Get a fresh key from your search provider and replace it.</span>
+        This key didn't work. Get a fresh key from your search provider and replace it.
       <% end %>
-    <% end %>
+    </p>
     <%= render SearchCredentialDetailsComponent.new(search_credential: search_credential) %>
   <% end %>
 

--- a/test/components/badge_component_test.rb
+++ b/test/components/badge_component_test.rb
@@ -35,4 +35,12 @@ class BadgeComponentTest < ViewComponent::TestCase
 
     assert_nil result.at_css("span")["data-key"]
   end
+
+  test "#call should render extra data attributes alongside the key" do
+    result = render_inline(BadgeComponent.new(text: "Valid", color: :success, key: "access_token.active", data: { status: "active" }))
+
+    badge = result.at_css("span")
+    assert_equal "active", badge["data-status"]
+    assert_equal "access_token.active", badge["data-key"]
+  end
 end

--- a/test/controllers/access_tokens/validations_controller_test.rb
+++ b/test/controllers/access_tokens/validations_controller_test.rb
@@ -64,7 +64,7 @@ class AccessTokens::ValidationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_match /data-status="active"/, response.body
-    assert_match /Token is valid and ready to use/, response.body
+    assert_match />Valid</, response.body
   end
 
   test "#show should render the Continue link with feed_id when feed_id is provided" do

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -71,6 +71,25 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", access_token.name
   end
 
+  test "#show should sum an active token up with a badge in the header" do
+    sign_in_as user
+    active = create(:access_token, :active, user: user)
+
+    get access_token_path(active)
+
+    assert_response :success
+    assert_select "header [data-key='access_token.status_badge'][data-status='active']", text: "Valid"
+  end
+
+  test "#show should not badge a token that is still being checked" do
+    sign_in_as user
+
+    get access_token_path(access_token)
+
+    assert_response :success
+    assert_select "[data-key='access_token.status_badge']", count: 0
+  end
+
   test "#show should place the token actions in the header menu" do
     sign_in_as user
     active = create(:access_token, :active, user: user)
@@ -149,7 +168,8 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-key='access_token.missing-identity-permission']", count: 0
-    assert_select "[data-status='inactive']", text: /expired, revoked, or incorrectly copied/
+    assert_select "[data-key='access_token.status_badge'][data-status='inactive']", text: "Inactive"
+    assert_select "[data-key='access_token.inactive-hint']", text: /expired, revoked, or incorrectly copied/
   end
 
   test "#show should not blame a permission when the check never read the token's scopes" do
@@ -160,7 +180,7 @@ class AccessTokensControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-key='access_token.missing-identity-permission']", count: 0
-    assert_select "[data-status='inactive']", text: /couldn't confirm this token/
+    assert_select "[data-key='access_token.inactive-hint']", text: /couldn't confirm this token/
   end
 
   test "#show should render Associated Feeds section when token has feeds" do

--- a/test/controllers/admin/ai_credentials_controller_test.rb
+++ b/test/controllers/admin/ai_credentials_controller_test.rb
@@ -37,7 +37,7 @@ class Admin::AiCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", ai_credential.display_name
     assert_select "a[href=?]", admin_user_path(ai_credential.user), text: ai_credential.user.email_address
     assert_select "a[href=?]", admin_path, text: "Admin Panel"
-    assert_select "[data-key='ai_credential.active']"
+    assert_select "[data-key='ai_credential.status_badge'][data-credential-state='active']", text: "Valid"
     assert_select "[data-key='ai_credential.provider']"
   end
 

--- a/test/controllers/admin/search_credentials_controller_test.rb
+++ b/test/controllers/admin/search_credentials_controller_test.rb
@@ -37,7 +37,7 @@ class Admin::SearchCredentialsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", search_credential.display_name
     assert_select "a[href=?]", admin_user_path(search_credential.user), text: search_credential.user.email_address
     assert_select "a[href=?]", admin_path, text: "Admin Panel"
-    assert_select "[data-key='search_credential.active']"
+    assert_select "[data-key='search_credential.status_badge'][data-credential-state='active']", text: "Valid"
     assert_select "[data-key='search_credential.usage']"
   end
 

--- a/test/controllers/ai_credentials_controller_test.rb
+++ b/test/controllers/ai_credentials_controller_test.rb
@@ -229,7 +229,7 @@ class AiCredentialsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-controller='polling']", false
-    assert_select "[data-key='ai_credential.active']"
+    assert_select "[data-key='ai_credential.status_badge'][data-credential-state='active']", text: "Valid"
   end
 
   test "#show should 404 for another user's credential" do

--- a/test/controllers/search_credentials/validations_controller_test.rb
+++ b/test/controllers/search_credentials/validations_controller_test.rb
@@ -50,7 +50,7 @@ class SearchCredentials::ValidationsControllerTest < ActionDispatch::Integration
     assert_response :success
     assert_equal "text/vnd.turbo-stream.html; charset=utf-8", response.content_type
     assert_includes response.body, "search-credential-show"
-    assert_includes response.body, "search_credential.active"
+    assert_includes response.body, "search_credential.status_badge"
   end
 
   test "#show should 404 for another user's credential" do

--- a/test/controllers/search_credentials_controller_test.rb
+++ b/test/controllers/search_credentials_controller_test.rb
@@ -174,7 +174,7 @@ class SearchCredentialsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-controller='polling']", count: 0
-    assert_select "[data-key='search_credential.active']"
+    assert_select "[data-key='search_credential.status_badge'][data-credential-state='active']", text: "Valid"
   end
 
   test "#show should render the inactive state without polling" do

--- a/test/helpers/credential_helper_test.rb
+++ b/test/helpers/credential_helper_test.rb
@@ -5,6 +5,46 @@ class CredentialHelperTest < ActionView::TestCase
     @user ||= create(:user)
   end
 
+  test "#access_token_status_badge should label an active token valid" do
+    access_token = create(:access_token, :active, user: user)
+
+    badge = render_inline_badge(access_token_status_badge(access_token))
+
+    assert_equal "Valid", badge.text
+    assert_equal "active", badge["data-status"]
+  end
+
+  test "#access_token_status_badge should label an inactive token inactive" do
+    access_token = create(:access_token, user: user, status: :inactive)
+
+    badge = render_inline_badge(access_token_status_badge(access_token))
+
+    assert_equal "Inactive", badge.text
+    assert_equal "inactive", badge["data-status"]
+  end
+
+  test "#access_token_status_badge should stay silent while the check is in flight" do
+    access_token = create(:access_token, user: user, status: :validating)
+
+    assert_nil access_token_status_badge(access_token)
+  end
+
+  test "#credential_status_badge should label a credential by its state" do
+    credential = create(:ai_credential, :inactive, user: user)
+
+    badge = render_inline_badge(credential_status_badge(credential))
+
+    assert_equal "Inactive", badge.text
+    assert_equal "inactive", badge["data-credential-state"]
+    assert_equal "ai_credential.status_badge", badge["data-key"]
+  end
+
+  test "#credential_status_badge should stay silent while the check is in flight" do
+    credential = create(:search_credential, user: user, state: :validating)
+
+    assert_nil credential_status_badge(credential)
+  end
+
   test "#credential_actions_menu_items should list edit, make default, and delete" do
     credential = create(:ai_credential, user: user)
 
@@ -69,5 +109,11 @@ class CredentialHelperTest < ActionView::TestCase
 
     assert_equal "delete-token-modal", delete_item.dig(:data, :modal_trigger_modal_id_value)
     assert_equal "click->modal-trigger#open", delete_item.dig(:data, :action)
+  end
+
+  private
+
+  def render_inline_badge(badge)
+    Nokogiri::HTML5.fragment(render(badge)).at_css("span")
   end
 end


### PR DESCRIPTION
Changes:

- Replace the status alert on access token and credential pages with a compact badge in the page header, the way the feed show page already does it
- Keep prose only where it's actionable: why an inactive one failed and what to do about it
- Let `BadgeComponent` carry extra data attributes, so the badge can hold the state the validation poller watches for

"Token is valid and ready to use" said nothing the page didn't already show, so the status moves to a small badge under the title and what's left below is the part worth reading. The badge appears only once a check has settled — while validation is in flight the spinner stays and no badge renders, so the poller keeps going until there's a verdict.
