### PR TITLE
Align restart detection naming with its contract

### DIFF
--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -24,7 +24,7 @@ class FeedIdentificationsController < ApplicationController
     return present_outcome if settled_identification?
 
     if feed_identification.new_record? || feed_identification.failed? || retryable_unreachable?
-      restarted = feed_identification.restart_detection!
+      restarted = feed_identification.restart_detection
       # A losing concurrent submit skips the enqueue; the winner owns the
       # in-flight detection.
       FeedIdentificationJob.perform_later(Current.user.id, source_url) if restarted

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -246,7 +246,7 @@ class FeedsController < ApplicationController
     end
 
     identification = FeedIdentification.find_or_initialize_by(user: current_user, input: canonical_submitted_url)
-    restarted = identification.restart_detection!
+    restarted = identification.restart_detection
     FeedIdentificationJob.perform_later(current_user.id, canonical_submitted_url) if restarted
 
     render_identification_state(attempted_url: canonical_submitted_url, checking: true)

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -17,7 +17,7 @@ class FeedIdentification < ApplicationRecord
   # loser's insert then hits the user+input unique index. Returns false in that
   # case — the winner's detection is already in flight, so the stale copy
   # should be discarded — and true when this call (re)started detection.
-  def restart_detection!
+  def restart_detection
     update!(status: :processing, started_at: Time.current, candidates: [], error: nil)
     true
   rescue ActiveRecord::RecordNotUnique

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -130,7 +130,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     url = "http://example.com/feed.xml"
     winner = create(:feed_identification, user: user, input: url, started_at: Time.current).reload
     # The loser's stale lookup result: it missed the winner's row, so its
-    # insert inside restart_detection! collides with the user+input unique index.
+    # insert inside restart_detection collides with the user+input unique index.
     loser = FeedIdentification.new(user: user, input: url)
 
     FeedIdentification.stub(:find_or_initialize_by, loser) do

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -1225,7 +1225,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     new_url = "https://example.com/new-feed.xml"
     winner = create(:feed_identification, user: user, input: new_url, started_at: Time.current).reload
     # The loser's stale lookup result: it missed the winner's row, so its
-    # insert inside restart_detection! collides with the user+input unique index.
+    # insert inside restart_detection collides with the user+input unique index.
     loser = FeedIdentification.new(user: user, input: new_url)
 
     FeedIdentification.stub(:find_or_initialize_by, loser) do

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -42,10 +42,10 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     refute_predicate identification, :invalid_processing?
   end
 
-  test "#restart_detection! should reset the row to a fresh in-flight detection" do
+  test "#restart_detection should reset the row to a fresh in-flight detection" do
     identification = create(:feed_identification, :failed, user: user)
 
-    assert identification.restart_detection!
+    assert identification.restart_detection
 
     identification.reload
     assert_predicate identification, :processing?
@@ -54,13 +54,13 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_nil identification.error
   end
 
-  test "#restart_detection! should return false after losing the insert race" do
+  test "#restart_detection should return false after losing the insert race" do
     winner = create(:feed_identification, user: user, started_at: Time.current).reload
     # The loser's stale lookup result: it missed the winner's row, so its
     # insert collides with the user+input unique index.
     loser = FeedIdentification.new(user: user, input: winner.input)
 
-    assert_not loser.restart_detection!
+    assert_not loser.restart_detection
     assert_predicate loser, :new_record?
     assert_equal winner.started_at, winner.reload.started_at, "the winner's detection should not be restarted"
   end


### PR DESCRIPTION
Changes:

- Rename `FeedIdentification#restart_detection!` to `#restart_detection` so its name matches its boolean return contract
- Update both controller callers and the focused tests

The method returns false when a concurrent insert wins the detection race. The non-bang name makes that handled outcome explicit while genuine persistence failures still raise.

References:

- Review feedback from: #1331