### PR TITLE
Remove stale working candidate cache

### DIFF
--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -33,9 +33,9 @@ class FeedIdentification < ApplicationRecord
   # Candidates that can fetch the source: the count of these drives how
   # the result is presented. A candidate counts unless it's known-broken — tested
   # and failed, or unreachable — so in practice this is the passed set (detection
-  # always records a verdict). Memoized: read a few times per request.
+  # always records a verdict).
   def working_candidates
-    @working_candidates ||= candidates.map { Candidate.new(_1) }.reject do |candidate|
+    candidates.map { Candidate.new(_1) }.reject do |candidate|
       candidate.failed? || candidate.unreachable?
     end
   end

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -54,6 +54,15 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_nil identification.error
   end
 
+  test "#restart_detection! should clear working candidates already read on the same instance" do
+    identification = create(:feed_identification, :success, user: user)
+    assert_equal ["rss"], identification.working_candidates.map(&:profile_key)
+
+    assert identification.restart_detection!
+
+    assert_equal [], identification.working_candidates
+  end
+
   test "#restart_detection! should return false after losing the insert race" do
     winner = create(:feed_identification, user: user, started_at: Time.current).reload
     # The loser's stale lookup result: it missed the winner's row, so its


### PR DESCRIPTION
Changes:

- Remove `working_candidates` memoization so it always reflects the current candidates.
- Add regression coverage for restarting an identification after its working candidates have been read.

The candidate list is small, so recomputing it avoids cache invalidation bookkeeping and prevents stale derived state on reused model instances.

References:

- Review feedback from: #1331