### PR TITLE
Drop spec references from code comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,8 @@ Comments:
 - Don't describe behavior implemented elsewhere; nothing protects such a
   comment from drifting.
 - Keep YARD tags (`@param`/`@return`): intentional public API annotation.
-  Trim bloated descriptions, but don't delete the tags.
+  Trim bloated descriptions, but don't delete the tags. Every tag gets a
+  short description, even one that repeats the method name.
 - No emdashes. Never the word "caveat".
 
 Colors:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,15 @@ Comments:
 - Comment only when the code can't speak for itself; never restate the obvious.
 - Explain the why (intent, trade-offs, non-obvious constraints), not the what.
 - Don't describe what the code doesn't do.
-- Keep comments compact and focused.
+- Keep comments compact: short sentences, plain language, cut hard.
+- Drop anything irrelevant after merge: rejected approaches, revision history,
+  references to specs, issues, or discussions. Specs are historical records,
+  not a source of truth.
+- Don't describe behavior implemented elsewhere; nothing protects such a
+  comment from drifting.
+- Keep YARD tags (`@param`/`@return`): intentional public API annotation.
+  Trim bloated descriptions, but don't delete the tags.
+- No emdashes. Never the word "caveat".
 
 Colors:
 

--- a/app/components/candidate_option_component.rb
+++ b/app/components/candidate_option_component.rb
@@ -2,7 +2,7 @@ class CandidateOptionComponent < ViewComponent::Base
   # Renders one working detection candidate as a radio option in the "How should
   # we fetch posts?" chooser: its name, description, post-count verdict, and a
   # "Suggested" flag on the preselected default. Only candidates that can fetch
-  # the source reach the chooser (spec §7), so every option is selectable.
+  # the source reach the chooser, so every option is selectable.
   def initialize(candidate:, input:, selected:)
     @candidate = candidate
     @input = input

--- a/app/components/feed_ai_settings_component.rb
+++ b/app/components/feed_ai_settings_component.rb
@@ -44,7 +44,7 @@ class FeedAiSettingsComponent < ViewComponent::Base
   # Each selectable credential's models, keyed by id and embedded so the Stimulus
   # controller can swap the model list on provider change. Gated to the capability
   # matrix ∩ the credential's live snapshot, so only dev-verified web+schema models
-  # are offered (spec §5); credentials left with no models are dropped entirely.
+  # are offered; credentials left with no models are dropped entirely.
   def models_by_credential
     @models_by_credential ||= active_credentials.to_h do |credential|
       models = credential.supported_models

--- a/app/components/feed_form_component.html.erb
+++ b/app/components/feed_form_component.html.erb
@@ -99,7 +99,7 @@
           <%= f.hidden_field :feed_profile_key %>
         <% end %>
 
-        <%# Duplicate-risk warning for a pending source/profile change (spec §4).
+        <%# Duplicate-risk warning for a pending source/profile change.
             A profile change reworks how posts are identified, so it's the louder
             warning and turns the "skip older posts" threshold on by default. %>
         <% if source_changed? && profile_changed? %>
@@ -140,7 +140,7 @@
               class: "inline-flex items-center gap-1 rounded-md border border-border bg-surface px-4 py-2 text-base font-semibold text-heading shadow-sm transition hover:bg-surface-muted cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
               data: { preview_button_target: "button", action: "click->preview-button#open", key: "preview.open" } %>
 
-        <%# Explains why Preview is disabled instead of leaving it inert (spec §4);
+        <%# Explains why Preview is disabled instead of leaving it inert;
             the preview-button controller fills and reveals it to match the button. %>
         <p class="mt-2 text-sm text-muted" hidden
            data-preview-button-target="hint"
@@ -198,7 +198,7 @@
             <% end %>
           <% end %>
 
-          <%# A push-ingested feed has no refresh cadence to pick (spec 006 §7). %>
+          <%# A push-ingested feed has no refresh cadence to pick. %>
           <% if feed.scheduled? %>
             <%= render PanelComponent.new do %>
               <div class="space-y-2">

--- a/app/components/feed_form_component.rb
+++ b/app/components/feed_form_component.rb
@@ -2,8 +2,8 @@
 # known (or when it needs none) — source identity, name, AI settings, preview,
 # reposting settings, advanced options, and the enable checkbox.
 #
-# Also paints the identification states of an edit's source re-detection
-# (spec §4/§7): frozen and polling while a check runs, or re-enabled with the
+# Also paints the identification states of an edit's source re-detection:
+# frozen and polling while a check runs, or re-enabled with the
 # failure hint under the source field.
 class FeedFormComponent < ViewComponent::Base
   POLLING_STOP_CONDITION = "[data-identification-state='complete'], [data-identification-state='error']"
@@ -40,7 +40,7 @@ class FeedFormComponent < ViewComponent::Base
   # preview-button is mounted on the whole form so it can read the selected
   # feed_profile_key (radios or hidden field) and react to candidate changes;
   # the button and the modal's frame are nested targets within it. While an
-  # edit's source re-detection runs (spec §4), the same wrapper freezes the
+  # edit's source re-detection runs, the same wrapper freezes the
   # form and polls for the outcome; a failure re-renders it enabled with the
   # hint under the source field.
   def wrapper_data
@@ -90,7 +90,7 @@ class FeedFormComponent < ViewComponent::Base
   end
 
   # The chooser is a real choice only with two or more working candidates; one
-  # working candidate is shown as a read-only annotation (spec §7). In edit
+  # working candidate is shown as a read-only annotation. In edit
   # mode it appears only after a source re-detection resolves to multiple
   # candidates.
   def show_chooser?
@@ -103,13 +103,13 @@ class FeedFormComponent < ViewComponent::Base
 
   # For an AI feed the prompt *is* the source: it stays an editable textarea
   # throughout, including edits to a live feed — the uid scheme is unchanged,
-  # so there's no duplicate risk, at most some older posts backfilled (spec §4).
+  # so there's no duplicate risk, at most some older posts backfilled.
   def ai_prompt_editable?
     FeedProfile.depends_on_ai?(feed.feed_profile_key)
   end
 
   # A deterministic feed's URL is editable when editing an existing feed — a
-  # change re-runs detection before saving (spec §4).
+  # change re-runs detection before saving.
   def source_editable?
     edit_mode? && !ai_prompt_editable?
   end
@@ -168,7 +168,7 @@ class FeedFormComponent < ViewComponent::Base
   end
 
   # A profile change reworks how posts are identified, so it defaults the
-  # skip-older-posts threshold on (spec §4); checkbox and panel visibility
+  # skip-older-posts threshold on; checkbox and panel visibility
   # must agree.
   def import_after_on?
     feed.import_after_enabled || profile_changed?

--- a/app/components/feed_form_component.rb
+++ b/app/components/feed_form_component.rb
@@ -1,10 +1,6 @@
-# The expanded feed form: the full editor a feed lands on once its source is
-# known (or when it needs none) — source identity, name, AI settings, preview,
-# reposting settings, advanced options, and the enable checkbox.
-#
-# Also paints the identification states of an edit's source re-detection:
-# frozen and polling while a check runs, or re-enabled with the
-# failure hint under the source field.
+# The expanded feed form. Also paints the identification states of an
+# edit's source re-detection: frozen and polling while a check runs, or
+# re-enabled with the failure hint under the source field.
 class FeedFormComponent < ViewComponent::Base
   POLLING_STOP_CONDITION = "[data-identification-state='complete'], [data-identification-state='error']"
 
@@ -30,19 +26,15 @@ class FeedFormComponent < ViewComponent::Base
   # source field explains the swap.
   def source_discovered? = @source_discovered
 
-  # Editing an existing feed vs. creating one. Every caller passes a persisted
-  # feed only from the edit flow (creation always builds a fresh record), so
-  # the flag needn't travel as a separate parameter.
+  # Creation always builds a fresh record, so persistence tells the flows
+  # apart.
   def edit_mode?
     feed.persisted?
   end
 
-  # preview-button is mounted on the whole form so it can read the selected
-  # feed_profile_key (radios or hidden field) and react to candidate changes;
-  # the button and the modal's frame are nested targets within it. While an
-  # edit's source re-detection runs, the same wrapper freezes the
-  # form and polls for the outcome; a failure re-renders it enabled with the
-  # hint under the source field.
+  # preview-button mounts on the whole form so it can read the selected
+  # feed_profile_key and react to candidate changes. While a re-detection
+  # runs, the same wrapper freezes the form and polls for the outcome.
   def wrapper_data
     data = {
       identification_state: identification_state,
@@ -57,9 +49,8 @@ class FeedFormComponent < ViewComponent::Base
     data
   end
 
-  # Profile-key → source-param-key map the preview button reads to build
-  # preview requests: every offered candidate while the chooser is live,
-  # otherwise just the feed's own profile.
+  # Profile-key to source-param-key map the preview button reads: offered
+  # candidates while the chooser is live, else the feed's own profile.
   def preview_source_keys
     if show_chooser?
       candidates.to_h { |candidate| [candidate.profile_key, FeedProfile.source_key_for(candidate.profile_key)] }
@@ -89,10 +80,7 @@ class FeedFormComponent < ViewComponent::Base
     }
   end
 
-  # The chooser is a real choice only with two or more working candidates; one
-  # working candidate is shown as a read-only annotation. In edit
-  # mode it appears only after a source re-detection resolves to multiple
-  # candidates.
+  # A single working candidate renders as a read-only annotation instead.
   def show_chooser?
     candidates.size >= 2
   end
@@ -101,15 +89,13 @@ class FeedFormComponent < ViewComponent::Base
     feed.source_input_url? ? "Source URL" : "Source prompt"
   end
 
-  # For an AI feed the prompt *is* the source: it stays an editable textarea
-  # throughout, including edits to a live feed — the uid scheme is unchanged,
-  # so there's no duplicate risk, at most some older posts backfilled.
+  # An AI feed's prompt is its source and stays editable even on a live
+  # feed; the uid scheme is unchanged, so no duplicate risk.
   def ai_prompt_editable?
     FeedProfile.depends_on_ai?(feed.feed_profile_key)
   end
 
-  # A deterministic feed's URL is editable when editing an existing feed — a
-  # change re-runs detection before saving.
+  # A changed URL re-runs detection before saving.
   def source_editable?
     edit_mode? && !ai_prompt_editable?
   end
@@ -146,9 +132,8 @@ class FeedFormComponent < ViewComponent::Base
     @active_tokens ||= feed.user.access_tokens.active.order(:host)
   end
 
-  # A token that went inactive isn't offered in the select, so the feed's own
-  # choice can't be kept — preselect a working token and say so below, instead
-  # of letting the browser swap silently.
+  # An inactive token isn't offered, so preselect a working one and say so
+  # instead of letting the browser swap silently.
   def token_swap?
     feed.access_token.present? && !feed.access_token.active?
   end
@@ -167,9 +152,8 @@ class FeedFormComponent < ViewComponent::Base
     feed.schedule_interval || Feed::DEFAULT_SCHEDULE_INTERVAL
   end
 
