### PR TITLE
Show integrations on the system status page

### DIFF
--- a/app/controllers/development/system_status_controller.rb
+++ b/app/controllers/development/system_status_controller.rb
@@ -1,7 +1,7 @@
 class Development::SystemStatusController < ApplicationController
   def show
     authorize :access, :dev?
-    @config = Config.status
+    @integrations = Config.integrations
     @release_info = release_info
     @configuration = configuration
     @disk_usage = Rails.cache.fetch("development/system_status/v5", expires_in: 5.minutes) do

--- a/app/views/development/system_status/show.html.erb
+++ b/app/views/development/system_status/show.html.erb
@@ -16,15 +16,15 @@
   <% end %>
 
   <section class="space-y-4">
-    <h2 class="text-2xl font-semibold mb-3 text-heading">External Configuration</h2>
-    <p class="text-body">Everything here is validated when the app starts. A broken value stops the boot, so a setting is either working or off.</p>
+    <h2 class="text-2xl font-semibold mb-3 text-heading">Integrations</h2>
+    <p class="text-body">Optional services this deploy talks to. Required settings aren't listed — the app refuses to start without them.</p>
     <%= render(DescriptionListComponent.new) do |list| %>
-      <% @config.each do |name, configured| %>
+      <% @integrations.each do |name, enabled| %>
         <% list.with_item(StatListItemComponent.new(
-          label: tag.code(name.to_s),
-          value: configured ? "Set" : "Not set",
-          key: "config.#{name}",
-          muted: !configured
+          label: name.to_s.humanize,
+          value: enabled ? "On" : "Off",
+          key: "integration.#{name}",
+          muted: !enabled
         )) %>
       <% end %>
     <% end %>

--- a/lib/boot/config.rb
+++ b/lib/boot/config.rb
@@ -74,6 +74,17 @@ class Config < ConfigRegistry
     IMGPROXY_SETTINGS.all? { |name| public_send("#{name}?") }
   end
 
+  # Optional integrations, for the system status page. Each is simply off when
+  # unconfigured. Required settings are left out: the boot gate means the app
+  # would not be running without them, so listing them says nothing.
+  def self.integrations
+    {
+      error_reporting: honeybadger_api_key?,
+      image_proxy: imgproxy?,
+      metrics: metrics_url?
+    }
+  end
+
   # imgproxy is configured all-or-nothing: off when every setting is absent,
   # on when all are present, and anything in between fails the gate. A
   # complete, individually valid trio must also sign a sample URL. Signing

--- a/lib/boot/config_registry.rb
+++ b/lib/boot/config_registry.rb
@@ -42,12 +42,6 @@ class ConfigRegistry
       raise ConfigurationError, "Invalid application configuration:\n#{violations.map { |text| "- #{text}" }.join("\n")}"
     end
 
-    # Effective configuration for the system status page. Booleans only,
-    # never values: most settings are secrets.
-    def status
-      settings.keys.index_with { |name| public_send("#{name}?") }
-    end
-
     private
 
     def settings

--- a/test/controllers/development/system_status_controller_test.rb
+++ b/test/controllers/development/system_status_controller_test.rb
@@ -42,29 +42,27 @@ class Development::SystemStatusControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-key='configuration.mailer_from.value'] code", text: "noreply@example.com"
   end
 
-  test "should list every registered setting with its effective state" do
+  test "should list every optional integration with its effective state" do
     sign_in_as(dev_user)
 
     get development_system_status_path
 
     assert_response :success
-    Config.status.each_key do |name|
-      assert_select "[data-key='config.#{name}.label'] code", text: name.to_s
-    end
-    assert_select "[data-key='config.resend_api_key.value']", text: "Not set"
-    # A setting with a default counts as set.
-    assert_select "[data-key='config.metrics_flush_interval.value']", text: "Set"
+    assert_select "[data-key='integration.error_reporting.label']", text: "Error reporting"
+    assert_select "[data-key='integration.image_proxy.label']", text: "Image proxy"
+    assert_select "[data-key='integration.metrics.label']", text: "Metrics"
+    assert_select "[data-key='integration.metrics.value']", text: "Off"
   end
 
-  test "should show a configured setting as set" do
-    Config.stub(:status, { metrics_url: true }) do
+  test "should show a configured integration as on" do
+    Config.stub(:integrations, { metrics: true }) do
       sign_in_as(dev_user)
 
       get development_system_status_path
     end
 
     assert_response :success
-    assert_select "[data-key='config.metrics_url.value']", text: "Set"
+    assert_select "[data-key='integration.metrics.value']", text: "On"
   end
 
   test "should show other tables total in table usage" do

--- a/test/lib/boot/config_test.rb
+++ b/test/lib/boot/config_test.rb
@@ -159,15 +159,6 @@ class ConfigTest < ActiveSupport::TestCase
     assert_not_includes error.message, "sensitive secret value"
   end
 
-  test "#status should map setting names to presence booleans" do
-    registry = build_registry do
-      setting :set_key, source: -> { "value" }
-      setting :unset_key, source: -> { }
-    end
-
-    assert_equal({ set_key: true, unset_key: false }, registry.status)
-  end
-
   test "#validate! should pass with empty credentials in test" do
     assert_nothing_raised { Config.validate! }
   end
@@ -192,6 +183,18 @@ class ConfigTest < ActiveSupport::TestCase
     Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("production")) do
       stub_credentials(resend) do
         assert_nothing_raised { Config.validate! }
+      end
+    end
+  end
+
+  test "#integrations should report an unconfigured integration as off" do
+    assert_equal({ error_reporting: false, image_proxy: false, metrics: false }, Config.integrations)
+  end
+
+  test "#integrations should report a configured integration as on" do
+    stub_credentials(IMGPROXY_CONFIG.merge([:honeybadger, :api_key] => "hb-api-key")) do
+      with_env("METRICS_URL", "https://metrics.example.com/api/v1/import/prometheus") do
+        assert_equal({ error_reporting: true, image_proxy: true, metrics: true }, Config.integrations)
       end
     end
   end


### PR DESCRIPTION
Changes:

- Replace the per-setting `Set`/`Not set` list on the system status page with the three optional integrations — error reporting, image proxy, metrics — shown as `On`/`Off`
- Drop `Config.status`, which has no callers left

The section is a leftover from the Health Checks list that preceded the boot gate. Since the gate landed, most of those rows carry no information: required settings are always set wherever the app is running, settings with defaults are always set, and the revision rows repeat the Deployed Version section right below them with less detail.

What's left is the one question the page couldn't answer any other way — which optional services this deploy actually talks to. The gate only enforces required settings, so absent optional config is legal and invisible everywhere else in the UI.

References:

- Related PR: #1283
