### PR TITLE
Discover the feed a pasted page advertises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-25
 
-- Paste a blog or site link when adding a feed and we'll find the feed it advertises for you — no more hunting for the RSS URL.
+- Paste a blog or site link when adding a feed and we'll find its feed for you. No more hunting for the RSS URL.
 - Feed previews now show attached pictures as small thumbnails instead of a list of links.
 - Hover any number in the stats row to see the full name of what it counts.
 - Feed entry pages now link to the original post, when the entry says where it came from.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-25
 
+- Paste a blog or site link when adding a feed and we'll find the feed it advertises for you — no more hunting for the RSS URL.
 - Feed previews now show attached pictures as small thumbnails instead of a list of links.
 - Hover any number in the stats row to see the full name of what it counts.
 - Feed entry pages now link to the original post, when the entry says where it came from.

--- a/app/components/feed_form_component.html.erb
+++ b/app/components/feed_form_component.html.erb
@@ -49,6 +49,8 @@
                 <p class="text-sm text-muted" role="status" data-key="form.source-checking">Checking this feed. This usually takes a few seconds.</p>
               <% elsif source_error %>
                 <p class="text-sm text-danger" data-key="form.source-error"><%= source_error %></p>
+              <% elsif source_discovered? %>
+                <p class="text-sm text-muted" data-key="form.source-discovered-note">That link goes to a page, not a feed — we found the page's feed, so that's what we'll follow.</p>
               <% else %>
                 <p class="text-sm text-muted" data-key="form.source-edit-note">Point this at a different feed and we'll re-check it before saving.</p>
               <% end %>
@@ -64,6 +66,9 @@
                                data: { key: "form.source-display" } %>
               <% feed.params&.each do |key, value| %>
                 <%= hidden_field_tag "feed[params][#{key}]", value %>
+              <% end %>
+              <% if source_discovered? %>
+                <p class="text-sm text-muted" data-key="form.source-discovered-note">That link goes to a page, not a feed — we found the page's feed, so that's what we'll follow.</p>
               <% end %>
             </div>
           <% end %>

--- a/app/components/feed_form_component.html.erb
+++ b/app/components/feed_form_component.html.erb
@@ -50,7 +50,7 @@
               <% elsif source_error %>
                 <p class="text-sm text-danger" data-key="form.source-error"><%= source_error %></p>
               <% elsif source_discovered? %>
-                <p class="text-sm text-muted" data-key="form.source-discovered-note">That link goes to a page, not a feed — we found the page's feed, so that's what we'll follow.</p>
+                <p class="text-sm text-muted" data-key="form.source-discovered-note">That link goes to a page, not a feed. We found the page's feed, so that's what we'll follow.</p>
               <% else %>
                 <p class="text-sm text-muted" data-key="form.source-edit-note">Point this at a different feed and we'll re-check it before saving.</p>
               <% end %>
@@ -68,7 +68,7 @@
                 <%= hidden_field_tag "feed[params][#{key}]", value %>
               <% end %>
               <% if source_discovered? %>
-                <p class="text-sm text-muted" data-key="form.source-discovered-note">That link goes to a page, not a feed — we found the page's feed, so that's what we'll follow.</p>
+                <p class="text-sm text-muted" data-key="form.source-discovered-note">That link goes to a page, not a feed. We found the page's feed, so that's what we'll follow.</p>
               <% end %>
             </div>
           <% end %>

--- a/app/components/feed_form_component.rb
+++ b/app/components/feed_form_component.rb
@@ -26,9 +26,8 @@ class FeedFormComponent < ViewComponent::Base
   def source_changed? = @source_changed
   def profile_changed? = @profile_changed
 
-  # The source URL was discovered on the page the user submitted (#1290): the
-  # form carries the feed's URL, not the pasted one, and a note explains the
-  # swap.
+  # The source URL was discovered on the submitted page; a note under the
+  # source field explains the swap.
   def source_discovered? = @source_discovered
 
   # Editing an existing feed vs. creating one. Every caller passes a persisted

--- a/app/components/feed_form_component.rb
+++ b/app/components/feed_form_component.rb
@@ -9,7 +9,7 @@ class FeedFormComponent < ViewComponent::Base
   POLLING_STOP_CONDITION = "[data-identification-state='complete'], [data-identification-state='error']"
 
   def initialize(feed:, candidates: [], source_changed: false, profile_changed: false,
-                 checking: false, source_error: nil, attempted_url: nil)
+                 checking: false, source_error: nil, attempted_url: nil, source_discovered: false)
     @feed = feed
     @candidates = candidates
     @source_changed = source_changed
@@ -17,6 +17,7 @@ class FeedFormComponent < ViewComponent::Base
     @checking = checking
     @source_error = source_error
     @attempted_url = attempted_url
+    @source_discovered = source_discovered
   end
 
   attr_reader :feed, :candidates, :source_error, :attempted_url
@@ -24,6 +25,11 @@ class FeedFormComponent < ViewComponent::Base
   def checking? = @checking
   def source_changed? = @source_changed
   def profile_changed? = @profile_changed
+
+  # The source URL was discovered on the page the user submitted (#1290): the
+  # form carries the feed's URL, not the pasted one, and a note explains the
+  # swap.
+  def source_discovered? = @source_discovered
 
   # Editing an existing feed vs. creating one. Every caller passes a persisted
   # feed only from the edit flow (creation always builds a fresh record), so

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -153,9 +153,8 @@ class FeedIdentificationsController < ApplicationController
     suggested = feed_identification.suggested_candidate
     profile_key = suggested&.profile_key
     source_key = FeedProfile.source_key_for(profile_key)
-    # A page URL identifies through the feed it advertises (#1290): the form
-    # carries the discovered feed URL — the URL the feed will actually read —
-    # and says so, keeping the swap visible.
+    # The form carries the URL the feed will actually read; for a page URL
+    # that's the discovered feed, and a note explains the swap.
     source_url = feed_identification.source_url_for(profile_key)
     discovered = source_url != feed_identification.input
 

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -153,6 +153,11 @@ class FeedIdentificationsController < ApplicationController
     suggested = feed_identification.suggested_candidate
     profile_key = suggested&.profile_key
     source_key = FeedProfile.source_key_for(profile_key)
+    # A page URL identifies through the feed it advertises (#1290): the form
+    # carries the discovered feed URL — the URL the feed will actually read —
+    # and says so, keeping the swap visible.
+    source_url = feed_identification.source_url_for(profile_key)
+    discovered = source_url != feed_identification.input
 
     if editing?
       # Re-render the feed being edited with the proposed source + profile
@@ -162,20 +167,22 @@ class FeedIdentificationsController < ApplicationController
       profile_changed = edit_feed.feed_profile_key != profile_key
       feed = edit_feed.tap do |f|
         f.feed_profile_key = profile_key
-        f.params = (f.params || {}).merge(source_key => feed_identification.input)
+        f.params = (f.params || {}).merge(source_key => source_url)
       end
 
       # A source (and possibly profile) change is pending confirmation, so the
       # form surfaces the matching duplicate-risk warning (spec §4).
       render(identification_success(feed, candidates: feed_identification.working_candidates,
-                                          source_changed: true, profile_changed: profile_changed))
+                                          source_changed: true, profile_changed: profile_changed,
+                                          source_discovered: discovered))
     else
       feed = Current.user.feeds.build(
-        params: { source_key => feed_identification.input },
+        params: { source_key => source_url },
         feed_profile_key: profile_key,
         name: suggested&.title&.truncate(Feed::NAME_MAX_LENGTH, omission: "…")
       )
-      render(identification_success(feed, candidates: feed_identification.working_candidates))
+      render(identification_success(feed, candidates: feed_identification.working_candidates,
+                                          source_discovered: discovered))
     end
   end
 
@@ -233,9 +240,11 @@ class FeedIdentificationsController < ApplicationController
     )
   end
 
-  def identification_success(feed, candidates: [], source_changed: false, profile_changed: false)
+  def identification_success(feed, candidates: [], source_changed: false, profile_changed: false,
+                             source_discovered: false)
     expanded_form(feed, candidates: candidates,
-                        source_changed: source_changed, profile_changed: profile_changed)
+                        source_changed: source_changed, profile_changed: profile_changed,
+                        source_discovered: source_discovered)
   end
 
   # The feed being edited (spec §4 source re-detection), or nil in the creation

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -209,8 +209,7 @@ class FeedsController < ApplicationController
   # The settled working identification for the submitted URL, or nil. A source
   # change is confirmed only when one exists and the submitted profile is one of
   # its working candidates — a candidate that actually read the source (spec §4).
