### PR TITLE
Fix the 7-day post count and its label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 
 - The name page in settings now says up front what a name is for.
 - The weekly post count now covers a true 7 days and counts only posts that made it to FreeFeed. It was spanning eight days and including drafts.
+- That stat is now labelled "Last 7 days" instead of "Last week", which is what it actually measures.
 
 ## 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-facing changes, newest first. Internal/technical changes are not listed her
 ## 2026-08-28
 
 - The name page in settings now says up front what a name is for.
+- The weekly post count now covers a true 7 days and counts only posts that made it to FreeFeed. It was spanning eight days and including drafts.
 
 ## 2026-08-27
 

--- a/app/components/feed_stats_component.rb
+++ b/app/components/feed_stats_component.rb
@@ -23,8 +23,8 @@ class FeedStatsComponent < StatsPanelComponent
       },
       {
         key: "posts_last_week",
-        label: "Posts published last week",
-        label_short: "Last week",
+        label: "Posts published in the last 7 days",
+        label_short: "Last 7 days",
         value: helpers.number_with_delimiter(posts_last_week_count),
         muted: posts_last_week_count.zero?
       },

--- a/app/components/global_stats_component.rb
+++ b/app/components/global_stats_component.rb
@@ -29,8 +29,8 @@ class GlobalStatsComponent < StatsPanelComponent
       },
       {
         key: "posts_last_week",
-        label: "Posts published last week",
-        label_short: "Last week",
+        label: "Posts published in the last 7 days",
+        label_short: "Last 7 days",
         value: number_with_delimiter(posts_published_last_week_count)
       },
       {

--- a/app/components/global_stats_component.rb
+++ b/app/components/global_stats_component.rb
@@ -59,7 +59,7 @@ class GlobalStatsComponent < StatsPanelComponent
   end
 
   def posts_published_last_week_count
-    Post.where(published_at: 1.week.ago.beginning_of_day..Time.current.end_of_day).count
+    Post.published.where(published_at: 6.days.ago.beginning_of_day..Time.current.end_of_day).count
   end
 
   def most_recent_repost_at

--- a/app/components/user_stats_component.rb
+++ b/app/components/user_stats_component.rb
@@ -29,8 +29,8 @@ class UserStatsComponent < StatsPanelComponent
       },
       {
         key: "posts_last_week",
-        label: "Posts published last week",
-        label_short: "Last week",
+        label: "Posts published in the last 7 days",
+        label_short: "Last 7 days",
         value: number_with_delimiter(user.posts_published_last_week_count)
       },
       {

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -321,9 +321,11 @@ class Feed < ApplicationRecord
     posts.published.maximum(:reposted_at)
   end
 
-  # @return [Integer] posts published in the last week, by source date
+  # Today plus the six preceding days, snapped to day boundaries so the count
+  # doesn't shift with the time of day.
+  # @return [Integer] published posts dated in the last 7 days, by source date
   def posts_published_last_week_count
-    posts.where(published_at: 1.week.ago.beginning_of_day..Time.current.end_of_day).count
+    posts.published.where(published_at: 6.days.ago.beginning_of_day..Time.current.end_of_day).count
   end
 
   # Single source of truth for the cached post counters. Post's create/destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
   end
 
   def posts_published_last_week_count
-    imported_posts.where(published_at: 1.week.ago.beginning_of_day..Time.current.end_of_day).count
+    published_posts.where(published_at: 6.days.ago.beginning_of_day..Time.current.end_of_day).count
   end
 
   def update_password!(new_password)

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -64,7 +64,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
     assert_equal "Recent", result.css(".hidden.md\\:flex [data-key=\"stats.most_recent_repost.label\"]").first.text
     assert_equal "Imported", result.css(".hidden.md\\:flex [data-key=\"stats.imported_posts.label\"]").first.text
     assert_equal "Published", result.css(".hidden.md\\:flex [data-key=\"stats.published_posts.label\"]").first.text
-    assert_equal "Last week", result.css(".hidden.md\\:flex [data-key=\"stats.posts_last_week.label\"]").first.text
+    assert_equal "Last 7 days", result.css(".hidden.md\\:flex [data-key=\"stats.posts_last_week.label\"]").first.text
   end
 
   test "#render should display fallback values for missing data" do

--- a/test/components/feed_stats_component_test.rb
+++ b/test/components/feed_stats_component_test.rb
@@ -41,7 +41,7 @@ class FeedStatsComponentTest < ViewComponent::TestCase
 
       last_week = result.css('[data-key="stats.posts_last_week"]').first
       assert_not_nil last_week
-      assert_equal "2", result.css('[data-key="stats.posts_last_week.value"]').first.text.strip
+      assert_equal "1", result.css('[data-key="stats.posts_last_week.value"]').first.text.strip
     end
   end
 

--- a/test/controllers/statuses_controller_test.rb
+++ b/test/controllers/statuses_controller_test.rb
@@ -129,13 +129,13 @@ class StatusesControllerTest < ActionDispatch::IntegrationTest
     assert css_select('[data-key="stats.most_recent_repost"]').empty?
   end
 
-  test "#show should display posts published last week" do
+  test "#show should display posts published in the last 7 days" do
     sign_in_as user
     feed = create(:feed, user: user)
     entry1 = create(:feed_entry, feed: feed)
     entry2 = create(:feed_entry, feed: feed)
-    create(:post, feed: feed, feed_entry: entry1, published_at: 2.days.ago)
-    create(:post, feed: feed, feed_entry: entry2, published_at: 1.day.ago)
+    create(:post, :published, feed: feed, feed_entry: entry1, published_at: 2.days.ago)
+    create(:post, :published, feed: feed, feed_entry: entry2, published_at: 1.day.ago)
 
     get status_path
     assert_response :success

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -1069,13 +1069,33 @@ class FeedTest < ActiveSupport::TestCase
     assert_nil feed.most_recent_repost_at
   end
 
-  test "#posts_published_last_week_count should count posts published within the last week" do
+  test "#posts_published_last_week_count should count published posts from the last 7 days" do
     feed = create(:feed)
-    create(:post, feed: feed, published_at: 2.days.ago)
-    create(:post, feed: feed, published_at: 6.days.ago)
-    create(:post, feed: feed, published_at: 10.days.ago)
+    create(:post, :published, feed: feed, published_at: 2.days.ago)
+    create(:post, :published, feed: feed, published_at: 6.days.ago)
+    create(:post, :published, feed: feed, published_at: 10.days.ago)
 
     assert_equal 2, feed.posts_published_last_week_count
+  end
+
+  test "#posts_published_last_week_count should exclude posts dated before the window" do
+    feed = create(:feed)
+
+    freeze_time do
+      create(:post, :published, feed: feed, published_at: 6.days.ago.beginning_of_day)
+      create(:post, :published, feed: feed, published_at: 7.days.ago.end_of_day)
+
+      assert_equal 1, feed.posts_published_last_week_count
+    end
+  end
+
+  test "#posts_published_last_week_count should ignore posts that are not published" do
+    feed = create(:feed)
+    create(:post, feed: feed, published_at: 1.day.ago)
+    create(:post, :rejected, feed: feed, published_at: 1.day.ago)
+    create(:post, :published, feed: feed, published_at: 1.day.ago)
+
+    assert_equal 1, feed.posts_published_last_week_count
   end
 
   test "#import_after_enabled should default to false when import_after is blank" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -282,18 +282,30 @@ class UserTest < ActiveSupport::TestCase
     assert_nil user.most_recent_repost_at
   end
 
-  test "#posts_published_last_week_count should return count of posts from the last 7 days" do
+  test "#posts_published_last_week_count should return count of published posts from the last 7 days" do
     user = create(:user)
     feed = create(:feed, user: user)
     entry1 = create(:feed_entry, feed: feed)
     entry2 = create(:feed_entry, feed: feed)
     entry3 = create(:feed_entry, feed: feed)
 
-    create(:post, feed: feed, feed_entry: entry1, published_at: 2.days.ago)
-    create(:post, feed: feed, feed_entry: entry2, published_at: 1.day.ago)
-    create(:post, feed: feed, feed_entry: entry3, published_at: 10.days.ago)
+    create(:post, :published, feed: feed, feed_entry: entry1, published_at: 2.days.ago)
+    create(:post, :published, feed: feed, feed_entry: entry2, published_at: 1.day.ago)
+    create(:post, :published, feed: feed, feed_entry: entry3, published_at: 10.days.ago)
 
     assert_equal 2, user.posts_published_last_week_count
+  end
+
+  test "#posts_published_last_week_count should ignore posts that are not published" do
+    user = create(:user)
+    feed = create(:feed, user: user)
+    entry1 = create(:feed_entry, feed: feed)
+    entry2 = create(:feed_entry, feed: feed)
+
+    create(:post, feed: feed, feed_entry: entry1, published_at: 1.day.ago)
+    create(:post, :published, feed: feed, feed_entry: entry2, published_at: 1.day.ago)
+
+    assert_equal 1, user.posts_published_last_week_count
   end
 
   test "#posts_published_last_week_count should return 0 when no posts" do


### PR DESCRIPTION
Changes:

- Count only posts that reached FreeFeed in the 7-day stat, instead of every imported post
- Narrow the window to a real 7 days; it was spanning eight calendar days
- Relabel the stat "Last 7 days", replacing "Last week"

The stat read "Last week" but measured neither a calendar week nor seven days: both endpoints were snapped to day boundaries a week apart, so it covered today plus the previous seven. It also had no status filter and keyed off `published_at`, the source publication date, so drafts, rejects and failures all counted toward a figure labelled "published".

Existing tests passed only because they relied on the post factory's default `:draft` status, which the count now excludes; they have been updated along with new coverage for the window boundary and the status filter.
