### PR TITLE
Split for_source by caller intent

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -315,7 +315,7 @@ class FeedsController < ApplicationController
   end
 
   def cleanup_feed_identification(input)
-    FeedIdentification.for_source(user: current_user, url: input)&.destroy
+    FeedIdentification.cleanup_for_source(user: current_user, url: input)
   end
 
   # Minted with the feed so the URL is pasteable immediately, destroyed when

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -208,13 +208,11 @@ class FeedsController < ApplicationController
 
   # The settled working identification for the submitted URL, or nil. A source
   # change is confirmed only when one exists and the submitted profile is one of
-  # its working candidates — a candidate that actually read the source (spec §4).
-  # for_source: a discovered feed URL is backed by its page's identification.
+  # its working candidates: a candidate that actually read the source (spec §4).
   def settled_working_identification
     return @settled_working_identification if defined?(@settled_working_identification)
 
-    fi = FeedIdentification.for_source(user: current_user, url: canonical_submitted_url)
-    @settled_working_identification = (fi&.success? && fi.outcome == :working) ? fi : nil
+    @settled_working_identification = FeedIdentification.working_for_source(user: current_user, url: canonical_submitted_url)
   end
 
   def source_change_confirmed?

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -21,7 +21,7 @@ class FeedsController < ApplicationController
     images_only
   ].freeze
 