-  # Looked up via for_source: a URL discovered on a submitted page (#1290) is
-  # backed by the identification of that page, not of the URL itself.
+  # for_source: a discovered feed URL is backed by its page's identification.
   def settled_working_identification
     return @settled_working_identification if defined?(@settled_working_identification)
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -209,10 +209,12 @@ class FeedsController < ApplicationController
   # The settled working identification for the submitted URL, or nil. A source
   # change is confirmed only when one exists and the submitted profile is one of
   # its working candidates — a candidate that actually read the source (spec §4).
+  # Looked up via for_source: a URL discovered on a submitted page (#1290) is
+  # backed by the identification of that page, not of the URL itself.
   def settled_working_identification
     return @settled_working_identification if defined?(@settled_working_identification)
 
-    fi = canonical_submitted_url && FeedIdentification.find_by(user: current_user, input: canonical_submitted_url)
+    fi = FeedIdentification.for_source(user: current_user, url: canonical_submitted_url)
     @settled_working_identification = (fi&.success? && fi.outcome == :working) ? fi : nil
   end
 
@@ -316,9 +318,7 @@ class FeedsController < ApplicationController
   end
 
   def cleanup_feed_identification(input)
-    return if input.blank?
-
-    FeedIdentification.find_by(user: current_user, input: input)&.destroy
+    FeedIdentification.for_source(user: current_user, url: input)&.destroy
   end
 
   # Minted with the feed so the URL is pasteable immediately, destroyed when

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -54,15 +54,18 @@ class FeedIdentification < ApplicationRecord
     candidate&.resolved_url || input
   end
 
-  # The identification behind a source URL: keyed by the input itself, or
-  # the identification of the page whose candidate resolved to the URL.
+  # The identification behind a source URL: the row keyed by the URL when
+  # it works, else a page identification whose working candidate resolved
+  # to the URL, else the keyed row (cleanup still destroys stale rows).
   def self.for_source(user:, url:)
     return nil if url.blank?
 
-    find_by(user: user, input: url) ||
-      where(user: user, status: :success).detect do |identification|
-        identification.working_candidates.any? { |c| c.resolved_url == url }
-      end
+    direct = find_by(user: user, input: url)
+    return direct if direct&.success? && direct.outcome == :working
+
+    where(user: user, status: :success).detect do |identification|
+      identification.working_candidates.any? { |c| c.resolved_url == url }
+    end || direct
   end
 
   # How the detection result should present (spec §7):

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -47,18 +47,15 @@ class FeedIdentification < ApplicationRecord
     working_candidates.map(&:profile_key)
   end
 
-  # The source URL the chosen profile's working candidate actually reads: the
-  # feed discovered on the submitted page (#1290) when there is one, otherwise
-  # the input itself. Feeds anchor to this, never to a page URL a profile
-  # can't parse.
+  # The URL the profile's working candidate actually reads: the discovered
+  # feed URL when there is one, otherwise the input. Feeds anchor to this.
   def source_url_for(profile_key)
     candidate = working_candidates.find { |c| c.profile_key == profile_key }
     candidate&.resolved_url || input
   end
 
-  # The identification behind a feed's source URL: keyed by the input itself,
-  # or — when the feed was created from a discovered feed URL (#1290) — the
-  # settled identification of the page that resolved to it.
+  # The identification behind a source URL: keyed by the input itself, or
+  # the identification of the page whose candidate resolved to the URL.
   def self.for_source(user:, url:)
     return nil if url.blank?
 

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -47,6 +47,27 @@ class FeedIdentification < ApplicationRecord
     working_candidates.map(&:profile_key)
   end
 
+  # The source URL the chosen profile's working candidate actually reads: the
+  # feed discovered on the submitted page (#1290) when there is one, otherwise
+  # the input itself. Feeds anchor to this, never to a page URL a profile
+  # can't parse.
+  def source_url_for(profile_key)
+    candidate = working_candidates.find { |c| c.profile_key == profile_key }
+    candidate&.resolved_url || input
+  end
+
+  # The identification behind a feed's source URL: keyed by the input itself,
+  # or — when the feed was created from a discovered feed URL (#1290) — the
+  # settled identification of the page that resolved to it.
+  def self.for_source(user:, url:)
+    return nil if url.blank?
+
+    find_by(user: user, input: url) ||
+      where(user: user, status: :success).detect do |identification|
+        identification.working_candidates.any? { |c| c.resolved_url == url }
+      end
+  end
+
   # How the detection result should present (spec §7):
   #   :working     — at least one candidate read the source → the feed form
   #   :unreachable — nothing connected (couldn't-reach) → the transient retry state

--- a/app/models/feed_identification/candidate.rb
+++ b/app/models/feed_identification/candidate.rb
@@ -14,6 +14,13 @@ class FeedIdentification
       @attributes["title"]
     end
 
+    # The feed URL discovered on the submitted page (#1290): the candidate was
+    # detected and tested against this URL, not the input itself. Absent when
+    # the input identified directly.
+    def resolved_url
+      @attributes["resolved_url"]
+    end
+
     def posts_found
       @attributes["posts_found"].to_i
     end

--- a/app/models/feed_identification/candidate.rb
+++ b/app/models/feed_identification/candidate.rb
@@ -2,6 +2,12 @@ class FeedIdentification
   # Wraps a persisted detection candidate (a JSONB hash) so callers read intent
   # (failed?/unreachable?/…) instead of indexing raw string keys.
   class Candidate
+    # Self-test verdicts, as persisted under "test_status". CandidateTester
+    # mints them.
+    PASSED = "passed"
+    FAILED = "failed"
+    UNREACHABLE = "unreachable"
+
     def initialize(attributes)
       @attributes = attributes
     end
@@ -24,12 +30,16 @@ class FeedIdentification
       @attributes["posts_found"].to_i
     end
 
+    def passed?
+      test_status == PASSED
+    end
+
     def failed?
-      test_status == "failed"
+      test_status == FAILED
     end
 
     def unreachable?
-      test_status == "unreachable"
+      test_status == UNREACHABLE
     end
 
     private

--- a/app/models/feed_identification/candidate.rb
+++ b/app/models/feed_identification/candidate.rb
@@ -14,8 +14,7 @@ class FeedIdentification
       @attributes["title"]
     end
 
-    # The feed URL discovered on the submitted page (#1290): the candidate was
-    # detected and tested against this URL, not the input itself. Absent when
+    # The discovered feed URL the candidate was tested against. Absent when
     # the input identified directly.
     def resolved_url
       @attributes["resolved_url"]

--- a/app/services/candidate_tester.rb
+++ b/app/services/candidate_tester.rb
@@ -1,22 +1,16 @@
-# Proves a detected non-AI candidate can actually read a source by running the
-# real loader → processor → normalizer pipeline (the same Feed stage instances
-# FeedPreviewWorkflow uses) and discarding the posts. Returns a Result:
+# Proves a detected non-AI candidate can read a source by running the real
+# loader, processor, and normalizer, then discarding the posts. Returns a
+# Result whose status is a FeedIdentification::Candidate verdict: PASSED
+# (readable, or empty but recognized), FAILED (fetched but not readable as
+# this profile), UNREACHABLE (couldn't fetch). posts_found counts sampled
+# entries that normalized.
 #
-#   status:
-#     :passed      — readable: at least one sampled entry produced a valid post,
-#                    or the processor recognized an empty-but-valid source
-#     :failed      — fetched fine but nothing normalized, or the payload was
-#                    unreadable (the processor didn't recognize it)
-#     :unreachable — couldn't fetch the source (timeout / connection)
-#   posts_found: number of sampled entries that normalized (0 = "no posts yet")
-#
-# The verdict is gated on parse/normalize failure, not fetch failure: a fetch
-# problem says nothing about whether the profile fits the source.
-#
-# AI candidates are never tested here — detection is deliberately LLM-free, and
-# an AI profile matches anything — so callers mark those :not_tested without
-# invoking this.
+# The verdict gates on parse failure, not fetch failure: a fetch problem
+# says nothing about whether the profile fits. AI candidates never come
+# here; detection is LLM-free.
 class CandidateTester
+  Candidate = FeedIdentification::Candidate
+
   # Normalize at most this many entries: enough to prove the profile reads the
   # source's shape without paying to normalize a whole backlog.
   SAMPLE_SIZE = 10
@@ -35,12 +29,11 @@ class CandidateTester
     posts_found = result.entries.first(SAMPLE_SIZE).count { |entry| normalized?(entry) }
     Result.new(status: verdict(result, posts_found), posts_found: posts_found)
   rescue Loader::Error => e
-    # Loaders wrap transport errors (timeout/connection), so a transient failure
-    # shows up as the cause → unreachable. Any other Loader::Error means we
-    # fetched but couldn't read the source (bad status, no feed link) → failure.
-    Result.new(status: e.cause.is_a?(HttpClient::Error) ? :unreachable : :failed, posts_found: 0)
+    # Loaders wrap transport errors, so a transient failure shows up as the
+    # cause. Any other Loader::Error means we fetched but couldn't read.
+    Result.new(status: e.cause.is_a?(HttpClient::Error) ? Candidate::UNREACHABLE : Candidate::FAILED, posts_found: 0)
   rescue StandardError
