### PR TITLE
Tidy feed menus, blank stat values, and page copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-27
 
+- The events page no longer wraps the filtered record's id in square brackets.
 - Any feed can now be deleted straight from the feeds list, not just paused ones, with the action set off below a divider.
 - Purge and Delete now sit below a divider in the feed page menu, clear of the everyday actions.
 - Checking a link again after a "no feed here" result now re-runs the check, so a source that gained a feed is picked up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-27
 
+- The publisher on a token page is now shown plainly, without the box around it.
 - Stats with nothing to show now read the same everywhere: one muted dash, instead of a different mark and colour per page.
 - Tightened up the wording on the feeds and posts pages.
 - The events page no longer wraps the filtered record's id in square brackets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-27
 
+- Tightened up the wording on the feeds and posts pages.
 - The events page no longer wraps the filtered record's id in square brackets.
 - Any feed can now be deleted straight from the feeds list, not just paused ones, with the action set off below a divider.
 - Purge and Delete now sit below a divider in the feed page menu, clear of the everyday actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-27
 
+- Stats with nothing to show now read the same everywhere: one muted dash, instead of a different mark and colour per page.
 - Tightened up the wording on the feeds and posts pages.
 - The events page no longer wraps the filtered record's id in square brackets.
 - Any feed can now be deleted straight from the feeds list, not just paused ones, with the action set off below a divider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-27
 
+- Trimmed the wording on the sign-up, password reset, and confirmation pages.
 - The publisher on a token page is now shown plainly, without the box around it.
 - Stats with nothing to show now read the same everywhere: one muted dash, instead of a different mark and colour per page.
 - Tightened up the wording on the feeds and posts pages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-27
 
+- Any feed can now be deleted straight from the feeds list, not just paused ones, with the action set off below a divider.
 - Purge and Delete now sit below a divider in the feed page menu, clear of the everyday actions.
 - Checking a link again after a "no feed here" result now re-runs the check, so a source that gained a feed is picked up.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 ## 2026-08-27
 
+- Purge and Delete now sit below a divider in the feed page menu, clear of the everyday actions.
 - Checking a link again after a "no feed here" result now re-runs the check, so a source that gained a feed is picked up.
 
 ## 2026-08-25

--- a/app/components/feed_list_item_component.rb
+++ b/app/components/feed_list_item_component.rb
@@ -111,11 +111,13 @@ class FeedListItemComponent < ListItemComponent
                    data: { key: "feed.#{feed.id}.enable", turbo_confirm: ENABLE_CONFIRM } }
       end
 
-      items << { label: "Discard…", href: feed_url, data: { key: "feed.#{feed.id}.discard", turbo_method: :delete, turbo_confirm: DISCARD_CONFIRM } } if draft?
+      # Separated from the routine actions above so a stray click doesn't land
+      # on the one entry that can't be undone.
+      items << { separator: true }
 
-      # An inactive feed may be a dead end — its token can be gone for good —
-      # so deletion is offered right here, not just on the feed page.
-      if deletable?
+      if draft?
+        items << { label: "Discard…", href: feed_url, data: { key: "feed.#{feed.id}.discard", turbo_method: :delete, turbo_confirm: DISCARD_CONFIRM } }
+      else
         items << { label: "Delete…", href: "#",
                    data: { key: "feed.#{feed.id}.delete", controller: "modal-trigger",
                            modal_trigger_modal_id_value: delete_modal_id, action: "click->modal-trigger#open" } }
@@ -131,10 +133,9 @@ class FeedListItemComponent < ListItemComponent
     render("feeds/delete_modal", feed: feed)
   end
 
-  # Drafts already have Discard; an enabled feed should be paused before it's
-  # removed, so the list offers deletion only for inactive feeds.
+  # Drafts get Discard instead, which deletes without the modal.
   def deletable?
-    management_actions? && feed.disabled?
+    management_actions? && !draft?
   end
 
   def delete_modal_id

--- a/app/components/feed_stats_component.rb
+++ b/app/components/feed_stats_component.rb
@@ -32,25 +32,23 @@ class FeedStatsComponent < StatsPanelComponent
         key: "last_refresh",
         label: @feed.scheduled? ? "Last refresh" : "Last post received",
         label_short: @feed.scheduled? ? "Refreshed" : "Received",
