### PR TITLE
Collapse feed identification state into one enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-26
+
+- Checking a link again after a "no feed here" result now re-runs the check, so a source that gained a feed is picked up.
+
 ## 2026-08-25
 
 - The "Invite a user" button is now blue, matching the other primary actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
-## 2026-08-26
+## 2026-08-27
 
 - Checking a link again after a "no feed here" result now re-runs the check, so a source that gained a feed is picked up.
 

--- a/app/controllers/feed_identifications_controller.rb
+++ b/app/controllers/feed_identifications_controller.rb
@@ -19,11 +19,11 @@ class FeedIdentificationsController < ApplicationController
     # text, so switching the mode radio is the bridge.
     return render(not_a_link_error) if source_url.nil?
 
-    # A settled result is shown as-is; everything else re-runs detection,
-    # so resubmitting after a couldn't-reach result re-checks it.
-    return present_outcome if settled_identification?
+    # A working result is shown as-is and an in-flight check keeps polling;
+    # any settled failure re-runs detection, so resubmitting re-checks it.
+    return present_result if feed_identification.working?
 
-    if feed_identification.new_record? || feed_identification.failed? || retryable_unreachable?
+    unless feed_identification.persisted? && feed_identification.processing?
       restarted = feed_identification.restart_detection!
       # A losing concurrent submit skips the enqueue; the winner owns the
       # in-flight detection.
@@ -40,7 +40,7 @@ class FeedIdentificationsController < ApplicationController
 
     return handle_processing_status if feed_identification.processing?
 
-    present_outcome
+    present_result
   end
 
   def destroy
@@ -120,28 +120,16 @@ class FeedIdentificationsController < ApplicationController
     head :no_content
   end
 
-  # Worth showing without re-detecting: a working feed or a reachable link
-  # with no feed. Couldn't-reach is excluded so resubmitting re-detects.
-  def settled_identification?
-    feed_identification.success? && feed_identification.outcome != :unreachable
-  end
-
-  # All candidates were unreachable; retrying should re-detect.
-  def retryable_unreachable?
-    feed_identification.success? && feed_identification.outcome == :unreachable
-  end
-
   # The feed form when a candidate works, otherwise the couldn't-reach or
   # no-feed hint.
-  def present_outcome
-    case feed_identification.outcome
-    when :working then handle_success_status
-    when :unreachable then render(unreachable_error)
-    else render(no_feed_error)
-    end
+  def present_result
+    return present_working if feed_identification.working?
+    return render(unreachable_error) if feed_identification.unreachable?
+
+    render(no_feed_error)
   end
 
-  def handle_success_status
+  def present_working
     suggested = feed_identification.suggested_candidate
     profile_key = suggested&.profile_key
     source_key = FeedProfile.source_key_for(profile_key)

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -3,9 +3,9 @@ class FeedIdentification < ApplicationRecord
 
   # The detection lifecycle: processing is in-flight; the rest are settled
   # results written by FeedIdentificationFetcher.
-  #   working     — at least one candidate read the source → the feed form
-  #   unreachable — nothing connected (transient) → the retry state
-  #   no_feed     — reachable, but nothing usable (terminal) → the AI bridge
+  #   working: at least one candidate read the source (the feed form)
+  #   unreachable: nothing connected, transient (the retry state)
+  #   no_feed: reachable but nothing usable, terminal (the AI bridge)
   enum :status, { processing: 0, working: 1, unreachable: 2, no_feed: 3 }
 
   validates :input, presence: true
@@ -36,8 +36,8 @@ class FeedIdentification < ApplicationRecord
   end
 
   # Candidates that can fetch the source. A candidate counts unless it's
-  # known-broken — tested and failed, or unreachable — so in practice this is
-  # the passed set (detection always records a verdict).
+  # known-broken (tested and failed, or unreachable), so in practice this is
+  # the passed set: detection always records a verdict.
   def working_candidates
     candidates.map { Candidate.new(_1) }.reject do |candidate|
       candidate.failed? || candidate.unreachable?

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -1,7 +1,12 @@
 class FeedIdentification < ApplicationRecord
   belongs_to :user
 
-  enum :status, { processing: 0, success: 1, failed: 2 }
+  # The detection lifecycle: processing is in-flight; the rest are settled
+  # results written by FeedIdentificationFetcher.
+  #   working     — at least one candidate read the source → the feed form
+  #   unreachable — nothing connected (transient) → the retry state
+  #   no_feed     — reachable, but nothing usable (terminal) → the AI bridge
+  enum :status, { processing: 0, working: 1, unreachable: 2, no_feed: 3 }
 
   validates :input, presence: true
 
@@ -10,7 +15,7 @@ class FeedIdentification < ApplicationRecord
   end
 
   # Reset the row to a fresh in-flight detection. Shared by the creation entry
-  # and the edit-source re-detection so both clear stale candidates/errors the
+  # and the edit-source re-detection so both clear stale candidates the
   # same way; the caller enqueues FeedIdentificationJob.
   #
   # Two concurrent submits can both look the row up before either inserts; the
@@ -18,7 +23,7 @@ class FeedIdentification < ApplicationRecord
   # case — the winner's detection is already in flight, so the stale copy
   # should be discarded — and true when this call (re)started detection.
   def restart_detection!
-    update!(status: :processing, started_at: Time.current, candidates: [], error: nil)
+    update!(status: :processing, started_at: Time.current, candidates: [])
     true
   rescue ActiveRecord::RecordNotUnique
     false
@@ -30,10 +35,10 @@ class FeedIdentification < ApplicationRecord
     working_candidates.first
   end
 