-  # Source-side fields, editable only while a feed is a draft (FR-007/008);
+  # Source-side fields, editable only while a feed is a draft;
   # once it first leaves :draft they lock in for good.
   DRAFT_ONLY_PERMITTED_PARAMS = [
     :feed_profile_key,
@@ -80,14 +80,14 @@ class FeedsController < ApplicationController
   # Operational fields (name, target_group, schedule, access_token) edit freely.
   # A live deterministic feed's source can be re-pointed, but only through
   # detection: a changed source URL re-runs identification and the confirming
-  # save applies it only once a working candidate is verified (spec §4). The
+  # save applies it only once a working candidate is verified. The
   # engine stays fixed — deterministic ↔ AI is a new feed.
   def update
     @feed = load_feed
     authorize @feed
 
     # A changed deterministic source that isn't yet backed by a verified working
-    # candidate hands off to the async detector and paints the §7 states; a
+    # candidate hands off to the async detector and paints the identification states; a
     # confirmed one falls through to the normal save below (with the source
     # applied), so enable/pause/schedule bookkeeping stays in one place. Capture
     # the decision before assign_attributes moves source_input onto the new URL.
@@ -96,7 +96,7 @@ class FeedsController < ApplicationController
 
     @feed.assign_attributes(update_feed_params)
     # Overwrite the raw submitted URL with the canonical, verified source and its
-    # detected profile (the confirm path — spec §4).
+    # detected profile (the confirm path).
     apply_confirmed_source if source_change
     @feed.assign_attributes(FeedProfile.defaults_for(@feed.feed_profile_key))
 
@@ -208,7 +208,7 @@ class FeedsController < ApplicationController
 
   # The settled working identification for the submitted URL, or nil. A source
   # change is confirmed only when one exists and the submitted profile is one of
-  # its working candidates: a candidate that actually read the source (spec §4).
+  # its working candidates: a candidate that actually read the source.
   def settled_working_identification
     return @settled_working_identification if defined?(@settled_working_identification)
 
@@ -227,14 +227,14 @@ class FeedsController < ApplicationController
   end
 
   # Persist the operational edits so they survive the async detection gap, then
-  # kick detection and freeze the form while it polls (spec §7). The source
+  # kick detection and freeze the form while it polls. The source
   # itself waits for a confirmed working candidate; no state transition happens
   # here, so a live feed keeps refreshing its verified source until the new one
   # is confirmed.
   def propose_source_redetection
     return render :edit, status: :unprocessable_entity unless @feed.update(operational_update_params)
 
-    # A non-link never reaches detection; the engine is fixed in edit (spec §4),
+    # A non-link never reaches detection; the engine is fixed in edit,
     # so there's no AI mode to bridge to — just ask for a link.
     if canonical_submitted_url.nil?
       return render_identification_state(
@@ -300,13 +300,13 @@ class FeedsController < ApplicationController
     if @feed.draft?
       ALWAYS_PERMITTED_PARAMS + DRAFT_ONLY_PERMITTED_PARAMS
     elsif FeedProfile.depends_on_ai?(@feed.feed_profile_key)
-      # A live AI feed's prompt stays editable (spec §4): the uid scheme is
+      # A live AI feed's prompt stays editable: the uid scheme is
       # unchanged, so a prompt edit carries no duplicate risk (just possible
       # backfill). The url isn't accepted here — an AI feed's source is its prompt.
       ALWAYS_PERMITTED_PARAMS + [{ params: [:prompt] }]
     else
-      # A live deterministic feed can move its source, but only through detection
-      # (spec §4). The URL rides operational params; the re-detected profile is
+      # A live deterministic feed can move its source, but only through
+      # detection. The URL rides operational params; the re-detected profile is
       # applied explicitly by the confirm path (from a verified chooser pick), so
       # feed_profile_key stays out of the mass-assignable set here — an unverified
       # profile switch can't leak in.
@@ -319,8 +319,7 @@ class FeedsController < ApplicationController
   end
 
   # Minted with the feed so the URL is pasteable immediately, destroyed when
-  # a draft moves off the webhook profile so the old URL stops resolving
-  # (spec 006 §2).
+  # a draft moves off the webhook profile so the old URL stops resolving.
   def sync_webhook_endpoint(feed)
     return unless feed.saved_change_to_feed_profile_key?
 

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -66,12 +66,13 @@ class FeedIdentification < ApplicationRecord
     resolved_to(user, url)
   end
 
-  # The row cleanup destroys once a feed anchors to this URL: keyed by the
-  # URL itself, else the page identification that resolved to it.
-  def self.for_source(user:, url:)
-    return nil if url.blank?
+  # Retire the rows behind a created feed's source: the row keyed by the
+  # URL and the page identification that resolved to it. Either could
+  # confirm a later edit, so neither may outlive its use.
+  def self.cleanup_for_source(user:, url:)
+    return if url.blank?
 
-    find_by(user: user, input: url) || resolved_to(user, url)
+    [find_by(user: user, input: url), resolved_to(user, url)].compact.each(&:destroy)
   end
 
   def self.resolved_to(user, url)

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -54,19 +54,32 @@ class FeedIdentification < ApplicationRecord
     candidate&.resolved_url || input
   end
 
-  # The identification behind a source URL: the row keyed by the URL when
-  # it works, else a page identification whose working candidate resolved
-  # to the URL, else the keyed row (cleanup still destroys stale rows).
-  def self.for_source(user:, url:)
+  # The settled identification a confirming save can trust for this URL:
+  # the row keyed by the URL when it works, else the page identification
+  # whose working candidate resolved to it.
+  def self.working_for_source(user:, url:)
     return nil if url.blank?
 
     direct = find_by(user: user, input: url)
     return direct if direct&.success? && direct.outcome == :working
 
+    resolved_to(user, url)
+  end
+
+  # The row cleanup destroys once a feed anchors to this URL: keyed by the
+  # URL itself, else the page identification that resolved to it.
+  def self.for_source(user:, url:)
+    return nil if url.blank?
+
+    find_by(user: user, input: url) || resolved_to(user, url)
+  end
+
+  def self.resolved_to(user, url)
     where(user: user, status: :success).detect do |identification|
       identification.working_candidates.any? { |c| c.resolved_url == url }
-    end || direct
+    end
   end
+  private_class_method :resolved_to
 
   # How the detection result should present (spec §7):
   #   :working     — at least one candidate read the source → the feed form

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -30,7 +30,7 @@ class FeedIdentification < ApplicationRecord
     working_candidates.first
   end
 
-  # Candidates that can fetch the source (spec §7): the count of these drives how
+  # Candidates that can fetch the source: the count of these drives how
   # the result is presented. A candidate counts unless it's known-broken — tested
   # and failed, or unreachable — so in practice this is the passed set (detection
   # always records a verdict). Memoized: read a few times per request.
@@ -41,7 +41,7 @@ class FeedIdentification < ApplicationRecord
   end
 
   # Profile keys of the working candidates, in rank order. An edit's confirming
-  # save (spec §4) only applies a source when the submitted profile is one of
+  # save only applies a source when the submitted profile is one of
   # these — a settled, source-reading candidate.
   def working_candidate_profile_keys
     working_candidates.map(&:profile_key)
@@ -81,7 +81,7 @@ class FeedIdentification < ApplicationRecord
   end
   private_class_method :resolved_to
 
-  # How the detection result should present (spec §7):
+  # How the detection result should present:
   #   :working     — at least one candidate read the source → the feed form
   #   :unreachable — nothing connected (couldn't-reach) → the transient retry state
   #   :no_feed     — reachable, but no candidate yields a feed → the terminal

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -212,13 +212,15 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_equal "https://example.com/feed.xml", identification.source_url_for("json_feed")
   end
 
-  test ".for_source should find the identification keyed by the URL itself" do
+  test ".cleanup_for_source should destroy the row keyed by the URL" do
     identification = create(:feed_identification, user: user, input: "https://example.com/feed.xml")
 
-    assert_equal identification, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
+    FeedIdentification.cleanup_for_source(user: user, url: "https://example.com/feed.xml")
+
+    assert_not FeedIdentification.exists?(identification.id)
   end
 
-  test ".for_source should find the identification whose candidate resolved to the URL" do
+  test ".cleanup_for_source should destroy the page row that resolved to the URL" do
     identification = create(
       :feed_identification,
       user: user,
@@ -229,7 +231,9 @@ class FeedIdentificationTest < ActiveSupport::TestCase
       ]
     )
 
-    assert_equal identification, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
+    FeedIdentification.cleanup_for_source(user: user, url: "https://example.com/feed.xml")
+
+    assert_not FeedIdentification.exists?(identification.id)
   end
 
   test ".working_for_source should prefer a working page identification over a stale keyed row" do
@@ -246,8 +250,25 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     )
 
     assert_equal page, FeedIdentification.working_for_source(user: user, url: "https://example.com/feed.xml")
