### PR TITLE
Unescape ampersands in Telegram link URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-25
 
-- Links in Telegram posts now keep their full address — a stray `&amp;` no longer sneaks into the middle and breaks them.
+- Links in Telegram posts now keep their full address, instead of breaking on a stray `&amp;`.
 - Feed previews now show attached pictures as small thumbnails instead of a list of links.
 - Hover any number in the stats row to see the full name of what it counts.
 - Feed entry pages now link to the original post, when the entry says where it came from.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-25
 
+- Links in Telegram posts now keep their full address — a stray `&amp;` no longer sneaks into the middle and breaks them.
 - Feed previews now show attached pictures as small thumbnails instead of a list of links.
 - Hover any number in the stats row to see the full name of what it counts.
 - Feed entry pages now link to the original post, when the entry says where it came from.

--- a/app/services/processor/telegram_processor.rb
+++ b/app/services/processor/telegram_processor.rb
@@ -14,6 +14,13 @@ module Processor
     ].join(", ").freeze
     BACKGROUND_IMAGE = /background-image:\s*url\(['"]?(.*?)['"]?\)/i
 
+    # t.me escapes the ampersands of a link URL on top of the escaping the
+    # surrounding HTML already gets — anchors carrying an onclick handler are
+    # the usual offenders — so one decode leaves a literal "&amp;" sitting in
+    # the query string. Left alone it travels into the post and breaks the
+    # link. Repairing decoded values is a no-op for correctly escaped markup.
+    ESCAPED_AMPERSAND = /&amp;/i
+
     def process
       entries = document.css(MESSAGE_SELECTOR).filter_map { |wrap| build_entry(wrap) }
       Result.new(entries: entries, recognized: true)
@@ -44,14 +51,40 @@ module Processor
         raw_data: {
           "uid" => uid,
           "url" => message_url(wrap, uid),
-          "text_html" => wrap.at_css(".tgme_widget_message_text")&.inner_html.to_s,
+          "text_html" => text_html(wrap),
           "images" => image_urls(wrap)
         }
       )
     end
 
     def message_url(wrap, uid)
-      wrap.at_css(".tgme_widget_message_date")&.[]("href").presence || "https://t.me/#{uid}"
+      href = wrap.at_css(".tgme_widget_message_date")&.[]("href").presence
+      href ? unescape_ampersands(href) : "https://t.me/#{uid}"
+    end
+
+    def text_html(wrap)
+      text = wrap.at_css(".tgme_widget_message_text")
+      return "" unless text
+
+      repair_link_urls(text)
+      text.inner_html
+    end
+
+    # Repairs both the href and the URL t.me renders as the link's own text.
+    # A caption is left as typed: a rendered URL never carries whitespace.
+    def repair_link_urls(node)
+      node.css("a[href]").each do |anchor|
+        anchor["href"] = unescape_ampersands(anchor["href"])
+        anchor.xpath(".//text()").each do |text|
+          next if text.content.match?(/\s/)
+
+          text.content = unescape_ampersands(text.content)
+        end
+      end
+    end
+
+    def unescape_ampersands(url)
+      url.gsub(ESCAPED_AMPERSAND, "&")
     end
 
     def image_urls(wrap)

--- a/app/services/processor/telegram_processor.rb
+++ b/app/services/processor/telegram_processor.rb
@@ -14,11 +14,9 @@ module Processor
     ].join(", ").freeze
     BACKGROUND_IMAGE = /background-image:\s*url\(['"]?(.*?)['"]?\)/i
 
-    # t.me escapes the ampersands of a link URL on top of the escaping the
-    # surrounding HTML already gets — anchors carrying an onclick handler are
-    # the usual offenders — so one decode leaves a literal "&amp;" sitting in
-    # the query string. Left alone it travels into the post and breaks the
-    # link. Repairing decoded values is a no-op for correctly escaped markup.
+    # t.me escapes a link URL's ampersands twice, so one decode still leaves a
+    # literal "&amp;" in the query string. Repairing an already decoded value
+    # is a no-op when the markup was escaped once.
     ESCAPED_AMPERSAND = /&amp;/i
 
     def process
@@ -70,8 +68,7 @@ module Processor
       text.inner_html
     end
 
-    # Repairs both the href and the URL t.me renders as the link's own text.
-    # A caption is left as typed: a rendered URL never carries whitespace.
+    # Skips captions: a rendered URL never carries whitespace.
     def repair_link_urls(node)
       node.css("a[href]").each do |anchor|
         anchor["href"] = unescape_ampersands(anchor["href"])

--- a/test/fixtures/files/feeds/telegram/channel.html
+++ b/test/fixtures/files/feeds/telegram/channel.html
@@ -1,6 +1,7 @@
 <!-- Trimmed, structurally faithful sample of a t.me/s/<channel> preview page.
      Covers: text-only, photo-only, a video post (whose duration <time> precedes
-     the dated <time>), and a service message with no data-post (skipped). -->
+     the dated <time>), a link whose ampersands t.me escaped twice, and a
+     service message with no data-post (skipped). -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -48,6 +49,17 @@
         <div class="tgme_widget_message_footer compact js-message_footer">
           <a class="tgme_widget_message_date" href="https://t.me/testchannel/3">
             <time datetime="2026-06-01T12:10:00+00:00" class="time">12:10</time>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="tgme_widget_message_wrap js-widget_message_wrap">
+      <div class="tgme_widget_message js-widget_message" data-post="testchannel/4">
+        <div class="tgme_widget_message_text js-message_text">Tickets: <a href="https://example.com/tickets?utm_source=tg&amp;amp;utm_campaign=spring" target="_blank" rel="noopener" onclick="return confirm('Open this link?\n\n'+this.href);">https://example.com/tickets?utm_source=tg&amp;amp;utm_campaign=spring</a></div>
+        <div class="tgme_widget_message_footer compact js-message_footer">
+          <a class="tgme_widget_message_date" href="https://t.me/testchannel/4">
+            <time datetime="2026-06-01T12:15:00+00:00" class="time">12:15</time>
           </a>
         </div>
       </div>

--- a/test/fixtures/files/feeds/telegram/normalized.json
+++ b/test/fixtures/files/feeds/telegram/normalized.json
@@ -32,5 +32,15 @@
     "status": "enqueued",
     "uid": "testchannel/3",
     "validation_errors": []
+  },
+  {
+    "attachment_urls": [],
+    "comments": [],
+    "content": "Tickets: https://example.com/tickets?utm_source=tg&utm_campaign=spring - https://t.me/testchannel/4",
+    "published_at": "2026-06-01T12:15:00.000Z",
+    "source_url": "https://t.me/testchannel/4",
+    "status": "enqueued",
+    "uid": "testchannel/4",
+    "validation_errors": []
   }
 ]

