### PR TITLE
Reserve card shadow for clickable cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-23
 
+- Cards only lift off the page when they're actually clickable, so a subtle shadow now means "you can tap this".
 - Adding or editing an AI or search key now starts with the cursor already in the first field.
 - While a token or credential is being checked, the rest of the page stays clickable — you can head back to the list instead of waiting for the check to finish.
 - Tokens and credentials that haven't been checked yet now show a question mark in the list, instead of a spinner that never spun.

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,5 +1,4 @@
 class CardComponent < ViewComponent::Base
-  # Elevation belongs to LinkedCardComponent: a raised surface reads as clickable.
   BASE_CLASSES = "w-full rounded-lg border border-border bg-surface"
   PADDED_CLASSES = "p-6"
   SECTIONED_CLASSES = "overflow-hidden divide-y divide-border"

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,5 +1,7 @@
 class CardComponent < ViewComponent::Base
-  BASE_CLASSES = "w-full rounded-lg border border-border bg-surface shadow-xs"
+  # No shadow here: a raised surface reads as clickable, so the elevation lives
+  # on LinkedCardComponent instead.
+  BASE_CLASSES = "w-full rounded-lg border border-border bg-surface"
   PADDED_CLASSES = "p-6"
   SECTIONED_CLASSES = "overflow-hidden divide-y divide-border"
 

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,6 +1,5 @@
 class CardComponent < ViewComponent::Base
-  # No shadow here: a raised surface reads as clickable, so the elevation lives
-  # on LinkedCardComponent instead.
+  # Elevation belongs to LinkedCardComponent: a raised surface reads as clickable.
   BASE_CLASSES = "w-full rounded-lg border border-border bg-surface"
   PADDED_CLASSES = "p-6"
   SECTIONED_CLASSES = "overflow-hidden divide-y divide-border"

--- a/app/components/freefeed_post_component.html.erb
+++ b/app/components/freefeed_post_component.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full rounded-lg border border-border bg-surface p-4 shadow-xs" data-key="freefeed_post">
+<div class="w-full rounded-lg border border-border bg-surface p-4" data-key="freefeed_post">
   <%# On narrow screens the avatar floats so the text wraps around it; from sm:
       up the container turns into a grid (grid items ignore float) where the
       avatar spans the header and body rows, keeping both top-aligned and

--- a/app/components/linked_card_component.rb
+++ b/app/components/linked_card_component.rb
@@ -1,7 +1,8 @@
-# A card that is itself a link: renders as an anchor and layers hover
-# affordances on top of the regular card frame.
+# A card that is itself a link: renders as an anchor and layers the clickable
+# affordances — a resting shadow that lifts on hover — over the regular card
+# frame.
 class LinkedCardComponent < CardComponent
-  BASE_CLASSES = "#{CardComponent::BASE_CLASSES} block no-underline hover:bg-surface-muted hover:shadow-md transition duration-75"
+  BASE_CLASSES = "#{CardComponent::BASE_CLASSES} block no-underline shadow-xs hover:bg-surface-muted hover:shadow-md transition duration-75"
 
   def initialize(href:, **html_options)
     @href = href

--- a/app/components/linked_card_component.rb
+++ b/app/components/linked_card_component.rb
@@ -1,6 +1,3 @@
-# A card that is itself a link: renders as an anchor and layers the clickable
-# affordances — a resting shadow that lifts on hover — over the regular card
-# frame.
 class LinkedCardComponent < CardComponent
   BASE_CLASSES = "#{CardComponent::BASE_CLASSES} block no-underline shadow-xs hover:bg-surface-muted hover:shadow-md transition duration-75"
 

--- a/app/components/modal_card_component.rb
+++ b/app/components/modal_card_component.rb
@@ -1,7 +1,3 @@
-# The sole card on a modal-layout page (sign-in, registration, password
-# flows). Framed like a regular card from the sm breakpoint up; below it the
-# card dissolves into the page, leaving the layout's own padding as the only
-# inset.
 class ModalCardComponent < CardComponent
   BASE_CLASSES = "w-full sm:rounded-lg sm:border sm:border-border sm:bg-surface"
   PADDED_CLASSES = "sm:p-6"

--- a/app/components/modal_card_component.rb
+++ b/app/components/modal_card_component.rb
@@ -3,6 +3,6 @@
 # card dissolves into the page, leaving the layout's own padding as the only
 # inset.
 class ModalCardComponent < CardComponent
-  BASE_CLASSES = "w-full sm:rounded-lg sm:border sm:border-border sm:bg-surface sm:shadow-xs"
+  BASE_CLASSES = "w-full sm:rounded-lg sm:border sm:border-border sm:bg-surface"
   PADDED_CLASSES = "sm:p-6"
 end

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -76,7 +76,7 @@
       <p class="text-body mb-4">
         Posts created with this token will appear on FreeFeed on behalf of the user who created this token.
       </p>
-      <div class="w-fit min-w-[240px] rounded-xl border border-border bg-surface p-4 shadow-sm">
+      <div class="w-fit min-w-[240px] rounded-xl border border-border bg-surface p-4">
         <%= render FreefeedUserComponent.new(user: access_token.access_token_detail.freefeed_user_info) %>
       </div>
     </div>

--- a/app/views/admin/access_tokens/show.html.erb
+++ b/app/views/admin/access_tokens/show.html.erb
@@ -31,7 +31,7 @@
         <p class="text-body mb-4">
           Posts created with this token appear on FreeFeed on behalf of the user who created it.
         </p>