-        value: last_refresh_value,
-        muted: last_refreshed_at.nil?
+        value: last_refresh_value
       },
       {
         key: "most_recent_repost",
         label: "Most recent repost",
         label_short: "Recent",
-        value: most_recent_repost_value,
-        muted: most_recent_repost_at.nil?
+        value: most_recent_repost_value
       }
     ]
   end
 
   def last_refresh_value
-    last_refreshed_at ? helpers.short_time_ago_tag(last_refreshed_at) : "–"
+    helpers.short_time_ago_tag(last_refreshed_at) if last_refreshed_at
   end
 
   def most_recent_repost_value
-    most_recent_repost_at ? helpers.short_time_ago_tag(most_recent_repost_at) : "–"
+    helpers.short_time_ago_tag(most_recent_repost_at) if most_recent_repost_at
   end
 
   def last_refreshed_at

--- a/app/components/global_stats_component.rb
+++ b/app/components/global_stats_component.rb
@@ -37,7 +37,7 @@ class GlobalStatsComponent < StatsPanelComponent
         key: "most_recent_repost",
         label: "Most recent repost",
         label_short: "Recent",
-        value: most_recent_repost_at.present? ? helpers.short_time_ago(most_recent_repost_at) : "—"
+        value: (helpers.short_time_ago(most_recent_repost_at) if most_recent_repost_at)
       }
     ]
   end

--- a/app/components/stat_item_component.rb
+++ b/app/components/stat_item_component.rb
@@ -1,5 +1,9 @@
 # Abstract base class — subclasses must define DEFAULT_ITEM_CLASS, LABEL_CLASSES, and VALUE_CLASSES.
 class StatItemComponent < ViewComponent::Base
+  # A figure with nothing behind it yet. Callers pass a blank value and every
+  # stat cell renders the same muted dash, rather than each inventing its own.
+  BLANK_VALUE = "–".freeze
+
   def initialize(label:, value:, key: nil, muted: false, truncate: false, tooltip: nil)
     @label = label
     @value = value
@@ -22,7 +26,12 @@ class StatItemComponent < ViewComponent::Base
   end
 
   def value_element
-    content_tag(:dd, value_content, class: class_names(self.class::VALUE_CLASSES, @muted ? "text-muted" : "text-heading", "min-w-0" => @truncate), data: value_data)
+    content_tag(:dd, value_content, class: class_names(self.class::VALUE_CLASSES, muted? ? "text-muted" : "text-heading", "min-w-0" => @truncate), data: value_data)
+  end
+
+  # A blank figure is always muted; :muted also de-emphasizes a real zero.
+  def muted?
+    @muted || @value.blank?
   end
 
   # Cropping a long value needs two cooperating pieces: min-w-0 so the flex
@@ -30,9 +39,10 @@ class StatItemComponent < ViewComponent::Base
   # the overflow with an ellipsis. Bundling them behind one option keeps the
   # contract in one place instead of split across callers.
   def value_content
-    return @value unless @truncate
+    value = @value.presence || BLANK_VALUE
+    return value unless @truncate
 
-    content_tag(:div, @value, class: "truncate")
+    content_tag(:div, value, class: "truncate")
   end
 
   def label_data

--- a/app/components/stats_panel_component.rb
+++ b/app/components/stats_panel_component.rb
@@ -4,8 +4,8 @@
 # Subclasses supply #layout_items — one hash per figure with :key, :label,
 # :label_short, :value, and an optional :muted — and override #key_prefix when
 # their data-key hooks live under a different namespace. The bar shows
-# :label_short and reveals :label on hover. A figure with no value yet is left
-# blank and renders as StatItemComponent's muted dash.
+# :label_short and reveals :label on hover. A figure with nothing behind it yet
+# is left blank.
 class StatsPanelComponent < ViewComponent::Base
   def call
     tag.div { safe_join([mobile_layout, desktop_layout]) }

--- a/app/components/stats_panel_component.rb
+++ b/app/components/stats_panel_component.rb
@@ -4,7 +4,8 @@
 # Subclasses supply #layout_items — one hash per figure with :key, :label,
 # :label_short, :value, and an optional :muted — and override #key_prefix when
 # their data-key hooks live under a different namespace. The bar shows
