### PR TITLE
Reword the name field label and hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 User-facing changes, newest first. Internal/technical changes are not listed here.
 
+## 2026-08-28
+
+- The name page in settings now says up front what a name is for.
+
 ## 2026-08-27
 
 - Settings now has a name you can set, so people you invite see who invited them instead of "Somebody".

--- a/app/views/settings/name_updates/edit.html.erb
+++ b/app/views/settings/name_updates/edit.html.erb
@@ -6,9 +6,9 @@
   <div class="max-w-2xl">
     <%= form_with model: @user, url: settings_name_update_path, method: :patch, local: true do |form| %>
       <div class="space-y-2">
-        <%= form.label :name, "Name", class: "block font-semibold text-heading" %>
+        <%= form.label :name, "Your real name or a nickname", class: "block font-semibold text-heading" %>
         <%= form.text_field :name, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2", placeholder: "Enter your name", maxlength: User::NAME_MAX_LENGTH, autofocus: true, autocomplete: "name" %>
-        <p class="text-sm text-muted" data-key="name_update.hint">Optional. Use your real name or a nickname, so people you invite can see who invited them. Leave it blank and they'll just see "Somebody".</p>
+        <p class="text-sm text-muted" data-key="name_update.hint">Optional. Set your name so people you invite will see who invited them. Leave it blank and they'll just see "Somebody".</p>
       </div>
 
       <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-body">

--- a/app/views/settings/name_updates/edit.html.erb
+++ b/app/views/settings/name_updates/edit.html.erb
@@ -8,7 +8,7 @@
       <div class="space-y-2">
         <%= form.label :name, "Your real name or a nickname", class: "block font-semibold text-heading" %>
         <%= form.text_field :name, class: "w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-lg leading-normal shadow-xs ring-ring transition focus:border-ring focus:outline-none focus:ring-2", placeholder: "Enter your name", maxlength: User::NAME_MAX_LENGTH, autofocus: true, autocomplete: "name" %>
-        <p class="text-sm text-muted" data-key="name_update.hint">Optional. Set your name so people you invite will see who invited them. Leave it blank and they'll just see "Somebody".</p>
+        <p class="text-sm text-muted" data-key="name_update.hint">Optional. Set a name so people getting an invite can see who sent it. Leave it blank and they'll just see "Somebody".</p>
       </div>
 
       <div class="mt-6 flex flex-wrap items-center justify-start gap-4 text-body">


### PR DESCRIPTION
Changes:

- Label the name field "Your real name or a nickname"
- Shorten the hint below it and take the second person out of it
- Log the copy change in the changelog

A bare "Name" label doesn't say why anyone would fill it in. Moving the "real name or a nickname" part up into the label lets the hint get to the point: it's optional, and setting a name means people getting an invite can see who sent it.