-  # Candidates that can fetch the source: the count of these drives how
-  # the result is presented. A candidate counts unless it's known-broken — tested
-  # and failed, or unreachable — so in practice this is the passed set (detection
-  # always records a verdict). Memoized: read a few times per request.
+  # Candidates that can fetch the source. A candidate counts unless it's
+  # known-broken — tested and failed, or unreachable — so in practice this is
+  # the passed set (detection always records a verdict). Memoized: read a few
+  # times per request.
   def working_candidates
     @working_candidates ||= candidates.map { Candidate.new(_1) }.reject do |candidate|
       candidate.failed? || candidate.unreachable?
@@ -61,7 +66,7 @@ class FeedIdentification < ApplicationRecord
     return nil if url.blank?
 
     direct = find_by(user: user, input: url)
-    return direct if direct&.success? && direct.outcome == :working
+    return direct if direct&.working?
 
     resolved_to(user, url)
   end
@@ -76,31 +81,9 @@ class FeedIdentification < ApplicationRecord
   end
 
   def self.resolved_to(user, url)
-    where(user: user, status: :success).detect do |identification|
+    where(user: user, status: :working).detect do |identification|
       identification.working_candidates.any? { |c| c.resolved_url == url }
     end
   end
   private_class_method :resolved_to
-
-  # How the detection result should present:
-  #   :working     — at least one candidate read the source → the feed form
-  #   :unreachable — nothing connected (couldn't-reach) → the transient retry state
-  #   :no_feed     — reachable, but no candidate yields a feed → the terminal
-  #                  error that offers the AI bridge
-  def outcome
-    return :working if working_candidates.any?
-    return :unreachable if unreachable_only?
-
-    :no_feed
-  end
-
-  private
-
-  # Nothing was reachable to judge: the initial fetch never connected, or every
-  # detected candidate failed on the network.
-  def unreachable_only?
-    return true if error == "unreachable"
-
-    candidates.present? && candidates.all? { |attributes| Candidate.new(attributes).unreachable? }
-  end
 end

--- a/app/models/feed_identification.rb
+++ b/app/models/feed_identification.rb
@@ -6,6 +6,9 @@ class FeedIdentification < ApplicationRecord
   #   working: at least one candidate read the source (the feed form)
   #   unreachable: nothing connected, transient (the retry state)
   #   no_feed: reachable but nothing usable, terminal (the AI bridge)
+  #
+  # The integers are persisted, so a new state appends; reordering these
+  # would silently reinterpret every existing row.
   enum :status, { processing: 0, working: 1, unreachable: 2, no_feed: 3 }
 
   validates :input, presence: true

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -1,7 +1,7 @@
 class FeedIdentificationFetcher
-  # A fetch that yielded no usable response. UnreachableError persists as
-  # "unreachable" (transient, retryable); every other FetchError persists
-  # as "unreadable" (terminal "no feed here"). The messages are for logs.
+  # A fetch that yielded no usable response. UnreachableError settles the row
+  # as unreachable (transient, retryable); every other FetchError settles it
+  # as no_feed (terminal "no feed here"). The messages are for logs.
   class FetchError < StandardError; end
   class UnreachableError < FetchError; end    # no answer: DNS, refused, or timeout
   class RedirectLimitError < FetchError; end  # followed too many redirects
@@ -17,26 +17,20 @@ class FeedIdentificationFetcher
   def identify
     response = fetch_response_for_input
     candidates = identify_candidates(response)
-
-    if candidates.any?
-      feed_identification.update!(status: :success, candidates: candidates, error: nil)
-    else
-      feed_identification.update!(status: :failed, candidates: [], error: "unidentifiable")
-    end
+    feed_identification.update!(status: settled_status(candidates), candidates: candidates)
   rescue UnreachableError => e
     # Transient: the UI offers a retry. Expected, so not reported as a bug.
     @logger.info("Feed identification couldn't reach #{sanitize_input_for_logging(@input)}: #{e.class} (#{e.message})")
-    feed_identification.update!(status: :failed, candidates: [], error: "unreachable")
+    feed_identification.update!(status: :unreachable, candidates: [])
   rescue FetchError => e
-    # Reachable but unusable: retrying won't help, terminal "no feed here".
     @logger.info("Feed identification fetch failed for #{sanitize_input_for_logging(@input)}: #{e.class} (#{e.message})")
-    feed_identification.update!(status: :failed, candidates: [], error: "unreadable")
+    feed_identification.update!(status: :no_feed, candidates: [])
   rescue StandardError => e
-    # Unexpected: report it as a bug, then surface a neutral code.
+    # Unexpected: report it as a bug, then settle on the terminal state.
     sanitized = sanitize_input_for_logging(@input)
     @logger.error("Feed identification failed for #{sanitized}: #{e.class} - #{e.message}")
     Rails.error.report(e, context: { input: sanitized })
-    feed_identification.update!(status: :failed, candidates: [], error: "internal_error")
+    feed_identification.update!(status: :no_feed, candidates: [])
   end
 
   private
@@ -90,6 +84,17 @@ class FeedIdentificationFetcher
 
   def working?(candidate_attributes)
     FeedIdentification::Candidate.new(candidate_attributes).passed?
+  end
+
+  # The settled result of a finished run: a candidate that read the source
+  # makes it working; candidates that all died on the network make it
+  # unreachable; anything else — no candidates, or none parsed — is no_feed.
+  def settled_status(candidates)
+    verdicts = candidates.map { |attributes| FeedIdentification::Candidate.new(attributes) }
+    return :working if verdicts.any?(&:passed?)
+    return :unreachable if verdicts.any? && verdicts.all?(&:unreachable?)
+
+    :no_feed
   end
 
   # A broken advertised feed is skipped; another may still work. The hrefs