-# :label_short and reveals :label on hover.
+# :label_short and reveals :label on hover. A figure with no value yet is left
+# blank and renders as StatItemComponent's muted dash.
 class StatsPanelComponent < ViewComponent::Base
   def call
     tag.div { safe_join([mobile_layout, desktop_layout]) }

--- a/app/components/token_details_component.rb
+++ b/app/components/token_details_component.rb
@@ -37,7 +37,7 @@ class TokenDetailsComponent < ViewComponent::Base
   end
 
   def freefeed_user
-    @access_token.owner.presence || "–"
+    @access_token.owner
   end
 
   def freefeed_instance

--- a/app/components/user_stats_component.rb
+++ b/app/components/user_stats_component.rb
@@ -37,7 +37,7 @@ class UserStatsComponent < StatsPanelComponent
         key: "most_recent_repost",
         label: "Most recent repost",
         label_short: "Recent",
-        value: user.most_recent_repost_at.present? ? helpers.short_time_ago(user.most_recent_repost_at) : "—"
+        value: (helpers.short_time_ago(user.most_recent_repost_at) if user.most_recent_repost_at)
       }
     ]
   end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -11,7 +11,7 @@ module EventsHelper
     end
   end
 
-  # Describes the active events filter as entity references — "Feed [ce23f]",
+  # Describes the active events filter as entity references — "Feed ce23f",
   # with the id linked when `entity_paths` resolves a page for the entity —
   # plus plain `key: value` parts for the remaining filter keys.
   def event_filter_summary(filter, entity_paths:)
@@ -70,7 +70,7 @@ module EventsHelper
 
   private
 
-  # "Feed [ce23f]" — a humanized entity type with a short linked id. Either
+  # "Feed ce23f" — a humanized entity type with a short linked id. Either
   # half may be missing: a type-only filter renders just the label, an id
   # without a type gets a generic label and stays unlinked.
   def event_entity_reference(type, id, entity_paths)
@@ -89,6 +89,6 @@ module EventsHelper
       tag.span(short_ref(id), title: id, class: "font-mono")
     end
 
-    tag.strong(safe_join([label, " [", ref, "]"]))
+    tag.strong(safe_join([label, " ", ref]))
   end
 end

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -51,17 +51,20 @@ module FeedHelper
 
   # Action menu items for the feed page header. Refresh applies only to an
   # enabled feed that actually pulls from a source; the destructive actions
-  # open the confirmation modals rendered alongside the feed page.
+  # open the confirmation modals rendered alongside the feed page, each behind
+  # a separator so a stray click doesn't land on one.
   def feed_actions_menu_items(feed)
     items = []
     items << { label: "Refresh", href: feed_refresh_path(feed), method: :post, data: { key: "feed.#{feed.id}.refresh" } } if feed.enabled? && feed.scheduled?
     items << { label: "Edit", href: edit_feed_path(feed), data: { key: "feed.#{feed.id}.edit" } }
 
     if feed.target_group.present?
+      items << { separator: true }
       items << { label: "Purge feed…", href: "#",
                  data: { key: "feed.#{feed.id}.purge", controller: "modal-trigger",
                          modal_trigger_modal_id_value: "purge-modal-#{feed.id}", action: "click->modal-trigger#open" } }
     end
+    items << { separator: true }
     items << { label: "Delete feed…", href: "#",
                data: { key: "feed.#{feed.id}.delete", controller: "modal-trigger",
                        modal_trigger_modal_id_value: "delete-feed-modal-#{feed.id}", action: "click->modal-trigger#open" } }

--- a/app/views/access_tokens/_show_content.html.erb
+++ b/app/views/access_tokens/_show_content.html.erb
@@ -74,11 +74,9 @@
     <div class="space-y-4">
       <h2 class="text-2xl font-semibold mb-3 text-heading">Publisher</h2>
       <p class="text-body mb-4">
-        Posts created with this token will appear on FreeFeed on behalf of the user who created this token.
+        FreeFeed posts will appear on behalf of the token owner.
       </p>
-      <div class="w-fit min-w-[240px] rounded-xl border border-border bg-surface p-4">
-        <%= render FreefeedUserComponent.new(user: access_token.access_token_detail.freefeed_user_info) %>
-      </div>
+      <%= render FreefeedUserComponent.new(user: access_token.access_token_detail.freefeed_user_info) %>
     </div>
 
     <%= render "access_tokens/available_groups", access_token: access_token %>