-        <div class="w-fit min-w-[240px] rounded-xl border border-border bg-surface p-4 shadow-sm">
+        <div class="w-fit min-w-[240px] rounded-xl border border-border bg-surface p-4">
           <%= render FreefeedUserComponent.new(user: @access_token.access_token_detail.freefeed_user_info) %>
         </div>
       </div>

--- a/app/views/admin/ai_credentials/show.html.erb
+++ b/app/views/admin/ai_credentials/show.html.erb
@@ -11,7 +11,7 @@
 
   <% case @ai_credential.state %>
   <% when "pending", "validating" %>
-    <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-xs"
+    <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3"
          data-key="ai_credential.validating">
       <div class="flex-shrink-0">
         <%= render SpinnerComponent.new %>

--- a/app/views/admin/search_credentials/show.html.erb
+++ b/app/views/admin/search_credentials/show.html.erb
@@ -11,7 +11,7 @@
 
   <% case @search_credential.state %>
   <% when "pending", "validating" %>
-    <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-xs"
+    <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3"
          data-key="search_credential.validating">
       <div class="flex-shrink-0"><%= render SpinnerComponent.new %></div>
       <div class="space-y-1">

--- a/app/views/ai_credentials/_show_content.html.erb
+++ b/app/views/ai_credentials/_show_content.html.erb
@@ -14,7 +14,7 @@
   <% when "pending", "validating" %>
     <%# aria-busy disables pointer events, so it stays on the waiting block —
         on the page it would take the breadcrumb and menus down with it. %>
-    <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-xs"
+    <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3"
          data-key="ai_credential.validating" aria-busy="true">
       <div class="flex-shrink-0">
         <%= render SpinnerComponent.new %>

--- a/app/views/feed_entries/show.html.erb
+++ b/app/views/feed_entries/show.html.erb
@@ -21,7 +21,7 @@
     <% end %>
   <% end %>
 
-  <div class="overflow-hidden rounded-lg border border-border bg-surface shadow-sm p-4">
+  <div class="overflow-hidden rounded-lg border border-border bg-surface p-4">
     <pre class="text-heading text-sm overflow-x-auto"><%= JSON.pretty_generate(@feed_entry.as_json) %></pre>
   </div>
 </div>

--- a/app/views/feed_previews/_processing.html.erb
+++ b/app/views/feed_previews/_processing.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (preview: nil) %>
 <% ai = preview && FeedProfile.depends_on_ai?(preview.feed_profile_key) %>
-<div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-xs"
+<div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3"
      role="status"
      aria-busy="true"
      data-key="preview.processing">

--- a/app/views/search_credentials/_show_content.html.erb
+++ b/app/views/search_credentials/_show_content.html.erb
@@ -14,7 +14,7 @@
   <% when "pending", "validating" %>
     <%# aria-busy disables pointer events, so it stays on the waiting block —
         on the page it would take the breadcrumb and menus down with it. %>
-    <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-xs"
+    <div class="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3"
          data-key="search_credential.validating" aria-busy="true">
       <div class="flex-shrink-0"><%= render SpinnerComponent.new %></div>
       <div class="space-y-1">

--- a/test/components/card_component_test.rb
+++ b/test/components/card_component_test.rb
@@ -11,8 +11,6 @@ class CardComponentTest < ViewComponent::TestCase
     assert_includes card["class"], "bg-surface"
     assert_includes card["class"], "rounded-lg"
     assert_includes card["class"], "p-6"
-    # Elevation is reserved for clickable cards.
-    refute_includes card["class"], "shadow-xs"
   end
 
   test "#call should render sections divided border-to-border" do

--- a/test/components/card_component_test.rb
+++ b/test/components/card_component_test.rb
@@ -11,6 +11,8 @@ class CardComponentTest < ViewComponent::TestCase
     assert_includes card["class"], "bg-surface"
     assert_includes card["class"], "rounded-lg"
     assert_includes card["class"], "p-6"
+    # Elevation is reserved for clickable cards.
+    refute_includes card["class"], "shadow-xs"
   end
 
   test "#call should render sections divided border-to-border" do

--- a/test/components/linked_card_component_test.rb
+++ b/test/components/linked_card_component_test.rb
@@ -15,6 +15,7 @@ class LinkedCardComponentTest < ViewComponent::TestCase
     assert_equal "noopener", card["rel"]
     assert_includes card["class"], "bg-surface"
     assert_includes card["class"], "p-6"
+    assert_includes card["class"], "shadow-xs"
     assert_includes card["class"], "hover:shadow-md"
     assert_includes card["class"], "hover:bg-surface-muted"
     assert_includes card["class"], "no-underline"

--- a/test/components/modal_card_component_test.rb
+++ b/test/components/modal_card_component_test.rb
@@ -15,5 +15,6 @@ class ModalCardComponentTest < ViewComponent::TestCase
     refute_includes classes, "border"
     refute_includes classes, "rounded-lg"
     refute_includes classes, "p-6"
+    refute_includes classes, "sm:shadow-xs"
   end
 end


### PR DESCRIPTION
Changes:

- Move the card shadow off `CardComponent` and onto `LinkedCardComponent`, so elevation belongs to the clickable variant
- Drop shadows from the remaining static surfaces: the FreeFeed post frame, modal-layout cards, validation spinners, and a few show-page panels
- Cover the new rule in the card component tests

Elevation was reading as an affordance on things you can't click — the heatmap card and the FreeFeed post preview looked tappable but weren't. A subtle shadow now consistently means "you can tap this", and everything else sits flat.

Form inputs, buttons, and floating overlays keep their shadows: those are either interactive or signalling layering rather than clickability.
