### PR TITLE
Show every preview attachment as a thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-25
 
+- Feed previews now show attached pictures as small thumbnails instead of a list of links.
 - Hover any number in the stats row to see the full name of what it counts.
 - Feed entry pages now link to the original post, when the entry says where it came from.
 - Feed entry pages now show a breadcrumb back to the post, above the title, instead of a button off to the side.

--- a/app/components/post_preview_component.rb
+++ b/app/components/post_preview_component.rb
@@ -1,6 +1,4 @@
 class PostPreviewComponent < ViewComponent::Base
-  IMAGE_EXTENSIONS = %w[jpg jpeg png gif webp avif bmp svg].freeze
-
   def initialize(post_data:, index: nil)
     @post_data = post_data || {}
     @index = index
@@ -114,17 +112,12 @@ class PostPreviewComponent < ViewComponent::Base
     attachment.is_a?(Hash) ? attachment["type"].presence : nil
   end
 
-  # Treat an attachment as an image when its declared type says so, or — when no
-  # type is given — when the URL ends in a known image extension. Only images get
-  # a thumbnail; everything else stays a link to avoid broken previews.
+  # Preview attachments arrive as bare URLs (FeedPreviewWorkflow passes
+  # Post#attachment_urls straight through), so an untyped one is an image the
+  # normalizer collected — thumbnail it, like the published post will.
   def image_attachment?(attachment)
     type = attachment[:type].to_s.downcase
-    return type.start_with?("image") if type.present?
-
-    extension = File.extname(URI.parse(attachment[:url]).path).delete(".").downcase
-    IMAGE_EXTENSIONS.include?(extension)
-  rescue URI::InvalidURIError
-    false
+    type.blank? || type.start_with?("image")
   end
 
   def attachment_list_item(attachment)

--- a/test/components/post_preview_component_test.rb
+++ b/test/components/post_preview_component_test.rb
@@ -69,6 +69,30 @@ class PostPreviewComponentTest < ViewComponent::TestCase
     assert_not_nil section.at_css('a[href="https://example.com/plain.jpg"] img')
   end
 
+  # Bluesky and most modern CDNs serve content-addressed image URLs with no file
+  # extension; those used to fall through to the plain-link list.
+  test "#render should thumbnail attachment urls that carry no file extension" do
+    url = "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:author/bafkphoto"
+    post_data = { "content" => "Body", "attachments" => [url] }
+
+    result = render_inline(PostPreviewComponent.new(post_data: post_data))
+
+    section = result.at_css('[data-key="preview.attachments"]')
+    assert_not_nil section.at_css("a[href='#{url}'] img")
+    assert_empty section.css("li")
+  end
+
+  test "#render should size attachment thumbnails through imgproxy" do
+    url = "https://example.com/photo.png"
+
+    result = render_inline(PostPreviewComponent.new(post_data: { "attachments" => [url] }))
+
+    image = result.at_css('[data-key="preview.attachments"] img')
+    assert_equal ImgproxyUrl.preview(url), image["src"]
+    assert_equal ImgproxyUrl.preview_srcset(url), image["srcset"]
+    assert_equal ImgproxyUrl::THUMBNAIL_SIZE.to_s, image["width"]
+  end
+
   test "keeps non-image attachments as links" do
     post_data = {
       "content" => "Body",
@@ -85,7 +109,7 @@ class PostPreviewComponentTest < ViewComponent::TestCase
     assert_not_nil section.at_css('a[href="https://example.com/clip.mp4"]')
   end
 
-  test "treats attachments with unparseable urls as non-images" do
+  test "#render should thumbnail attachments with unparseable urls" do
     post_data = {
       "content" => "Body",
       "attachments" => ["https://example.com/bad image.jpg"]
@@ -94,9 +118,8 @@ class PostPreviewComponentTest < ViewComponent::TestCase
     result = render_inline(PostPreviewComponent.new(post_data: post_data))
 
     section = result.at_css('[data-key="preview.attachments"]')
-    assert_not_nil section
-    assert_empty section.css("img")
-    assert_includes section.text, "https://example.com/bad image.jpg"
+    assert_not_nil section.at_css("img")
+    assert_empty section.css("li")
   end
 
   test "renders content without a synthesized title heading" do


### PR DESCRIPTION
Changes:

- Feed preview attachments render as imgproxy thumbnails whatever their URL looks like, instead of only the ones whose path ends in a known image extension.
- Dropped the file-extension sniffing and the `IMAGE_EXTENSIONS` list it relied on. A declared non-image type still renders as a labelled link.

Preview attachments arrive as bare URLs — `FeedPreviewWorkflow` passes `Post#attachment_urls` straight through — so there was never a declared type to test, and classification fell back to `File.extname`. Content-addressed CDN URLs carry no extension, so Bluesky previews (and anything LLM- or webhook-supplied) listed raw links where the published post shows pictures.

This matches `FreefeedPostComponent` on the post page, which has always thumbnailed every attachment URL unconditionally. Both call `ImgproxyUrl.preview`, so the signed URLs are byte-identical and share imgproxy's cache — no image is fetched twice. imgproxy already answers with a placeholder at HTTP 200 for anything it can't render, so no app-side fallback is needed.
