### PR TITLE
Extract Bluesky external link cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-25
 
+- Bluesky posts that are just a shared link now come through with the link and its title, instead of only a link back to Bluesky.
 - Feed previews now show attached pictures as small thumbnails instead of a list of links.
 - Hover any number in the stats row to see the full name of what it counts.
 - Feed entry pages now link to the original post, when the entry says where it came from.

--- a/app/services/normalizer/bluesky_normalizer.rb
+++ b/app/services/normalizer/bluesky_normalizer.rb
@@ -1,9 +1,10 @@
 module Normalizer
   # Maps a parsed Bluesky post into a Post: the post text becomes the content
-  # with the bsky.app permalink appended, and any embedded images, gallery
-  # items, or video thumbnails become attachments. The permalink is always
-  # constructed by the processor, so unlike feed-sourced profiles no extra
-  # URL validation is needed beyond the base checks.
+  # with the bsky.app permalink appended, an external link card is folded into
+  # the text, and any embedded images, gallery items, or video thumbnails
+  # become attachments. The permalink is always constructed by the processor,
+  # so unlike feed-sourced profiles no extra URL validation is needed beyond
+  # the base checks.
   class BlueskyNormalizer < Base
     private
 
@@ -12,11 +13,32 @@ module Normalizer
     end
 
     def normalize_content
-      post_content_with_url(raw_data["text"].to_s, source_url)
+      post_content_with_url(text_with_link_card, source_url)
     end
 
     def normalize_attachment_urls
       Array(raw_data["images"]).uniq
+    end
+
+    def text_with_link_card
+      [post_text, link_card_text].compact_blank.join("\n\n")
+    end
+
+    def post_text
+      raw_data["text"].to_s
+    end
+
+    # Link cards usually come with little or no text of their own, so the
+    # card's target is what the post is about. Bluesky also keeps the link in
+    # the text when the author typed it there — no need to repeat it.
+    def link_card_text
+      card = raw_data["link_card"]
+      return nil unless card.is_a?(Hash)
+
+      url = card["url"].to_s
+      return nil if url.blank? || post_text.include?(url)
+
+      [card["title"].presence, url].compact.join("\n")
     end
   end
 end

--- a/app/services/processor/bluesky_processor.rb
+++ b/app/services/processor/bluesky_processor.rb
@@ -2,8 +2,9 @@ module Processor
   # Parses a Bluesky getAuthorFeed JSON payload into FeedEntry objects. Only
   # the author's own top-level posts survive: reposts (items carrying a
   # `reason`) and replies are skipped. Truncated link text is expanded to the
-  # full target URL from the post's facets, and embedded images, gallery
-  # items, and video thumbnails are collected as attachment candidates.
+  # full target URL from the post's facets, embedded images, gallery items, and
+  # video thumbnails are collected as attachment candidates, and an external
+  # link card contributes its target URL and title.
   class BlueskyProcessor < Base
     LINK_FACET = "app.bsky.richtext.facet#link".freeze
     # Placeholder the AppView serves when an account's handle no longer
@@ -42,6 +43,8 @@ module Processor
       published_at = parse_time(post.dig("record", "createdAt"))
       return nil unless published_at
 
+      embed = post["embed"] || {}
+
       FeedEntry.new(
         feed: feed,
         uid: uid,
@@ -51,7 +54,8 @@ module Processor
           "uid" => uid,
           "url" => post_url(post),
           "text" => post_text(post["record"] || {}),
-          "images" => embed_images(post["embed"] || {})
+          "images" => embed_images(embed),
+          "link_card" => embed_link_card(embed)
         }
       )
     end
@@ -114,6 +118,20 @@ module Processor
       else
         []
       end.uniq
+    end
+
+    # A link card keeps its target outside the post text, so a post that is
+    # nothing but a card would otherwise normalize to an empty body.
+    def embed_link_card(embed)
+      case embed["$type"]
+      when "app.bsky.embed.external#view"
+        external = embed["external"]
+        return nil unless external.is_a?(Hash) && external["uri"].present?
+
+        { "url" => external["uri"], "title" => external["title"].presence }.compact
+      when "app.bsky.embed.recordWithMedia#view"
+        embed_link_card(embed["media"] || {})
+      end
     end
 
     def parse_time(value)