-    assert_equal stale, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml"),
-                 "cleanup should target the row keyed by the URL"
+  end
+
+  test ".cleanup_for_source should destroy both the keyed row and the resolving page row" do
+    stale = create(:feed_identification, user: user, input: "https://example.com/feed.xml",
+                                         status: :failed, error: "unreachable")
+    page = create(
+      :feed_identification,
+      user: user,
+      input: "https://example.com/blog",
+      status: :success,
+      candidates: [
+        { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
+      ]
+    )
+
+    FeedIdentification.cleanup_for_source(user: user, url: "https://example.com/feed.xml")
+
+    assert_not FeedIdentification.exists?(stale.id)
+    assert_not FeedIdentification.exists?(page.id)
   end
 
   test ".working_for_source should return nothing when no identification works" do
@@ -258,7 +279,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_nil FeedIdentification.working_for_source(user: user, url: nil)
   end
 
-  test ".for_source should scope discovered lookups to the user and working candidates" do
+  test ".cleanup_for_source should spare other users' rows and non-working candidates" do
     create(
       :feed_identification,
       user: create(:user),
@@ -278,7 +299,9 @@ class FeedIdentificationTest < ActiveSupport::TestCase
       ]
     )
 
-    assert_nil FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
-    assert_nil FeedIdentification.for_source(user: user, url: nil)
+    assert_no_difference("FeedIdentification.count") do
+      FeedIdentification.cleanup_for_source(user: user, url: "https://example.com/feed.xml")
+      FeedIdentification.cleanup_for_source(user: user, url: nil)
+    end
   end
 end

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -232,9 +232,9 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_equal identification, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
   end
 
-  test ".for_source should prefer a working page identification over a stale keyed row" do
-    create(:feed_identification, user: user, input: "https://example.com/feed.xml",
-                                 status: :failed, error: "unreachable")
+  test ".working_for_source should prefer a working page identification over a stale keyed row" do
+    stale = create(:feed_identification, user: user, input: "https://example.com/feed.xml",
+                                         status: :failed, error: "unreachable")
     page = create(
       :feed_identification,
       user: user,
@@ -245,7 +245,17 @@ class FeedIdentificationTest < ActiveSupport::TestCase
       ]
     )
 
-    assert_equal page, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml")
+    assert_equal page, FeedIdentification.working_for_source(user: user, url: "https://example.com/feed.xml")
+    assert_equal stale, FeedIdentification.for_source(user: user, url: "https://example.com/feed.xml"),
+                 "cleanup should target the row keyed by the URL"
+  end
+
+  test ".working_for_source should return nothing when no identification works" do
+    create(:feed_identification, user: user, input: "https://example.com/feed.xml",
+                                 status: :failed, error: "unreachable")
+
+    assert_nil FeedIdentification.working_for_source(user: user, url: "https://example.com/feed.xml")
+    assert_nil FeedIdentification.working_for_source(user: user, url: nil)
   end
 
   test ".for_source should scope discovered lookups to the user and working candidates" do


### PR DESCRIPTION
Changes:

- Split `FeedIdentification.for_source` into two intent-named methods: `working_for_source` backs the edit confirmation and returns only working identifications, while `cleanup_for_source` retires both the row keyed by the URL and the page identification that resolved to it
- Drop spec references from the touched files' comments

One method was serving two callers with different needs, which forced a three-branch priority rule in the model and a compensating guard in the controller. Each method is now trivial, the controller guard is gone, and cleanup no longer leaves behind a resolving page row that could confirm a later edit from a stale result.

References:

- Related PR: #1331