--- a/app/views/admin/access_tokens/show.html.erb
+++ b/app/views/admin/access_tokens/show.html.erb
@@ -30,11 +30,9 @@
       <div class="space-y-4">
         <h2 class="text-2xl font-semibold mb-3 text-heading">Publisher</h2>
         <p class="text-body mb-4">
-          Posts created with this token appear on FreeFeed on behalf of the user who created it.
+          FreeFeed posts will appear on behalf of the token owner.
         </p>
-        <div class="w-fit min-w-[240px] rounded-xl border border-border bg-surface p-4">
-          <%= render FreefeedUserComponent.new(user: @access_token.access_token_detail.freefeed_user_info) %>
-        </div>
+        <%= render FreefeedUserComponent.new(user: @access_token.access_token_detail.freefeed_user_info) %>
       </div>
 
       <div class="space-y-4">

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="space-y-8">
   <%= render PageHeaderComponent.new(title: "Feeds") do |header| %>
-    <% header.with_context_paragraph("Each feed is a source Feeder watches. It reposts new content to a FreeFeed group on the schedule you pick.") %>
+    <% header.with_context_paragraph("Each feed watches a source and reposts new content to a FreeFeed group on a set schedule.") %>
     <% if @feeds.any? %>
       <% if (summary_line = feed_summary_line(active_count: @active_feed_count, inactive_count: @inactive_feed_count, draft_count: @draft_feed_count)) %>
         <% header.with_context_paragraph(summary_line) %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -3,7 +3,7 @@
 <%= render ModalCardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Forgot your password?</h1>
-    <p class="text-body">Enter your email address and we’ll send you a reset link.</p>
+    <p class="text-body">Enter your email. We'll send a reset link.</p>
 
     <% if flash[:alert] %>
       <%= render AlertComponent.new(variant: :error) do %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -8,13 +8,13 @@
       <% label = @feed.display_name + (group ? " (@#{group})" : "") %>
       <% header.with_context_paragraph("Posts from #{label}.") %>
     <% else %>
-      <% header.with_context_paragraph("Everything Feeder imports from your feeds shows up here, along with each post's status on FreeFeed.") %>
+      <% header.with_context_paragraph("Every publication imported from your feeds shows up here.") %>
     <% end %>
     <% if @posts.empty? %>
       <% if @feed %>
         <% header.with_context_paragraph("No posts imported yet from this feed.") %>
       <% elsif @feeds.any?(&:enabled?) %>
-        <% header.with_context_paragraph("No posts yet. They'll show up here as your feeds import new content.") %>
+        <% header.with_context_paragraph("Nothing imported yet.") %>
       <% elsif @feeds.any? %>
         <% header.with_context_paragraph do %>
           No posts yet. <%= link_to "Enable one of your feeds", feeds_path, class: "font-medium text-brand underline underline-offset-4 transition hover:text-brand-hover" %> and new content will show up here.

--- a/app/views/registration/confirmations/new.html.erb
+++ b/app/views/registration/confirmations/new.html.erb
@@ -3,7 +3,7 @@
 <%= render ModalCardComponent.new do %>
   <div class="space-y-6">
     <h1 class="text-4xl font-semibold mb-6 text-heading">Resend Confirmation</h1>
-    <p class="text-body">Enter your email and we'll send you a new confirmation link.</p>
+    <p class="text-body">Enter your email. We'll send a new confirmation link.</p>
 
     <%= form_with url: registration_confirmations_path, method: :post, local: true do |form| %>
       <div class="space-y-6">

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -70,13 +70,13 @@
           <div class="space-y-2">
             <%= form.label :email_address, "Email", class: "block font-semibold text-heading" %>
             <%= form.email_field :email_address, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2", required: true, autofocus: true %>
-            <p class="text-sm text-muted">Only used for password resets—we don't send marketing emails.</p>
+            <p class="text-sm text-muted">Only for password resets. No marketing.</p>
           </div>
 
           <div class="space-y-2">
             <%= form.label :password, class: "block font-semibold text-heading" %>
             <%= form.password_field :password, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2", required: true %>
-            <p class="text-sm text-muted">Choose at least <%= User::PASSWORD_MIN_LENGTH %> characters to keep things secure.</p>
+            <p class="text-sm text-muted">At least <%= User::PASSWORD_MIN_LENGTH %> characters. A few random words work well.</p>
           </div>
         </div>
         <div class="mt-6 flex flex-col items-start gap-4 text-body sm:flex-row sm:items-center sm:justify-between">