-    Result.new(status: :failed, posts_found: 0)
+    Result.new(status: Candidate::FAILED, posts_found: 0)
   end
 
   private
@@ -54,10 +47,10 @@ class CandidateTester
   # An empty result passes only if the processor recognized the payload —
   # otherwise the page was unreadable, not empty-but-valid.
   def verdict(result, posts_found)
-    return :passed if posts_found.positive?
-    return :passed if result.entries.empty? && result.recognized?
+    return Candidate::PASSED if posts_found.positive?
+    return Candidate::PASSED if result.entries.empty? && result.recognized?
 
-    :failed
+    Candidate::FAILED
   end
 
   # Whether one entry yields a publishable post. The normalizer raises on a

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -1,9 +1,7 @@
 class FeedIdentificationFetcher
-  # A fetch that yielded no usable response. UnreachableError (couldn't connect)
-  # persists as "unreachable" and reads as a transient retry; every other
-  # FetchError (bad status, redirect loop, a blocked non-public host) persists as
-  # "unreadable" and reads as a terminal "no feed here" (spec §7). The class and
-  # its message exist only for the logs.
+  # A fetch that yielded no usable response. UnreachableError persists as
+  # "unreachable" (transient, retryable); every other FetchError persists
+  # as "unreadable" (terminal "no feed here"). The messages are for logs.
   class FetchError < StandardError; end
   class UnreachableError < FetchError; end    # no answer: DNS, refused, or timeout
   class RedirectLimitError < FetchError; end  # followed too many redirects
@@ -26,13 +24,11 @@ class FeedIdentificationFetcher
       feed_identification.update!(status: :failed, candidates: [], error: "unidentifiable")
     end
   rescue UnreachableError => e
-    # Couldn't connect (DNS, refused, timeout): genuinely transient, so the UI
-    # offers a retry. Expected, so log without reporting it as a bug.
+    # Transient: the UI offers a retry. Expected, so not reported as a bug.
     @logger.info("Feed identification couldn't reach #{sanitize_input_for_logging(@input)}: #{e.class} (#{e.message})")
     feed_identification.update!(status: :failed, candidates: [], error: "unreachable")
   rescue FetchError => e
-    # Reached the source but it's unusable (bad status, redirect loop): retrying
-    # won't help, so this reads as a terminal "no feed here".
+    # Reachable but unusable: retrying won't help, terminal "no feed here".
     @logger.info("Feed identification fetch failed for #{sanitize_input_for_logging(@input)}: #{e.class} (#{e.message})")
     feed_identification.update!(status: :failed, candidates: [], error: "unreadable")
   rescue StandardError => e
@@ -45,15 +41,9 @@ class FeedIdentificationFetcher
 
   private
 
-  # Fetch the source URL for inspection by the URL matchers. The input is
-  # always a canonical URL here (Mode A), so we always fetch. Translates the HTTP
-  # layer's failures into FetchError subclasses, keeping the original error as the
-  # message (and as #cause) for diagnosis.
-  #
-  # Refuse a non-public target before the GET (SSRF, spec §8): the silent
-  # scheme-fix now lets a bare `169.254.169.254` reach this fetch, so a private,
-  # loopback, or metadata address must not be dialed. Redirects that hop into a
-  # private range are a separate fetch-layer gap tracked in #920.
+  # The input may be a raw address (the entry form's silent scheme-fix), so
+  # refuse non-public targets before the GET (SSRF). Redirect hops are not
+  # validated on this fetch.
   def fetch_response_for_input
     raise FetchError, "blocked non-public URL" unless PublicUrl.safe?(@input)
 
@@ -67,9 +57,8 @@ class FeedIdentificationFetcher
     raise UnreachableError, e.message
   end
 
-  # Falls back to the advertised feeds unless a direct candidate actually
-  # reads the source; a matcher can trip on page markup that no profile can
-  # parse.
+  # Fall back to advertised feeds unless a direct candidate actually reads
+  # the source; a matcher can trip on markup no profile parses.
   def identify_candidates(response)
     direct = tested_candidates(FeedProfileDetector.call(input: @input, fetched_body: response.body).candidates, input: @input)
     return direct if direct.any? { |candidate| working?(candidate) }
@@ -77,13 +66,10 @@ class FeedIdentificationFetcher
     direct + discovered_candidates(response)
   end
 
-  # Runs regular identification against each advertised feed URL, tagging
-  # candidates with the URL they were verified against. Stops at the first
-  # URL with a working candidate: the chooser, the preview, and the edit
-  # confirmation all expect one source URL per identification.
-  #
-  # Relative feed links resolve against the URL the fetch landed on, not
-  # necessarily the typed one (redirects).
+  # Stops at the first URL with a working candidate: the chooser, the
+  # preview, and the edit confirmation expect one source URL per
+  # identification. Relative links resolve against where the fetch landed,
+  # not the typed URL.
   def discovered_candidates(response)
     candidates = []
     base_url = response.url.presence || @input
@@ -139,10 +125,9 @@ class FeedIdentificationFetcher
     end
   end
 
-  # Serialize each candidate with its self-test verdict from running the
-  # real pipeline against input (the typed URL or a discovered feed URL).
-  # Only deterministic profiles appear here; the AI profile registers no
-  # matcher, so detection stays LLM-free.
+  # Self-test each candidate by running the real pipeline against input
+  # (the typed URL or a discovered feed URL). Only deterministic profiles
+  # appear here: the AI profile registers no matcher.
   def tested_candidates(candidates, input:)
     candidates.map { |candidate| candidate.as_json.merge(test_result(candidate, input: input)) }
   end
@@ -161,9 +146,7 @@ class FeedIdentificationFetcher
     }
   end
 