--- a/app/services/feed_identification_fetcher.rb
+++ b/app/services/feed_identification_fetcher.rb
@@ -88,7 +88,7 @@ class FeedIdentificationFetcher
 
   # The settled result of a finished run: a candidate that read the source
   # makes it working; candidates that all died on the network make it
-  # unreachable; anything else — no candidates, or none parsed — is no_feed.
+  # unreachable; anything else (no candidates, or none parsed) is no_feed.
   def settled_status(candidates)
     verdicts = candidates.map { |attributes| FeedIdentification::Candidate.new(attributes) }
     return :working if verdicts.any?(&:passed?)

--- a/db/migrate/20260826120000_collapse_feed_identification_status.rb
+++ b/db/migrate/20260826120000_collapse_feed_identification_status.rb
@@ -2,48 +2,22 @@
 # success/failed pair plus the error code and the candidate verdicts all
 # encoded the settled result; the fetcher now writes that result directly,
 # so the error column has nothing left to carry.
+#
+# Existing rows are scratch state for the add-a-feed flow, destroyed once a
+# feed is created and rebuilt on demand, so they are cleared rather than
+# remapped: a check in flight reports as expired and the user runs it again.
+# Irreversible, and deliberately so; the old error code is not recoverable
+# from the status alone.
 class CollapseFeedIdentificationStatus < ActiveRecord::Migration[8.0]
-  # Old statuses: processing 0, success 1, failed 2.
-  # New statuses: processing 0, working 1, unreachable 2, no_feed 3.
   def up
-    execute <<~SQL
-      UPDATE feed_identifications SET status = CASE
-        WHEN status = 1 AND EXISTS (
-          SELECT 1 FROM jsonb_array_elements(candidates) c
-          WHERE COALESCE(c->>'test_status', '') NOT IN ('failed', 'unreachable')
-        ) THEN 1
-        WHEN status = 1 AND jsonb_array_length(candidates) > 0 AND NOT EXISTS (
-          SELECT 1 FROM jsonb_array_elements(candidates) c
-          WHERE COALESCE(c->>'test_status', '') <> 'unreachable'
-        ) THEN 2
-        WHEN status = 1 THEN 3
-        WHEN status = 2 AND error = 'unreachable' THEN 2
-        WHEN status = 2 THEN 3
-        ELSE 0
-      END
-    SQL
+    execute "DELETE FROM feed_identifications"
 
     remove_column :feed_identifications, :error
   end
 
-  # Restores rows that behave the same under the old derivation; the exact
-  # error code a failed row carried is not recoverable.
+  # Refuses rather than omitting `down`: an absent down is a silent no-op that
+  # de-registers the migration while leaving the column dropped.
   def down
-    add_column :feed_identifications, :error, :text
-
-    execute <<~SQL
-      UPDATE feed_identifications SET error = CASE
-        WHEN status = 2 AND jsonb_array_length(candidates) = 0 THEN 'unreachable'
-        WHEN status = 3 AND jsonb_array_length(candidates) = 0 THEN 'unidentifiable'
-      END
-    SQL
-
-    execute <<~SQL
-      UPDATE feed_identifications SET status = CASE
-        WHEN status IN (2, 3) AND jsonb_array_length(candidates) = 0 THEN 2
-        WHEN status IN (1, 2, 3) THEN 1
-        ELSE 0
-      END
-    SQL
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20260826120000_collapse_feed_identification_status.rb
+++ b/db/migrate/20260826120000_collapse_feed_identification_status.rb
@@ -1,0 +1,49 @@
+# Collapses the identification state into one explicit status. The old
+# success/failed pair plus the error code and the candidate verdicts all
+# encoded the settled result; the fetcher now writes that result directly,
+# so the error column has nothing left to carry.
+class CollapseFeedIdentificationStatus < ActiveRecord::Migration[8.0]
+  # Old statuses: processing 0, success 1, failed 2.
+  # New statuses: processing 0, working 1, unreachable 2, no_feed 3.
+  def up
+    execute <<~SQL
+      UPDATE feed_identifications SET status = CASE
+        WHEN status = 1 AND EXISTS (
+          SELECT 1 FROM jsonb_array_elements(candidates) c
+          WHERE COALESCE(c->>'test_status', '') NOT IN ('failed', 'unreachable')
+        ) THEN 1
+        WHEN status = 1 AND jsonb_array_length(candidates) > 0 AND NOT EXISTS (
+          SELECT 1 FROM jsonb_array_elements(candidates) c
+          WHERE COALESCE(c->>'test_status', '') <> 'unreachable'
+        ) THEN 2
+        WHEN status = 1 THEN 3
+        WHEN status = 2 AND error = 'unreachable' THEN 2
+        WHEN status = 2 THEN 3
+        ELSE 0
+      END
+    SQL
+
+    remove_column :feed_identifications, :error
+  end
+
+  # Restores rows that behave the same under the old derivation; the exact
+  # error code a failed row carried is not recoverable.
+  def down
+    add_column :feed_identifications, :error, :text
+
+    execute <<~SQL
+      UPDATE feed_identifications SET error = CASE
+        WHEN status = 2 AND jsonb_array_length(candidates) = 0 THEN 'unreachable'
+        WHEN status = 3 AND jsonb_array_length(candidates) = 0 THEN 'unidentifiable'
+      END
+    SQL
+
+    execute <<~SQL
+      UPDATE feed_identifications SET status = CASE
+        WHEN status IN (2, 3) AND jsonb_array_length(candidates) = 0 THEN 2
+        WHEN status IN (1, 2, 3) THEN 1
+        ELSE 0
+      END
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_08_23_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_08_26_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -112,7 +112,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_23_120000) do
   create_table "feed_identifications", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.jsonb "candidates", default: [], null: false
     t.datetime "created_at", null: false