--- a/test/components/feed_list_item_component_test.rb
+++ b/test/components/feed_list_item_component_test.rb
@@ -161,14 +161,34 @@ class FeedListItemComponentTest < ViewComponent::TestCase
     end
   end
 
-  test "#render should not show Delete action for enabled feeds" do
+  test "#render should show Delete action and confirmation modal for enabled feeds" do
     enabled_feed = create(:feed, :enabled, user: user)
 
     with_request_url("/feeds") do
       result = render_inline FeedListItemComponent.new(feed: enabled_feed)
 
-      assert_empty result.css("[data-key='feed.#{enabled_feed.id}.delete']")
-      assert_empty result.css("#delete-feed-modal-#{enabled_feed.id}")
+      assert_not_empty result.css("[data-key='feed.#{enabled_feed.id}.delete']")
+      assert_not_empty result.css("#delete-feed-modal-#{enabled_feed.id}")
+    end
+  end
+
+  test "#render should separate Delete from the rest of the menu" do
+    enabled_feed = create(:feed, :enabled, user: user)
+
+    with_request_url("/feeds") do
+      result = render_inline FeedListItemComponent.new(feed: enabled_feed)
+
+      assert_separator_above result, "feed.#{enabled_feed.id}.delete"
+    end
+  end
+
+  test "#render should separate Discard from the rest of the menu for draft feeds" do
+    draft_feed = create(:feed, :draft, user: user)
+
+    with_request_url("/feeds") do
+      result = render_inline FeedListItemComponent.new(feed: draft_feed)
+
+      assert_separator_above result, "feed.#{draft_feed.id}.discard"
     end
   end
 
@@ -290,5 +310,17 @@ class FeedListItemComponentTest < ViewComponent::TestCase
       assert_empty result.css("[data-key='feed.#{enabled_feed.id}.disable']")
       assert_not_empty result.css("[data-key='feed.#{enabled_feed.id}.details']")
     end
+  end
+
+  private
+
+  # The menu renders separators as sibling <li role="separator"> rows, so an
+  # item is "separated" when the entry right above it is one.
+  def assert_separator_above(result, data_key)
+    entries = result.css("ul > li")
+    index = entries.index { |entry| entry.at_css("[data-key='#{data_key}']") }
+
+    assert_not_nil index, "expected a menu item with data-key #{data_key}"
+    assert_equal "separator", entries[index - 1]["role"]
   end
 end

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -73,10 +73,10 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     result = render_inline(FeedStatsComponent.new(feed: feed_without_data))
 
     last_refresh_value = result.css('[data-key="stats.last_refresh.value"]').first.text
-    assert_equal "–", last_refresh_value
+    assert_equal StatItemComponent::BLANK_VALUE, last_refresh_value
 
     most_recent_value = result.css('[data-key="stats.most_recent_repost.value"]').first.text
-    assert_equal "–", most_recent_value
+    assert_equal StatItemComponent::BLANK_VALUE, most_recent_value
   end
 
   test "#render should mute zero counts and fallback values" do

--- a/test/components/global_stats_component_test.rb
+++ b/test/components/global_stats_component_test.rb
@@ -50,10 +50,12 @@ class GlobalStatsComponentTest < ViewComponent::TestCase
     assert_equal "1", result.css(".hidden.md\\:flex [data-key=\"stats.total_published_posts.value\"]").first.text
   end
 
-  test "#render should display fallback value when no published posts" do
+  test "#render should display a muted fallback value when no published posts" do
     result = render_inline(GlobalStatsComponent.new)
 
-    recent_value = result.css('[data-key="stats.most_recent_repost.value"]').first.text
-    assert_equal "—", recent_value
+    result.css('[data-key="stats.most_recent_repost.value"]').each do |value|
+      assert_equal StatItemComponent::BLANK_VALUE, value.text
+      assert_includes value["class"], "text-muted"
+    end
   end
 end

--- a/test/components/stat_bar_item_component_test.rb
+++ b/test/components/stat_bar_item_component_test.rb
@@ -31,6 +31,14 @@ class StatBarItemComponentTest < ViewComponent::TestCase
     assert_not_includes result.at_css("dd")["class"], "text-heading"
   end
 