-  # A per-run cache so matching and per-candidate testing fetch each URL once.
-  # Scoped to this fetcher instance (one identification run); scheduled refreshes
-  # build their own loaders and are unaffected.
+  # Per-run cache: matching and candidate testing fetch each URL once.
   def http_client
     @http_client ||= HttpClient.build(
       adapter: HttpClient::CachingAdapter, timeout: 15, max_redirects: 5

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -17,8 +17,8 @@ class FeedIdentificationFetcher
   end
 
   def identify
-    body = fetch_body_for_input
-    candidates = identify_candidates(body)
+    response = fetch_response_for_input
+    candidates = identify_candidates(response)
 
     if candidates.any?
       feed_identification.update!(status: :success, candidates: candidates, error: nil)
@@ -45,7 +45,7 @@ class FeedIdentificationFetcher
 
   private
 
-  # Fetch the source URL body for inspection by the URL matchers. The input is
+  # Fetch the source URL for inspection by the URL matchers. The input is
   # always a canonical URL here (Mode A), so we always fetch. Translates the HTTP
   # layer's failures into FetchError subclasses, keeping the original error as the
   # message (and as #cause) for diagnosis.
@@ -54,15 +54,13 @@ class FeedIdentificationFetcher
   # scheme-fix now lets a bare `169.254.169.254` reach this fetch, so a private,
   # loopback, or metadata address must not be dialed. Redirects that hop into a
   # private range are a separate fetch-layer gap tracked in #920.
-  def fetch_body_for_input
+  def fetch_response_for_input
     raise FetchError, "blocked non-public URL" unless PublicUrl.safe?(@input)
 
     response = http_client.get(@input)
     raise ResponseStatusError, "HTTP #{response.status}" unless response.success?
 
-    # The base for resolving discovered relative feed links.
-    @fetched_url = response.url.presence || @input
-    response.body
+    response
   rescue HttpClient::TooManyRedirectsError => e
     raise RedirectLimitError, e.message
   rescue HttpClient::Error => e
@@ -72,21 +70,25 @@ class FeedIdentificationFetcher
   # Falls back to the advertised feeds unless a direct candidate actually
   # reads the source; a matcher can trip on page markup that no profile can
   # parse.
-  def identify_candidates(body)
-    direct = tested_candidates(FeedProfileDetector.call(input: @input, fetched_body: body).candidates, input: @input)
+  def identify_candidates(response)
+    direct = tested_candidates(FeedProfileDetector.call(input: @input, fetched_body: response.body).candidates, input: @input)
     return direct if direct.any? { |candidate| working?(candidate) }
 
-    direct + discovered_candidates(body)
+    direct + discovered_candidates(response)
   end
 
   # Runs regular identification against each advertised feed URL, tagging
   # candidates with the URL they were verified against. Stops at the first
   # URL with a working candidate: the chooser, the preview, and the edit
   # confirmation all expect one source URL per identification.
-  def discovered_candidates(body)
+  #
+  # Relative feed links resolve against the URL the fetch landed on, not
+  # necessarily the typed one (redirects).
+  def discovered_candidates(response)
     candidates = []
+    base_url = response.url.presence || @input
 
-    FeedLinkDiscovery.call(body, base_url: @fetched_url).each do |feed_url|
+    FeedLinkDiscovery.call(response.body, base_url: base_url).each do |feed_url|
       feed_body = fetch_discovered_body(feed_url)
       next if feed_body.nil?
 

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -18,15 +18,10 @@ class FeedIdentificationFetcher
 
   def identify
     body = fetch_body_for_input
+    candidates = identify_candidates(body)
 
-    result = FeedProfileDetector.call(input: @input, fetched_body: body)
-
-    if result.candidates.any?
-      feed_identification.update!(
-        status: :success,
-        candidates: tested_candidates(result.candidates),
-        error: nil
-      )
+    if candidates.any?
+      feed_identification.update!(status: :success, candidates: candidates, error: nil)
     else
       feed_identification.update!(status: :failed, candidates: [], error: "unidentifiable")
     end
@@ -65,11 +60,58 @@ class FeedIdentificationFetcher
     response = http_client.get(@input)
     raise ResponseStatusError, "HTTP #{response.status}" unless response.success?
 
+    # Discovery resolves the page's relative feed links against where the
+    # fetch landed (after redirects), not necessarily the typed URL.
+    @fetched_url = response.url.presence || @input
     response.body
   rescue HttpClient::TooManyRedirectsError => e
     raise RedirectLimitError, e.message
   rescue HttpClient::Error => e
     raise UnreachableError, e.message
+  end
+
+  # Direct identification of the input URL, falling back to the feeds the
+  # page advertises (#1290) when its body matches no profile: a blog or site
+  # URL then identifies through its feed links instead of dead-ending on
+  # "no feed here".
+  def identify_candidates(body)
+    direct = FeedProfileDetector.call(input: @input, fetched_body: body).candidates
+    return tested_candidates(direct, input: @input) if direct.any?
+
+    discovered_candidates(body)
+  end
+
+  # Identify each advertised feed URL the normal way (bounded fan-out, same
+  # caching client), tagging candidates with the URL they were verified
+  # against so the created feed anchors to the feed, not the page. Stops at
+  # the first URL yielding a working candidate: one identification maps to
+  # one source URL — the chooser, the preview, and the edit confirmation all
+  # rely on that — and document order conventionally lists the main feed
+  # ahead of auxiliary ones.
+  def discovered_candidates(body)
+    candidates = []
+
+    FeedLinkDiscovery.call(body, base_url: @fetched_url).each do |feed_url|
+      feed_body = fetch_discovered_body(feed_url)
+      next if feed_body.nil?
+
+      detected = FeedProfileDetector.call(input: feed_url, fetched_body: feed_body).candidates
+      tested = tested_candidates(detected, input: feed_url)
+                 .map { |attributes| attributes.merge("resolved_url" => feed_url) }
+      candidates.concat(tested)
+      break if tested.any? { |attributes| attributes["test_status"] == "passed" }
+    end
+
+    candidates
+  end
+
+  # A discovered URL that can't be fetched is skipped, not fatal: the page
+  # itself was reachable, and another advertised feed may still work.
+  def fetch_discovered_body(feed_url)
+    response = http_client.get(feed_url)
+    response.success? ? response.body : nil
+  rescue HttpClient::Error
+    nil
   end
 
   def sanitize_input_for_logging(input)
@@ -93,16 +135,17 @@ class FeedIdentificationFetcher
   end
 
   # Serialize each candidate with its self-test verdict from running the real
-  # pipeline. Only deterministic profiles can appear here — the AI profile
-  # registers no matcher — so detection stays LLM-free.
-  def tested_candidates(candidates)
-    candidates.map { |candidate| candidate.as_json.merge(test_result(candidate)) }
+  # pipeline against `input` — the typed URL, or a discovered feed URL. Only
+  # deterministic profiles can appear here — the AI profile registers no
+  # matcher — so detection stays LLM-free.
+  def tested_candidates(candidates, input:)
+    candidates.map { |candidate| candidate.as_json.merge(test_result(candidate, input: input)) }
   end
 
-  def test_result(candidate)
+  def test_result(candidate, input:)
     result = CandidateTester.new(
       user: @user,
-      input: @input,
+      input: input,
       profile_key: candidate.profile_key,
       http_client: http_client
     ).call

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -69,11 +69,14 @@ class FeedIdentificationFetcher
     raise UnreachableError, e.message
   end
 
+  # Falls back to the advertised feeds unless a direct candidate actually
+  # reads the source; a matcher can trip on page markup that no profile can
+  # parse.
   def identify_candidates(body)
-    direct = FeedProfileDetector.call(input: @input, fetched_body: body).candidates
-    return tested_candidates(direct, input: @input) if direct.any?
+    direct = tested_candidates(FeedProfileDetector.call(input: @input, fetched_body: body).candidates, input: @input)
+    return direct if direct.any? { |candidate| working?(candidate) }
 
-    discovered_candidates(body)
+    direct + discovered_candidates(body)
   end
 
   # Runs regular identification against each advertised feed URL, tagging
@@ -91,17 +94,26 @@ class FeedIdentificationFetcher
       tested = tested_candidates(detected, input: feed_url)
                  .map { |attributes| attributes.merge("resolved_url" => feed_url) }
       candidates.concat(tested)
-      break if tested.any? { |attributes| attributes["test_status"] == "passed" }
+      break if tested.any? { |attributes| working?(attributes) }
     end
 
     candidates
   end
 
-  # A broken advertised feed is skipped; another may still work.
+  def working?(candidate_attributes)
+    candidate_attributes["test_status"] == "passed"
+  end
+
+  # A broken advertised feed is skipped; another may still work. The hrefs
+  # are author-controlled, so redirect hops are validated too (SSRF).
   def fetch_discovered_body(feed_url)
-    response = http_client.get(feed_url)
-    response.success? ? response.body : nil
-  rescue HttpClient::Error
+    response = http_client.get(feed_url, options: { validate_url: PublicUrl.method(:safe?) })
+    return response.body if response.success?
+
+    @logger.info("Feed discovery skipped #{sanitize_input_for_logging(feed_url)}: HTTP #{response.status}")
+    nil
+  rescue HttpClient::Error => e
+    @logger.info("Feed discovery skipped #{sanitize_input_for_logging(feed_url)}: #{e.class} (#{e.message})")
     nil
   end
 

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -60,8 +60,7 @@ class FeedIdentificationFetcher
     response = http_client.get(@input)
     raise ResponseStatusError, "HTTP #{response.status}" unless response.success?
 
-    # Discovery resolves the page's relative feed links against where the
-    # fetch landed (after redirects), not necessarily the typed URL.
+    # The base for resolving discovered relative feed links.
     @fetched_url = response.url.presence || @input
     response.body
   rescue HttpClient::TooManyRedirectsError => e
@@ -70,10 +69,6 @@ class FeedIdentificationFetcher
     raise UnreachableError, e.message
   end
 
-  # Direct identification of the input URL, falling back to the feeds the
-  # page advertises (#1290) when its body matches no profile: a blog or site
-  # URL then identifies through its feed links instead of dead-ending on
-  # "no feed here".
   def identify_candidates(body)
     direct = FeedProfileDetector.call(input: @input, fetched_body: body).candidates
     return tested_candidates(direct, input: @input) if direct.any?
@@ -81,13 +76,10 @@ class FeedIdentificationFetcher
     discovered_candidates(body)
   end
 
-  # Identify each advertised feed URL the normal way (bounded fan-out, same
-  # caching client), tagging candidates with the URL they were verified
-  # against so the created feed anchors to the feed, not the page. Stops at
-  # the first URL yielding a working candidate: one identification maps to
-  # one source URL — the chooser, the preview, and the edit confirmation all
-  # rely on that — and document order conventionally lists the main feed
-  # ahead of auxiliary ones.
+  # Runs regular identification against each advertised feed URL, tagging
+  # candidates with the URL they were verified against. Stops at the first
+  # URL with a working candidate: the chooser, the preview, and the edit
+  # confirmation all expect one source URL per identification.
   def discovered_candidates(body)
     candidates = []
 
@@ -105,8 +97,7 @@ class FeedIdentificationFetcher
     candidates
   end
 
-  # A discovered URL that can't be fetched is skipped, not fatal: the page
-  # itself was reachable, and another advertised feed may still work.
+  # A broken advertised feed is skipped; another may still work.
   def fetch_discovered_body(feed_url)
     response = http_client.get(feed_url)
     response.success? ? response.body : nil
@@ -134,10 +125,10 @@ class FeedIdentificationFetcher
     end
   end
 
-  # Serialize each candidate with its self-test verdict from running the real
-  # pipeline against `input` — the typed URL, or a discovered feed URL. Only
-  # deterministic profiles can appear here — the AI profile registers no
-  # matcher — so detection stays LLM-free.
+  # Serialize each candidate with its self-test verdict from running the
+  # real pipeline against input (the typed URL or a discovered feed URL).
+  # Only deterministic profiles appear here; the AI profile registers no
+  # matcher, so detection stays LLM-free.
   def tested_candidates(candidates, input:)
     candidates.map { |candidate| candidate.as_json.merge(test_result(candidate, input: input)) }
   end

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -89,7 +89,7 @@ class FeedIdentificationFetcher
   end
 
   def working?(candidate_attributes)
-    candidate_attributes["test_status"] == "passed"
+    FeedIdentification::Candidate.new(candidate_attributes).passed?
   end
 
   # A broken advertised feed is skipped; another may still work. The hrefs
@@ -141,7 +141,7 @@ class FeedIdentificationFetcher
     ).call
 
     {
-      "test_status" => result.status.to_s,
+      "test_status" => result.status,
       "posts_found" => result.posts_found
     }
   end