--- a/test/fixtures/files/feeds/bluesky/author_feed.json
+++ b/test/fixtures/files/feeds/bluesky/author_feed.json
@@ -212,6 +212,84 @@
     },
     {
       "post": {
+        "uri": "at://did:plc:testauthor/app.bsky.feed.post/3lll",
+        "cid": "bafylll",
+        "author": {
+          "did": "did:plc:testauthor",
+          "handle": "testuser.bsky.social",
+          "displayName": "Test User"
+        },
+        "record": {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "2026-06-04T23:00:00.000Z",
+          "embed": {
+            "$type": "app.bsky.embed.external",
+            "external": {
+              "uri": "https://example.com/an-article",
+              "title": "An Article Worth Reading",
+              "description": "Everything you never asked about link cards."
+            }
+          },
+          "langs": ["en"],
+          "text": "Worth a read"
+        },
+        "embed": {
+          "$type": "app.bsky.embed.external#view",
+          "external": {
+            "uri": "https://example.com/an-article",
+            "title": "An Article Worth Reading",
+            "description": "Everything you never asked about link cards.",
+            "thumb": "https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:testauthor/bafkcarda"
+          }
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "likeCount": 2,
+        "indexedAt": "2026-06-04T23:00:05.000Z",
+        "labels": []
+      }
+    },
+    {
+      "post": {
+        "uri": "at://did:plc:testauthor/app.bsky.feed.post/3mmm",
+        "cid": "bafymmm",
+        "author": {
+          "did": "did:plc:testauthor",
+          "handle": "testuser.bsky.social",
+          "displayName": "Test User"
+        },
+        "record": {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "2026-06-05T00:00:00.000Z",
+          "embed": {
+            "$type": "app.bsky.embed.external",
+            "external": {
+              "uri": "https://example.com/link-only",
+              "title": "A Post With No Words",
+              "description": "The card is the whole post."
+            }
+          },
+          "langs": ["en"],
+          "text": ""
+        },
+        "embed": {
+          "$type": "app.bsky.embed.external#view",
+          "external": {
+            "uri": "https://example.com/link-only",
+            "title": "A Post With No Words",
+            "description": "The card is the whole post.",
+            "thumb": "https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:testauthor/bafkcardb"
+          }
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "likeCount": 1,
+        "indexedAt": "2026-06-05T00:00:05.000Z",
+        "labels": []
+      }
+    },
+    {
+      "post": {
         "uri": "at://did:plc:someoneelse/app.bsky.feed.post/3fff",
         "cid": "bafyfff",
         "author": {

--- a/test/fixtures/files/feeds/bluesky/normalized.json
+++ b/test/fixtures/files/feeds/bluesky/normalized.json
@@ -58,5 +58,25 @@
     "status": "enqueued",
     "uid": "at://did:plc:testauthor/app.bsky.feed.post/3eee",
     "validation_errors": []
+  },
+  {
+    "attachment_urls": [],
+    "comments": [],
+    "content": "Worth a read\n\nAn Article Worth Reading\nhttps://example.com/an-article - https://bsky.app/profile/testuser.bsky.social/post/3lll",
+    "published_at": "2026-06-04T23:00:00.000Z",
+    "source_url": "https://bsky.app/profile/testuser.bsky.social/post/3lll",
+    "status": "enqueued",
+    "uid": "at://did:plc:testauthor/app.bsky.feed.post/3lll",
+    "validation_errors": []
+  },
+  {
+    "attachment_urls": [],
+    "comments": [],
+    "content": "A Post With No Words\nhttps://example.com/link-only - https://bsky.app/profile/testuser.bsky.social/post/3mmm",
+    "published_at": "2026-06-05T00:00:00.000Z",
+    "source_url": "https://bsky.app/profile/testuser.bsky.social/post/3mmm",
+    "status": "enqueued",
+    "uid": "at://did:plc:testauthor/app.bsky.feed.post/3mmm",
+    "validation_errors": []
   }
 ]

--- a/test/services/normalizer/bluesky_normalizer_test.rb
+++ b/test/services/normalizer/bluesky_normalizer_test.rb
@@ -11,6 +11,19 @@ class Normalizer::BlueskyNormalizerTest < ActiveSupport::TestCase
       .map { |entry| Normalizer::BlueskyNormalizer.new(entry).normalize }
   end
 
+  def normalize(raw_data)
+    url = "https://bsky.app/profile/testuser.bsky.social/post/3nnn"
+    entry = FeedEntry.new(
+      feed: feed,
+      uid: "at://did:plc:testauthor/app.bsky.feed.post/3nnn",
+      published_at: 1.hour.ago,
+      status: :pending,
+      raw_data: { "uid" => "at://did:plc:testauthor/app.bsky.feed.post/3nnn", "url" => url, "images" => [] }.merge(raw_data)
+    )
+
+    Normalizer::BlueskyNormalizer.new(entry).normalize
+  end
+
   test "#normalize should match the expected normalization result" do
     assert_matches_snapshot(posts.map(&:normalized_attributes), snapshot: "feeds/bluesky/normalized.json")
   end
@@ -35,6 +48,37 @@ class Normalizer::BlueskyNormalizerTest < ActiveSupport::TestCase
       "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgallerya",
       "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkgalleryb"
     ], posts[3].attachment_urls
+  end
+
+  test "#normalize should fold the link card into the content" do
+    assert_equal(
+      "Worth a read\n\nAn Article Worth Reading\nhttps://example.com/an-article - " \
+      "https://bsky.app/profile/testuser.bsky.social/post/3lll",
+      posts[5].content
+    )
+  end
+
+  test "#normalize should build the content of a text-less post from its link card" do
+    assert_equal(
+      "A Post With No Words\nhttps://example.com/link-only - " \
+      "https://bsky.app/profile/testuser.bsky.social/post/3mmm",
+      posts[6].content
+    )
+  end
+
+  test "#normalize should not repeat a link card URL already present in the text" do
+    post = normalize(
+      "text" => "Have a look at https://example.com/an-article",
+      "link_card" => { "url" => "https://example.com/an-article", "title" => "An Article Worth Reading" }
+    )
+
+    assert_equal "Have a look at https://example.com/an-article - https://bsky.app/profile/testuser.bsky.social/post/3nnn", post.content
+  end
+
+  test "#normalize should use the link card URL alone when the card has no title" do
+    post = normalize("text" => "", "link_card" => { "url" => "https://example.com/untitled" })
+
+    assert_equal "https://example.com/untitled - https://bsky.app/profile/testuser.bsky.social/post/3nnn", post.content
   end
 
   test "#normalize should enqueue valid posts" do

--- a/test/services/processor/bluesky_processor_test.rb
+++ b/test/services/processor/bluesky_processor_test.rb
@@ -13,11 +13,26 @@ class Processor::BlueskyProcessorTest < ActiveSupport::TestCase
     @entries ||= Processor::BlueskyProcessor.new(feed, sample_json).process.entries
   end
 
+  def external_embed_payload(embed:)
+    {
+      "feed" => [
+        {
+          "post" => {
+            "uri" => "at://did:plc:testauthor/app.bsky.feed.post/3nnn",
+            "author" => { "did" => "did:plc:testauthor", "handle" => "testuser.bsky.social" },
+            "record" => { "createdAt" => "2026-06-04T18:00:00.000Z", "text" => "" },
+            "embed" => embed
+          }
+        }
+      ]
+    }.to_json
+  end
+
   test "#process should create a FeedEntry per own post and skip reposts and replies" do
-    assert_equal 5, entries.size
+    assert_equal 7, entries.size
     assert entries.all? { |entry| entry.is_a?(FeedEntry) }
     assert entries.all? { |entry| entry.status == "pending" }
-    assert_equal %w[3aaa 3bbb 3ccc 3ddd 3eee], entries.map { |entry| entry.uid.split("/").last }
+    assert_equal %w[3aaa 3bbb 3ccc 3ddd 3eee 3lll 3mmm], entries.map { |entry| entry.uid.split("/").last }
   end
 
   test "#process should use the at:// URI as the uid" do
@@ -110,6 +125,56 @@ class Processor::BlueskyProcessorTest < ActiveSupport::TestCase
 
   test "#process should extract images from a quote post with media" do
     assert_equal ["https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:testauthor/bafkquotepic"], entries[4].raw_data["images"]
+  end
+
+  test "#process should extract the external link card URL and title" do
+    assert_equal(
+      { "url" => "https://example.com/an-article", "title" => "An Article Worth Reading" },
+      entries[5].raw_data["link_card"]
+    )
+  end
+
+  test "#process should extract the link card of a post with no text" do
+    assert_equal "", entries[6].raw_data["text"]
+    assert_equal "https://example.com/link-only", entries[6].raw_data["link_card"]["url"]
+  end
+
+  test "#process should leave the link empty for posts without a card" do
+    assert_nil entries.first.raw_data["link_card"]
+    assert_nil entries[1].raw_data["link_card"]
+  end
+
+  test "#process should extract the link card of a quote post with an external embed" do
+    result = Processor::BlueskyProcessor.new(feed, external_embed_payload(embed: {
+      "$type" => "app.bsky.embed.recordWithMedia#view",
+      "media" => {
+        "$type" => "app.bsky.embed.external#view",
+        "external" => { "uri" => "https://example.com/quoted", "title" => "Quoted card" }
+      }
+    })).process
+
+    assert_equal(
+      { "url" => "https://example.com/quoted", "title" => "Quoted card" },
+      result.entries.first.raw_data["link_card"]
+    )
+  end
+
+  test "#process should omit a blank link card title" do
+    result = Processor::BlueskyProcessor.new(feed, external_embed_payload(embed: {
+      "$type" => "app.bsky.embed.external#view",
+      "external" => { "uri" => "https://example.com/untitled", "title" => "" }
+    })).process
+
+    assert_equal({ "url" => "https://example.com/untitled" }, result.entries.first.raw_data["link_card"])
+  end
+
+  test "#process should ignore a link card without a URL" do
+    result = Processor::BlueskyProcessor.new(feed, external_embed_payload(embed: {
+      "$type" => "app.bsky.embed.external#view",
+      "external" => { "title" => "No target" }
+    })).process
+
+    assert_nil result.entries.first.raw_data["link_card"]
   end
 
   test "#process should fall back to the DID permalink when the handle did not resolve" do


### PR DESCRIPTION
Changes:

- Pull the external link card out of a Bluesky post's embed, including cards nested in quote posts
- Fold the card's title and URL into the post content, skipping the URL when the post text already spells it out

A post whose payload is a link card kept its target URL only in the embed, so link-only posts normalized to a bare permalink with nothing to read. The card now travels through the pipeline as structured data and lands in the content where the post text would be.

References:

- Closes #1328