-  # A profile change reworks how posts are identified, so it defaults the
-  # skip-older-posts threshold on; checkbox and panel visibility
-  # must agree.
+  # A profile change reworks post identity, so it defaults the skip-older
+  # threshold on; checkbox and panel visibility must agree.
   def import_after_on?
     feed.import_after_enabled || profile_changed?
   end
@@ -190,11 +174,9 @@ class FeedFormComponent < ViewComponent::Base
     @ai_settings ||= FeedAiSettingsComponent.new(feed: feed, form: form)
   end
 
-  # When a setup gate replaced the token or credential fields, enabling can
-  # only fail — and the failure's errors would render inside the missing
-  # fields, i.e. nowhere. The checkbox locks off and says what's missing
-  # instead. A (legacy) still-enabled feed keeps an interactive checkbox so
-  # unchecking-to-pause stays available.
+  # With required credentials missing, enabling can only fail and the
+  # errors would render nowhere; the checkbox locks off and says what's
+  # missing. A still-enabled feed keeps its checkbox so pausing works.
   def enable_blocked?(form)
     enable_missing(form).any? && !feed.enabled?
   end

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -17,7 +17,7 @@ class FeedIdentificationsController < ApplicationController
 
     # Mode A input that isn't a link can't be detected: the entry form re-renders
     # with the AI panel carrying the text, so switching the mode radio is the
-    # bridge (spec §1) — the user stays in the mode they chose.
+    # bridge — the user stays in the mode they chose.
     return render(not_a_link_error) if source_url.nil?
 
     # A settled result — a working feed, or a reachable link with no feed — is
@@ -76,7 +76,7 @@ class FeedIdentificationsController < ApplicationController
   end
 
   # Build a draft webhook feed straight away — there is no source input at all;
-  # the secret posting URL is minted when the draft is saved (spec 006 §7).
+  # the secret posting URL is minted when the draft is saved.
   def handle_webhook_submission
     feed = Current.user.feeds.build(feed_profile_key: "webhook")
     render(identification_success(feed, candidates: []))
@@ -84,7 +84,7 @@ class FeedIdentificationsController < ApplicationController
 
   # Build a draft AI feed straight from the prompt — no detection, the AI
   # profile is the destination and the prompt is the source. AI feeds default
-  # to a daily cadence (spec §1).
+  # to a daily cadence.
   def handle_prompt_submission
     if raw_prompt.blank?
       return render(entry_form(mode: "ai", error: "Tell AI what to follow — a link or a few words about it."))
@@ -138,8 +138,8 @@ class FeedIdentificationsController < ApplicationController
     feed_identification.success? && feed_identification.outcome == :unreachable
   end
 
-  # Present the finished identification by how many candidates actually work
-  # (spec §7): the feed form when at least one does, otherwise the form re-renders
+  # Present the finished identification by how many candidates actually
+  # work: the feed form when at least one does, otherwise the form re-renders
   # with the transient couldn't-reach hint or the terminal no-feed one.
   def present_outcome
     case feed_identification.outcome
@@ -161,7 +161,7 @@ class FeedIdentificationsController < ApplicationController
     if editing?
       # Re-render the feed being edited with the proposed source + profile
       # applied in memory only; the confirming PATCH persists it after the
-      # source-verified guard clears (spec §4). Operational edits were saved
+      # source-verified guard clears. Operational edits were saved
       # on the propose PATCH, so the reloaded record already carries them.
       profile_changed = edit_feed.feed_profile_key != profile_key
       feed = edit_feed.tap do |f|
@@ -170,7 +170,7 @@ class FeedIdentificationsController < ApplicationController
       end
 
       # A source (and possibly profile) change is pending confirmation, so the
-      # form surfaces the matching duplicate-risk warning (spec §4).
+      # form surfaces the matching duplicate-risk warning.
       render(identification_success(feed, candidates: feed_identification.working_candidates,
                                           source_changed: true, profile_changed: profile_changed,
                                           source_discovered: discovered))
@@ -185,7 +185,7 @@ class FeedIdentificationsController < ApplicationController
     end
   end
 
-  # Creation states re-render the entry form itself (spec §1/§7): frozen while
+  # Creation states re-render the entry form itself: frozen while
   # checking, or enabled with the hint under the active mode's input. Every
   # response in this flow swaps the same "feed-form" frame.
   def entry_form(mode: "link", url: raw_url, prompt: nil, checking: false, error: nil)
@@ -200,7 +200,7 @@ class FeedIdentificationsController < ApplicationController
     { turbo_stream: turbo_stream.replace("feed-form", FeedFormComponent.new(feed: feed, **options)) }
   end
 
-  # Edit states re-render the edit form — the engine is fixed (spec §4), so
+  # Edit states re-render the edit form — the engine is fixed, so
   # there's no AI mode to switch to, just the hint under the source field.
   def edit_form(attempted_url:, error: nil)
     expanded_form(edit_feed, attempted_url: attempted_url, source_error: error)
@@ -213,7 +213,7 @@ class FeedIdentificationsController < ApplicationController
   end
 
   # Terminal: the link was reachable but no deterministic profile reads it. In
-  # creation the AI mode is the way forward (spec §7) and the panel carries the
+  # creation the AI mode is the way forward and the panel carries the
   # link over; in edit it just invites another link.
   def no_feed_error
     if editing?
@@ -227,7 +227,7 @@ class FeedIdentificationsController < ApplicationController
   end
 
   # Transient: nothing connected. Resubmitting re-runs detection, and in
-  # creation the AI panel stays available as a secondary escape (spec §7).
+  # creation the AI panel stays available as a secondary escape.
   def unreachable_error
     if editing?
       return identification_error(error: "We couldn't reach that link. It might be a temporary hiccup — save again to retry, or keep the current source.")
@@ -246,7 +246,7 @@ class FeedIdentificationsController < ApplicationController
                         source_discovered: source_discovered)
   end
 
-  # The feed being edited (spec §4 source re-detection), or nil in the creation
+  # The feed being edited, or nil in the creation
   # flow. Scoped to the current user so a forged feed_id can't reach another's.
   def edit_feed
     return @edit_feed if defined?(@edit_feed)

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -15,21 +15,18 @@ class FeedIdentificationsController < ApplicationController
 
     return render(blank_input_error) if raw_url.blank?
 
-    # Mode A input that isn't a link can't be detected: the entry form re-renders
-    # with the AI panel carrying the text, so switching the mode radio is the
-    # bridge — the user stays in the mode they chose.
+    # A non-link input re-renders the form with the AI panel carrying the
+    # text, so switching the mode radio is the bridge.
     return render(not_a_link_error) if source_url.nil?
 
-    # A settled result — a working feed, or a reachable link with no feed — is
-    # shown as-is. Everything else kicks off a fresh detection, so resubmitting
-    # after a couldn't-reach result actually re-checks it.
+    # A settled result is shown as-is; everything else re-runs detection,
+    # so resubmitting after a couldn't-reach result re-checks it.
     return present_outcome if settled_identification?
 
     if feed_identification.new_record? || feed_identification.failed? || retryable_unreachable?
       restarted = feed_identification.restart_detection!
-      # A losing concurrent submit skips the enqueue: the winner that just
-      # created the row owns the in-flight detection, and both requests render
-      # the same checking state.
+      # A losing concurrent submit skips the enqueue; the winner owns the
+      # in-flight detection.
       FeedIdentificationJob.perform_later(Current.user.id, source_url) if restarted
     end
 
@@ -75,16 +72,14 @@ class FeedIdentificationsController < ApplicationController
     end
   end
 
-  # Build a draft webhook feed straight away — there is no source input at all;
-  # the secret posting URL is minted when the draft is saved.
+  # No source input; the posting URL is minted when the draft is saved.
   def handle_webhook_submission
     feed = Current.user.feeds.build(feed_profile_key: "webhook")
     render(identification_success(feed, candidates: []))
   end
 
-  # Build a draft AI feed straight from the prompt — no detection, the AI
-  # profile is the destination and the prompt is the source. AI feeds default
-  # to a daily cadence.
+  # No detection: the prompt is the source. AI feeds default to a daily
+  # cadence.
   def handle_prompt_submission
     if raw_prompt.blank?
       return render(entry_form(mode: "ai", error: "Tell AI what to follow — a link or a few words about it."))
@@ -115,8 +110,8 @@ class FeedIdentificationsController < ApplicationController
       return render(identification_error(error: "Error identifying feed. Oh no."))
     end
 
-    # Past the deadline: drop the row and re-enable the form with the message,
-    # so the checking state stops with an explanation instead of freezing.
+    # Past the deadline: drop the row so the checking state stops with an
+    # explanation instead of freezing.
     if feed_identification.started_at < polling_timeout.ago
       feed_identification.destroy
       return render(identification_error(error: "This check is taking longer than expected — the link may not be responding. Please try again."))
@@ -125,22 +120,19 @@ class FeedIdentificationsController < ApplicationController
     head :no_content
   end
 
-  # A finished identification worth showing without re-detecting: a working feed
-  # or a reachable-but-featureless link. A couldn't-reach result is deliberately
-  # excluded so resubmitting re-runs detection rather than re-rendering itself.
+  # Worth showing without re-detecting: a working feed or a reachable link
+  # with no feed. Couldn't-reach is excluded so resubmitting re-detects.
   def settled_identification?
     feed_identification.success? && feed_identification.outcome != :unreachable
   end
 
-  # A prior success whose candidates were all unreachable — retrying should
-  # re-detect rather than re-render the same couldn't-reach state.
+  # All candidates were unreachable; retrying should re-detect.
   def retryable_unreachable?
     feed_identification.success? && feed_identification.outcome == :unreachable
   end
 
-  # Present the finished identification by how many candidates actually
-  # work: the feed form when at least one does, otherwise the form re-renders
-  # with the transient couldn't-reach hint or the terminal no-feed one.
+  # The feed form when a candidate works, otherwise the couldn't-reach or
+  # no-feed hint.
   def present_outcome
     case feed_identification.outcome
     when :working then handle_success_status
@@ -159,10 +151,9 @@ class FeedIdentificationsController < ApplicationController
     discovered = source_url != feed_identification.input
 
     if editing?
-      # Re-render the feed being edited with the proposed source + profile
-      # applied in memory only; the confirming PATCH persists it after the
-      # source-verified guard clears. Operational edits were saved
-      # on the propose PATCH, so the reloaded record already carries them.
+      # The proposed source and profile apply in memory only; the
+      # confirming PATCH persists them. Operational edits were saved on
+      # the propose PATCH.
       profile_changed = edit_feed.feed_profile_key != profile_key
       feed = edit_feed.tap do |f|
         f.feed_profile_key = profile_key
@@ -185,9 +176,8 @@ class FeedIdentificationsController < ApplicationController
     end
   end
 