+  test "#render should show a muted dash for a blank value" do
+    result = render_inline(StatBarItemComponent.new(label: "Recent", value: nil))
+
+    assert_equal StatItemComponent::BLANK_VALUE, result.at_css("dd").text
+    assert_includes result.at_css("dd")["class"], "text-2xl font-semibold whitespace-nowrap"
+    assert_includes result.at_css("dd")["class"], "text-muted"
+  end
+
   test "#render should expose the tooltip as tippy content" do
     result = render_inline(StatBarItemComponent.new(label: "Active", value: "38", tooltip: "Active feeds"))
 

--- a/test/components/stat_list_item_component_test.rb
+++ b/test/components/stat_list_item_component_test.rb
@@ -39,6 +39,19 @@ class StatListItemComponentTest < ViewComponent::TestCase
     assert_not_includes result.at_css("dd")["class"], "text-muted"
   end
 
+  test "#render should show a muted dash for a blank value" do
+    result = render_inline(StatListItemComponent.new(label: "Owner", value: nil))
+
+    assert_equal StatItemComponent::BLANK_VALUE, result.at_css("dd").text
+    assert_includes result.at_css("dd")["class"], "text-muted"
+  end
+
+  test "#render should keep a zero value rather than treating it as blank" do
+    result = render_inline(StatListItemComponent.new(label: "Posts", value: "0"))
+
+    assert_equal "0", result.at_css("dd").text
+  end
+
   test "#render should use list item CSS classes" do
     result = render_inline(StatListItemComponent.new(label: "Posts", value: "42"))
 

--- a/test/components/stats_panel_component_test.rb
+++ b/test/components/stats_panel_component_test.rb
@@ -9,7 +9,8 @@ class StatsPanelComponentTest < ViewComponent::TestCase
       [
         { key: "plain", label: "Plain figure", label_short: "Plain", value: "1" },
         { key: "dimmed", label: "Dimmed figure", label_short: "Dimmed", value: "0", muted: true },
-        { key: "same", label: "Same", label_short: "Same", value: "2" }
+        { key: "same", label: "Same", label_short: "Same", value: "2" },
+        { key: "blank", label: "Blank figure", label_short: "Blank", value: nil }
       ]
     end
   end
@@ -35,6 +36,23 @@ class StatsPanelComponentTest < ViewComponent::TestCase
 
     assert_includes result.css('.md\\:hidden [data-key="stats.dimmed.value"]').first["class"], "text-muted"
     assert_not_includes result.css('.md\\:hidden [data-key="stats.plain.value"]').first["class"], "text-muted"
+  end
+
+  test "#render should show a muted dash for a figure with no value" do
+    result = render_inline(SampleStatsComponent.new)
+
+    result.css('[data-key="stats.blank.value"]').each do |value|
+      assert_equal StatItemComponent::BLANK_VALUE, value.text
+      assert_includes value["class"], "text-muted"
+    end
+  end
+
+  test "#render should style the bar value the same whether or not it is blank" do
+    result = render_inline(SampleStatsComponent.new)
+
+    blank = result.css('.hidden.md\\:flex [data-key="stats.blank.value"]').first["class"]
+    assert_includes blank, "text-2xl font-semibold whitespace-nowrap"
+    assert_includes blank, "text-muted"
   end
 
   test "#render should namespace data keys with the subclass key_prefix" do

--- a/test/components/user_stats_component_test.rb
+++ b/test/components/user_stats_component_test.rb
@@ -45,12 +45,14 @@ class UserStatsComponentTest < ViewComponent::TestCase
     assert_equal "Published", result.css(".hidden.md\\:flex [data-key=\"stats.total_published_posts.label\"]").first.text
   end
 
-  test "#render should display fallback value when no published posts" do
+  test "#render should display a muted fallback value when no published posts" do
     user_without_posts = create(:user)
 
     result = render_inline(UserStatsComponent.new(user: user_without_posts))
 