--- a/app/services/feed_link_discovery.rb
+++ b/app/services/feed_link_discovery.rb
@@ -1,0 +1,59 @@
+# Finds the feeds a web page advertises: typed alternate links in its markup
+# (application/rss+xml, application/atom+xml, application/feed+json), resolved
+# against the URL the page was fetched from — the final one after redirects,
+# so relative hrefs point where the page actually lives.
+#
+# This feeds the identification fallback for page URLs (#1290): when a pasted
+# link matches no profile directly, these are the URLs worth checking next.
+#
+# Page authors control the hrefs, so every resolved URL passes the PublicUrl
+# SSRF guard before being offered for fetching (redirect hops stay the fetch
+# layer's concern, #920). Returns at most LIMIT URLs, deduplicated, in
+# document order — sites conventionally list the main feed before auxiliary
+# ones like comment feeds.
+class FeedLinkDiscovery
+  FEED_MIME_TYPES = %w[application/rss+xml application/atom+xml application/feed+json].freeze
+  LIMIT = 3
+
+  def self.call(html, base_url:)
+    new(html, base_url: base_url).call
+  end
+
+  def initialize(html, base_url:)
+    @html = html
+    @base_url = base_url
+  end
+
+  def call
+    return [] if @html.blank? || @base_url.blank?
+
+    Nokogiri::HTML(@html)
+      .css("link")
+      .filter_map { |link| feed_url(link) }
+      .uniq
+      .select { |url| PublicUrl.safe?(url) }
+      .first(LIMIT)
+  end
+
+  private
+
+  def feed_url(link)
+    return nil unless alternate_feed_link?(link)
+
+    href = link["href"].to_s.strip
+    return nil if href.empty?
+
+    URI.join(@base_url, href).to_s
+  rescue URI::Error
+    nil
+  end
+
+  # rel is a space-separated token list, and type may carry parameters
+  # ("application/rss+xml; charset=utf-8"); both compare case-insensitively.
+  def alternate_feed_link?(link)
+    rel_tokens = link["rel"].to_s.downcase.split
+    type = link["type"].to_s.downcase.split(";").first.to_s.strip
+
+    rel_tokens.include?("alternate") && FEED_MIME_TYPES.include?(type)
+  end
+end

--- a/app/services/feed_link_discovery.rb
+++ b/app/services/feed_link_discovery.rb
@@ -1,16 +1,8 @@
-# Finds the feeds a web page advertises: typed alternate links in its markup
-# (application/rss+xml, application/atom+xml, application/feed+json), resolved
-# against the URL the page was fetched from — the final one after redirects,
-# so relative hrefs point where the page actually lives.
-#
-# This feeds the identification fallback for page URLs (#1290): when a pasted
-# link matches no profile directly, these are the URLs worth checking next.
-#
-# Page authors control the hrefs, so every resolved URL passes the PublicUrl
-# SSRF guard before being offered for fetching (redirect hops stay the fetch
-# layer's concern, #920). Returns at most LIMIT URLs, deduplicated, in
-# document order — sites conventionally list the main feed before auxiliary
-# ones like comment feeds.
+# Extracts the feed URLs a page advertises via typed alternate links
+# (RSS, Atom, JSON Feed). Relative hrefs resolve against base_url, the
+# final URL after redirects. The hrefs are author-controlled, so non-public
+# URLs are dropped (SSRF). Returns at most LIMIT URLs, deduplicated, in
+# document order; sites conventionally list the main feed first.
 class FeedLinkDiscovery
   FEED_MIME_TYPES = %w[application/rss+xml application/atom+xml application/feed+json].freeze
   LIMIT = 3
@@ -48,8 +40,8 @@ class FeedLinkDiscovery
     nil
   end
 
-  # rel is a space-separated token list, and type may carry parameters
-  # ("application/rss+xml; charset=utf-8"); both compare case-insensitively.
+  # rel is a space-separated token list; type may carry parameters
+  # ("application/rss+xml; charset=utf-8").
   def alternate_feed_link?(link)
     rel_tokens = link["rel"].to_s.downcase.split
     type = link["type"].to_s.downcase.split(";").first.to_s.strip

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -13,10 +13,8 @@ module HttpClient
   class Response
     attr_reader :status, :body, :headers, :url
 
-    # `url` is the final URL the response came from — after redirects, it names
-    # the landing URL rather than the requested one, so relative references in
-    # the body can be resolved against the right base. nil when the adapter
-    # doesn't track it (e.g. hand-built responses in tests).
+    # Final URL after redirects, for resolving relative references in the
+    # body. nil when the adapter doesn't track it.
     def initialize(status:, body:, headers: {}, url: nil)
       @status = status
       @body = body

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -13,8 +13,8 @@ module HttpClient
   class Response
     attr_reader :status, :body, :headers, :url
 
-    # Final URL after redirects, for resolving relative references in the
-    # body. nil when the adapter doesn't track it.
+    # The URL this response came from: the requested URL, or the final hop
+    # when redirects were followed. nil when the adapter doesn't track it.
     def initialize(status:, body:, headers: {}, url: nil)
       @status = status
       @body = body

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -11,12 +11,17 @@ require_relative "http_client/caching_adapter"
 
 module HttpClient
   class Response
-    attr_reader :status, :body, :headers
+    attr_reader :status, :body, :headers, :url
 
-    def initialize(status:, body:, headers: {})
+    # `url` is the final URL the response came from — after redirects, it names
+    # the landing URL rather than the requested one, so relative references in
+    # the body can be resolved against the right base. nil when the adapter
+    # doesn't track it (e.g. hand-built responses in tests).
+    def initialize(status:, body:, headers: {}, url: nil)
       @status = status
       @body = body
       @headers = headers
+      @url = url
     end
 
     def success?

--- a/lib/http_client/faraday_adapter.rb
+++ b/lib/http_client/faraday_adapter.rb
@@ -50,7 +50,7 @@ module HttpClient
         status: response.status,
         body: response.body,
         headers: response.headers.to_hash,
-        # After redirects env.url names the final hop, not the requested URL.
+        # env.url is the final hop after redirects.
         url: response.env.url.to_s
       )
     rescue Faraday::TimeoutError, Timeout::Error => e

--- a/lib/http_client/faraday_adapter.rb
+++ b/lib/http_client/faraday_adapter.rb
@@ -49,7 +49,9 @@ module HttpClient
       Response.new(
         status: response.status,
         body: response.body,
-        headers: response.headers.to_hash
+        headers: response.headers.to_hash,
+        # After redirects env.url names the final hop, not the requested URL.
+        url: response.env.url.to_s
       )
     rescue Faraday::TimeoutError, Timeout::Error => e
       raise TimeoutError, "Request timed out: #{e.message}"

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -467,6 +467,48 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "label[data-key='candidate.xkcd'] [data-key='candidate.suggested-badge']"
   end
 