-  # Creation states re-render the entry form itself: frozen while
-  # checking, or enabled with the hint under the active mode's input. Every
-  # response in this flow swaps the same "feed-form" frame.
+  # Creation states re-render the entry form: frozen while checking, or
+  # enabled with the hint. Every response swaps the same "feed-form" frame.
   def entry_form(mode: "link", url: raw_url, prompt: nil, checking: false, error: nil)
     { turbo_stream: turbo_stream.replace(
       "feed-form",
@@ -200,8 +190,8 @@ class FeedIdentificationsController < ApplicationController
     { turbo_stream: turbo_stream.replace("feed-form", FeedFormComponent.new(feed: feed, **options)) }
   end
 
-  # Edit states re-render the edit form — the engine is fixed, so
-  # there's no AI mode to switch to, just the hint under the source field.
+  # The engine is fixed in edit, so there is no AI mode to switch to, just
+  # the hint under the source field.
   def edit_form(attempted_url:, error: nil)
     expanded_form(edit_feed, attempted_url: attempted_url, source_error: error)
   end
@@ -212,9 +202,8 @@ class FeedIdentificationsController < ApplicationController
     entry_form(url: url, prompt: prompt, error: error)
   end
 
-  # Terminal: the link was reachable but no deterministic profile reads it. In
-  # creation the AI mode is the way forward and the panel carries the
-  # link over; in edit it just invites another link.
+  # Terminal: reachable, but no profile reads it. Creation offers the AI
+  # bridge; edit just invites another link.
   def no_feed_error
     if editing?
       return identification_error(error: "We couldn't pull any posts from that link. Try a different one — your current source is untouched.")

--- a/app/controllers/feed_previews_controller.rb
+++ b/app/controllers/feed_previews_controller.rb
@@ -14,7 +14,7 @@ class FeedPreviewsController < ApplicationController
 
   # AI previews browse the web (Sonnet gather runs 40–120s, plus structuring), so
   # they need a far longer budget than a deterministic fetch or they'd time out
-  # mid-run (spec §6). ~4 minutes at the shared 2.5s poll interval.
+  # mid-run. ~4 minutes at the shared 2.5s poll interval.
   AI_PREVIEW_MAX_POLLS = 98
 
   # GET /feed_preview?profile_key=…&params[…]=…

--- a/app/javascript/controllers/preview_button_controller.js
+++ b/app/javascript/controllers/preview_button_controller.js
@@ -72,7 +72,7 @@ export default class extends Controller {
 
   // What's still missing before a preview can run, phrased for the user, or null
   // when it's ready. Mirrors the enable checks so the hint never disagrees with
-  // the button (spec §4 nicety).
+  // the button.
   _unavailableReason() {
     const profileKey = selectedProfileKey(this.element)
     if (!profileKey) return "Pick a feed type to preview."

--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -1,7 +1,7 @@
 class FeedRefreshJob < ApplicationJob
   queue_as :default
 
-  # @param feed_id [Integer]
+  # @param feed_id [Integer] ID of the feed to refresh
   # @param manual [Boolean] a user-initiated refresh forces through the
   #   digest cadence skip; scheduled runs may skip a redundant same-period
   #   digest.

--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -1,10 +1,8 @@
 class FeedRefreshJob < ApplicationJob
   queue_as :default
 
-  # @param feed_id [Integer] ID of the feed to refresh
-  # @param manual [Boolean] a user-initiated refresh forces through the digest
-  #   cadence skip; scheduled runs (the default) may skip a redundant same-period
-  #   digest before any LLM call.
+  # A manual (user-initiated) refresh forces through the digest cadence
+  # skip; scheduled runs may skip a redundant same-period digest.
   def perform(feed_id, manual: false)
     feed = Feed.find_by(id: feed_id)
     return unless feed

--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -9,7 +9,7 @@ class FeedRefreshJob < ApplicationJob
     feed = Feed.find_by(id: feed_id)
     return unless feed
 
-    # Webhook feeds have no loader to run; drop stray kicks (spec 006 §7).
+    # Webhook feeds have no loader to run; drop stray kicks.
     return if feed.feed_profile_key == "webhook"
 
     Feed.with_advisory_lock!("feed_refresh_#{feed.id}", timeout_seconds: 0) do

--- a/app/jobs/feed_refresh_job.rb
+++ b/app/jobs/feed_refresh_job.rb
@@ -1,8 +1,10 @@
 class FeedRefreshJob < ApplicationJob
   queue_as :default
 
-  # A manual (user-initiated) refresh forces through the digest cadence
-  # skip; scheduled runs may skip a redundant same-period digest.
+  # @param feed_id [Integer]
+  # @param manual [Boolean] a user-initiated refresh forces through the
+  #   digest cadence skip; scheduled runs may skip a redundant same-period
+  #   digest.
   def perform(feed_id, manual: false)
     feed = Feed.find_by(id: feed_id)
     return unless feed

--- a/app/models/ai_credential.rb
+++ b/app/models/ai_credential.rb
@@ -16,7 +16,7 @@ class AiCredential < ApplicationRecord
   end
 
   # Models this credential can actually back a feed with: the dev-verified
-  # capability matrix intersected with the provider's live snapshot (spec §5).
+  # capability matrix intersected with the provider's live snapshot.
   # Membership is qualification — a snapshot model absent from the matrix (or a
   # provider with no matrix rows) yields nothing, so nothing unverified leaks
   # into the picker or a run.

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -183,14 +183,17 @@ class Feed < ApplicationRecord
     feed_profile_key.present? && FeedProfile.exists?(feed_profile_key)
   end
 
+  # @return [Class]
   def loader_class
     FeedProfile.loader_class_for(feed_profile_key)
   end
 
+  # @return [Class]
   def processor_class
     FeedProfile.processor_class_for(feed_profile_key)
   end
 
+  # @return [Class]
   def normalizer_class
     FeedProfile.normalizer_class_for(feed_profile_key)
   end
@@ -283,32 +286,42 @@ class Feed < ApplicationRecord
     )
   end
 
+  # @param options [Hash] e.g. a shared :http_client
+  # @return [Loader::Base]
   def loader_instance(options = {})
     loader_class.new(self, options)
   end
 
+  # @param raw_data [String] raw payload from the loader
+  # @return [Processor::Base]
   def processor_instance(raw_data)
     processor_class.new(self, raw_data)
   end
 
+  # @param feed_entry [FeedEntry]
+  # @return [Normalizer::Base]
   def normalizer_instance(feed_entry)
     normalizer_class.new(feed_entry)
   end
 
+  # @return [Time, nil]
   def last_refreshed_at
     feed_entries.maximum(:created_at)
   end
 
+  # @return [Time, nil]
   def most_recent_post_date
     posts.maximum(:published_at)
   end
 
   # Time of the most recent repost to FreeFeed, regardless of the source
   # publication date.
+  # @return [Time, nil]
   def most_recent_repost_at
     posts.published.maximum(:reposted_at)
   end
 
+  # @return [Integer] posts published in the last week, by source date
   def posts_published_last_week_count
     posts.where(published_at: 1.week.ago.beginning_of_day..Time.current.end_of_day).count
   end
@@ -332,6 +345,7 @@ class Feed < ApplicationRecord
 
   # Creates the schedule pointed at the next cron slot, without triggering
   # an immediate run. Only called when a feed gains its schedule on enable.
+  # @return [FeedSchedule]
   def defer_schedule!
     schedule = build_feed_schedule(last_run_at: Time.current)
     schedule.next_run_at = schedule.calculate_next_run_at

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -49,7 +49,7 @@ class Feed < ApplicationRecord
   }, default: :draft
 
   # Set true by the edit controller only after a settled detection confirmed the
-  # new source (spec §4). Lets `source_change_reverified` reject a Mode A source
+  # new source. Lets `source_change_reverified` reject a Mode A source
   # move that never passed through identification.
   attr_accessor :source_verified
 
@@ -239,7 +239,7 @@ class Feed < ApplicationRecord
 
     # A dropped model no longer blocks preview — a run resolves to the
     # credential's default supported model, so preview only needs some verified
-    # model to exist (spec §5).
+    # model to exist.
     ai_credential.supported_models.any?
   end
 
@@ -252,7 +252,7 @@ class Feed < ApplicationRecord
   # The model an AI run/preview actually uses with `credential`: the chosen one
   # when still supported, otherwise the credential's default supported model.
   # Never hard-fails on a dropped model — the caller records the fallback so the
-  # feed page can prompt a re-pick (spec §5).
+  # feed page can prompt a re-pick.
   def effective_ai_model(credential = ai_credential)
     return ai_model if credential.nil?
     return ai_model if credential.supports_model?(ai_model)
@@ -278,7 +278,7 @@ class Feed < ApplicationRecord
   end
 
   # Records that an AI gather came back empty, so the structure call was skipped
-  # and the run produced nothing (spec §6/§8). Debug level keeps this routine,
+  # and the run produced nothing. Debug level keeps this routine,
   # expected outcome out of the user event feed while leaving it visible to
   # operators. No-op for an unpersisted (preview) feed.
   def note_ai_gather_empty!
@@ -485,8 +485,7 @@ class Feed < ApplicationRecord
   end
 
   # The engine (deterministic vs AI) is fixed at creation: an existing feed never
-  # switches across the AI boundary in edit — you create a new feed instead (spec
-  # §4). A deterministic → deterministic profile change is fine.
+  # switches across the AI boundary in edit — you create a new feed instead. A deterministic → deterministic profile change is fine.
   def engine_fixed_on_edit
     return unless persisted? && feed_profile_key_changed?
     return unless FeedProfile.exists?(feed_profile_key) && FeedProfile.exists?(feed_profile_key_was)
@@ -495,7 +494,7 @@ class Feed < ApplicationRecord
     errors.add(:feed_profile_key, "can't switch between AI and non-AI feeds — start a new feed instead")
   end
 
-  # A deterministic feed's source can only move through identification (spec §4):
+  # A deterministic feed's source can only move through identification:
   # the edit controller re-runs detection and sets `source_verified` once a
   # working candidate confirms the new source. This blocks a forged direct edit
   # from silently pointing a live feed at an unverified, possibly-broken source.

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -105,13 +105,10 @@ class Feed < ApplicationRecord
     self.cron_expression = SCHEDULE_INTERVALS.dig(key, :cron)
   end
 
-  # Form-facing accessors splitting import_after into a checkbox plus
-  # separate date and time inputs. The checkbox drives everything: when it's
-  # off, import_after resets to nil no matter what the date and time fields
-  # contain. The setters only record their part; import_after itself is
-  # composed once in before_validation — composing on every part-write let
-  # earlier parts read fallbacks from a half-updated import_after, making the
-  # result depend on assignment order.
+  # Form-facing accessors splitting import_after into checkbox, date, and
+  # time inputs. The checkbox drives everything: off resets import_after to
+  # nil. Setters only record their part; the value is composed once in
+  # before_validation so the result cannot depend on assignment order.
   def import_after_enabled
     return @import_after_enabled unless @import_after_enabled.nil?
 
@@ -186,20 +183,14 @@ class Feed < ApplicationRecord
     feed_profile_key.present? && FeedProfile.exists?(feed_profile_key)
   end
 
-  # Resolves and returns the loader class for this feed
-  # @return [Class] the loader class
   def loader_class
     FeedProfile.loader_class_for(feed_profile_key)
   end
 
-  # Resolves and returns the processor class for this feed
-  # @return [Class] the processor class
   def processor_class
     FeedProfile.processor_class_for(feed_profile_key)
   end
 
-  # Resolves and returns the normalizer class for this feed
-  # @return [Class] the normalizer class
   def normalizer_class
     FeedProfile.normalizer_class_for(feed_profile_key)
   end
@@ -292,48 +283,32 @@ class Feed < ApplicationRecord
     )
   end
 
-  # Creates and returns a loader instance for this feed
-  # @param options [Hash] loader options (e.g. a shared :http_client)
-  # @return [Loader::Base] loader instance
   def loader_instance(options = {})
     loader_class.new(self, options)
   end
 
-  # Creates and returns a processor instance for this feed
-  # @param raw_data [String] raw feed data to process
-  # @return [Processor::Base] processor instance
   def processor_instance(raw_data)
     processor_class.new(self, raw_data)
   end
 
-  # Creates and returns a normalizer instance for the given feed entry
-  # @param feed_entry [FeedEntry] the feed entry to normalize
-  # @return [Normalizer::Base]
   def normalizer_instance(feed_entry)
     normalizer_class.new(feed_entry)
   end
 
-  # Returns the date when the feed was last refreshed
-  # @return [Time, nil] last refresh time or nil if never refreshed
   def last_refreshed_at
     feed_entries.maximum(:created_at)
   end
 
-  # Returns the date of the most recent imported post
-  # @return [Time, nil] most recent post date or nil if no posts
   def most_recent_post_date
     posts.maximum(:published_at)
   end
 
-  # Returns the time of the most recent repost (publication to FreeFeed),
-  # regardless of the original source publication date.
-  # @return [Time, nil] most recent repost time or nil if no published posts
+  # Time of the most recent repost to FreeFeed, regardless of the source
+  # publication date.
   def most_recent_repost_at
     posts.published.maximum(:reposted_at)
   end
 
-  # Returns the count of posts published in the last week (by source date)
-  # @return [Integer] number of posts published in the last week
   def posts_published_last_week_count
     posts.where(published_at: 1.week.ago.beginning_of_day..Time.current.end_of_day).count
   end
@@ -355,10 +330,8 @@ class Feed < ApplicationRecord
     feed_schedule&.update!(next_run_at: Time.current)
   end
 
-  # Creates the schedule pointed at the next cron slot, without triggering an
-  # immediate run. Only called when a feed gains its schedule on enable
-  # (create_schedule_on_enable guards the already-scheduled case).
-  # @return [FeedSchedule]
+  # Creates the schedule pointed at the next cron slot, without triggering
+  # an immediate run. Only called when a feed gains its schedule on enable.
   def defer_schedule!
     schedule = build_feed_schedule(last_run_at: Time.current)
     schedule.next_run_at = schedule.calculate_next_run_at
@@ -456,10 +429,9 @@ class Feed < ApplicationRecord
     errors.add(:cron_expression, "is not a valid cron expression") unless parsed_cron
   end
 
-  # Structural sanity check: in normal use the form is generated from the
-  # same parameter_schema, so this can only fire on a forged POST or a code
-  # bug. The "<pointer> <message>" output is machine-only; the future
-  # per-field form renderer translates it; nothing surfaces raw to users.
+  # Can only fire on a forged POST or a code bug: the form is generated
+  # from the same parameter_schema. The "<pointer> <message>" output is
+  # machine-only.
   def params_against_profile_schema
     return unless feed_profile_present?
 
@@ -484,8 +456,9 @@ class Feed < ApplicationRecord
     end
   end
 
-  # The engine (deterministic vs AI) is fixed at creation: an existing feed never
-  # switches across the AI boundary in edit — you create a new feed instead. A deterministic → deterministic profile change is fine.
+  # The engine (deterministic vs AI) is fixed at creation; crossing the AI
+  # boundary means a new feed. A deterministic to deterministic profile
+  # change is fine.
   def engine_fixed_on_edit
     return unless persisted? && feed_profile_key_changed?
     return unless FeedProfile.exists?(feed_profile_key) && FeedProfile.exists?(feed_profile_key_was)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -183,17 +183,17 @@ class Feed < ApplicationRecord
     feed_profile_key.present? && FeedProfile.exists?(feed_profile_key)
   end
 
-  # @return [Class]
+  # @return [Class] the profile's loader class
   def loader_class
     FeedProfile.loader_class_for(feed_profile_key)
   end
 
-  # @return [Class]
+  # @return [Class] the profile's processor class
   def processor_class
     FeedProfile.processor_class_for(feed_profile_key)
   end
 
-  # @return [Class]
+  # @return [Class] the profile's normalizer class
   def normalizer_class
     FeedProfile.normalizer_class_for(feed_profile_key)
   end
@@ -287,36 +287,36 @@ class Feed < ApplicationRecord
   end
 
   # @param options [Hash] e.g. a shared :http_client
-  # @return [Loader::Base]
+  # @return [Loader::Base] the feed's loader
   def loader_instance(options = {})
     loader_class.new(self, options)
   end
 
   # @param raw_data [String] raw payload from the loader
-  # @return [Processor::Base]
+  # @return [Processor::Base] the feed's processor
   def processor_instance(raw_data)
     processor_class.new(self, raw_data)
   end
 
-  # @param feed_entry [FeedEntry]
-  # @return [Normalizer::Base]
+  # @param feed_entry [FeedEntry] the entry to normalize
+  # @return [Normalizer::Base] the entry's normalizer
   def normalizer_instance(feed_entry)
     normalizer_class.new(feed_entry)
   end
 
-  # @return [Time, nil]
+  # @return [Time, nil] last refresh time or nil if never refreshed
   def last_refreshed_at
     feed_entries.maximum(:created_at)
   end
 
-  # @return [Time, nil]
+  # @return [Time, nil] most recent post date or nil if no posts
   def most_recent_post_date
     posts.maximum(:published_at)
   end
 
   # Time of the most recent repost to FreeFeed, regardless of the source
   # publication date.
-  # @return [Time, nil]
+  # @return [Time, nil] most recent repost time or nil if no published posts
   def most_recent_repost_at
     posts.published.maximum(:reposted_at)
   end
@@ -345,7 +345,7 @@ class Feed < ApplicationRecord
 
   # Creates the schedule pointed at the next cron slot, without triggering
   # an immediate run. Only called when a feed gains its schedule on enable.
-  # @return [FeedSchedule]
+  # @return [FeedSchedule] the created schedule
   def defer_schedule!
     schedule = build_feed_schedule(last_run_at: Time.current)
     schedule.next_run_at = schedule.calculate_next_run_at

--- a/app/models/feed_preview.rb
+++ b/app/models/feed_preview.rb
@@ -35,7 +35,7 @@ class FeedPreview < ApplicationRecord
   end
 
   # Transitions to :failed only if still non-terminal. Rotating run_id makes the
-  # timeout terminal (spec §6): the still-running job holds the old run_id, so its
+  # timeout terminal: the still-running job holds the old run_id, so its
   # run_id-gated transitions now update 0 rows and can't flip the row back to
   # :ready after the user has already seen the timeout and left.
   def timeout!

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -12,10 +12,9 @@ class FeedProfile
         "items" => {
           "type" => "object",
           "properties" => {
-            # The model never mints the uid — the processor derives it from
-            # source_url. `uid` stays an accepted-but-optional property
-            # only so a stray field from a non-strict provider doesn't fail the
-            # schema; it's ignored downstream.
+            # The processor derives the uid from source_url. `uid` is
+            # accepted only so a stray field from a non-strict provider
+            # doesn't fail the schema; it's ignored downstream.
             "uid" => { "type" => "string" },
             "title" => { "type" => "string" },
             "body" => { "type" => "string" },
@@ -313,12 +312,10 @@ class FeedProfile
       loader: {
         class: "Loader::LlmLoader",
         config: {
-          # The user message: the task, output contract, and safeguards live in
-          # the system prompt (Loader::LlmPrompts). The user's own prompt is a
-          # legitimate instruction — it says what to follow and how to transform
-          # it — so it travels as the user message, distinct from
-          # the untrusted web content the model later fetches. Web access is
-          # provided per-provider by the adapter.
+          # The task, output contract, and safeguards live in the system
+          # prompt (Loader::LlmPrompts). The user's own prompt is a
+          # legitimate instruction, so it travels as the user message,
+          # distinct from the untrusted web content the model fetches.
           prompt_template: <<~PROMPT,
             Feed request — what to follow and how to present it:
 
@@ -409,90 +406,58 @@ class FeedProfile
   }.freeze
 
   class << self
-    # Returns all available profile keys
-    # @return [Array<String>] list of profile keys
     def all
       PROFILES.keys
     end
 
-    # Checks if a profile key exists
-    # @param key [String] the profile key to check
-    # @return [Boolean] true if the profile exists
     def exists?(key)
       PROFILES.key?(key)
     end
 
-    # Bracket access to the full registry entry for a profile key
-    # @param key [String] the profile key
-    # @return [Hash, nil] the registry entry hash or nil if not found
     def [](key)
       PROFILES[key]
     end
 
-    # Matcher classes for every profile that registers one, in registration
-    # order. The AI profile deliberately registers none, so it
-    # can never be detected.
-    # @return [Array<Class>] matcher classes
+    # In registration order. The AI profile registers no matcher, so it can
+    # never be detected.
     def matchers
       PROFILES.filter_map { |_key, entry| entry[:matcher].presence&.constantize }
     end
 
-    # @param key [String] the profile key
-    # @return [Boolean] true if any of the profile's stages calls an LLM
     def depends_on_ai?(key)
       !!PROFILES.dig(key, :depends_on_ai)
     end
 
-    # @param key [String] the profile key
-    # @return [Boolean] true if the profile uses periodic scheduling
     def scheduled?(key)
       !!PROFILES.dig(key, :scheduled)
     end
 
-    # @param key [String] the profile key
-    # @return [Hash] attributes enforced after user-submitted attributes
     def defaults_for(key)
       PROFILES.dig(key, :defaults) || {}
     end
 
-    # @return [Array<String>] keys of the AI-backed profiles
     def ai_profile_keys
       PROFILES.keys.select { |key| depends_on_ai?(key) }
     end
 
-    # Returns the JSON Schema describing the feed's params hash
-    # @param key [String] the profile key
-    # @return [Hash, nil] the parameter schema (nil if profile not found)
     def parameter_schema_for(key)
       PROFILES.dig(key, :parameter_schema)
     end
 
-    # The params key holding the feed's source input (e.g. "url", "prompt").
-    # Derived from the profile's single required param, so the storage key is
-    # independent of input_shape (which an `:any` profile can't double as).
-    # Unknown profiles fall back to "url". An input-less (:none) profile
-    # returns nil, which keeps source_input nil even if a stray key lands in
-    # the params jsonb.
-    # @param key [String] the profile key
-    # @return [String, nil] the source params key
+    # The params key holding the source input ("url", "prompt"), derived
+    # from the profile's single required param. Unknown profiles fall back
+    # to "url"; an input-less profile returns nil.
     def source_key_for(key)
       return nil if PROFILES.dig(key, :input_shape) == :none
 
       PROFILES.dig(key, :parameter_schema, "required")&.first || "url"
     end
 
-    # The user-facing source value stored in a params hash, read by the
-    # profile's source key.
-    # @param key [String] the profile key
-    # @param params [Hash, nil] a feed/preview params hash
-    # @return [String, nil] the source value
+    # The user-facing source value in a params hash.
     def source_input_for(key, params)
       (params || {})[source_key_for(key)]
     end
 
-    # @param key [String] the profile key
-    # @param stage [Symbol] the stage (:loader, :processor, :normalizer)
-    # @return [Hash] the stage's config hash (frozen empty hash if none)
     def config_for(key, stage)
       raise ArgumentError, "Profile '#{key}' not found" unless PROFILES.key?(key)
 
@@ -505,47 +470,28 @@ class FeedProfile
       end
     end
 
-    # Resolves and returns the loader class for a given profile key
-    # @param key [String] the profile key
-    # @return [Class] the loader class
     def loader_class_for(key)
       class_for(key, :loader)
     end
 
-    # Resolves and returns the processor class for a given profile key
-    # @param key [String] the profile key
-    # @return [Class] the processor class
     def processor_class_for(key)
       class_for(key, :processor)
     end
 
-    # Resolves and returns the normalizer class for a given profile key
-    # @param key [String] the profile key
-    # @return [Class] the normalizer class
     def normalizer_class_for(key)
       class_for(key, :normalizer)
     end
 
-    # Resolves and returns the title extractor class for a given profile key
-    # @param key [String] the profile key
-    # @return [Class] the title extractor class
     def title_extractor_class_for(key)
       class_for(key, :title_extractor)
     end
 
-    # Returns a human-readable display name for a profile key
-    # @param key [String] the profile key
-    # @return [String] the display name
     def display_name_for(key)
       PROFILES.dig(key, :display_name) || key.to_s.titleize
     end
 
     private
 
-    # Resolves a stage class for a given profile key and stage type.
-    # @param key [String] the profile key
-    # @param stage [Symbol] the stage (:loader, :processor, :normalizer, :title_extractor)
-    # @return [Class] the stage class
     def class_for(key, stage)
       raise ArgumentError, "Profile '#{key}' not found" unless PROFILES.key?(key)
 

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -406,40 +406,55 @@ class FeedProfile
   }.freeze
 
   class << self
+    # @return [Array<String>] all profile keys
     def all
       PROFILES.keys
     end
 
+    # @param key [String] the profile key
+    # @return [Boolean]
     def exists?(key)
       PROFILES.key?(key)
     end
 
+    # @param key [String] the profile key
+    # @return [Hash, nil] the registry entry
     def [](key)
       PROFILES[key]
     end
 
     # In registration order. The AI profile registers no matcher, so it can
     # never be detected.
+    # @return [Array<Class>]
     def matchers
       PROFILES.filter_map { |_key, entry| entry[:matcher].presence&.constantize }
     end
 
+    # @param key [String] the profile key
+    # @return [Boolean] true if any stage calls an LLM
     def depends_on_ai?(key)
       !!PROFILES.dig(key, :depends_on_ai)
     end
 
+    # @param key [String] the profile key
+    # @return [Boolean] true if the profile uses periodic scheduling
     def scheduled?(key)
       !!PROFILES.dig(key, :scheduled)
     end
 
+    # @param key [String] the profile key
+    # @return [Hash] attributes enforced after user-submitted attributes
     def defaults_for(key)
       PROFILES.dig(key, :defaults) || {}
     end
 
+    # @return [Array<String>] keys of the AI-backed profiles
     def ai_profile_keys
       PROFILES.keys.select { |key| depends_on_ai?(key) }
     end
 
+    # @param key [String] the profile key
+    # @return [Hash, nil]
     def parameter_schema_for(key)
       PROFILES.dig(key, :parameter_schema)
     end
@@ -447,6 +462,8 @@ class FeedProfile
     # The params key holding the source input ("url", "prompt"), derived
     # from the profile's single required param. Unknown profiles fall back
     # to "url"; an input-less profile returns nil.
+    # @param key [String] the profile key
+    # @return [String, nil]
     def source_key_for(key)
       return nil if PROFILES.dig(key, :input_shape) == :none
 
@@ -454,10 +471,16 @@ class FeedProfile
     end
 
     # The user-facing source value in a params hash.
+    # @param key [String] the profile key
+    # @param params [Hash, nil]
+    # @return [String, nil]
     def source_input_for(key, params)
       (params || {})[source_key_for(key)]
     end
 
+    # @param key [String] the profile key
+    # @param stage [Symbol] :loader, :processor, or :normalizer
+    # @return [Hash] the stage's config (frozen empty hash if none)
     def config_for(key, stage)
       raise ArgumentError, "Profile '#{key}' not found" unless PROFILES.key?(key)
 
@@ -470,28 +493,41 @@ class FeedProfile
       end
     end
 
+    # @param key [String] the profile key
+    # @return [Class]
     def loader_class_for(key)
       class_for(key, :loader)
     end
 
+    # @param key [String] the profile key
+    # @return [Class]
     def processor_class_for(key)
       class_for(key, :processor)
     end
 
+    # @param key [String] the profile key
+    # @return [Class]
     def normalizer_class_for(key)
       class_for(key, :normalizer)
     end
 
+    # @param key [String] the profile key
+    # @return [Class]
     def title_extractor_class_for(key)
       class_for(key, :title_extractor)
     end
 
+    # @param key [String] the profile key
+    # @return [String]
     def display_name_for(key)
       PROFILES.dig(key, :display_name) || key.to_s.titleize
     end
 
     private
 
+    # @param key [String] the profile key
+    # @param stage [Symbol] :loader, :processor, :normalizer, or :title_extractor
+    # @return [Class]
     def class_for(key, stage)
       raise ArgumentError, "Profile '#{key}' not found" unless PROFILES.key?(key)
 

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -412,7 +412,7 @@ class FeedProfile
     end
 
     # @param key [String] the profile key
-    # @return [Boolean]
+    # @return [Boolean] true if the profile exists
     def exists?(key)
       PROFILES.key?(key)
     end
@@ -425,7 +425,7 @@ class FeedProfile
 
     # In registration order. The AI profile registers no matcher, so it can
     # never be detected.
-    # @return [Array<Class>]
+    # @return [Array<Class>] matcher classes
     def matchers
       PROFILES.filter_map { |_key, entry| entry[:matcher].presence&.constantize }
     end
@@ -454,7 +454,7 @@ class FeedProfile
     end
 
     # @param key [String] the profile key
-    # @return [Hash, nil]
+    # @return [Hash, nil] the params JSON Schema, nil for an unknown profile
     def parameter_schema_for(key)
       PROFILES.dig(key, :parameter_schema)
     end
@@ -463,7 +463,7 @@ class FeedProfile
     # from the profile's single required param. Unknown profiles fall back
     # to "url"; an input-less profile returns nil.
     # @param key [String] the profile key
-    # @return [String, nil]
+    # @return [String, nil] the source params key
     def source_key_for(key)
       return nil if PROFILES.dig(key, :input_shape) == :none
 
@@ -472,8 +472,8 @@ class FeedProfile
 
     # The user-facing source value in a params hash.
     # @param key [String] the profile key
-    # @param params [Hash, nil]
-    # @return [String, nil]
+    # @param params [Hash, nil] a feed or preview params hash
+    # @return [String, nil] the source value
     def source_input_for(key, params)
       (params || {})[source_key_for(key)]
     end
@@ -494,31 +494,31 @@ class FeedProfile
     end
 
     # @param key [String] the profile key
-    # @return [Class]
+    # @return [Class] the loader class
     def loader_class_for(key)
       class_for(key, :loader)
     end
 
     # @param key [String] the profile key
-    # @return [Class]
+    # @return [Class] the processor class
     def processor_class_for(key)
       class_for(key, :processor)
     end
 
     # @param key [String] the profile key
-    # @return [Class]
+    # @return [Class] the normalizer class
     def normalizer_class_for(key)
       class_for(key, :normalizer)
     end
 
     # @param key [String] the profile key
-    # @return [Class]
+    # @return [Class] the title extractor class
     def title_extractor_class_for(key)
       class_for(key, :title_extractor)
     end
 
     # @param key [String] the profile key
-    # @return [String]
+    # @return [String] the human-readable display name
     def display_name_for(key)
       PROFILES.dig(key, :display_name) || key.to_s.titleize
     end
@@ -527,7 +527,7 @@ class FeedProfile
 
     # @param key [String] the profile key
     # @param stage [Symbol] :loader, :processor, :normalizer, or :title_extractor
-    # @return [Class]
+    # @return [Class] the stage class
     def class_for(key, stage)
       raise ArgumentError, "Profile '#{key}' not found" unless PROFILES.key?(key)
 

--- a/app/models/feed_profile.rb
+++ b/app/models/feed_profile.rb
@@ -13,7 +13,7 @@ class FeedProfile
           "type" => "object",
           "properties" => {
             # The model never mints the uid — the processor derives it from
-            # source_url (spec §3). `uid` stays an accepted-but-optional property
+            # source_url. `uid` stays an accepted-but-optional property
             # only so a stray field from a non-strict provider doesn't fail the
             # schema; it's ignored downstream.
             "uid" => { "type" => "string" },
@@ -22,7 +22,7 @@ class FeedProfile
             "supplementary" => { "type" => "array", "items" => { "type" => "string" } },
             "images" => { "type" => "array", "items" => { "type" => "string" } },
             # An explicit null signals the digest/standing-query regime; a real
-            # permalink signals feed-style (spec §3). The key is always required —
+            # permalink signals feed-style. The key is always required —
             # a missing key is malformed, not a digest.
             "source_url" => { "type" => ["string", "null"] },
             "published_at" => { "type" => "string" }
@@ -298,7 +298,7 @@ class FeedProfile
       # Accepts anything (a link, several links, or a description); the prompt
       # is the source. The params key is `prompt`, not derived from input_shape.
       # Registers NO matcher: the AI profile is structurally excluded from
-      # detection (spec §7) — Mode B selects it directly, detection never can.
+      # detection — Mode B selects it directly, detection never can.
       input_shape: :any,
       depends_on_ai: true,
       scheduled: true,
@@ -316,7 +316,7 @@ class FeedProfile
           # The user message: the task, output contract, and safeguards live in
           # the system prompt (Loader::LlmPrompts). The user's own prompt is a
           # legitimate instruction — it says what to follow and how to transform
-          # it (spec §2/§8) — so it travels as the user message, distinct from
+          # it — so it travels as the user message, distinct from
           # the untrusted web content the model later fetches. Web access is
           # provided per-provider by the adapter.
           prompt_template: <<~PROMPT,
@@ -386,7 +386,7 @@ class FeedProfile
     "webhook" => {
       display_name: "Webhook",
       description: "Posts sent in from your own scripts through a secret URL",
-      # Push-ingested (spec 006): content arrives over HTTP, so there is
+      # Push-ingested: content arrives over HTTP, so there is
       # nothing to fetch and nothing to detect — no loader/processor, no
       # matcher, no schedule.
       input_shape: :none,
@@ -430,7 +430,7 @@ class FeedProfile
     end
 
     # Matcher classes for every profile that registers one, in registration
-    # order. The AI profile deliberately registers none (spec 005 §7), so it
+    # order. The AI profile deliberately registers none, so it
     # can never be detected.
     # @return [Array<Class>] matcher classes
     def matchers

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -30,7 +30,7 @@ class Post < ApplicationRecord
   validates :uid, presence: true
   validates :uid, uniqueness: { scope: :feed_id }
   validates :published_at, presence: true
-  # A digest/standing-query post carries source_url = null (spec §3); allow_nil
+  # A digest/standing-query post carries source_url = null; allow_nil
   # lets that through while still rejecting a blank string on a feed-style post.
   validates :source_url, presence: true, allow_nil: true
   # Length limits gate enqueueing only. Once a post leaves the queue (published,

--- a/app/policies/feed_policy.rb
+++ b/app/policies/feed_policy.rb
@@ -20,7 +20,7 @@ class FeedPolicy < ApplicationPolicy
   end
 
   # Refresh is meaningless for push-ingested (schedule-less) feeds — there is
-  # no loader to run (spec 006 §7).
+  # no loader to run.
   def refresh?
     owner? && record.enabled? && record.scheduled?
   end

--- a/app/services/feed_profile_detector.rb
+++ b/app/services/feed_profile_detector.rb
@@ -20,7 +20,7 @@ class FeedProfileDetector
 
   # Detection is URL-only and deterministic: the input is always a Mode A source
   # URL (SourceLink canonicalized it upstream). The AI profile registers no
-  # matcher, so it can never appear here (spec §7).
+  # matcher, so it can never appear here.
   def call
     Thread.current[:llm_detection_phase] = true
 

--- a/app/services/feed_refresh_workflow.rb
+++ b/app/services/feed_refresh_workflow.rb
@@ -38,7 +38,7 @@ class FeedRefreshWorkflow
   # A digest feed's period slot is consumed the moment it produces a period-keyed
   # post; refreshing again in the same period just re-runs the costly gather +
   # structure only to dedup the result away. Skip such a scheduled run before any
-  # LLM call (spec §3). A manual refresh always forces through — the user asked
+  # LLM call. A manual refresh always forces through — the user asked
   # for it — and mixed/feed-style runs never mark a period, so they never skip.
   def skip_current_digest_period(input)
     return input unless skip_scheduled_digest_run?

--- a/app/services/llm_capability_probe.rb
+++ b/app/services/llm_capability_probe.rb
@@ -281,7 +281,7 @@ module LlmCapabilityProbe
         { status: "FAIL", note: "schema-valid but the items are a refusal", evidence: evidence }
       elsif expect_null_source_url && items.none? { |item| item["source_url"].nil? }
         # Accepting the union in the schema is not the same as emitting it, and
-        # a digest feed depends on the null branch (spec 005 §3).
+        # a digest feed depends on the null branch.
         { status: "FAIL", note: "schema-valid but no item emitted a null source_url", evidence: evidence }
       else
         { status: "PASS", note: "#{items.size} items, schema-valid", evidence: evidence }

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -165,7 +165,7 @@ class LlmClient
   def invoke_provider(ctx: nil, model:, prompt:, output_schema:, web:, system: nil)
     chat = credential.chat(model)
     # System prompt is the privileged instruction channel; the user prompt sent
-    # by #ask travels as a separate user-role message (spec §8).
+    # by #ask travels as a separate user-role message.
     chat.with_instructions(system) if system.present?
     chat.with_schema(adapter.schema_payload(output_schema)) if output_schema.present?
     apply_params(chat, model, schema: output_schema.present?, web: web)

--- a/app/services/llm_client/tools/web_fetch.rb
+++ b/app/services/llm_client/tools/web_fetch.rb
@@ -2,7 +2,7 @@ class LlmClient
   module Tools
     # Client-side retrieval for providers without usable server-side web access
     # (Moonshot/Kimi). The model supplies the URL, so it is validated as a
-    # public http(s) URL (PublicUrl, spec 005 §8) before any request.
+    # public http(s) URL (PublicUrl) before any request.
     class WebFetch < RubyLLM::Tool
       description "Fetch the readable text of a public web page. Pass one absolute http(s) URL."
       param :url, desc: "Absolute http(s) URL of the page to fetch", required: true
@@ -24,7 +24,7 @@ class LlmClient
         return { error: "Refused: pass one absolute public http(s) URL." }.to_json unless PublicUrl.safe?(url)
 
         # public-only so a redirect can't slip past the check above to an
-        # internal address (SSRF; spec 005 §8).
+        # internal address (SSRF).
         response = HttpClient.build(max_redirects: MAX_REDIRECTS)
                              .get(url.to_s.strip, options: { validate_url: PublicUrl.method(:safe?) })
         return { error: "HTTP #{response.status}" }.to_json unless response.success?

--- a/app/services/loader/llm_loader.rb
+++ b/app/services/loader/llm_loader.rb
@@ -48,7 +48,7 @@ module Loader
 
     # A blank/whitespace gather yields zero items and skips the structure call:
     # feeding emptiness (or a model refusal) into structuring invites fabricated
-    # items, exactly what the grounding safeguard forbids (spec §6/§8). Recorded
+    # items, exactly what the grounding safeguard forbids. Recorded
     # so a persistently empty AI feed is visible to operators.
     def empty_gather_result
       feed.note_ai_gather_empty!
@@ -79,7 +79,7 @@ module Loader
 
     # The chosen model when the credential still supports it, otherwise its
     # default supported model — a dropped model degrades gracefully instead of
-    # failing the run (spec §5). The provider default is the last resort when the
+    # failing the run. The provider default is the last resort when the
     # credential exposes no verified models at all. A persisted feed records the
     # fallback once, keyed on the model actually used, so the page prompts a
     # re-pick even when the whole snapshot dropped out.

--- a/app/services/loader/llm_prompts.rb
+++ b/app/services/loader/llm_prompts.rb
@@ -1,5 +1,5 @@
 module Loader
-  # System prompts for the AI extraction stages (spec 005 §2, §6, §8).
+  # System prompts for the AI extraction stages.
   #
   # These are the *privileged* instruction channel: they travel as a system-role
   # message, while the user's feed prompt travels separately as a user-role

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -5,7 +5,7 @@ module Normalizer
   class Base
     include HtmlTextUtils
 
-    # @param feed_entry [FeedEntry]
+    # @param feed_entry [FeedEntry] the feed entry to normalize
     def initialize(feed_entry)
       @feed_entry = feed_entry
     end

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -11,6 +11,8 @@ module Normalizer
 
     # Raises if the subclass produced a Post missing dedup or ordering
     # invariants; those are programming errors.
+    # 
+    # @return [Post] post with status set based on validation
     def normalize
       post = build_post
       raise MissingUidError, "#{self.class.name} produced a Post with no uid" if post.uid.blank?

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -66,7 +66,7 @@ module Normalizer
       @content ||= normalize_content
     end
 
-    # §8: every attachment URL must be an absolute public http(s) URL or be
+    # Every attachment URL must be an absolute public http(s) URL or be
     # dropped (the attachment, not the post). Filtering here — the choke point
     # every normalizer flows through — keeps a relative or local-path value (e.g.
     # a feed's `<img src="/etc/passwd">`) from reaching FileBuffer at publish,

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -5,13 +5,14 @@ module Normalizer
   class Base
     include HtmlTextUtils
 
+    # @param feed_entry [FeedEntry]
     def initialize(feed_entry)
       @feed_entry = feed_entry
     end
 
     # Raises if the subclass produced a Post missing dedup or ordering
     # invariants; those are programming errors.
-    # 
+    #
     # @return [Post] post with status set based on validation
     def normalize
       post = build_post

--- a/app/services/normalizer/base.rb
+++ b/app/services/normalizer/base.rb
@@ -1,24 +1,16 @@
-# Base class for feed entry normalizers
-#
-# Normalizer should normalize the feed entry content to make it compatible with
-# publication on FreeFeed. If normalization is not possible, normalizer should
-# reject the post with a list of validation errors. The Post record can always
-# be persisted regardless of whether normalization is performed.
-#
+# Normalizers shape feed entry content for publication on FreeFeed, or
+# reject the post with validation errors. The Post record persists either
+# way.
 module Normalizer
   class Base
     include HtmlTextUtils
 
-    # @param feed_entry [FeedEntry] the feed entry to normalize
     def initialize(feed_entry)
       @feed_entry = feed_entry
     end
 
-    # Normalizes feed entry into a Post with validation. Raises if the
-    # subclass produced a Post missing dedup or ordering invariants —
-    # those are programming errors, covered by per-profile tests.
-    #
-    # @return [Post] post with status set based on validation
+    # Raises if the subclass produced a Post missing dedup or ordering
+    # invariants; those are programming errors.
     def normalize
       post = build_post
       raise MissingUidError, "#{self.class.name} produced a Post with no uid" if post.uid.blank?

--- a/app/services/normalizer/llm_normalizer.rb
+++ b/app/services/normalizer/llm_normalizer.rb
@@ -6,7 +6,7 @@ module Normalizer
   class LlmNormalizer < Base
     private
 
-    # A digest item carries source_url = null end-to-end (spec §3): keep it nil
+    # A digest item carries source_url = null end-to-end: keep it nil
     # (not "") so the nullable column stores NULL and Post's conditional
     # validation lets it publish. A feed-style item keeps its string permalink.
     def normalize_source_url
@@ -23,7 +23,7 @@ module Normalizer
       truncate_text(raw_data["body"].to_s)
     end
 
-    # Base#attachment_urls filters non-public URLs at the choke point (§8).
+    # Base#attachment_urls filters non-public URLs at the choke point.
     def normalize_attachment_urls
       Array(raw_data["images"]).map(&:to_s)
     end

--- a/app/services/normalizer/missing_uid_error.rb
+++ b/app/services/normalizer/missing_uid_error.rb
@@ -1,6 +1,6 @@
 module Normalizer
   # Raised when a normalizer returns a Post with a blank uid. The
-  # dedup workflow needs a stable per-source identifier (FR-020); a
+  # dedup workflow needs a stable per-source identifier; a
   # missing one is a programming error in the normalizer.
   class MissingUidError < StandardError; end
 end

--- a/app/services/normalizer/webhook_normalizer.rb
+++ b/app/services/normalizer/webhook_normalizer.rb
@@ -1,5 +1,5 @@
 module Normalizer
-  # Maps a stored webhook payload (spec 006 §3) onto a Post through the Base
+  # Maps a stored webhook payload onto a Post through the Base
   # choke-point guarantees: attachment SSRF filtering, comment clamping, and
   # the content rules.
   class WebhookNormalizer < Base
@@ -20,7 +20,7 @@ module Normalizer
 
     def normalize_comments = payload.comments
 
-    # Content is required unless images are present (spec 006 §3). Checked on
+    # Content is required unless images are present. Checked on
     # the raw payload field: in the composed content a bare source_url would
     # masquerade as content.
     def validate_content

--- a/app/services/processor/passthrough_processor.rb
+++ b/app/services/processor/passthrough_processor.rb
@@ -13,7 +13,7 @@ module Processor
           feed: feed,
           # A digest item (source_url: null) gets a period uid; a feed-style
           # permalink a normalized uid; an unusable permalink resolves to nil and
-          # is dropped-and-counted by the workflow (spec §3), so we no longer
+          # is dropped-and-counted by the workflow, so we no longer
           # swallow it here.
           uid: Uid::Resolver.call(item, clock: Time.current),
           # AI-extracted items rarely come with a reliable published_at;

--- a/app/services/public_url.rb
+++ b/app/services/public_url.rb
@@ -1,17 +1,13 @@
 require "ipaddr"
 require "socket"
 
-# Guards model-supplied URLs the app would fetch server-side — attachment
-# uploads at publish time and the client-side web-fetch tool. A URL is safe
-# only if it is an absolute http(s) URL to a public host; non-http schemes,
-# embedded credentials, localhost, and any address literal in a private,
-# loopback, or link-local range are rejected (server-side request forgery).
-#
-# Address literals are canonicalized the way the HTTP client's resolver reads
-# them, so encoded forms (decimal/hex/octal, e.g. http://2130706433 → 127.0.0.1)
-# can't smuggle a private target past a plain string check. DNS names are not
-# resolved here, so a name pointing at a private address is a residual gap best
-# closed at the fetch layer (resolve-and-pin).
+# Guards URLs the app would fetch server-side (SSRF). Safe means an
+# absolute http(s) URL to a public host; non-http schemes, embedded
+# credentials, localhost, and private/loopback/link-local literals are
+# rejected. Literals are canonicalized the way resolvers read them, so
+# encoded forms (http://2130706433 = 127.0.0.1) can't sneak through. DNS
+# names are not resolved here; a name pointing at a private address must
+# be caught at the fetch layer.
 module PublicUrl
   # Addresses IPAddr's loopback?/private?/link_local? predicates don't cover:
   # "this host" (v4 0.0.0.0/8 and the v6 unspecified ::) and carrier-grade NAT.

--- a/app/services/public_url.rb
+++ b/app/services/public_url.rb
@@ -5,8 +5,7 @@ require "socket"
 # uploads at publish time and the client-side web-fetch tool. A URL is safe
 # only if it is an absolute http(s) URL to a public host; non-http schemes,
 # embedded credentials, localhost, and any address literal in a private,
-# loopback, or link-local range are rejected (server-side request forgery;
-# spec 005 §8).
+# loopback, or link-local range are rejected (server-side request forgery).
 #
 # Address literals are canonicalized the way the HTTP client's resolver reads
 # them, so encoded forms (decimal/hex/octal, e.g. http://2130706433 → 127.0.0.1)

--- a/app/services/source_link.rb
+++ b/app/services/source_link.rb
@@ -1,5 +1,5 @@
 # Decides whether a Mode A input counts as a source URL and returns the URL to
-# fetch, applying the silent scheme-fix from spec 005 §1:
+# fetch, applying the silent scheme-fix:
 #
 # - An explicit `http(s)://` input is honored as typed — `http://` is never
 #   forced to `https://`, since some feeds are http-only.

--- a/app/services/source_link.rb
+++ b/app/services/source_link.rb
@@ -1,15 +1,8 @@
-# Decides whether a Mode A input counts as a source URL and returns the URL to
-# fetch, applying the silent scheme-fix:
-#
-# - An explicit `http(s)://` input is honored as typed — `http://` is never
-#   forced to `https://`, since some feeds are http-only.
-# - A bare, host-shaped input gets an `https://` scheme (`example.com` →
-#   `https://example.com`). "Host-shaped" means the fix yields a dotted host, so
-#   `r/x` never becomes `https://r/x` (host `r`) — a non-URL like that routes to
-#   the AI bridge instead of dead-ending in the couldn't-reach state.
-#
-# Anything else (a handle, a few words, a non-http scheme like `mailto:`) is not
-# a URL and returns nil, which the entry flow reads as "offer Mode B".
+# Decides whether an input counts as a source URL and returns the URL to
+# fetch. Explicit http(s) inputs pass as typed; http is never forced to
+# https since some feeds are http-only. A bare dotted host gets https
+# prepended. Anything else (a handle, free text, a non-http scheme)
+# returns nil, which the entry flow reads as "offer the AI mode".
 class SourceLink
   def self.canonical(input)
     new(input).canonical
@@ -43,16 +36,15 @@ class SourceLink
     nil
   end
 
-  # A real non-http scheme (`mailto:`, `ftp:`, `javascript:`) has a dotless
-  # scheme. A dotted "scheme" is actually a bare `host:port` (`example.com:8080`
-  # parses as scheme `example.com`), which we still want to scheme-fix.
+  # A real non-http scheme (mailto:, ftp:) is dotless. A dotted "scheme" is
+  # a bare host:port (`example.com:8080` parses as scheme `example.com`),
+  # which we still scheme-fix.
   def non_http_scheme?(uri)
     uri.scheme.present? && !uri.scheme.include?(".")
   end
 
-  # No usable scheme: prepend https:// and accept only if it yields a host with an
-  # interior dot — so `example.com` works but `r/x` (host `r`) and malformed
-  # `.example` / `example.` don't.
+  # Prepend https:// and accept only a host with an interior dot, so
+  # `example.com` works but `r/x` and `.example` don't.
   def scheme_fixed_url
     fixed = "https://#{@input}"
     uri = safe_parse(fixed)

--- a/app/services/uid/resolver.rb
+++ b/app/services/uid/resolver.rb
@@ -28,7 +28,7 @@ module Uid
     end
 
     # The system-owned period for a digest run: the UTC date of the run. Shared
-    # with the cadence guard so both agree on "this period" (spec §3).
+    # with the cadence guard so both agree on "this period".
     def self.digest_period(clock)
       clock.utc.to_date
     end
@@ -77,7 +77,7 @@ module Uid
       # Non-ASCII/IDN permalinks make URI.parse raise, which used to silently
       # drop the item. Percent-encode the path and punycode the host via
       # Addressable, then retry — a Cyrillic URL should yield a stable uid,
-      # not vanish (spec §3).
+      # not vanish.
       def parse_http(raw)
         URI.parse(raw)
       rescue URI::InvalidURIError
@@ -93,7 +93,7 @@ module Uid
       def normalize(uri)
         # The uid is an identity key, not a fetch URL. Coerce the scheme to
         # https and drop a leading www. and default ports, so a model flipping
-        # http/https/www between runs doesn't mint a duplicate repost (spec §3).
+        # http/https/www between runs doesn't mint a duplicate repost.
         uri.scheme = "https"
         uri.host = uri.host.downcase.sub(/\Awww\./, "")
         uri.port = nil if [80, 443].include?(uri.port)
@@ -128,7 +128,7 @@ module Uid
 
     # The digest regime is signalled only by an explicit null source_url. A
     # missing key is malformed and an empty/unusable string is dropped — neither
-    # is reinterpreted as a digest (spec §3's "unusable ≠ null").
+    # is reinterpreted as a digest.
     def digest?
       item.key?("source_url") && item["source_url"].nil?
     end

--- a/app/services/webhook_ingestion.rb
+++ b/app/services/webhook_ingestion.rb
@@ -1,6 +1,6 @@
 require "addressable/uri"
 
-# Ingests one webhook delivery into the existing pipeline (spec 006 §§3-4):
+# Ingests one webhook delivery into the existing pipeline:
 # validate the payload, resolve its uid, run it through the profile normalizer,
 # then persist FeedEntry + FeedEntryUid + Post in a single transaction and kick
 # the publish chain. A payload that fails validation persists nothing — the
@@ -187,7 +187,7 @@ class WebhookIngestion
   # the delivery falls back to a random uid instead of a 500.
   MAX_URL_UID_BYTES = 2048
 
-  # Uid precedence (spec 006 §4): explicit idempotency key (the uid field or
+  # Uid precedence: explicit idempotency key (the uid field or
   # the equivalent Idempotency-Key header — validation guarantees they agree),
   # then the permalink normalized exactly like pull feeds', then a random uuid
   # (each request is a new post; callers with retrying pipelines should pass a

--- a/app/services/webhook_payload.rb
+++ b/app/services/webhook_payload.rb
@@ -1,4 +1,4 @@
-# One reader for a webhook delivery payload (spec 006 §3). Both the ingress
+# One reader for a webhook delivery payload. Both the ingress
 # service, which answers a 422 synchronously, and the normalizer, which builds
 # the Post later from the stored copy, go through it — so there is no second
 # reading of a field to keep in sync with the first.

--- a/app/views/feeds/_form_collapsed.html.erb
+++ b/app/views/feeds/_form_collapsed.html.erb
@@ -1,12 +1,12 @@
 <%# locals: (url: nil, prompt: nil, mode: "link", checking: false, error: nil) %>
-<%# The creation modes (spec 005 §1, webhook per spec 006 §7) as a radio group:
+<%# The creation modes as a radio group:
     the radios carry the mechanism choice, each panel keeps its own form, and
     switching is pure disclosure — nothing is shared between the modes' fields.
     The action row sits below the whole radio group; each mode's buttons
     associate with their form through the `form` attribute and swap with the
     mode like the panels.
 
-    One partial, three states (spec §7): the idle entry form; checking, which
+    One partial, three states: the idle entry form; checking, which
     freezes the controls and polls for the detection outcome; and an error
     re-render with the hint under the active mode's input. A non-link error
     arrives with the AI panel pre-filled, so switching the mode radio is the

--- a/lib/http_client/faraday_adapter.rb
+++ b/lib/http_client/faraday_adapter.rb
@@ -86,7 +86,7 @@ module HttpClient
     # PublicUrl.method(:safe?)). We check the initial URL and, via the redirect
     # callback below, every hop — because follow_redirects otherwise chases a
     # public URL's 302 straight to a private/loopback/metadata address, past the
-    # caller's one-time check (SSRF; spec 005 §8).
+    # caller's one-time check (SSRF).
     def ensure_public_url!(url, validate_url)
       raise BlockedUrlError, "Blocked non-public URL: #{url}" unless validate_url.call(url.to_s)
     end

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -209,7 +209,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, 'data-identification-state="error"'
     assert_includes response.body, "look like a link"
-    # The user stays in the mode they chose (spec §1); the AI panel carries the
+    # The user stays in the mode they chose; the AI panel carries the
     # text so switching the radio is the bridge.
     assert_select "[data-key='entry.mode-link'] input[type=radio][checked]"
     assert_select "[data-key='entry.error']", text: /look like a link/
@@ -253,7 +253,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
                                     headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    # The prompt is the source, so it stays editable while creating (spec §1);
+    # The prompt is the source, so it stays editable while creating;
     # exactly one prompt field, and the profile key still submits.
     assert_select "textarea[name='feed[params][prompt]']", { count: 1, text: "follow the A24 blog" }
     assert_select "input[type=text][name='feed[params][url]']", count: 0
@@ -367,7 +367,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    # No structured profile matches and detection can't select AI (spec §7), so
+    # No structured profile matches and detection can't select AI, so
     # the form re-renders with the no-feed hint pointing at the AI mode.
     assert_includes response.body, 'data-identification-state="error"'
     assert_select "[data-key='entry.error']", text: /pull any posts/
@@ -848,7 +848,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
         headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    # The engine is fixed in edit (spec §4): the edit form comes back with the
+    # The engine is fixed in edit: the edit form comes back with the
     # attempted URL and the hint, and no AI mode is on offer.
     assert_select "form[action=?]", feed_path(feed)
     assert_select "input[data-key='form.source-edit'][value=?]", new_url

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -1173,7 +1173,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     end
 
     # The source isn't applied until detection confirms a working candidate; the
-    # response is the §7 checking state, and the profile/params can't be forged in.
+    # response is the checking state, and the profile/params can't be forged in.
     assert_response :success
     feed.reload
     assert_equal original_url, feed.url

--- a/test/integration/smart_feed_creation_edit_test.rb
+++ b/test/integration/smart_feed_creation_edit_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 # Edit semantics: operational fields edit freely; a deterministic feed's source
 # re-runs detection before saving. An AI feed's prompt is its source and the uid
-# scheme never changes, so it stays editable throughout — draft or live (spec §4).
+# scheme never changes, so it stays editable throughout — draft or live.
 class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 

--- a/test/integration/smart_feed_creation_entry_test.rb
+++ b/test/integration/smart_feed_creation_entry_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
-# The creation-mode entry on the new-feed page (spec 005 §1, webhook mode per
-# spec 006 §7): radios carry the mechanism, all panels render server-side, and
+# The creation-mode entry on the new-feed page: radios carry the mechanism, all panels render server-side, and
 # only the selected mode's panel is visible.
 class SmartFeedCreationEntryTest < ActionDispatch::IntegrationTest
   def user

--- a/test/integration/smart_feed_creation_handle_query_test.rb
+++ b/test/integration/smart_feed_creation_handle_query_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-# The two entry modes for a non-link input (spec 005 §1): Mode B ("Follow with
+# The two entry modes for a non-link input: Mode B ("Follow with
 # AI") bridges straight to a draft AI feed, while a non-link typed in Mode A
 # ("Follow a feed or channel") re-renders the entry form with the AI panel
 # carrying the text — switching the mode radio is the bridge.

--- a/test/integration/smart_feed_creation_reload_test.rb
+++ b/test/integration/smart_feed_creation_reload_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-# FR-018 + FR-019 reload semantics: reloading an in-progress confirmation
+# Reload semantics: reloading an in-progress confirmation
 # does not re-run detection or the preview. An explicit Refresh control
 # re-runs the preview on demand.
 class SmartFeedCreationReloadTest < ActionDispatch::IntegrationTest

--- a/test/integration/smart_feed_creation_state_gating_test.rb
+++ b/test/integration/smart_feed_creation_state_gating_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-# FR-012 + FR-013 state gating: the controller uses a save-then-promote flow:
+# State gating: the controller uses a save-then-promote flow:
 # the initial save persists the feed as a draft (new records default to :draft),
 # then `Feed#enable` attempts the promotion under the `:enable` validation context.
 # Previewing is optional — a feed can be enabled with or without a recent preview.

--- a/test/integration/smart_feed_creation_vocabulary_test.rb
+++ b/test/integration/smart_feed_creation_vocabulary_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-# FR-022 + SC-005 vocabulary firewall: no implementation jargon in any
+# Vocabulary firewall: no implementation jargon in any
 # user-visible string on the feed-creation surface or the AI-credentials
 # pages. "AI", "AI credentials", and provider brand names are allowed.
 class SmartFeedCreationVocabularyTest < ActionDispatch::IntegrationTest

--- a/test/models/feed_profile_test.rb
+++ b/test/models/feed_profile_test.rb
@@ -160,7 +160,7 @@ class FeedProfileTest < ActiveSupport::TestCase
   end
 
   test ".matchers never includes the AI profile (structural exclusion)" do
-    # The AI profile registers no matcher, so detection can't select it (spec §7)
+    # The AI profile registers no matcher, so detection can't select it
     # — it's reachable only via Mode B, never by auto-detection.
     keys = FeedProfile.matchers.map(&:profile_key)
     assert_not_includes keys, "llm"

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -47,7 +47,7 @@ class PostTest < ActiveSupport::TestCase
   end
 
   test "should allow a null source_url for a digest post but reject a blank string" do
-    assert build(:post, source_url: nil).valid?, "a digest post carries source_url = null (spec §3)"
+    assert build(:post, source_url: nil).valid?, "a digest post carries source_url = null"
 
     blank = build(:post, source_url: "")
     assert_not blank.valid?

--- a/test/services/feed_identification_fetcher_test.rb
+++ b/test/services/feed_identification_fetcher_test.rb
@@ -106,7 +106,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
   end
 
   test "#identify should fail as unidentifiable when no structured profile matches" do
-    # The AI profile registers no matcher (spec §7), so a reachable page with no
+    # The AI profile registers no matcher, so a reachable page with no
     # standard feed yields no candidates — the entry flow offers the AI bridge.
     url = "http://example.com/unknown.txt"
 

--- a/test/services/feed_refresh_workflow_test.rb
+++ b/test/services/feed_refresh_workflow_test.rb
@@ -1020,7 +1020,7 @@ class FeedRefreshWorkflowTest < ActiveSupport::TestCase
     end
   end
 
-  # --- Digest cadence skip (spec §3) ---
+  # --- Digest cadence skip ---
 
   def digest_feed_with_schedule(last_digest_period: nil)
     user = create(:user)

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -532,7 +532,7 @@ class LlmClientTest < ActiveSupport::TestCase
 
   # A chat double that records the system prompt and the asked user prompt, so we
   # can verify the system message travels via with_instructions and the user
-  # prompt via #ask — the injection-defense channel separation (spec §8).
+  # prompt via #ask — the injection-defense channel separation.
   class FakeChat
     attr_reader :instructions, :asked, :schema, :params
 

--- a/test/services/loader/llm_prompts_test.rb
+++ b/test/services/loader/llm_prompts_test.rb
@@ -49,8 +49,8 @@ class Loader::LlmPromptsTest < ActiveSupport::TestCase
   end
 
   test "the gather-side prompts should ask the model to apply the requested transformation" do
-    # The feed prompt captures both what to follow and how to transform it
-    # (spec §2); the model must honor the transformation, not just relay posts.
+    # The feed prompt captures both what to follow and how to transform it;
+    # the model must honor the transformation, not just relay posts.
     [Loader::LlmPrompts::COMBINED_SYSTEM, Loader::LlmPrompts::GATHER_SYSTEM].each do |prompt|
       assert_match(/transformation/, prompt)
     end
@@ -58,7 +58,7 @@ class Loader::LlmPromptsTest < ActiveSupport::TestCase
 
   test "safeguards should name the feed request as a legitimate instruction source" do
     # Injection defense targets fetched web content, not the user's own prompt —
-    # the feed request is a trusted instruction (spec §8).
+    # the feed request is a trusted instruction.
     assert_match(/your only instructions are this system prompt and the\s+feed request/, Loader::LlmPrompts::SAFEGUARDS)
   end
 end

--- a/test/services/normalizer/rss_normalizer_test.rb
+++ b/test/services/normalizer/rss_normalizer_test.rb
@@ -36,7 +36,7 @@ class Normalizer::RssNormalizerTest < ActiveSupport::TestCase
 
   test "#normalize should drop a non-public attachment URL and keep the public one" do
     # A feed-supplied local path or relative URL must not reach FileBuffer, where
-    # File.exist? would read it off the server at publish (§8, LFI).
+    # File.exist? would read it off the server at publish (LFI).
     entry = create(:feed_entry, raw_data: {
       "summary" => "Photo of the day.",
       "link" => "https://example.com/photo",

--- a/test/services/profile_matcher/reddit_profile_matcher_test.rb
+++ b/test/services/profile_matcher/reddit_profile_matcher_test.rb
@@ -31,7 +31,7 @@ class ProfileMatcher::RedditProfileMatcherTest < ActiveSupport::TestCase
   end
 
   test "#match? should not match bare r/x shorthand (only full reddit URLs)" do
-    # Shorthand expansion was dropped with the smart input (spec 005 §1); a
+    # Shorthand expansion was dropped with the smart input; a
     # subreddit is followed by pasting its full URL.
     assert_not matcher("r/worldnews").match?
     assert_not matcher("user/someuser").match?

--- a/test/support/feed_profile_validator.rb
+++ b/test/support/feed_profile_validator.rb
@@ -1,5 +1,5 @@
 # Test-only helper: validates entries from FeedProfile::PROFILES against
-# the registry contract (specs/001-smart-feed-creation/contracts/profile_registry.md).
+# the registry contract.
 # Lives under test/support because nothing in production needs it — the
 # constant is frozen at load time, so we only need to assert its shape during CI.
 module FeedProfileValidator
@@ -59,9 +59,9 @@ module FeedProfileValidator
         failures << "FeedProfile #{key.inspect}: loader.config.output_schema is required when depends_on_ai is true"
       end
 
-      # The webhook profile has nothing to fetch (spec 006 §1), so it alone
+      # The webhook profile has nothing to fetch, so it alone
       # omits matcher, loader, and processor. Every other profile declares a
-      # loader/processor, and a matcher unless it's AI-backed (spec 005 §7).
+      # loader/processor, and a matcher unless it's AI-backed.
       if key == "webhook"
         %i[matcher loader processor].each do |stage|
           failures << "FeedProfile #{key.inspect}: #{stage} must be absent for the webhook profile" if entry[stage]
@@ -69,7 +69,7 @@ module FeedProfileValidator
       else
         failures << "FeedProfile #{key.inspect}: loader is required" if entry[:loader].nil?
         failures << "FeedProfile #{key.inspect}: processor is required" if entry[:processor].nil?
-        # AI profiles are excluded from detection (spec 005 §7), so they must
+        # AI profiles are excluded from detection, so they must
         # not register a matcher; every other non-webhook profile requires one.
         if entry[:depends_on_ai]
           failures << "FeedProfile #{key.inspect}: matcher must be absent for AI profiles" if entry[:matcher]


### PR DESCRIPTION
Changes:

- Remove all references to spec documents (`spec §N`, `spec 00X`, `FR-NNN`, contract paths) from code comments and test descriptions
- Trim bloated comments in the same files: delete boilerplate that restates signatures and compress wordy comments to their load-bearing facts
- Keep YARD tags (`@param`/`@return`) as public API annotation, with tightened descriptions
- Codify the comment practices in CLAUDE.md

Comment-only, no behavior change. Specs are historical design records, not a persistent source of truth; comments coupling to them go stale as the documents age.