-    t.text "error"
     t.datetime "started_at"
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false

--- a/test/controllers/feed_identifications_controller_test.rb
+++ b/test/controllers/feed_identifications_controller_test.rb
@@ -392,12 +392,11 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "textarea#entry-ai-input", text: url
   end
 
-  test "#create should re-run detection when retrying a couldn't-reach success" do
+  test "#create should re-run detection when retrying a couldn't-reach result" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
-    # A success whose only candidate was unreachable: Retry must re-detect rather
-    # than re-render the same couldn't-reach state.
-    create(:feed_identification, user: user, input: url, started_at: Time.current, status: :success,
+    # Retry must re-detect rather than re-render the same couldn't-reach state.
+    create(:feed_identification, user: user, input: url, started_at: Time.current, status: :unreachable,
                                  candidates: [{ "profile_key" => "youtube", "test_status" => "unreachable" }])
 
     assert_enqueued_with(job: FeedIdentificationJob) do
@@ -411,7 +410,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
   test "#show should show the terminal no-feed error when a reachable link has no working feed" do
     sign_in_as(user)
     url = "http://example.com/page.html"
-    create(:feed_identification, user: user, input: url, started_at: Time.current, status: :success,
+    create(:feed_identification, user: user, input: url, started_at: Time.current, status: :no_feed,
                                  candidates: [{ "profile_key" => "rss", "test_status" => "failed" }])
 
     get feed_identifications_path, params: { url: url }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
@@ -496,7 +495,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       user: user,
       input: url,
       started_at: Time.current,
-      status: :success,
+      status: :working,
       candidates: [{ "profile_key" => "rss", "title" => "Example", "test_status" => "passed" }]
     )
 
@@ -514,7 +513,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     FeedIdentification.create!(
       user: user,
       input: url,
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "title" => "Example" }
       ]
@@ -537,7 +536,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     FeedIdentification.create!(
       user: user,
       input: url,
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "title" => "Example" }
       ]
@@ -558,7 +557,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     FeedIdentification.create!(
       user: user,
       input: url,
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "title" => "Example" }
       ]
@@ -583,7 +582,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     FeedIdentification.create!(
       user: user,
       input: url,
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "title" => "Example" }
       ]
@@ -605,7 +604,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       user: user,
       input: handle,
       started_at: Time.current,
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "llm", "title" => nil }
       ]
@@ -626,7 +625,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       user: user,
       input: query,
       started_at: Time.current,
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "llm", "title" => nil }
       ]
@@ -683,7 +682,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
       user: user,
       input: url,
       started_at: Time.current,
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 2 },
         { "profile_key" => "json_feed", "title" => "Example", "test_status" => "passed", "posts_found" => 3 }
@@ -701,8 +700,8 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "label", text: "How should we fetch posts?"
   end
 
-  def success_identification(url, candidates)
-    create(:feed_identification, user: user, input: url, started_at: Time.current, status: :success, candidates: candidates)
+  def working_identification(url, candidates)
+    create(:feed_identification, user: user, input: url, started_at: Time.current, status: :working, candidates: candidates)
   end
 
   def show_chooser(url)
@@ -712,7 +711,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
   test "#show should show a single working candidate as an annotation, not a chooser" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