-    recent_value = result.css('[data-key="stats.most_recent_repost.value"]').first.text
-    assert_equal "—", recent_value
+    result.css('[data-key="stats.most_recent_repost.value"]').each do |value|
+      assert_equal StatItemComponent::BLANK_VALUE, value.text
+      assert_includes value["class"], "text-muted"
+    end
   end
 end

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -305,7 +305,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '[data-key="events.type"]', count: 2
-    assert_select '[data-key="admin.events.filter-summary"]', text: /Filtering by Feed \[#{feed1.id.to_s.last(5)}\]\./
+    assert_select '[data-key="admin.events.filter-summary"]', text: /Filtering by Feed #{feed1.id.to_s.last(5)}\./
     assert_select '[data-key="admin.events.filter-summary"] a[href=?]', admin_feed_path(feed1), text: feed1.id.to_s.last(5)
   end
 
@@ -363,7 +363,7 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '[data-key="events.type"]', count: 2
-    assert_select '[data-key="admin.events.filter-summary"]', text: /Filtering by User \[#{user1.id.to_s.last(5)}\]\./
+    assert_select '[data-key="admin.events.filter-summary"]', text: /Filtering by User #{user1.id.to_s.last(5)}\./
     assert_select '[data-key="admin.events.filter-summary"] a[href=?]', admin_user_path(user1), text: user1.id.to_s.last(5)
   end
 

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -228,7 +228,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     get events_path, params: { filter: { subject_type: "Feed", subject_id: feed.id } }
 
     assert_response :success
-    assert_select '[data-key="events.filter-summary"]', text: /Filtering by Feed \[#{feed.id.to_s.last(5)}\]\./
+    assert_select '[data-key="events.filter-summary"]', text: /Filtering by Feed #{feed.id.to_s.last(5)}\./
     assert_select '[data-key="events.filter-summary"] a[href=?]', feed_path(feed), text: feed.id.to_s.last(5)
   end
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -571,6 +571,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "#feed-header-menu-#{enabled.id} a[data-key='feed.#{enabled.id}.edit'][href='#{edit_feed_path(enabled)}']", text: "Edit"
     assert_select "#feed-header-menu-#{enabled.id} a[data-key='feed.#{enabled.id}.purge']", text: "Purge feed…"
     assert_select "#feed-header-menu-#{enabled.id} a[data-key='feed.#{enabled.id}.delete']", text: "Delete feed…"
+    assert_select "#feed-header-menu-#{enabled.id} li[role='separator']", 2
   end
 
   test "#show should render the webhook API panel for a webhook feed" do

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -56,7 +56,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     create(:feed, :enabled, user: user)
     get posts_url
     assert_response :success
-    assert_select "p", text: /No posts yet\. They'll show up here as your feeds import new content/
+    assert_select "p", text: /Nothing imported yet/
     assert_select "[data-key='posts.empty.new-feed']", count: 0
   end
 

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -10,7 +10,7 @@ class EventsHelperTest < ActionView::TestCase
     fragment = Nokogiri::HTML.fragment(result)
     link = fragment.at_css("strong a")
 
-    assert_equal "Feed [#{subject_id.last(5)}]", fragment.text
+    assert_equal "Feed #{subject_id.last(5)}", fragment.text
     assert_equal admin_feed_path(subject_id), link["href"]
     assert_equal subject_id, link["title"]
   end
@@ -31,7 +31,7 @@ class EventsHelperTest < ActionView::TestCase
     fragment = Nokogiri::HTML.fragment(result)
     label = fragment.at_css("strong span")
 
-    assert_equal "Job run [#{subject_id.last(5)}]", fragment.text
+    assert_equal "Job run #{subject_id.last(5)}", fragment.text
     assert_equal subject_id, label["title"]
     assert_nil fragment.at_css("a")
   end
@@ -43,7 +43,7 @@ class EventsHelperTest < ActionView::TestCase
     fragment = Nokogiri::HTML.fragment(result)
     link = fragment.at_css("strong a")
 
-    assert_equal "User [#{user_id.last(5)}]", fragment.text
+    assert_equal "User #{user_id.last(5)}", fragment.text
     assert_equal admin_user_path(user_id), link["href"]
   end
 
@@ -56,7 +56,7 @@ class EventsHelperTest < ActionView::TestCase
     )
     fragment = Nokogiri::HTML.fragment(result)
 
-    assert_equal "Feed [#{subject_id.last(5)}] • level: error • type: feed_refresh, feed_auto_disabled", fragment.text
+    assert_equal "Feed #{subject_id.last(5)} • level: error • type: feed_refresh, feed_auto_disabled", fragment.text
   end
 
   test "#event_filter_summary should render a type-only filter as a bare label" do
@@ -73,7 +73,7 @@ class EventsHelperTest < ActionView::TestCase
     result = event_filter_summary({ subject_id: subject_id }, entity_paths: EventEntityPaths.new)
     fragment = Nokogiri::HTML.fragment(result)
 
-    assert_equal "Subject [#{subject_id.last(5)}]", fragment.text
+    assert_equal "Subject #{subject_id.last(5)}", fragment.text
     assert_nil fragment.at_css("a")
   end
 

--- a/test/helpers/feed_helper_test.rb
+++ b/test/helpers/feed_helper_test.rb
@@ -180,7 +180,7 @@ class FeedHelperTest < ActionView::TestCase
   test "#feed_actions_menu_items should list refresh, edit, purge, and delete for an enabled feed" do
     feed = create(:feed, :enabled, target_group: "testgroup")
 
-    labels = feed_actions_menu_items(feed).map { |item| item[:label] }
+    labels = menu_labels(feed)
 
     assert_equal ["Refresh", "Edit", "Purge feed…", "Delete feed…"], labels
   end
@@ -188,7 +188,7 @@ class FeedHelperTest < ActionView::TestCase
   test "#feed_actions_menu_items should omit refresh for a feed that is not enabled" do
     feed = create(:feed, :disabled, target_group: "testgroup")
 
-    labels = feed_actions_menu_items(feed).map { |item| item[:label] }
+    labels = menu_labels(feed)
 
     assert_equal ["Edit", "Purge feed…", "Delete feed…"], labels
   end
@@ -197,15 +197,34 @@ class FeedHelperTest < ActionView::TestCase
     feed = create(:feed, :enabled, target_group: "testgroup")
     feed.target_group = nil
 
-    labels = feed_actions_menu_items(feed).map { |item| item[:label] }
+    labels = menu_labels(feed)
 
     assert_equal ["Refresh", "Edit", "Delete feed…"], labels
+  end
+
+  test "#feed_actions_menu_items should separate purge and delete from the actions above them" do
+    feed = create(:feed, :enabled, target_group: "testgroup")
+
+    items = feed_actions_menu_items(feed)
+    separators = items.each_index.select { |index| items[index][:separator] }
+
+    assert_equal ["Purge feed…", "Delete feed…"], separators.map { |index| items[index + 1][:label] }
+  end
+
+  test "#feed_actions_menu_items should keep the delete separator when purge is unavailable" do
+    feed = create(:feed, :enabled, target_group: "testgroup")
+    feed.target_group = nil
+
+    items = feed_actions_menu_items(feed)
+
+    assert items[-2][:separator]
+    assert_equal "Delete feed…", items[-1][:label]
   end
 
   test "#feed_actions_menu_items should wire refresh to a POST and danger actions to their modals" do
     feed = create(:feed, :enabled, target_group: "testgroup")
 
-    items = feed_actions_menu_items(feed).index_by { |item| item[:label] }
+    items = feed_actions_menu_items(feed).reject { |item| item[:separator] }.index_by { |item| item[:label] }
 
     assert_equal :post, items["Refresh"][:method]
     assert_equal feed_refresh_path(feed), items["Refresh"][:href]
@@ -252,5 +271,11 @@ class FeedHelperTest < ActionView::TestCase
   test "#candidate_summary should personalize the AI profile with a handle input" do
     assert_equal "Follow with AI: \"@alice\"",
                  candidate_summary("llm", "@alice")
+  end
+
+  private
+
+  def menu_labels(feed)
+    feed_actions_menu_items(feed).reject { |item| item[:separator] }.map { |item| item[:label] }
   end
 end


### PR DESCRIPTION
Changes:

- Group destructive actions below a divider in the feed page menu and the feeds list, and offer Delete for any feed instead of only paused ones
- Render every blank stat value as one muted dash
- Show the publisher on token pages without the box around it
- Trim copy on the feeds, posts, token, sign-up, password reset, and confirmation pages
- Drop the square brackets around record ids in the events filter summary

Mostly consistency cleanup. The placeholder for a missing stat had drifted into
three variants (two different dashes, muted on some pages and not on others), so
it now lives in `StatItemComponent`, where the bar cell and the list cell both
pick it up and callers simply leave the value blank. That also covers the
description lists on the token and admin pages, which were rolling their own.