+  test "#show should carry the discovered feed URL into the form for a page URL" do
+    sign_in_as(user)
+    page_url = "http://example.com/blog"
+    feed_url = "http://example.com/feed.xml"
+    html = %(<html><head><link rel="alternate" type="application/rss+xml" href="/feed.xml"></head><body></body></html>)
+    rss_body = "<?xml version=\"1.0\"?><rss><channel><title>Example Blog</title></channel></rss>"
+    stub_request(:get, page_url).to_return(status: 200, body: html)
+    stub_request(:get, feed_url).to_return(status: 200, body: rss_body)
+
+    post feed_identifications_path, params: { url: page_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    perform_enqueued_jobs
+
+    get feed_identifications_path, params: { url: page_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    # The feed anchors to the discovered feed URL, and the swap is visible: the
+    # source field shows the feed URL with the discovery note underneath.
+    assert_select "input[type=hidden][name='feed[params][url]'][value=?]", feed_url
+    assert_select "input[data-key='form.source-display'][value=?]", feed_url
+    assert_select "[data-key='form.source-discovered-note']"
+    assert_select "input[type=hidden][name='feed[feed_profile_key]'][value=?]", "rss"
+  end
+
+  test "#show should not show the discovery note when the input identified directly" do
+    sign_in_as(user)
+    url = "http://example.com/feed.xml"
+    create(
+      :feed_identification,
+      user: user,
+      input: url,
+      started_at: Time.current,
+      status: :success,
+      candidates: [{ "profile_key" => "rss", "title" => "Example", "test_status" => "passed" }]
+    )
+
+    get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "input[type=hidden][name='feed[params][url]'][value=?]", url
+    assert_select "[data-key='form.source-discovered-note']", count: 0
+  end
+
   test "#show should preselect the default schedule interval with no blank option" do
     sign_in_as(user)
     create(:access_token, :active, user: user)

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -482,8 +482,6 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     get feed_identifications_path, params: { url: page_url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    # The feed anchors to the discovered feed URL, and the swap is visible: the
-    # source field shows the feed URL with the discovery note underneath.
     assert_select "input[type=hidden][name='feed[params][url]'][value=?]", feed_url
     assert_select "input[data-key='form.source-display'][value=?]", feed_url
     assert_select "[data-key='form.source-discovered-note']"

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -1265,9 +1265,8 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
                                  candidates: [{ "profile_key" => "rss", "test_status" => "passed",
                                                 "resolved_url" => "https://example.com/feed.xml" }])
 
-    # The re-rendered form carries the discovered feed URL (not the typed page
-    # URL), so the confirming save submits it; the page's settled identification
-    # backs it as a working source — no re-detection round.
+    # The form carries the discovered feed URL, so the confirming save
+    # submits it directly.
     assert_no_enqueued_jobs(only: FeedIdentificationJob) do
       patch feed_url(disabled), params: {
         feed: { feed_profile_key: "rss", params: { url: "https://example.com/feed.xml" } }

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -172,6 +172,30 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Feed saved as draft", flash[:success]
   end
 
+  test "#create should clean up the page identification behind a discovered feed URL" do
+    sign_in_as(user)
+    access_token
+    create(:feed_identification, user: user, input: "https://example.com/blog",
+                                 status: :success, started_at: Time.current,
+                                 candidates: [{ "profile_key" => "rss", "test_status" => "passed",
+                                                "resolved_url" => "http://example.com/feed.xml" }])
+
+    feed_params = {
+      params: { url: "http://example.com/feed.xml" },
+      name: "Blog",
+      feed_profile_key: "rss",
+      access_token_id: access_token.id,
+      target_group: "testgroup",
+      schedule_interval: "1h"
+    }
+
+    assert_difference("Feed.count", 1) do
+      post feeds_path, params: { feed: feed_params, enable_feed: "0" }
+    end
+
+    assert_nil FeedIdentification.find_by(user: user, input: "https://example.com/blog")
+  end
+
   test "#create should enable a feed without any preview" do
     sign_in_as(user)
     access_token
@@ -1230,6 +1254,30 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
 
     disabled.reload
     assert_equal "https://original.com/feed.xml", disabled.url
+  end
+
+  test "#update should apply a discovered feed URL once its page identification confirms it" do
+    sign_in_as(user)
+    disabled = create(:feed, :disabled, user: user,
+                      params: { "url" => "https://original.com/feed.xml" })
+    create(:feed_identification, user: user, input: "https://example.com/blog",
+                                 status: :success, started_at: Time.current,
+                                 candidates: [{ "profile_key" => "rss", "test_status" => "passed",
+                                                "resolved_url" => "https://example.com/feed.xml" }])
+
+    # The re-rendered form carries the discovered feed URL (not the typed page
+    # URL), so the confirming save submits it; the page's settled identification
+    # backs it as a working source — no re-detection round.
+    assert_no_enqueued_jobs(only: FeedIdentificationJob) do
+      patch feed_url(disabled), params: {
+        feed: { feed_profile_key: "rss", params: { url: "https://example.com/feed.xml" } }
+      }
+    end
+
+    disabled.reload
+    assert_equal "https://example.com/feed.xml", disabled.url
+    assert_nil FeedIdentification.find_by(user: user, input: "https://example.com/blog"),
+               "the page identification should be cleaned up after the confirming save"
   end
 
   test "#update should reset schedule next_run_at when interval changes" do

--- a/test/lib/http_client/faraday_adapter_test.rb
+++ b/test/lib/http_client/faraday_adapter_test.rb
@@ -125,6 +125,27 @@ class HttpClient::FaradayAdapterTest < ActiveSupport::TestCase
     assert response.success?
   end
 
+  test "exposes the requested URL on the response" do
+    stub_request(:get, "https://example.com/test")
+      .to_return(status: 200, body: "ok")
+
+    response = client.get("https://example.com/test")
+
+    assert_equal "https://example.com/test", response.url
+  end
+
+  test "exposes the final URL after redirects" do
+    stub_request(:get, "https://example.com/redirect")
+      .to_return(status: 302, headers: { "Location" => "https://blog.example.com/final" })
+
+    stub_request(:get, "https://blog.example.com/final")
+      .to_return(status: 200, body: "Final destination")
+
+    response = client.get("https://example.com/redirect")
+
+    assert_equal "https://blog.example.com/final", response.url
+  end
+
   test "does not follow redirects when explicitly disabled" do
     stub_request(:get, "https://example.com/redirect")
       .to_return(status: 302, headers: { "Location" => "https://example.com/final" })

--- a/test/models/feed_identification/candidate_test.rb
+++ b/test/models/feed_identification/candidate_test.rb
@@ -12,6 +12,12 @@ class FeedIdentification::CandidateTest < ActiveSupport::TestCase
     assert_equal "Example", subject.title
   end
 
+  test "#resolved_url should read the discovered feed URL when present" do
+    assert_equal "https://example.com/feed.xml",
+                 candidate("resolved_url" => "https://example.com/feed.xml").resolved_url
+    assert_nil candidate({}).resolved_url
+  end
+
   test "#posts_found should default to zero" do
     assert_equal 0, candidate({}).posts_found
     assert_equal 3, candidate("posts_found" => 3).posts_found

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -187,4 +187,72 @@ class FeedIdentificationTest < ActiveSupport::TestCase
 
     assert_equal %w[rss], identification.working_candidate_profile_keys
   end
+
+  test "#source_url_for should prefer the working candidate's discovered feed URL" do
+    identification = FeedIdentification.new(
+      input: "https://example.com/blog",
+      status: :success,
+      candidates: [
+        { "profile_key" => "rss", "test_status" => "failed", "resolved_url" => "https://example.com/broken.xml" },
+        { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
+      ]
+    )
+
+    assert_equal "https://example.com/feed.xml", identification.source_url_for("rss")
+  end
+
+  test "#source_url_for should fall back to the input for direct candidates" do
+    identification = FeedIdentification.new(
+      input: "https://example.com/feed.xml",
+      status: :success,
+      candidates: [{ "profile_key" => "rss", "test_status" => "passed" }]
+    )
+
+    assert_equal "https://example.com/feed.xml", identification.source_url_for("rss")
+    assert_equal "https://example.com/feed.xml", identification.source_url_for("json_feed")
+  end
+
+  test ".for_source should find the identification keyed by the URL itself" do
+    identification = create(:feed_identification, user: user, input: "https://example.com/feed.xml")
+
+    assert_equal identification, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
+  end
+
+  test ".for_source should find the identification whose candidate resolved to the URL" do
+    identification = create(
+      :feed_identification,
+      user: user,
+      input: "https://example.com/blog",
+      status: :success,
+      candidates: [
+        { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
+      ]
+    )
+
+    assert_equal identification, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
+  end
+
+  test ".for_source should scope discovered lookups to the user and working candidates" do
+    create(
+      :feed_identification,
+      user: create(:user),
+      input: "https://example.com/blog",
+      status: :success,
+      candidates: [
+        { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
+      ]
+    )
+    create(
+      :feed_identification,
+      user: user,
+      input: "https://example.com/other",
+      status: :success,
+      candidates: [
+        { "profile_key" => "rss", "test_status" => "failed", "resolved_url" => "https://example.com/feed.xml" }
+      ]
+    )
+
+    assert_nil FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
+    assert_nil FeedIdentification.for_source(user: user, url: nil)
+  end
 end

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -232,6 +232,22 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_equal identification, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
   end
 
+  test ".for_source should prefer a working page identification over a stale keyed row" do
+    create(:feed_identification, user: user, input: "https://example.com/feed.xml",
+                                 status: :failed, error: "unreachable")
+    page = create(
+      :feed_identification,
+      user: user,
+      input: "https://example.com/blog",
+      status: :success,
+      candidates: [
+        { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
+      ]
+    )
+
+    assert_equal page, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
+  end
+
   test ".for_source should scope discovered lookups to the user and working candidates" do
     create(
       :feed_identification,

--- a/test/services/candidate_tester_test.rb
+++ b/test/services/candidate_tester_test.rb
@@ -51,7 +51,7 @@ class CandidateTesterTest < ActiveSupport::TestCase
     stub_request(:get, url).to_return(status: 200, body: rss_feed(rss_item))
 
     result = result_for(url)
-    assert_equal :passed, result.status
+    assert_equal FeedIdentification::Candidate::PASSED, result.status
     assert_equal 1, result.posts_found
   end
 
@@ -60,7 +60,7 @@ class CandidateTesterTest < ActiveSupport::TestCase
     stub_request(:get, url).to_return(status: 200, body: rss_feed(""))
 
     result = result_for(url)
-    assert_equal :passed, result.status
+    assert_equal FeedIdentification::Candidate::PASSED, result.status
     assert_equal 0, result.posts_found
   end
 
@@ -71,7 +71,7 @@ class CandidateTesterTest < ActiveSupport::TestCase
     stub_request(:get, url).to_return(status: 200, body: rss_feed(rss_item(uid: false) + rss_item))
 
     result = result_for(url)
-    assert_equal :passed, result.status
+    assert_equal FeedIdentification::Candidate::PASSED, result.status
     assert_equal 1, result.posts_found
   end
 
@@ -79,7 +79,7 @@ class CandidateTesterTest < ActiveSupport::TestCase
     url = "https://example.com/broken.xml"
     stub_request(:get, url).to_return(status: 200, body: rss_feed(rss_item(uid: false)))
 
-    assert_equal :failed, result_for(url).status
+    assert_equal FeedIdentification::Candidate::FAILED, result_for(url).status
   end
 
   test "#call should fail when entries normalize only into rejected posts" do
@@ -89,7 +89,7 @@ class CandidateTesterTest < ActiveSupport::TestCase
     stub_request(:get, url).to_return(status: 200, body: rss_feed(rss_item_rejected))
 
     result = result_for(url)
-    assert_equal :failed, result.status
+    assert_equal FeedIdentification::Candidate::FAILED, result.status
     assert_equal 0, result.posts_found
   end
 
@@ -97,14 +97,14 @@ class CandidateTesterTest < ActiveSupport::TestCase
     url = "https://example.com/down.xml"
     stub_request(:get, url).to_return(status: 503, body: "boom")
 
-    assert_equal :failed, result_for(url).status
+    assert_equal FeedIdentification::Candidate::FAILED, result_for(url).status
   end
 
   test "#call should be unreachable on a transport timeout" do
     url = "https://example.com/slow.xml"
     stub_request(:get, url).to_raise(HttpClient::TimeoutError.new("timed out"))
 
-    assert_equal :unreachable, result_for(url).status
+    assert_equal FeedIdentification::Candidate::UNREACHABLE, result_for(url).status
   end
 
   test "#call should fail an RSS page that matched textually but isn't a feed" do
@@ -114,7 +114,7 @@ class CandidateTesterTest < ActiveSupport::TestCase
     stub_request(:get, url).to_return(status: 200, body: '<rss version="2.0"><channel></channel></rss>')
 
     result = result_for(url)
-    assert_equal :failed, result.status
+    assert_equal FeedIdentification::Candidate::FAILED, result.status
     assert_equal 0, result.posts_found
   end
 
@@ -124,7 +124,7 @@ class CandidateTesterTest < ActiveSupport::TestCase
     url = "https://syndication.twitter.com/srv/timeline-profile/screen-name/ghost"
     stub_request(:get, url).to_return(status: 200, body: "<html><body>nothing here</body></html>")
 
-    assert_equal :failed, result_for("ghost", profile_key: "twitter").status
+    assert_equal FeedIdentification::Candidate::FAILED, result_for("ghost", profile_key: "twitter").status
   end
 
   test "#call should fail when the source is reachable but exposes no feed" do
@@ -133,7 +133,7 @@ class CandidateTesterTest < ActiveSupport::TestCase
     url = "https://www.youtube.com/@handle"
     stub_request(:get, url).to_return(status: 200, body: "<html><head></head><body>no feed</body></html>")
 
-    assert_equal :failed, result_for(url, profile_key: "youtube").status
+    assert_equal FeedIdentification::Candidate::FAILED, result_for(url, profile_key: "youtube").status
   end
 
   test "#call should reuse a warm http client instead of fetching again" do

--- a/test/services/candidate_tester_test.rb
+++ b/test/services/candidate_tester_test.rb
@@ -46,6 +46,17 @@ class CandidateTesterTest < ActiveSupport::TestCase
     CandidateTester.new(user: user, input: url, profile_key: profile_key).call
   end
 
+  test "#call should fail when the pipeline raises unexpectedly" do
+    url = "https://example.com/feed.xml"
+    stub_request(:get, url).to_return(status: 200, body: rss_feed(rss_item))
+
+    Processor::RssProcessor.stub(:new, ->(*) { raise "boom" }) do
+      result = result_for(url)
+      assert_equal FeedIdentification::Candidate::FAILED, result.status
+      assert_equal 0, result.posts_found
+    end
+  end
+
   test "#call should pass and count posts for a source that yields valid posts" do
     url = "https://example.com/feed.xml"
     stub_request(:get, url).to_return(status: 200, body: rss_feed(rss_item))

--- a/test/services/feed_identification_fetcher_test.rb
+++ b/test/services/feed_identification_fetcher_test.rb
@@ -268,4 +268,129 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     profile_keys = feed_identification.candidates.map { |c| c["profile_key"] }
     assert_equal %w[xkcd rss], profile_keys, "xkcd > rss for xkcd.com URLs"
   end
+
+  test "#identify should not tag directly identified candidates with a resolved URL" do
+    url = "http://example.com/feed.xml"
+    stub_request(:get, url).to_return(status: 200, body: rss_body("Direct Feed"))
+
+    FeedIdentificationFetcher.new(user: user, input: url, logger: @logger).identify
+
+    candidate = FeedIdentification.find_by(user: user, input: url).candidates.first
+    assert_nil candidate["resolved_url"]
+  end
+
+  test "#identify should discover the feed a page advertises" do
+    page_url = "http://example.com/blog"
+    feed_url = "http://example.com/feed.xml"
+
+    stub_request(:get, page_url).to_return(status: 200, body: page_body(%(<link rel="alternate" type="application/rss+xml" href="/feed.xml">)))
+    stub_request(:get, feed_url).to_return(status: 200, body: rss_body("Discovered Feed"))
+
+    FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
+
+    feed_identification = FeedIdentification.find_by(user: user, input: page_url)
+    assert_equal "success", feed_identification.status
+    assert_equal :working, feed_identification.outcome
+
+    candidate = feed_identification.suggested_candidate
+    assert_equal "rss", candidate.profile_key
+    assert_equal "Discovered Feed", candidate.title
+    assert_equal feed_url, candidate.resolved_url
+    assert_equal feed_url, feed_identification.source_url_for("rss")
+  end
+
+  test "#identify should resolve relative feed links against the final redirected URL" do
+    stub_request(:get, "http://example.com/").to_return(status: 301, headers: { "Location" => "http://www.example.com/blog/" })
+    stub_request(:get, "http://www.example.com/blog/").to_return(status: 200, body: page_body(%(<link rel="alternate" type="application/rss+xml" href="feed.xml">)))
+    stub_request(:get, "http://www.example.com/blog/feed.xml").to_return(status: 200, body: rss_body("Moved Feed"))
+
+    FeedIdentificationFetcher.new(user: user, input: "http://example.com/", logger: @logger).identify
+
+    feed_identification = FeedIdentification.find_by(user: user, input: "http://example.com/")
+    assert_equal :working, feed_identification.outcome
+    assert_equal "http://www.example.com/blog/feed.xml", feed_identification.suggested_candidate.resolved_url
+  end
+
+  test "#identify should keep trying advertised feeds until one works" do
+    page_url = "http://example.com/blog"
+    links = <<~HTML
+      <link rel="alternate" type="application/rss+xml" href="/missing.xml">
+      <link rel="alternate" type="application/atom+xml" href="/feed.xml">
+    HTML
+
+    stub_request(:get, page_url).to_return(status: 200, body: page_body(links))
+    stub_request(:get, "http://example.com/missing.xml").to_return(status: 404)
+    stub_request(:get, "http://example.com/feed.xml").to_return(status: 200, body: rss_body("Second Feed"))
+
+    FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
+
+    feed_identification = FeedIdentification.find_by(user: user, input: page_url)
+    assert_equal :working, feed_identification.outcome
+    assert_equal "http://example.com/feed.xml", feed_identification.suggested_candidate.resolved_url
+  end
+
+  test "#identify should stop at the first advertised feed that works" do
+    page_url = "http://example.com/blog"
+    links = <<~HTML
+      <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+      <link rel="alternate" type="application/rss+xml" href="/comments.xml">
+    HTML
+
+    stub_request(:get, page_url).to_return(status: 200, body: page_body(links))
+    stub_request(:get, "http://example.com/feed.xml").to_return(status: 200, body: rss_body("Main Feed"))
+    stub_request(:get, "http://example.com/comments.xml").to_return(status: 200, body: rss_body("Comments Feed"))
+
+    FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
+
+    feed_identification = FeedIdentification.find_by(user: user, input: page_url)
+    assert_equal %w[http://example.com/feed.xml], feed_identification.working_candidates.map(&:resolved_url).uniq
+    assert_not_requested :get, "http://example.com/comments.xml"
+  end
+
+  test "#identify should stay unidentifiable when no advertised feed works" do
+    page_url = "http://example.com/blog"
+
+    stub_request(:get, page_url).to_return(status: 200, body: page_body(%(<link rel="alternate" type="application/rss+xml" href="/gone.xml">)))
+    stub_request(:get, "http://example.com/gone.xml").to_return(status: 404)
+
+    FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
+
+    feed_identification = FeedIdentification.find_by(user: user, input: page_url)
+    assert_equal "failed", feed_identification.status
+    assert_equal "unidentifiable", feed_identification.error
+  end
+
+  test "#identify should never fetch a non-public advertised feed URL" do
+    page_url = "http://example.com/blog"
+
+    stub_request(:get, page_url).to_return(status: 200, body: page_body(%(<link rel="alternate" type="application/rss+xml" href="http://127.0.0.1/feed.xml">)))
+
+    FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
+
+    assert_equal "unidentifiable", FeedIdentification.find_by(user: user, input: page_url).error
+    assert_not_requested :get, "http://127.0.0.1/feed.xml"
+  end
+
+  private
+
+  def page_body(links)
+    "<html><head><title>My Blog</title>#{links}</head><body>Posts</body></html>"
+  end
+
+  def rss_body(title)
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>#{title}</title>
+          <link>http://example.com</link>
+          <item>
+            <title>Hello</title>
+            <description>World</description>
+            <link>http://example.com/post1</link>
+          </item>
+        </channel>
+      </rss>
+    XML
+  end
 end

--- a/test/services/feed_identification_fetcher_test.rb
+++ b/test/services/feed_identification_fetcher_test.rb
@@ -360,6 +360,40 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     assert_equal "unidentifiable", feed_identification.error
   end
 
+  test "#identify should not follow an advertised feed's redirect to a private address" do
+    page_url = "http://example.com/blog"
+
+    stub_request(:get, page_url).to_return(status: 200, body: page_body(%(<link rel="alternate" type="application/rss+xml" href="/feed.xml">)))
+    stub_request(:get, "http://example.com/feed.xml")
+      .to_return(status: 302, headers: { "Location" => "http://127.0.0.1/feed.xml" })
+
+    FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
+
+    assert_equal "unidentifiable", FeedIdentification.find_by(user: user, input: page_url).error
+    assert_not_requested :get, "http://127.0.0.1/feed.xml"
+  end
+
+  test "#identify should fall back to advertised feeds when a matched candidate fails its test" do
+    page_url = "http://example.com/blog"
+    html = <<~HTML
+      <html><head>
+        <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+      </head><body>
+        <p>Example markup:</p>
+        <pre><rss version="2.0"><channel></channel></rss></pre>
+      </body></html>
+    HTML
+
+    stub_request(:get, page_url).to_return(status: 200, body: html)
+    stub_request(:get, "http://example.com/feed.xml").to_return(status: 200, body: rss_body("Real Feed"))
+
+    FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
+
+    feed_identification = FeedIdentification.find_by(user: user, input: page_url)
+    assert_equal :working, feed_identification.outcome
+    assert_equal "http://example.com/feed.xml", feed_identification.suggested_candidate.resolved_url
+  end
+
   test "#identify should never fetch a non-public advertised feed URL" do
     page_url = "http://example.com/blog"
 

--- a/test/services/feed_link_discovery_test.rb
+++ b/test/services/feed_link_discovery_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+
+class FeedLinkDiscoveryTest < ActiveSupport::TestCase
+  BASE_URL = "https://example.com/blog/post".freeze
+
+  def discover(html, base_url: BASE_URL)
+    FeedLinkDiscovery.call(html, base_url: base_url)
+  end
+
+  test "#call should collect typed alternate links in document order" do
+    html = <<~HTML
+      <html><head>
+        <link rel="alternate" type="application/rss+xml" href="https://example.com/feed.xml">
+        <link rel="alternate" type="application/atom+xml" href="https://example.com/atom.xml">
+        <link rel="alternate" type="application/feed+json" href="https://example.com/feed.json">
+      </head><body></body></html>
+    HTML
+
+    assert_equal %w[
+      https://example.com/feed.xml
+      https://example.com/atom.xml
+      https://example.com/feed.json
+    ], discover(html)
+  end
+
+  test "#call should resolve relative hrefs against the base URL" do
+    html = <<~HTML
+      <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+      <link rel="alternate" type="application/atom+xml" href="atom.xml">
+      <link rel="alternate" type="application/feed+json" href="//cdn.example.com/feed.json">
+    HTML
+
+    assert_equal %w[
+      https://example.com/feed.xml
+      https://example.com/blog/atom.xml
+      https://cdn.example.com/feed.json
+    ], discover(html)
+  end
+
+  test "#call should ignore links that are not typed feed alternates" do
+    html = <<~HTML
+      <link rel="stylesheet" href="/style.css">
+      <link rel="preconnect" href="https://fonts.example.com">
+      <link rel="alternate" type="text/html" hreflang="de" href="/de/">
+      <link rel="alternate" href="/untyped">
+      <link rel="icon" type="application/rss+xml" href="/not-alternate.xml">
+    HTML
+
+    assert_empty discover(html)
+  end
+
+  test "#call should match rel tokens and type parameters case-insensitively" do
+    html = <<~HTML
+      <link rel="ALTERNATE" type="Application/RSS+XML; charset=utf-8" href="/feed.xml">
+    HTML
+
+    assert_equal %w[https://example.com/feed.xml], discover(html)
+  end
+
+  test "#call should skip blank and unparseable hrefs" do
+    html = <<~HTML
+      <link rel="alternate" type="application/rss+xml" href="">
+      <link rel="alternate" type="application/rss+xml">
+      <link rel="alternate" type="application/rss+xml" href="fe ed.xml">
+      <link rel="alternate" type="application/rss+xml" href="/good.xml">
+    HTML
+
+    assert_equal %w[https://example.com/good.xml], discover(html)
+  end
+
+  test "#call should deduplicate repeated feed URLs" do
+    html = <<~HTML
+      <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+      <link rel="alternate" type="application/rss+xml" href="https://example.com/feed.xml">
+    HTML
+
+    assert_equal %w[https://example.com/feed.xml], discover(html)
+  end
+
+  test "#call should cap the result at three URLs" do
+    links = (1..5).map do |n|
+      %(<link rel="alternate" type="application/rss+xml" href="/feed-#{n}.xml">)
+    end
+
+    assert_equal %w[
+      https://example.com/feed-1.xml
+      https://example.com/feed-2.xml
+      https://example.com/feed-3.xml
+    ], discover(links.join("\n"))
+  end
+
+  test "#call should reject non-public feed URLs" do
+    html = <<~HTML
+      <link rel="alternate" type="application/rss+xml" href="http://localhost/feed.xml">
+      <link rel="alternate" type="application/rss+xml" href="http://127.0.0.1/feed.xml">
+      <link rel="alternate" type="application/rss+xml" href="http://169.254.169.254/latest">
+      <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+    HTML
+
+    assert_equal %w[https://example.com/feed.xml], discover(html)
+  end
+
+  test "#call should return nothing for blank input or missing base" do
+    html = %(<link rel="alternate" type="application/rss+xml" href="/feed.xml">)
+
+    assert_empty discover(nil)
+    assert_empty discover("")
+    assert_empty discover(html, base_url: nil)
+  end
+
+  test "#call should return nothing for non-HTML text" do
+    assert_empty discover("just some plain text without any markup")
+  end
+end


### PR DESCRIPTION
Changes:

- When a pasted URL matches no profile, fall back to the feeds the page advertises in its typed alternate links. A blog or site URL now identifies instead of dead-ending on "no feed here"
- Anchor the created or re-pointed feed to the discovered feed URL, with a note under the source field showing the swap
- Expose the final post-redirect URL on `HttpClient::Response` so relative feed links resolve correctly

Discovery is deterministic and bounded: typed RSS/Atom/JSON Feed links only, at most three in document order, SSRF-filtered, fetched through the identification run's caching client. It stops at the first URL with a working candidate, keeping one source URL per identification.

References:

- Closes #1290
- Related issue: #920