-    success_identification(url, [
+    working_identification(url, [
       { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 3 }
     ])
 
@@ -727,7 +726,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
   test "#show should render the chooser and preselect the suggested candidate for two working candidates" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
-    success_identification(url, [
+    working_identification(url, [
       { "profile_key" => "xkcd", "title" => "Example", "test_status" => "passed", "posts_found" => 5 },
       { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 3 }
     ])
@@ -744,7 +743,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
   test "#show should note when a working candidate has no posts yet" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
-    success_identification(url, [
+    working_identification(url, [
       { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 0 },
       { "profile_key" => "json_feed", "title" => "Example", "test_status" => "passed", "posts_found" => 2 }
     ])
@@ -758,7 +757,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
   test "#show should drop non-working candidates from the presentation" do
     sign_in_as(user)
     url = "http://example.com/feed.xml"
-    success_identification(url, [
+    working_identification(url, [
       { "profile_key" => "rss", "title" => "Example", "test_status" => "passed", "posts_found" => 2 },
       { "profile_key" => "xkcd", "title" => "Example", "test_status" => "unreachable" }
     ])
@@ -779,7 +778,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     FeedIdentification.create!(
       user: user,
       input: url,
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "title" => long_title }
       ]
@@ -795,7 +794,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
     new_url = "http://example.com/new.xml"
-    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+    create(:feed_identification, user: user, input: new_url, status: :working, started_at: Time.current,
            candidates: [{ "profile_key" => "rss", "test_status" => "passed", "title" => "New" }])
 
     get feed_identifications_path, params: { url: new_url, feed_id: feed.id },
@@ -811,7 +810,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
     new_url = "http://example.com/new.xml"
-    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+    create(:feed_identification, user: user, input: new_url, status: :working, started_at: Time.current,
            candidates: [{ "profile_key" => "rss", "test_status" => "passed", "title" => "New" }])
 
     get feed_identifications_path, params: { url: new_url, feed_id: feed.id },
@@ -826,7 +825,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
     new_url = "https://xkcd.com/rss.xml"
-    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+    create(:feed_identification, user: user, input: new_url, status: :working, started_at: Time.current,
            candidates: [{ "profile_key" => "xkcd", "test_status" => "passed", "title" => "xkcd" }])
 
     get feed_identifications_path, params: { url: new_url, feed_id: feed.id },
@@ -841,7 +840,7 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
     new_url = "http://example.com/none.xml"
-    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+    create(:feed_identification, user: user, input: new_url, status: :no_feed, started_at: Time.current,
            candidates: [{ "profile_key" => "rss", "test_status" => "failed" }])
 
     get feed_identifications_path, params: { url: new_url, feed_id: feed.id },
@@ -860,8 +859,8 @@ class FeedIdentificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     feed = create(:feed, user: user, feed_profile_key: "rss", params: { "url" => "http://example.com/old.xml" })
     new_url = "http://example.com/down.xml"
-    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
-           error: "unreachable", candidates: [])
+    create(:feed_identification, user: user, input: new_url, status: :unreachable, started_at: Time.current,
+           candidates: [])
 
     get feed_identifications_path, params: { url: new_url, feed_id: feed.id },
         headers: { "Accept" => "text/vnd.turbo-stream.html" }

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -199,7 +199,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     access_token
     create(:feed_identification, user: user, input: "https://example.com/blog",
-                                 status: :success, started_at: Time.current,
+                                 status: :working, started_at: Time.current,
                                  candidates: [{ "profile_key" => "rss", "test_status" => "passed",
                                                 "resolved_url" => "http://example.com/feed.xml" }])
 
@@ -1284,7 +1284,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     disabled = create(:feed, :disabled, user: user,
                       params: { "url" => "https://original.com/feed.xml" })
     create(:feed_identification, user: user, input: "https://example.com/blog",
-                                 status: :success, started_at: Time.current,
+                                 status: :working, started_at: Time.current,
                                  candidates: [{ "profile_key" => "rss", "test_status" => "passed",
                                                 "resolved_url" => "https://example.com/feed.xml" }])
 

--- a/test/factories/feed_identifications.rb
+++ b/test/factories/feed_identifications.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     status { :processing }
     candidates { [] }
 
-    trait :success do
-      status { :success }
+    trait :working do
+      status { :working }
       candidates do
         [
           { "profile_key" => "rss", "title" => "Sample Feed" }
@@ -14,9 +14,8 @@ FactoryBot.define do
       end
     end
 
-    trait :failed do
-      status { :failed }
-      error { "Could not detect feed profile" }
+    trait :no_feed do
+      status { :no_feed }
     end
   end
 end

--- a/test/integration/smart_feed_creation_edit_test.rb
+++ b/test/integration/smart_feed_creation_edit_test.rb
@@ -101,7 +101,7 @@ class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
   test "#patch should apply a re-detected source once a working candidate confirms it" do
     sign_in_as(user)
     new_url = "http://example.com/other.xml"
-    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+    create(:feed_identification, user: user, input: new_url, status: :working, started_at: Time.current,
            candidates: [{ "profile_key" => "rss", "test_status" => "passed", "title" => "Other" }])
 
     patch feed_url(feed), params: { feed: { params: { url: new_url }, feed_profile_key: "rss" }, enable_feed: "1" }
@@ -118,7 +118,7 @@ class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
                              target_group: "testgroup", feed_profile_key: "rss",
                              params: { "url" => "http://example.com/feed.xml" })
     new_url = "http://example.com/other.xml"
-    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+    create(:feed_identification, user: user, input: new_url, status: :working, started_at: Time.current,
            candidates: [{ "profile_key" => "rss", "test_status" => "passed", "title" => "Other" }])
 
     patch feed_url(disabled), params: { feed: { params: { url: new_url }, feed_profile_key: "rss" }, enable_feed: "1" }
@@ -132,7 +132,7 @@ class SmartFeedCreationEditTest < ActionDispatch::IntegrationTest
   test "#patch should re-detect rather than confirm a profile that isn't a working candidate" do
     sign_in_as(user)
     new_url = "http://example.com/other.xml"
-    create(:feed_identification, user: user, input: new_url, status: :success, started_at: Time.current,
+    create(:feed_identification, user: user, input: new_url, status: :working, started_at: Time.current,
            candidates: [{ "profile_key" => "rss", "test_status" => "passed", "title" => "Other" }])
 
     assert_enqueued_with(job: FeedIdentificationJob) do

--- a/test/models/feed_identification_test.rb
+++ b/test/models/feed_identification_test.rb
@@ -14,7 +14,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     identification = FeedIdentification.create!(
       user: user,
       input: "https://example.com/feed.xml",
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "title" => "Sample Feed" }
       ]
@@ -38,12 +38,12 @@ class FeedIdentificationTest < ActiveSupport::TestCase
   end
 
   test "#invalid_processing? should be false for non-processing status" do
-    identification = FeedIdentification.new(user: user, input: "https://example.com/feed.xml", status: :success, started_at: nil)
+    identification = FeedIdentification.new(user: user, input: "https://example.com/feed.xml", status: :working, started_at: nil)
     refute_predicate identification, :invalid_processing?
   end
 
   test "#restart_detection! should reset the row to a fresh in-flight detection" do
-    identification = create(:feed_identification, :failed, user: user)
+    identification = create(:feed_identification, :no_feed, user: user)
 
     assert identification.restart_detection!
 
@@ -51,7 +51,6 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_predicate identification, :processing?
     assert_not_nil identification.started_at
     assert_equal [], identification.candidates
-    assert_nil identification.error
   end
 
   test "#restart_detection! should return false after losing the insert race" do
@@ -117,53 +116,11 @@ class FeedIdentificationTest < ActiveSupport::TestCase
     assert_equal ["rss"], id.working_candidates.map(&:profile_key)
   end
 
-  test "#outcome should be :working when at least one candidate reads the source" do
-    id = identification([
-      { "profile_key" => "rss", "test_status" => "passed" },
-      { "profile_key" => "atom", "test_status" => "failed" }
-    ])
-
-    assert_equal :working, id.outcome
-  end
-
-  test "#outcome should be :no_feed when the source is reachable but no candidate works" do
-    id = identification([{ "profile_key" => "rss", "test_status" => "failed" }])
-
-    assert_equal :no_feed, id.outcome
-  end
-
-  test "#outcome should be :unreachable when every candidate failed on the network" do
-    id = identification([
-      { "profile_key" => "rss", "test_status" => "unreachable" },
-      { "profile_key" => "atom", "test_status" => "unreachable" }
-    ])
-
-    assert_equal :unreachable, id.outcome
-  end
-
-  test "#outcome should be :unreachable when the initial fetch couldn't connect" do
-    id = FeedIdentification.new(user: user, input: "https://example.com", status: :failed, error: "unreachable", candidates: [])
-
-    assert_equal :unreachable, id.outcome
-  end
-
-  test "#outcome should be :no_feed when the source was reachable but unreadable" do
-    id = FeedIdentification.new(user: user, input: "https://example.com", status: :failed, error: "unreadable", candidates: [])
-
-    assert_equal :no_feed, id.outcome
-  end
-
-  test "#outcome should be :no_feed when nothing was identified" do
-    id = FeedIdentification.new(user: user, input: "https://example.com", status: :failed, error: "unidentifiable", candidates: [])
-
-    assert_equal :no_feed, id.outcome
-  end
-
   test "should accept multiple ranked candidates" do
     identification = FeedIdentification.create!(
       user: user,
       input: "https://example.com/article",
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss" },
         { "profile_key" => "llm" }
@@ -177,7 +134,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
 
   test "#working_candidate_profile_keys should list only candidates that read the source" do
     identification = FeedIdentification.new(
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "test_status" => "passed" },
         { "profile_key" => "atom", "test_status" => "failed" },
@@ -191,7 +148,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
   test "#source_url_for should prefer the working candidate's discovered feed URL" do
     identification = FeedIdentification.new(
       input: "https://example.com/blog",
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "test_status" => "failed", "resolved_url" => "https://example.com/broken.xml" },
         { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
@@ -204,7 +161,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
   test "#source_url_for should fall back to the input for direct candidates" do
     identification = FeedIdentification.new(
       input: "https://example.com/feed.xml",
-      status: :success,
+      status: :working,
       candidates: [{ "profile_key" => "rss", "test_status" => "passed" }]
     )
 
@@ -225,7 +182,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
       :feed_identification,
       user: user,
       input: "https://example.com/blog",
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
       ]
@@ -238,12 +195,12 @@ class FeedIdentificationTest < ActiveSupport::TestCase
 
   test ".working_for_source should prefer a working page identification over a stale keyed row" do
     stale = create(:feed_identification, user: user, input: "https://example.com/feed.xml",
-                                         status: :failed, error: "unreachable")
+                                         status: :unreachable)
     page = create(
       :feed_identification,
       user: user,
       input: "https://example.com/blog",
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
       ]
@@ -254,12 +211,12 @@ class FeedIdentificationTest < ActiveSupport::TestCase
 
   test ".cleanup_for_source should destroy both the keyed row and the resolving page row" do
     stale = create(:feed_identification, user: user, input: "https://example.com/feed.xml",
-                                         status: :failed, error: "unreachable")
+                                         status: :unreachable)
     page = create(
       :feed_identification,
       user: user,
       input: "https://example.com/blog",
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
       ]
@@ -273,7 +230,7 @@ class FeedIdentificationTest < ActiveSupport::TestCase
 
   test ".working_for_source should return nothing when no identification works" do
     create(:feed_identification, user: user, input: "https://example.com/feed.xml",
-                                 status: :failed, error: "unreachable")
+                                 status: :unreachable)
 
     assert_nil FeedIdentification.working_for_source(user: user, url: "https://example.com/feed.xml")
     assert_nil FeedIdentification.working_for_source(user: user, url: nil)
@@ -284,17 +241,20 @@ class FeedIdentificationTest < ActiveSupport::TestCase
       :feed_identification,
       user: create(:user),
       input: "https://example.com/blog",
-      status: :success,
+      status: :working,
       candidates: [
         { "profile_key" => "rss", "test_status" => "passed", "resolved_url" => "https://example.com/feed.xml" }
       ]
     )
+    # A working page row whose *other* candidate resolved to the URL but never
+    # read it: only the candidate-level filter keeps this from matching.
     create(
       :feed_identification,
       user: user,
       input: "https://example.com/other",
-      status: :success,
+      status: :working,
       candidates: [
+        { "profile_key" => "atom", "test_status" => "passed", "resolved_url" => "https://example.com/other.xml" },
         { "profile_key" => "rss", "test_status" => "failed", "resolved_url" => "https://example.com/feed.xml" }
       ]
     )

--- a/test/services/feed_identification_fetcher_test.rb
+++ b/test/services/feed_identification_fetcher_test.rb
@@ -36,7 +36,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_not_nil feed_identification
-    assert_equal "success", feed_identification.status
+    assert_equal "working", feed_identification.status
     assert_equal url, feed_identification.input
     suggested = feed_identification.candidates.first
     assert_equal "rss", suggested["profile_key"]
@@ -65,7 +65,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_not_nil feed_identification
-    assert_equal "success", feed_identification.status
+    assert_equal "working", feed_identification.status
     assert_equal "xkcd", feed_identification.candidates.first["profile_key"]
   end
 
@@ -89,8 +89,10 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_not_nil feed_identification
-    assert_equal "success", feed_identification.status
     assert_equal "example.com", feed_identification.candidates.first["title"]
+    # The candidate is detected but reads nothing, so the run settles terminal.
+    assert_equal "no_feed", feed_identification.status
+    assert_equal "failed", feed_identification.candidates.first["test_status"]
   end
 
   test "#identify should refuse a non-public URL without fetching it" do
@@ -100,12 +102,11 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     FeedIdentificationFetcher.new(user: user, input: url, logger: @logger).identify
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
-    assert_equal "failed", feed_identification.status
-    assert_equal "unreadable", feed_identification.error
+    assert_equal "no_feed", feed_identification.status
     assert_not_requested :get, url
   end
 
-  test "#identify should fail as unidentifiable when no structured profile matches" do
+  test "#identify should settle as no_feed when no structured profile matches" do
     # The AI profile registers no matcher, so a reachable page with no
     # standard feed yields no candidates — the entry flow offers the AI bridge.
     url = "http://example.com/unknown.txt"
@@ -118,11 +119,10 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_not_nil feed_identification
-    assert_equal "failed", feed_identification.status
-    assert_equal "unidentifiable", feed_identification.error
+    assert_equal "no_feed", feed_identification.status
   end
 
-  test "#identify should mark a bad response status as unreadable (reachable, no feed)" do
+  test "#identify should mark a bad response status as no_feed (reachable, terminal)" do
     url = "http://example.com/error.xml"
 
     stub_request(:get, url)
@@ -133,11 +133,10 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_not_nil feed_identification
-    assert_equal "failed", feed_identification.status
-    assert_equal "unreadable", feed_identification.error
+    assert_equal "no_feed", feed_identification.status
   end
 
-  test "#identify should mark a redirect loop as unreadable" do
+  test "#identify should mark a redirect loop as no_feed" do
     url = "http://example.com/loop.xml"
 
     stub_request(:get, url)
@@ -147,8 +146,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     service.identify
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
-    assert_equal "failed", feed_identification.status
-    assert_equal "unreadable", feed_identification.error
+    assert_equal "no_feed", feed_identification.status
   end
 
   test "#identify should mark a connection failure as unreachable (transient)" do
@@ -162,8 +160,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
     assert_not_nil feed_identification
-    assert_equal "failed", feed_identification.status
-    assert_equal "unreachable", feed_identification.error
+    assert_equal "unreachable", feed_identification.status
   end
 
   test "#identify should log the failure class and status for diagnosis" do
@@ -176,7 +173,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     assert_match(/ResponseStatusError \(HTTP 404\)/, log.string)
   end
 
-  test "#identify should record internal_error and report an unexpected failure" do
+  test "#identify should settle as no_feed and report an unexpected failure" do
     url = "http://example.com/feed.xml"
     stub_request(:get, url).to_return(status: 200, body: "<rss></rss>")
 
@@ -185,11 +182,10 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     end
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
-    assert_equal "failed", feed_identification.status
-    assert_equal "internal_error", feed_identification.error
+    assert_equal "no_feed", feed_identification.status
   end
 
-  test "#identify should record unidentifiable when no candidates are detected" do
+  test "#identify should settle as no_feed when no candidates are detected" do
     url = "http://example.com/feed.xml"
     stub_request(:get, url).to_return(status: 200, body: "x")
 
@@ -199,8 +195,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     end
 
     feed_identification = FeedIdentification.find_by(user: user, input: url)
-    assert_equal "failed", feed_identification.status
-    assert_equal "unidentifiable", feed_identification.error
+    assert_equal "no_feed", feed_identification.status
   end
 
   test "#identify should persist a ranked candidates array on success" do
@@ -289,8 +284,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
 
     feed_identification = FeedIdentification.find_by(user: user, input: page_url)
-    assert_equal "success", feed_identification.status
-    assert_equal :working, feed_identification.outcome
+    assert_equal "working", feed_identification.status
 
     candidate = feed_identification.suggested_candidate
     assert_equal "rss", candidate.profile_key
@@ -307,7 +301,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     FeedIdentificationFetcher.new(user: user, input: "http://example.com/", logger: @logger).identify
 
     feed_identification = FeedIdentification.find_by(user: user, input: "http://example.com/")
-    assert_equal :working, feed_identification.outcome
+    assert_equal "working", feed_identification.status
     assert_equal "http://www.example.com/blog/feed.xml", feed_identification.suggested_candidate.resolved_url
   end
 
@@ -325,7 +319,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
 
     feed_identification = FeedIdentification.find_by(user: user, input: page_url)
-    assert_equal :working, feed_identification.outcome
+    assert_equal "working", feed_identification.status
     assert_equal "http://example.com/feed.xml", feed_identification.suggested_candidate.resolved_url
   end
 
@@ -347,7 +341,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     assert_not_requested :get, "http://example.com/comments.xml"
   end
 
-  test "#identify should stay unidentifiable when no advertised feed works" do
+  test "#identify should stay no_feed when no advertised feed works" do
     page_url = "http://example.com/blog"
 
     stub_request(:get, page_url).to_return(status: 200, body: page_body(%(<link rel="alternate" type="application/rss+xml" href="/gone.xml">)))
@@ -356,8 +350,47 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
 
     feed_identification = FeedIdentification.find_by(user: user, input: page_url)
-    assert_equal "failed", feed_identification.status
-    assert_equal "unidentifiable", feed_identification.error
+    assert_equal "no_feed", feed_identification.status
+  end
+
+  test "#identify should settle as unreachable when every candidate dies on the network" do
+    url = "http://example.com/feed.xml"
+    stub_request(:get, url).to_return(status: 200, body: "x")
+
+    detected = Struct.new(:candidates).new([Struct.new(:profile_key).new("rss")])
+    verdict = CandidateTester::Result.new(status: FeedIdentification::Candidate::UNREACHABLE, posts_found: 0)
+
+    FeedProfileDetector.stub(:call, detected) do
+      CandidateTester.stub(:new, ->(**) { Struct.new(:call).new(verdict) }) do
+        FeedIdentificationFetcher.new(user: user, input: url, logger: @logger).identify
+      end
+    end
+
+    feed_identification = FeedIdentification.find_by(user: user, input: url)
+    assert_equal "unreachable", feed_identification.status
+    assert_equal "unreachable", feed_identification.candidates.first["test_status"]
+  end
+
+  test "#identify should settle as no_feed when candidates mix network and parse failures" do
+    url = "http://example.com/feed.xml"
+    stub_request(:get, url).to_return(status: 200, body: "x")
+
+    detected = Struct.new(:candidates).new([
+      Struct.new(:profile_key).new("rss"),
+      Struct.new(:profile_key).new("atom")
+    ])
+    verdicts = [
+      CandidateTester::Result.new(status: FeedIdentification::Candidate::UNREACHABLE, posts_found: 0),
+      CandidateTester::Result.new(status: FeedIdentification::Candidate::FAILED, posts_found: 0)
+    ]
+
+    FeedProfileDetector.stub(:call, detected) do
+      CandidateTester.stub(:new, ->(**) { Struct.new(:call).new(verdicts.shift) }) do
+        FeedIdentificationFetcher.new(user: user, input: url, logger: @logger).identify
+      end
+    end
+
+    assert_equal "no_feed", FeedIdentification.find_by(user: user, input: url).status
   end
 
   test "#identify should not follow an advertised feed's redirect to a private address" do
@@ -369,7 +402,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
 
-    assert_equal "unidentifiable", FeedIdentification.find_by(user: user, input: page_url).error
+    assert_equal "no_feed", FeedIdentification.find_by(user: user, input: page_url).status
     assert_not_requested :get, "http://127.0.0.1/feed.xml"
   end
 
@@ -390,7 +423,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
     FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
 
     feed_identification = FeedIdentification.find_by(user: user, input: page_url)
-    assert_equal :working, feed_identification.outcome
+    assert_equal "working", feed_identification.status
     assert_equal "http://example.com/feed.xml", feed_identification.suggested_candidate.resolved_url
   end
 
@@ -401,7 +434,7 @@ class FeedIdentificationFetcherTest < ActiveSupport::TestCase
 
     FeedIdentificationFetcher.new(user: user, input: page_url, logger: @logger).identify
 
-    assert_equal "unidentifiable", FeedIdentification.find_by(user: user, input: page_url).error
+    assert_equal "no_feed", FeedIdentification.find_by(user: user, input: page_url).status
     assert_not_requested :get, "http://127.0.0.1/feed.xml"
   end
 


### PR DESCRIPTION
Changes:

- Replace the `status`/`error`/`outcome` trio on `FeedIdentification` with a single persisted enum: `processing`/`working`/`unreachable`/`no_feed`
- Have `FeedIdentificationFetcher` write the settled result directly instead of leaving it to be derived on read
- Drop the `error` column and the derived `outcome`, and branch the controller on enum predicates
- Resubmitting a link that settled as "no feed here" now re-runs detection instead of re-rendering the stored result

Three vocabularies encoded one question, and they interacted non-obviously: `:unreachable` was reachable both through a failed row carrying the `"unreachable"` error string and through a successful row whose candidates had all failed on the network. The controller compensated with compound predicates spanning two of them (`success? && outcome == ...`), so the model's encoding leaked into its callers.

The fetcher already knows the answer at write time, so it writes it once. Of the four error codes only `"unreachable"` was ever read back; the other three were write-only and collapsed into the same terminal state, which is why the column goes rather than getting constants. Per-candidate `test_status` stays as it is, wrapped by `FeedIdentification::Candidate`.

The migration clears existing identifications rather than carrying a mapping for them. They are scratch state for the add-a-feed flow, destroyed once a feed is created and rebuilt on demand, so a check in flight reports as expired and the user runs it again. It is deliberately irreversible, and says so by raising rather than by omitting `down`, since an absent `down` is a silent no-op that would de-register the migration while leaving the column dropped.

One accepted trade-off, noted so it isn't rediscovered later: this is not a zero-downtime migration. The new web container migrates while the old web and `jobs` containers are still serving, so for roughly a minute per deploy an old process can hit the dropped column. The effect is a brief error on the feed-creation flow and failed detection jobs; a stalled row is cleaned up by the existing polling deadline and the user is invited to retry, so nothing is lost. Stopping the app across the deploy closes the window entirely.

References:

- Follow-up to PR: #1331