--- a/test/services/normalizer/telegram_normalizer_test.rb
+++ b/test/services/normalizer/telegram_normalizer_test.rb
@@ -27,6 +27,11 @@ class Normalizer::TelegramNormalizerTest < ActiveSupport::TestCase
     assert_equal "https://t.me/testchannel/2", posts[1].content
   end
 
+  test "#normalize should carry a link's query string into the post unbroken" do
+    assert_includes posts[3].content, "https://example.com/tickets?utm_source=tg&utm_campaign=spring"
+    assert_not_includes posts[3].content, "&amp;"
+  end
+
   test "#normalize should expose photos as attachments" do
     assert_equal ["https://cdn-test.telesco.pe/file/photo2.jpg"], posts[1].attachment_urls
   end

--- a/test/services/processor/telegram_processor_test.rb
+++ b/test/services/processor/telegram_processor_test.rb
@@ -13,8 +13,26 @@ class Processor::TelegramProcessorTest < ActiveSupport::TestCase
     @entries ||= Processor::TelegramProcessor.new(feed, sample_html).process.entries
   end
 
+  def message_html(text_html)
+    <<~HTML
+      <div class="tgme_widget_message_wrap">
+        <div class="tgme_widget_message" data-post="testchannel/9">
+          <div class="tgme_widget_message_text">#{text_html}</div>
+          <a class="tgme_widget_message_date" href="https://t.me/testchannel/9">
+            <time datetime="2026-06-01T12:00:00+00:00"></time>
+          </a>
+        </div>
+      </div>
+    HTML
+  end
+
+  def link_from(html)
+    entry = Processor::TelegramProcessor.new(feed, html).process.entries.sole
+    Nokogiri::HTML::DocumentFragment.parse(entry.raw_data["text_html"]).at_css("a")
+  end
+
   test "#process should create a FeedEntry per message with a data-post id" do
-    assert_equal 3, entries.size
+    assert_equal 4, entries.size
     assert entries.all? { |entry| entry.is_a?(FeedEntry) }
     assert entries.all? { |entry| entry.feed == feed }
     assert entries.all? { |entry| entry.status == "pending" }
@@ -22,7 +40,7 @@ class Processor::TelegramProcessorTest < ActiveSupport::TestCase
 
   test "#process should skip service messages without a data-post id" do
     assert_not_includes entries.map(&:uid), nil
-    assert_equal %w[testchannel/1 testchannel/2 testchannel/3], entries.map(&:uid)
+    assert_equal %w[testchannel/1 testchannel/2 testchannel/3 testchannel/4], entries.map(&:uid)
   end
 
   test "#process should store the message permalink and text html" do
@@ -43,6 +61,30 @@ class Processor::TelegramProcessorTest < ActiveSupport::TestCase
     video_entry = entries[2]
 
     assert_equal ["https://cdn-test.telesco.pe/file/vthumb3.jpg"], video_entry.raw_data["images"]
+  end
+
+  test "#process should unescape the ampersands t.me escaped twice in a link" do
+    link_html = entries[3].raw_data["text_html"]
+    anchor = Nokogiri::HTML::DocumentFragment.parse(link_html).at_css("a")
+
+    assert_equal "https://example.com/tickets?utm_source=tg&utm_campaign=spring", anchor["href"]
+    assert_equal "https://example.com/tickets?utm_source=tg&utm_campaign=spring", anchor.text
+  end
+
+  test "#process should leave a correctly escaped link URL alone" do
+    html = message_html(%(<a href="https://example.com/?a=1&amp;b=2">https://example.com/?a=1&amp;b=2</a>))
+    anchor = link_from(html)
+
+    assert_equal "https://example.com/?a=1&b=2", anchor["href"]
+    assert_equal "https://example.com/?a=1&b=2", anchor.text
+  end
+
+  test "#process should keep link captions as written" do
+    html = message_html(%(<a href="https://example.com/?a=1&amp;amp;b=2">Tea &amp;amp; coffee</a>))
+    anchor = link_from(html)
+
+    assert_equal "https://example.com/?a=1&b=2", anchor["href"]
+    assert_equal "Tea &amp; coffee", anchor.text
   end
 
   test "#process should use the dated time, not the video duration, for published_at" do


### PR DESCRIPTION
Changes:

- Unescape the ampersands t.me leaves in scraped link URLs, so query strings survive into posts
- Add processor and normalizer tests, plus a fixture message carrying such a link

t.me escapes a link URL's ampersands twice, so one decode still leaves a literal `&amp;` in the query string. The scraper now repairs the anchor href, the URL rendered as link text, and the message permalink. Captions are left as typed.

References:

- Closes #1329
